### PR TITLE
fix(release): honor severity filter in Trivy SARIF scan gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: "1"
           format: sarif
+          limit-severities-for-sarif: true
           output: trivy-release.sarif
           trivyignores: .trivyignore
       - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
@@ -138,6 +139,7 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: "1"
           format: sarif
+          limit-severities-for-sarif: true
           output: trivy-release-distroless.sarif
           trivyignores: .trivyignore
       - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [x] 🏗️ CI/CD

## Description

Fixes the release workflow Trivy scan gate after #7 merged.

With `format: sarif`, `trivy-action` defaults to scanning **all severities** and unsets the configured `severity:` filter unless `limit-severities-for-sarif: true` is set ([trivy-action README](https://github.com/aquasecurity/trivy-action), issues [#309](https://github.com/aquasecurity/trivy-action/issues/309) / [#386](https://github.com/aquasecurity/trivy-action/issues/386)). The release job then fails on MEDIUM/LOW findings even when `severity: CRITICAL,HIGH` and `.trivyignore` are configured.

Add `limit-severities-for-sarif: true` to both release scan steps so the gate, SARIF output, and `.trivyignore` all respect `CRITICAL,HIGH`.

## Related Issues

N/A

## How Has This Been Tested?

<!--
Describe the tests you ran to verify your changes.
Provide instructions so reviewers can reproduce.
-->

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

Reproduced locally with Trivy 0.70.0:

| Config | Exit code |
|--------|-----------|
| SARIF + ignore (current release workflow) | 1 |
| SARIF + ignore + severity kept (`limit-severities-for-sarif`) | 0 |

Failed release run after #7: [27453355855](https://github.com/devops-thiago/ThrillhouseBot/actions/runs/27453355855) (`scan` job).

After merge:

```bash
gh workflow run release.yml -f version=v0.1.0
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

| Failure | Cause | Fix in this PR |
|---------|-------|----------------|
| `scan` job exit 1 | SARIF mode ignores `severity:` by default; gate fails on all severities | `limit-severities-for-sarif: true` on both Trivy steps |

## Additional Notes

- SARIF uploaded to the Security tab will contain CRITICAL/HIGH only (not full LOW/MEDIUM inventory). That matches the release gate intent.
- `trivy-action` remains pinned by SHA to v0.36.0 with Trivy v0.70.0 (post–March 2026 supply-chain incident safe versions).
- No application or image changes; re-run release for existing `v0.1.0` tag after merge.
