### PR TITLE
ci: honor severity filter in Trivy SARIF image scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,7 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: "0"
           format: sarif
+          limit-severities-for-sarif: true
           output: trivy-image.sarif
       - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
         if: always()
@@ -246,6 +247,7 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: "0"
           format: sarif
+          limit-severities-for-sarif: true
           output: trivy-image-distroless.sarif
       - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
         if: always()

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -32,6 +32,7 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: "0"
           format: sarif
+          limit-severities-for-sarif: true
           output: trivy-latest.sarif
       - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
         with:
@@ -44,6 +45,7 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: "0"
           format: sarif
+          limit-severities-for-sarif: true
           output: trivy-latest-distroless.sarif
       - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
         with:


### PR DESCRIPTION
## What type of PR is this?

- [x] 🏗️ CI/CD
- [x] 🔒 Security

## Description

With `format: sarif`, `aquasecurity/trivy-action` scans **all** severities by default, so the configured `severity: CRITICAL,HIGH` filter (and `.trivyignore`) is ignored for both the SARIF report and the exit code unless `limit-severities-for-sarif: true` is set. This is the same fix that landed for the release gate in #8 (`release.yml`).

This adds the flag to the remaining SARIF image scans so the GitHub Security tab reflects the configured gate instead of noisy LOW/MEDIUM findings:

- **`ci.yml` → `trivy-image`**: default (UBI9) and distroless image scans
- **`security-scan.yml` → `trivy-latest`**: scheduled `:latest` and `:latest-distroless` scans

Severity filters are unchanged (`CRITICAL,HIGH`), per the issue's intent. Both jobs keep `exit-code: "0"`, so they stay report-only — this change only affects which findings are reported, not pass/fail.

```diff
           severity: CRITICAL,HIGH
           exit-code: "0"
           format: sarif
+          limit-severities-for-sarif: true
           output: trivy-image.sarif
```

(applied to all four SARIF trivy steps across the two jobs)

## Related Issues

Fixes #12

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

- Both workflow files parse as valid YAML.
- Change matches the convention established in `release.yml` (#8): flag placed directly after `format: sarif`.
- Note: the edited `trivy-image` / `trivy-latest` jobs are gated on `push` to `main` / `schedule`, so they do not execute on PR CI; this is a config-only change that first runs on the post-merge `main` push.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes <!-- N/A: CI workflow YAML change only -->
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Out of scope for this issue: the `trivy` **fs** job in `ci.yml` also uses `format: sarif` but with `exit-code: "1"` and no flag, so it currently gates on *all* severities rather than its declared `severity: CRITICAL`. That's a separate (gating, not report-only) concern, tracked in #76.

