### PR TITLE
fix(dashboard): paginate installations and installed repos in access checks

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
@@ -28,6 +28,8 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.IntFunction;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
@@ -44,6 +46,15 @@ public class DashboardAccessChecker {
   private static final Duration OWNER_CACHE_TTL = Duration.ofHours(1);
   private static final Duration OWNER_NEGATIVE_CACHE_TTL = Duration.ofMinutes(1);
   static final int ACCESS_CACHE_SWEEP_THRESHOLD = 1_000;
+  private static final int PER_PAGE = 100;
+
+  /**
+   * Loud safety valve for the page walk. Pagination terminates on GitHub's short final page, so
+   * this ceiling is only reached if an endpoint misbehaves and never returns one. It sits far above
+   * any real account (100,000 entries); reaching it throws so the walk fails closed and is logged,
+   * rather than spinning a request thread forever or silently dropping data.
+   */
+  private static final int MAX_PAGES = 1_000;
 
   /** Outcome of an access check, letting callers distinguish denial from a misconfigured owner. */
   public enum AccessDecision {
@@ -217,25 +228,10 @@ public class DashboardAccessChecker {
     String installationAuth = null;
     try {
       var jwt = "Bearer " + authClient.generateAppJwt();
-      Optional<GitHubInstallationClient.Installation> matchingInstallation =
-          installationClient.listInstallations(jwt, ACCEPT, 100).stream()
-              .filter(
-                  i -> i.account() != null && accountOwner.equalsIgnoreCase(i.account().login()))
-              .findFirst();
+      var matchingInstallation = findInstallation(jwt, accountOwner);
       if (matchingInstallation.isPresent()) {
         installationAuth = authClient.getAuthHeader(matchingInstallation.get().id());
-        var response =
-            installationClient.listInstallationRepositories(installationAuth, ACCEPT, 100, 1);
-        if (response.repositories() != null) {
-          for (GitHubInstallationClient.InstallationRepositoriesResponse.Repository repo :
-              response.repositories()) {
-            if (repo.owner() != null
-                && accountOwner.equalsIgnoreCase(repo.owner().login())
-                && repo.name() != null) {
-              repos.add(new RepoRef(repo.owner().login(), repo.name()));
-            }
-          }
-        }
+        collectInstalledRepos(installationAuth, accountOwner, repos);
       }
     } catch (RuntimeException e) {
       log.warn("Failed to list installed repositories for {}: {}", accountOwner, e.getMessage());
@@ -246,6 +242,81 @@ public class DashboardAccessChecker {
     cachedSnapshot.set(updated);
     log.info("Loaded {} installed repos for dashboard access control", repos.size());
     return updated;
+  }
+
+  /**
+   * Pages through the app's installations until the one matching {@code accountOwner} is found,
+   * stopping as soon as it matches or the listing ends.
+   */
+  private Optional<GitHubInstallationClient.Installation> findInstallation(
+      String jwt, String accountOwner) {
+    var match = new AtomicReference<GitHubInstallationClient.Installation>();
+    paginate(
+        page -> installationClient.listInstallations(jwt, ACCEPT, PER_PAGE, page),
+        installations -> {
+          var found =
+              installations.stream()
+                  .filter(
+                      i ->
+                          i.account() != null && accountOwner.equalsIgnoreCase(i.account().login()))
+                  .findFirst();
+          found.ifPresent(match::set);
+          return found.isPresent();
+        });
+    return Optional.ofNullable(match.get());
+  }
+
+  /** Collects every repository owned by {@code accountOwner} that the installation can access. */
+  private void collectInstalledRepos(
+      String installationAuth, String accountOwner, List<RepoRef> repos) {
+    paginate(
+        page ->
+            installationClient
+                .listInstallationRepositories(installationAuth, ACCEPT, PER_PAGE, page)
+                .repositories(),
+        pageRepos -> {
+          collectOwnerRepos(pageRepos, accountOwner, repos);
+          return false;
+        });
+  }
+
+  /**
+   * Walks 1-based pages from {@code fetchPage}, handing each non-empty page to {@code consumePage}.
+   * The walk ends when a page is shorter than {@code PER_PAGE} (GitHub's marker for the final
+   * page), when a page is empty or null, or when {@code consumePage} returns {@code true} to stop
+   * early. Termination follows the rows actually returned rather than any separately reported
+   * total, so it can never under-fetch. {@code MAX_PAGES} guards against an endpoint that never
+   * serves a short page; exceeding it throws rather than looping forever or returning a partial
+   * result.
+   */
+  private <T> void paginate(IntFunction<List<T>> fetchPage, Predicate<List<T>> consumePage) {
+    for (var page = 1; page <= MAX_PAGES; page++) {
+      var items = fetchPage.apply(page);
+      if (items == null || items.isEmpty()) {
+        return;
+      }
+      if (consumePage.test(items)) {
+        return;
+      }
+      if (items.size() < PER_PAGE) {
+        return;
+      }
+    }
+    throw new IllegalStateException(
+        "GitHub pagination exceeded " + MAX_PAGES + " pages; aborting to avoid an unbounded fetch");
+  }
+
+  private void collectOwnerRepos(
+      List<GitHubInstallationClient.InstallationRepositoriesResponse.Repository> pageRepos,
+      String accountOwner,
+      List<RepoRef> repos) {
+    for (var repo : pageRepos) {
+      if (repo.owner() != null
+          && accountOwner.equalsIgnoreCase(repo.owner().login())
+          && repo.name() != null) {
+        repos.add(new RepoRef(repo.owner().login(), repo.name()));
+      }
+    }
   }
 
   private Optional<String> accountOwner() {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubInstallationClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubInstallationClient.java
@@ -37,7 +37,8 @@ public interface GitHubInstallationClient {
   List<Installation> listInstallations(
       @HeaderParam("Authorization") String authorization,
       @HeaderParam("Accept") String accept,
-      @QueryParam("per_page") @DefaultValue("100") int perPage);
+      @QueryParam("per_page") @DefaultValue("100") int perPage,
+      @QueryParam("page") @DefaultValue("1") int page);
 
   @GET
   @Path("/installation/repositories")

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
@@ -114,6 +114,212 @@ class DashboardAccessCheckerTest {
   }
 
   @Test
+  void shouldFindInstallationBeyondFirstPage() {
+    // A full first page of non-matching installations forces pagination; the owner's installation
+    // only appears on page 2.
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
+        .thenReturn(otherInstallations(0, 100));
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(2)))
+        .thenReturn(List.of(installationFor("myowner", 99L)));
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+    when(installationClient.listInstallationRepositories(
+            eq("Bearer inst-token"), anyString(), eq(100), eq(1)))
+        .thenReturn(
+            new GitHubInstallationClient.InstallationRepositoriesResponse(
+                1, ownerRepos("myowner", "demo")));
+
+    Response collab = mock(Response.class);
+    when(collab.getStatus()).thenReturn(204);
+    when(installationClient.checkCollaborator(
+            eq("Bearer inst-token"), anyString(), eq("myowner"), eq("demo"), eq("collab")))
+        .thenReturn(collab);
+
+    assertTrue(checker.hasAccess("collab"));
+    verify(installationClient).listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(2));
+  }
+
+  @Test
+  void shouldFindInstallationOnThirdPageWithoutArbitraryCap() {
+    // Two full pages of non-matching installations precede the owner's; pagination must keep going
+    // with no fixed page ceiling.
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
+        .thenReturn(otherInstallations(0, 100));
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(2)))
+        .thenReturn(otherInstallations(100, 100));
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(3)))
+        .thenReturn(List.of(installationFor("myowner", 99L)));
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+    when(installationClient.listInstallationRepositories(
+            eq("Bearer inst-token"), anyString(), eq(100), eq(1)))
+        .thenReturn(
+            new GitHubInstallationClient.InstallationRepositoriesResponse(
+                1, ownerRepos("myowner", "demo")));
+
+    Response collab = mock(Response.class);
+    when(collab.getStatus()).thenReturn(204);
+    when(installationClient.checkCollaborator(
+            eq("Bearer inst-token"), anyString(), eq("myowner"), eq("demo"), eq("collab")))
+        .thenReturn(collab);
+
+    assertTrue(checker.hasAccess("collab"));
+    verify(installationClient).listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(3));
+  }
+
+  @Test
+  void shouldAllowCollaboratorOnRepoBeyondFirstPage() {
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
+        .thenReturn(List.of(installationFor("myowner", 99L)));
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+
+    // A full first page of owner repos the user does not collaborate on...
+    when(installationClient.listInstallationRepositories(
+            eq("Bearer inst-token"), anyString(), eq(100), eq(1)))
+        .thenReturn(
+            new GitHubInstallationClient.InstallationRepositoriesResponse(
+                101, ownerRepos("myowner", repoNames(0, 100))));
+    // ...and the one shared repo only on page 2.
+    when(installationClient.listInstallationRepositories(
+            eq("Bearer inst-token"), anyString(), eq(100), eq(2)))
+        .thenReturn(
+            new GitHubInstallationClient.InstallationRepositoriesResponse(
+                101, ownerRepos("myowner", "special-repo")));
+
+    Response notCollaborator = mock(Response.class);
+    when(notCollaborator.getStatus()).thenReturn(404);
+    when(installationClient.checkCollaborator(
+            anyString(), anyString(), anyString(), anyString(), eq("collab")))
+        .thenReturn(notCollaborator);
+    Response collaborator = mock(Response.class);
+    when(collaborator.getStatus()).thenReturn(204);
+    when(installationClient.checkCollaborator(
+            eq("Bearer inst-token"), anyString(), eq("myowner"), eq("special-repo"), eq("collab")))
+        .thenReturn(collaborator);
+
+    assertTrue(checker.hasAccess("collab"));
+    verify(installationClient)
+        .listInstallationRepositories(eq("Bearer inst-token"), anyString(), eq(100), eq(2));
+  }
+
+  @Test
+  void shouldPageReposBeyondUnderReportedTotalCount() {
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
+        .thenReturn(List.of(installationFor("myowner", 99L)));
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+
+    // total_count claims a single page, but page 1 is full and a 101st repo exists on page 2.
+    // Pagination must follow the actual rows (a full page means keep going), never the count.
+    when(installationClient.listInstallationRepositories(
+            eq("Bearer inst-token"), anyString(), eq(100), eq(1)))
+        .thenReturn(
+            new GitHubInstallationClient.InstallationRepositoriesResponse(
+                100, ownerRepos("myowner", repoNames(0, 100))));
+    when(installationClient.listInstallationRepositories(
+            eq("Bearer inst-token"), anyString(), eq(100), eq(2)))
+        .thenReturn(
+            new GitHubInstallationClient.InstallationRepositoriesResponse(
+                100, ownerRepos("myowner", "late-repo")));
+
+    Response notCollaborator = mock(Response.class);
+    when(notCollaborator.getStatus()).thenReturn(404);
+    when(installationClient.checkCollaborator(
+            anyString(), anyString(), anyString(), anyString(), eq("collab")))
+        .thenReturn(notCollaborator);
+    Response collaborator = mock(Response.class);
+    when(collaborator.getStatus()).thenReturn(204);
+    // The only repo the user collaborates on is the one total_count failed to account for.
+    when(installationClient.checkCollaborator(
+            eq("Bearer inst-token"), anyString(), eq("myowner"), eq("late-repo"), eq("collab")))
+        .thenReturn(collaborator);
+
+    assertTrue(checker.hasAccess("collab"));
+    verify(installationClient)
+        .listInstallationRepositories(eq("Bearer inst-token"), anyString(), eq(100), eq(2));
+  }
+
+  @Test
+  void shouldDenyWhenPaginationExceedsSafetyCeiling() {
+    // A misbehaving endpoint that always returns a full, non-matching page would loop forever; the
+    // MAX_PAGES ceiling makes the walk fail closed (throw -> caught -> denied) instead of hanging.
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), anyInt()))
+        .thenReturn(otherInstallations(0, 100));
+
+    assertFalse(checker.hasAccess("collab"));
+  }
+
+  @Test
+  void shouldSkipInstallationWithNullAccountWhilePaging() {
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
+        .thenReturn(
+            List.of(
+                new GitHubInstallationClient.Installation(1L, null),
+                installationFor("myowner", 99L)));
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+    when(installationClient.listInstallationRepositories(
+            eq("Bearer inst-token"), anyString(), eq(100), eq(1)))
+        .thenReturn(
+            new GitHubInstallationClient.InstallationRepositoriesResponse(
+                1, ownerRepos("myowner", "demo")));
+
+    Response collab = mock(Response.class);
+    when(collab.getStatus()).thenReturn(204);
+    when(installationClient.checkCollaborator(
+            eq("Bearer inst-token"), anyString(), eq("myowner"), eq("demo"), eq("collab")))
+        .thenReturn(collab);
+
+    assertTrue(checker.hasAccess("collab"));
+  }
+
+  @Test
+  void shouldDenyWhenInstallationListingIsNull() {
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
+        .thenReturn(null);
+
+    assertFalse(checker.hasAccess("collab"));
+  }
+
+  @Test
+  void shouldOnlyConsiderOwnerReposWithCompleteMetadata() {
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
+        .thenReturn(List.of(installationFor("myowner", 99L)));
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+
+    // A mix the filter must reject: missing name, missing owner, foreign owner — plus one keeper.
+    var mixed =
+        List.of(
+            new GitHubInstallationClient.InstallationRepositoriesResponse.Repository(
+                null,
+                new GitHubInstallationClient.InstallationRepositoriesResponse.Repository.Owner(
+                    "myowner")),
+            new GitHubInstallationClient.InstallationRepositoriesResponse.Repository(
+                "orphan", null),
+            new GitHubInstallationClient.InstallationRepositoriesResponse.Repository(
+                "foreign",
+                new GitHubInstallationClient.InstallationRepositoriesResponse.Repository.Owner(
+                    "other-owner")),
+            new GitHubInstallationClient.InstallationRepositoriesResponse.Repository(
+                "demo",
+                new GitHubInstallationClient.InstallationRepositoriesResponse.Repository.Owner(
+                    "myowner")));
+    when(installationClient.listInstallationRepositories(
+            eq("Bearer inst-token"), anyString(), eq(100), eq(1)))
+        .thenReturn(new GitHubInstallationClient.InstallationRepositoriesResponse(4, mixed));
+
+    Response collab = mock(Response.class);
+    when(collab.getStatus()).thenReturn(204);
+    when(installationClient.checkCollaborator(
+            eq("Bearer inst-token"), anyString(), eq("myowner"), eq("demo"), eq("collab")))
+        .thenReturn(collab);
+
+    assertTrue(checker.hasAccess("collab"));
+    // Only the fully specified owner repo is collaborator-checked; the rejected entries are not.
+    verify(installationClient)
+        .checkCollaborator(
+            eq("Bearer inst-token"), anyString(), eq("myowner"), eq("demo"), eq("collab"));
+    verify(installationClient, never())
+        .checkCollaborator(anyString(), anyString(), eq("other-owner"), anyString(), anyString());
+  }
+
+  @Test
   void shouldDenyNullLogin() {
     assertFalse(checker.hasAccess(null));
   }
