### PR TITLE
fix(webhook): restrict manual /review triggers to authorized users

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
@@ -16,6 +16,7 @@
 package dev.thiagogonzaga.thrillhousebot.webhook;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -28,6 +29,13 @@ public class TriggerDetector {
               ".*(?:^|\\s)/review(?:\\s|$).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL),
           Pattern.compile(
               ".*@thrillhousebot\\s+review\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+
+  /**
+   * GitHub {@code author_association} values that grant write access to the repository and are
+   * therefore allowed to spend the operator's API budget on a manual review.
+   */
+  private static final Set<String> AUTHORIZED_ASSOCIATIONS =
+      Set.of("OWNER", "MEMBER", "COLLABORATOR");
 
   /**
    * Checks whether a comment body contains a review trigger keyword. Triggers: "/review" or
@@ -45,5 +53,17 @@ public class TriggerDetector {
     if (authorLogin == null) return false;
     return ("thrillhousebot[bot]".equalsIgnoreCase(authorLogin)
         || "thrillhouse-bot[bot]".equalsIgnoreCase(authorLogin));
+  }
+
+  /**
+   * Checks whether a commenter is authorized to manually trigger a review based on their GitHub
+   * {@code author_association}. Only owners, organization members, and collaborators (users with
+   * write access) may run a manual review; everyone else — {@code CONTRIBUTOR}, {@code
+   * FIRST_TIME_CONTRIBUTOR}, {@code NONE}, etc. — is rejected so that arbitrary users on public
+   * repositories cannot spend the operator's API budget.
+   */
+  public boolean isAuthorizedToTrigger(String authorAssociation) {
+    if (authorAssociation == null) return false;
+    return AUTHORIZED_ASSOCIATIONS.contains(authorAssociation.trim().toUpperCase(Locale.ROOT));
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -151,6 +151,16 @@ public class WebhookController {
     }
 
     if (triggerDetector.isReviewTrigger(payload.comment().body())) {
+      // Manual triggers spend the operator's API budget, so restrict them to users with write
+      // access (owner/member/collaborator). Otherwise anyone could repeatedly trigger paid reviews.
+      if (!triggerDetector.isAuthorizedToTrigger(payload.comment().authorAssociation())) {
+        log.info(
+            "Ignoring unauthorized manual review trigger from @{} (association: {}) on PR #{}",
+            payload.comment().user().login(),
+            payload.comment().authorAssociation(),
+            payload.issue().number());
+        return;
+      }
       var repo = payload.repository();
       if (repo == null || payload.installation() == null) {
         log.debug("Ignoring review trigger with missing repository or installation");

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookPayload.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookPayload.java
@@ -76,7 +76,11 @@ public record WebhookPayload(
 
   @RegisterForReflection
   @JsonIgnoreProperties(ignoreUnknown = true)
-  public record Comment(long id, String body, User user) {}
+  public record Comment(
+      long id,
+      String body,
+      User user,
+      @JsonProperty("author_association") String authorAssociation) {}
 
   @RegisterForReflection
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
@@ -59,4 +59,29 @@ class TriggerDetectorTest {
     assertFalse(detector.isBotComment("thrillhousebot"));
     assertFalse(detector.isBotComment(""));
   }
+
+  @Test
+  void shouldAuthorizeWriteAccessAssociations() {
+    assertTrue(detector.isAuthorizedToTrigger("OWNER"));
+    assertTrue(detector.isAuthorizedToTrigger("MEMBER"));
+    assertTrue(detector.isAuthorizedToTrigger("COLLABORATOR"));
+  }
+
+  @Test
+  void shouldAuthorizeRegardlessOfCaseAndWhitespace() {
+    assertTrue(detector.isAuthorizedToTrigger("owner"));
+    assertTrue(detector.isAuthorizedToTrigger("Collaborator"));
+    assertTrue(detector.isAuthorizedToTrigger("  MEMBER  "));
+  }
+
+  @Test
+  void shouldRejectNonWriteAssociations() {
+    assertFalse(detector.isAuthorizedToTrigger("CONTRIBUTOR"));
+    assertFalse(detector.isAuthorizedToTrigger("FIRST_TIME_CONTRIBUTOR"));
+    assertFalse(detector.isAuthorizedToTrigger("FIRST_TIMER"));
+    assertFalse(detector.isAuthorizedToTrigger("MANNEQUIN"));
+    assertFalse(detector.isAuthorizedToTrigger("NONE"));
+    assertFalse(detector.isAuthorizedToTrigger(""));
+    assertFalse(detector.isAuthorizedToTrigger(null));
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -212,6 +212,7 @@ class WebhookControllerTest {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
     when(triggerDetector.isReviewTrigger("/review")).thenReturn(true);
     when(triggerDetector.isBotComment("octocat")).thenReturn(false);
+    when(triggerDetector.isAuthorizedToTrigger("OWNER")).thenReturn(true);
 
     var body =
         buildIssueCommentPayload("created", 77, "owner/repo", "octocat", "/review")
@@ -224,6 +225,24 @@ class WebhookControllerTest {
         .dispatch(
             new ReviewOrchestrator.ReviewRequest(
                 "owner", "repo", 77, "", "(manual review)", "", "", "main", 12345L, true));
+  }
+
+  @Test
+  void shouldIgnoreUnauthorizedManualReviewTrigger() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(triggerDetector.isReviewTrigger("/review")).thenReturn(true);
+    when(triggerDetector.isBotComment("stranger")).thenReturn(false);
+    when(triggerDetector.isAuthorizedToTrigger("NONE")).thenReturn(false);
+
+    var body =
+        buildIssueCommentPayload("created", 88, "owner/repo", "stranger", "/review", "NONE")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, body);
+    assertEquals(200, response.getStatus());
+
+    // A non-collaborator must not be able to spend the operator's API budget.
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
   }
 
   @Test
@@ -452,6 +471,16 @@ class WebhookControllerTest {
 
   private String buildIssueCommentPayload(
       String action, int issueNumber, String fullName, String userLogin, String commentBody) {
+    return buildIssueCommentPayload(action, issueNumber, fullName, userLogin, commentBody, "OWNER");
+  }
+
+  private String buildIssueCommentPayload(
+      String action,
+      int issueNumber,
+      String fullName,
+      String userLogin,
+      String commentBody,
+      String authorAssociation) {
     return ("{"
         + "\"action\":\""
         + action
@@ -472,6 +501,9 @@ class WebhookControllerTest {
         + "\"id\":1,"
         + "\"body\":\""
         + commentBody
+        + "\","
+        + "\"author_association\":\""
+        + authorAssociation
         + "\","
         + "\"user\":{\"login\":\""
         + userLogin


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [x] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Manual `/review` and `@thrillhousebot review` comment triggers previously ran for **any** commenter. `WebhookController.handleIssueComment` and `TriggerDetector` only skipped the bot's own comments, so on a public repository anyone could repeatedly trigger paid AI reviews and spend the operator's API budget — a cost/abuse vector.

This PR gates manual triggers on the commenter's GitHub `author_association`:

- Only `OWNER`, `MEMBER`, and `COLLABORATOR` (users with write access) may run a manual review.
- Everyone else (`CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `NONE`, …) gets a polite no-op: the attempt is logged and no review is dispatched.
- The check **fails closed** when `author_association` is missing or unknown.
- Automatic `pull_request` reviews (opened/reopened/synchronize) are **unaffected**.

Changes:
- `WebhookPayload.Comment` now parses the `author_association` field.
- `TriggerDetector.isAuthorizedToTrigger(...)` encapsulates the write-access check (case/whitespace-insensitive, null-safe).
- `WebhookController.handleIssueComment` rejects unauthorized triggers before dispatching.

## Related Issues

Fixes #70

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- `TriggerDetectorTest`: authorized associations (incl. mixed case/whitespace), and rejection of non-write associations / blank / null.
- `WebhookControllerTest`: added `shouldIgnoreUnauthorizedManualReviewTrigger` (a `NONE` commenter is not dispatched) and updated the existing trigger test to stub authorization.
- Full suite: `./mvnw test` → 724 tests, 0 failures. `./mvnw spotless:check` passes.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

On an unauthorized attempt the bot logs and stops, e.g.:

```
INFO  Ignoring unauthorized manual review trigger from @stranger (association: NONE) on PR #88
```

## Additional Notes

The fix is secure-by-default and needs no configuration. If a configurable allowlist of additional usernames is desired later, it can layer on top of `isAuthorizedToTrigger` without changing the gate's call site.