@@ -165,7 +371,8 @@ class DashboardAccessCheckerTest {
 
     assertEquals(DashboardAccessChecker.AccessDecision.DENIED, checker.checkAccess("outsider"));
     assertFalse(checker.hasAccess("outsider"));
-    verify(installationClient, never()).listInstallations(anyString(), anyString(), anyInt());
+    verify(installationClient, never())
+        .listInstallations(anyString(), anyString(), anyInt(), anyInt());
   }
 
   @Test
@@ -194,7 +401,7 @@ class DashboardAccessCheckerTest {
 
   @Test
   void shouldHandleNullRepositoriesResponse() {
-    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100)))
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
         .thenReturn(
             List.of(
                 new GitHubInstallationClient.Installation(
@@ -208,7 +415,7 @@ class DashboardAccessCheckerTest {
 
   @Test
   void shouldSkipInstallationWithNoMatchingAccount() {
-    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100)))
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
         .thenReturn(
             List.of(
                 new GitHubInstallationClient.Installation(
@@ -250,7 +457,7 @@ class DashboardAccessCheckerTest {
 
   @Test
   void shouldReturnSnapshotFromCacheOnRepoFetchFailure() {
-    when(installationClient.listInstallations(anyString(), anyString(), eq(100)))
+    when(installationClient.listInstallations(anyString(), anyString(), eq(100), eq(1)))
         .thenThrow(new RuntimeException("API error"));
 
     assertFalse(checker.hasAccess("collab"));
@@ -286,7 +493,8 @@ class DashboardAccessCheckerTest {
     assertFalse(checker.hasAccess("outsider"));
     assertFalse(checker.hasAccess("another-outsider"));
 
-    verify(installationClient, times(1)).listInstallations(eq("Bearer jwt"), anyString(), eq(100));
+    verify(installationClient, times(1))
+        .listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1));
   }
 
   @Test
@@ -302,25 +510,55 @@ class DashboardAccessCheckerTest {
     assertTrue(checker.hasAccess("collab-one"));
     assertTrue(checker.hasAccess("collab-two"));
 
-    verify(installationClient, times(1)).listInstallations(eq("Bearer jwt"), anyString(), eq(100));
+    verify(installationClient, times(1))
+        .listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1));
   }
 
   private void stubInstalledRepo(String owner, String repo) {
-    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100)))
-        .thenReturn(
-            List.of(
-                new GitHubInstallationClient.Installation(
-                    99L, new GitHubInstallationClient.Installation.Account(owner, "User"))));
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
+        .thenReturn(List.of(installationFor(owner, 99L)));
     when(installationClient.listInstallationRepositories(
             eq("Bearer inst-token"), anyString(), eq(100), eq(1)))
         .thenReturn(
             new GitHubInstallationClient.InstallationRepositoriesResponse(
-                1,
-                List.of(
-                    new GitHubInstallationClient.InstallationRepositoriesResponse.Repository(
-                        repo,
-                        new GitHubInstallationClient.InstallationRepositoriesResponse.Repository
-                            .Owner(owner)))));
+                1, ownerRepos(owner, repo)));
+  }
+
+  private static GitHubInstallationClient.Installation installationFor(String login, long id) {
+    return new GitHubInstallationClient.Installation(
+        id, new GitHubInstallationClient.Installation.Account(login, "User"));
+  }
+
+  private static List<GitHubInstallationClient.Installation> otherInstallations(
+      int start, int count) {
+    var installations = new java.util.ArrayList<GitHubInstallationClient.Installation>();
+    for (var i = start; i < start + count; i++) {
+      installations.add(installationFor("other-" + i, i));
+    }
+    return installations;
+  }
+
+  private static List<GitHubInstallationClient.InstallationRepositoriesResponse.Repository>
+      ownerRepos(String owner, String... names) {
+    var repos =
+        new java.util.ArrayList<
+            GitHubInstallationClient.InstallationRepositoriesResponse.Repository>();
+    for (var name : names) {
+      repos.add(
+          new GitHubInstallationClient.InstallationRepositoriesResponse.Repository(
+              name,
+              new GitHubInstallationClient.InstallationRepositoriesResponse.Repository.Owner(
+                  owner)));
+    }
+    return repos;
+  }
+
+  private static String[] repoNames(int start, int count) {
+    var names = new String[count];
+    for (var i = 0; i < count; i++) {
+      names[i] = "repo-" + (start + i);
+    }
+    return names;
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Dashboard access control only inspected the **first page** (100 entries) of both app installations and installed repositories, so collaborators whose only shared repo sorted beyond the first 100 were wrongly denied access.

This change paginates through both lists in `DashboardAccessChecker`:

- Add a `page` query param to `GitHubInstallationClient.listInstallations` (the repositories endpoint already had one).
- `findInstallation(...)` pages through installations until the owner's installation is found, stopping early on a match or the first short page so we never fetch more pages than necessary.
- `collectInstalledRepos(...)` pages through **all** installed repositories, collecting owner-owned repos across every page.
- Both loops are bounded by `MAX_PAGES` (100 pages / 10k entries) so a misbehaving API that keeps returning full pages can never loop forever.

No behavioral change for accounts with ≤100 installations/repos; the cache, owner resolution, and collaborator-check logic are untouched.

## Related Issues

Fixes #18

## How Has This Been Tested?

`./mvnw test` — full suite green (722 tests, 0 failures), `spotless:check` passes. Two new unit tests were added that fail without the fix:

- `shouldFindInstallationBeyondFirstPage` — owner's installation only appears on page 2 of `/app/installations`.
- `shouldAllowCollaboratorOnRepoBeyondFirstPage` — the collaborator's only shared repo only appears on page 2 of `/installation/repositories`.

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

The `page` parameter added to `listInstallations` is backward-compatible (defaults to page 1). Only `DashboardAccessChecker` and its test call these methods.