### PR TITLE
fix(dashboard): fail closed when GitHub App owner cannot be resolved

### DIFF
--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -21,13 +21,31 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
-  const { user, loading, accessDenied, logout } = useAuth();
+  const { user, loading, accessDenied, notConfigured, logout } = useAuth();
 
   useEffect(() => {
-    if (!loading && !user && !accessDenied) {
+    if (!loading && !user && !accessDenied && !notConfigured) {
       window.location.replace("/dashboard/");
     }
-  }, [loading, user, accessDenied]);
+  }, [loading, user, accessDenied, notConfigured]);
+
+  if (!loading && notConfigured) {
+    return (
+      <div style={styles.deniedPage}>
+        <div style={styles.deniedCard}>
+          <h1 style={{ marginTop: 0 }}>Dashboard not configured</h1>
+          <p style={{ color: "var(--text-muted)" }}>
+            Dashboard access control is not configured: the GitHub App owner could not be
+            resolved. An administrator must set{" "}
+            <code>thrillhousebot.dashboard.github.account-owner</code> before anyone can sign in.
+          </p>
+          <button type="button" onClick={logout} style={styles.logoutBtn}>
+            Log out
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   if (!loading && accessDenied) {
     return (

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -5,7 +5,7 @@ import GithubCorner from "@/components/GithubCorner";
 import SiteFooter from "@/components/SiteFooter";
 
 export default function LoginPage() {
-  const { user, loading, accessDenied, login, logout } = useAuth();
+  const { user, loading, accessDenied, notConfigured, login, logout } = useAuth();
 
   if (loading)
     return (
@@ -13,6 +13,28 @@ export default function LoginPage() {
         <p>Loading...</p>
       </div>
     );
+  if (notConfigured) {
+    return (
+      <div style={styles.page}>
+        <GithubCorner />
+        <div style={styles.center}>
+          <div style={styles.card}>
+            <h1 style={styles.title}>Dashboard not configured</h1>
+            <p style={styles.subtitle}>
+              Dashboard access control is not configured: the GitHub App owner
+              could not be resolved. An administrator must set{" "}
+              <code>thrillhousebot.dashboard.github.account-owner</code> before
+              anyone can sign in.
+            </p>
+            <button type="button" onClick={logout} style={styles.logoutBtn}>
+              Log out
+            </button>
+          </div>
+        </div>
+        <SiteFooter />
+      </div>
+    );
+  }
   if (accessDenied) {
     return (
       <div style={styles.page}>

--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -12,20 +12,25 @@ interface User {
 async function fetchAuthUser(): Promise<{
   user: User | null;
   accessDenied: boolean;
+  notConfigured: boolean;
 }> {
   const response = await fetch('/api/auth/me', { credentials: 'include' });
   if (response.status === 403) {
-    return { user: null, accessDenied: true };
+    return { user: null, accessDenied: true, notConfigured: false };
+  }
+  if (response.status === 503) {
+    return { user: null, accessDenied: false, notConfigured: true };
   }
   if (!response.ok) {
-    return { user: null, accessDenied: false };
+    return { user: null, accessDenied: false, notConfigured: false };
   }
-  return { user: await response.json(), accessDenied: false };
+  return { user: await response.json(), accessDenied: false, notConfigured: false };
 }
 
 export function useAuth() {
   const [user, setUser] = useState<User | null>(MOCK_MODE ? mockUser : null);
   const [accessDenied, setAccessDenied] = useState(false);
+  const [notConfigured, setNotConfigured] = useState(false);
   const [loading, setLoading] = useState(!MOCK_MODE);
 
   useEffect(() => {
@@ -35,14 +40,16 @@ export function useAuth() {
 
     const refresh = (background = false) => {
       fetchAuthUser()
-        .then(({ user: nextUser, accessDenied: denied }) => {
+        .then(({ user: nextUser, accessDenied: denied, notConfigured: misconfigured }) => {
           if (cancelled) return;
           setAccessDenied(denied);
+          setNotConfigured(misconfigured);
           setUser(nextUser);
         })
         .catch(() => {
           if (cancelled || background) return;
           setAccessDenied(false);
+          setNotConfigured(false);
           setUser(null);
         })
         .finally(() => {
@@ -70,9 +77,18 @@ export function useAuth() {
     } finally {
       setUser(null);
       setAccessDenied(false);
+      setNotConfigured(false);
       window.location.href = "/dashboard/";
     }
   };
 
-  return { user, loading, accessDenied, login, logout, isAuthenticated: !!user };
+  return {
+    user,
+    loading,
+    accessDenied,
+    notConfigured,
+    login,
+    logout,
+    isAuthenticated: !!user,
+  };
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/AuthResource.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/AuthResource.java
@@ -73,6 +73,9 @@ public class AuthResource {
   private static final String MSG_AUTH_FAILED_GITHUB = "Failed to authenticate with GitHub";
   private static final String MSG_ACCESS_DENIED =
       "Access denied — you must be a collaborator on an installed repository";
+  private static final String MSG_OWNER_NOT_CONFIGURED =
+      "Dashboard access control is not configured: the GitHub App owner could not be resolved. "
+          + "Set thrillhousebot.dashboard.github.account-owner to enable access.";
 
   private final ThrillhouseConfig config;
   private final DashboardAccessChecker accessChecker;
@@ -235,11 +238,9 @@ public class AuthResource {
             .build();
       }
 
-      if (!accessChecker.hasAccess(login)) {
-        return Response.status(Response.Status.FORBIDDEN)
-            .entity(Map.of(KEY_ERROR, MSG_ACCESS_DENIED))
-            .cookie(clearedStateCookie)
-            .build();
+      var denial = accessDenial(login);
+      if (denial != null) {
+        return denial.cookie(clearedStateCookie).build();
       }
 
       String avatarUrl = userData.get("avatar_url") instanceof String url ? url : null;
@@ -292,15 +293,36 @@ public class AuthResource {
     }
 
     var user = session.get();
-    if (!accessChecker.hasAccess(user.login())) {
-      return Response.status(Response.Status.FORBIDDEN)
-          .entity(Map.of(KEY_ERROR, MSG_ACCESS_DENIED))
-          .build();
+    var denial = accessDenial(user.login());
+    if (denial != null) {
+      return denial.build();
     }
 
     return Response.ok(
             Map.of(KEY_LOGIN, user.login(), "avatarUrl", user.avatarUrl(), "name", user.name()))
         .build();
+  }
+
+  /**
+   * Decides whether {@code login} may reach the dashboard. Returns {@code null} when access is
+   * granted, or a builder for the denial response otherwise. Fails closed: a misconfigured/unknown
+   * owner yields a 503 with a clear "owner not configured" message rather than silently granting
+   * access, while a known owner with a non-collaborator login yields a 403.
+   */
+  private Response.ResponseBuilder accessDenial(String login) {
+    if (!accessChecker.isAccessControlEnabled()) {
+      log.error(
+          "Dashboard access blocked for {}: account owner is not configured and could not be "
+              + "resolved; set thrillhousebot.dashboard.github.account-owner",
+          login);
+      return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+          .entity(Map.of(KEY_ERROR, MSG_OWNER_NOT_CONFIGURED));
+    }
+    if (!accessChecker.hasAccess(login)) {
+      return Response.status(Response.Status.FORBIDDEN)
+          .entity(Map.of(KEY_ERROR, MSG_ACCESS_DENIED));
+    }
+    return null;
   }
 
   @POST

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/AuthResource.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/AuthResource.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -238,9 +239,9 @@ public class AuthResource {
             .build();
       }
 
-      var denial = accessDenial(login);
-      if (denial != null) {
-        return denial.cookie(clearedStateCookie).build();
+      var denial = denialResponse(accessChecker.checkAccess(login));
+      if (denial.isPresent()) {
+        return denial.get().cookie(clearedStateCookie).build();
       }
 
       String avatarUrl = userData.get("avatar_url") instanceof String url ? url : null;
@@ -293,9 +294,9 @@ public class AuthResource {
     }
 
     var user = session.get();
-    var denial = accessDenial(user.login());
-    if (denial != null) {
-      return denial.build();
+    var denial = denialResponse(accessChecker.checkAccess(user.login()));
+    if (denial.isPresent()) {
+      return denial.get().build();
     }
 
     return Response.ok(
@@ -304,25 +305,24 @@ public class AuthResource {
   }
 
   /**
-   * Decides whether {@code login} may reach the dashboard. Returns {@code null} when access is
-   * granted, or a builder for the denial response otherwise. Fails closed: a misconfigured/unknown
-   * owner yields a 503 with a clear "owner not configured" message rather than silently granting
-   * access, while a known owner with a non-collaborator login yields a 403.
+   * Maps an access decision to a denial response, or empty when access is granted. Fails closed: a
+   * misconfigured/unresolvable owner yields a 503 with a clear "owner not configured" message
+   * rather than silently granting access, while a known owner with a non-collaborator login yields
+   * a 403.
    */
-  private Response.ResponseBuilder accessDenial(String login) {
-    if (!accessChecker.isAccessControlEnabled()) {
-      log.error(
-          "Dashboard access blocked for {}: account owner is not configured and could not be "
-              + "resolved; set thrillhousebot.dashboard.github.account-owner",
-          login);
-      return Response.status(Response.Status.SERVICE_UNAVAILABLE)
-          .entity(Map.of(KEY_ERROR, MSG_OWNER_NOT_CONFIGURED));
-    }
-    if (!accessChecker.hasAccess(login)) {
-      return Response.status(Response.Status.FORBIDDEN)
-          .entity(Map.of(KEY_ERROR, MSG_ACCESS_DENIED));
-    }
-    return null;
+  private Optional<Response.ResponseBuilder> denialResponse(
+      DashboardAccessChecker.AccessDecision decision) {
+    return switch (decision) {
+      case ALLOWED -> Optional.empty();
+      case NOT_CONFIGURED ->
+          Optional.of(
+              Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                  .entity(Map.of(KEY_ERROR, MSG_OWNER_NOT_CONFIGURED)));
+      case DENIED ->
+          Optional.of(
+              Response.status(Response.Status.FORBIDDEN)
+                  .entity(Map.of(KEY_ERROR, MSG_ACCESS_DENIED)));
+    };
   }
 
   @POST

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
@@ -42,7 +42,18 @@ public class DashboardAccessChecker {
   private static final Duration REPO_CACHE_TTL = Duration.ofMinutes(10);
   private static final Duration ACCESS_CACHE_TTL = Duration.ofMinutes(5);
   private static final Duration OWNER_CACHE_TTL = Duration.ofHours(1);
+  private static final Duration OWNER_NEGATIVE_CACHE_TTL = Duration.ofMinutes(1);
   static final int ACCESS_CACHE_SWEEP_THRESHOLD = 1_000;
+
+  /** Outcome of an access check, letting callers distinguish denial from a misconfigured owner. */
+  public enum AccessDecision {
+    /** The login may use the dashboard. */
+    ALLOWED,
+    /** Access control is active but this login is neither the owner nor a collaborator. */
+    DENIED,
+    /** No account owner is configured or resolvable, so access control cannot be enforced. */
+    NOT_CONFIGURED
+  }
 
   private final ThrillhouseConfig config;
   private final GitHubAuthClient authClient;
@@ -84,31 +95,31 @@ public class DashboardAccessChecker {
     this.clock = clock;
   }
 
-  public boolean isAccessControlEnabled() {
-    return accountOwner().isPresent();
+  public boolean hasAccess(String githubLogin) {
+    return checkAccess(githubLogin) == AccessDecision.ALLOWED;
   }
 
-  public boolean hasAccess(String githubLogin) {
+  /**
+   * Resolves whether {@code githubLogin} may use the dashboard. Fails closed: when no account owner
+   * can be determined the result is {@link AccessDecision#NOT_CONFIGURED} (deny), never an implicit
+   * grant. The underlying misconfiguration is logged once per resolution attempt in {@link
+   * #accountOwner()}, so this method does not log per call.
+   */
+  public AccessDecision checkAccess(String githubLogin) {
     if (githubLogin == null || githubLogin.isBlank()) {
-      return false;
+      return AccessDecision.DENIED;
     }
 
     Optional<String> owner = accountOwner();
     if (owner.isEmpty()) {
-      // Fail closed: with no account owner configured or resolvable, we cannot tell who is allowed,
-      // so deny everyone rather than exposing the dashboard to any authenticated GitHub user.
-      log.warn(
-          "Dashboard access denied for GitHub user {}: account owner is not configured and could "
-              + "not be resolved; set thrillhousebot.dashboard.github.account-owner",
-          githubLogin);
-      return false;
+      return AccessDecision.NOT_CONFIGURED;
     }
 
     var normalizedLogin = githubLogin.toLowerCase(Locale.ROOT);
     var cached = accessCache.get(normalizedLogin);
     if (cached != null) {
       if (cached.cachedAt().isAfter(clock.get().minus(ACCESS_CACHE_TTL))) {
-        return cached.allowed();
+        return cached.allowed() ? AccessDecision.ALLOWED : AccessDecision.DENIED;
       }
       accessCache.remove(normalizedLogin, cached);
     }
@@ -119,7 +130,7 @@ public class DashboardAccessChecker {
     if (!allowed) {
       log.warn("Dashboard access denied for GitHub user {}", githubLogin);
     }
-    return allowed;
+    return allowed ? AccessDecision.ALLOWED : AccessDecision.DENIED;
   }
 
   /**
@@ -244,23 +255,34 @@ public class DashboardAccessChecker {
     }
 
     var cached = ownerCache.get();
-    if (cached.owner() != null && cached.cachedAt().isAfter(clock.get().minus(OWNER_CACHE_TTL))) {
-      return Optional.of(cached.owner());
+    var ttl = cached.owner() != null ? OWNER_CACHE_TTL : OWNER_NEGATIVE_CACHE_TTL;
+    if (cached.cachedAt().isAfter(clock.get().minus(ttl))) {
+      return Optional.ofNullable(cached.owner());
     }
 
+    String resolved = null;
     try {
       var jwt = "Bearer " + authClient.generateAppJwt();
       var app = installationClient.getApp(jwt, ACCEPT);
       if (app.owner() != null && app.owner().login() != null && !app.owner().login().isBlank()) {
-        var owner = app.owner().login();
-        ownerCache.set(new OwnerCache(owner, clock.get()));
-        log.info("Resolved dashboard account owner from GitHub App: {}", owner);
-        return Optional.of(owner);
+        resolved = app.owner().login();
+        log.info("Resolved dashboard account owner from GitHub App: {}", resolved);
+      } else {
+        log.warn(
+            "GitHub App returned no owner login; dashboard access stays denied until "
+                + "thrillhousebot.dashboard.github.account-owner is set");
       }
     } catch (RuntimeException e) {
-      log.warn("Failed to resolve GitHub App owner: {}", e.getMessage());
+      log.warn(
+          "Failed to resolve dashboard account owner from GitHub App ({}); access stays denied "
+              + "until thrillhousebot.dashboard.github.account-owner is set",
+          e.getMessage());
     }
 
-    return Optional.empty();
+    // Cache both success and failure: the negative result is short-lived (OWNER_NEGATIVE_CACHE_TTL)
+    // so a misconfigured deployment stops hammering the GitHub App endpoint every request, while
+    // still recovering promptly once the owner becomes resolvable.
+    ownerCache.set(new OwnerCache(resolved, clock.get()));
+    return Optional.ofNullable(resolved);
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
@@ -95,7 +95,13 @@ public class DashboardAccessChecker {
 
     Optional<String> owner = accountOwner();
     if (owner.isEmpty()) {
-      return true;
+      // Fail closed: with no account owner configured or resolvable, we cannot tell who is allowed,
+      // so deny everyone rather than exposing the dashboard to any authenticated GitHub user.
+      log.warn(
+          "Dashboard access denied for GitHub user {}: account owner is not configured and could "
+              + "not be resolved; set thrillhousebot.dashboard.github.account-owner",
+          githubLogin);
+      return false;
     }
 
     var normalizedLogin = githubLogin.toLowerCase(Locale.ROOT);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/AuthResourceCallbackTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/AuthResourceCallbackTest.java
@@ -65,6 +65,24 @@ class AuthResourceCallbackTest {
   }
 
   @Test
+  void callbackShouldReturn503WhenOwnerNotConfigured() throws Exception {
+    when(fixtureContext.accessChecker.isAccessControlEnabled()).thenReturn(false);
+    when(fixtureContext.httpClient.send(any(HttpRequest.class), any())).thenReturn(httpResponse);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body())
+        .thenReturn("{\"access_token\":\"gho_test123\"}")
+        .thenReturn("{\"login\":\"someuser\",\"avatar_url\":\"https://a.co\",\"name\":\"Some\"}");
+
+    var response = resource.callback("valid-code", "test-state", "test-state");
+
+    assertEquals(503, response.getStatus());
+    assertTrue(
+        ((Map<?, ?>) response.getEntity()).get("error").toString().contains("account-owner"));
+    // Fail closed: no session is created when access control cannot be enforced.
+    verify(fixtureContext.accessChecker, never()).hasAccess(any());
+  }
+
+  @Test
   void callbackShouldExchangeCodeAndSetOpaqueSessionCookie() throws Exception {
     when(fixtureContext.httpClient.send(any(HttpRequest.class), any())).thenReturn(httpResponse);
     when(httpResponse.statusCode()).thenReturn(200);
@@ -357,6 +375,20 @@ class AuthResourceCallbackTest {
     assertEquals(200, response.getStatus());
     var entity = (Map<?, ?>) response.getEntity();
     assertEquals("testuser", entity.get("login"));
+  }
+
+  @Test
+  void meShouldReturn503WhenOwnerNotConfigured() {
+    when(fixtureContext.accessChecker.isAccessControlEnabled()).thenReturn(false);
+    var sessionId =
+        fixtureContext.sessionStore.createSession("testuser", "gho_secret", "https://a.co", "Test");
+
+    var response = resource.me(sessionId);
+
+    assertEquals(503, response.getStatus());
+    assertTrue(
+        ((Map<?, ?>) response.getEntity()).get("error").toString().contains("account-owner"));
+    verify(fixtureContext.accessChecker, never()).hasAccess(any());
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/AuthResourceCallbackTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/AuthResourceCallbackTest.java
@@ -52,8 +52,8 @@ class AuthResourceCallbackTest {
 
   @Test
   void callbackShouldRejectUserWithoutRepoAccess() throws Exception {
-    when(fixtureContext.accessChecker.isAccessControlEnabled()).thenReturn(true);
-    when(fixtureContext.accessChecker.hasAccess("outsider")).thenReturn(false);
+    when(fixtureContext.accessChecker.checkAccess("outsider"))
+        .thenReturn(DashboardAccessChecker.AccessDecision.DENIED);
     when(fixtureContext.httpClient.send(any(HttpRequest.class), any())).thenReturn(httpResponse);
     when(httpResponse.statusCode()).thenReturn(200);
     when(httpResponse.body())
@@ -66,7 +66,8 @@ class AuthResourceCallbackTest {
 
   @Test
   void callbackShouldReturn503WhenOwnerNotConfigured() throws Exception {
-    when(fixtureContext.accessChecker.isAccessControlEnabled()).thenReturn(false);
+    when(fixtureContext.accessChecker.checkAccess("someuser"))
+        .thenReturn(DashboardAccessChecker.AccessDecision.NOT_CONFIGURED);
     when(fixtureContext.httpClient.send(any(HttpRequest.class), any())).thenReturn(httpResponse);
     when(httpResponse.statusCode()).thenReturn(200);
     when(httpResponse.body())
@@ -78,8 +79,8 @@ class AuthResourceCallbackTest {
     assertEquals(503, response.getStatus());
     assertTrue(
         ((Map<?, ?>) response.getEntity()).get("error").toString().contains("account-owner"));
-    // Fail closed: no session is created when access control cannot be enforced.
-    verify(fixtureContext.accessChecker, never()).hasAccess(any());
+    // Fail closed: no session cookie is issued when access control cannot be enforced.
+    assertFalse(response.getCookies().containsKey("thrillhouse_session"));
   }
 
   @Test
@@ -366,8 +367,8 @@ class AuthResourceCallbackTest {
 
   @Test
   void meShouldReturnUserWhenAccessControlEnabledAndAllowed() {
-    when(fixtureContext.accessChecker.isAccessControlEnabled()).thenReturn(true);
-    when(fixtureContext.accessChecker.hasAccess("testuser")).thenReturn(true);
+    when(fixtureContext.accessChecker.checkAccess("testuser"))
+        .thenReturn(DashboardAccessChecker.AccessDecision.ALLOWED);
     var sessionId =
         fixtureContext.sessionStore.createSession("testuser", "gho_secret", "https://a.co", "Test");
 
@@ -379,7 +380,8 @@ class AuthResourceCallbackTest {
 
   @Test
   void meShouldReturn503WhenOwnerNotConfigured() {
-    when(fixtureContext.accessChecker.isAccessControlEnabled()).thenReturn(false);
+    when(fixtureContext.accessChecker.checkAccess("testuser"))
+        .thenReturn(DashboardAccessChecker.AccessDecision.NOT_CONFIGURED);
     var sessionId =
         fixtureContext.sessionStore.createSession("testuser", "gho_secret", "https://a.co", "Test");
 
@@ -388,13 +390,12 @@ class AuthResourceCallbackTest {
     assertEquals(503, response.getStatus());
     assertTrue(
         ((Map<?, ?>) response.getEntity()).get("error").toString().contains("account-owner"));
-    verify(fixtureContext.accessChecker, never()).hasAccess(any());
   }
 
   @Test
   void meShouldReturn403WhenAccessControlEnabledAndAccessDenied() {
-    when(fixtureContext.accessChecker.isAccessControlEnabled()).thenReturn(true);
-    when(fixtureContext.accessChecker.hasAccess("outsider")).thenReturn(false);
+    when(fixtureContext.accessChecker.checkAccess("outsider"))
+        .thenReturn(DashboardAccessChecker.AccessDecision.DENIED);
     var sessionId =
         fixtureContext.sessionStore.createSession("outsider", "gho_secret", "https://a.co", "Out");
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/AuthResourceTestFixtures.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/AuthResourceTestFixtures.java
@@ -72,6 +72,6 @@ final class AuthResourceTestFixtures {
 
   static void wirePermissiveAccess(DashboardAccessChecker accessChecker) {
     when(accessChecker.hasAccess(anyString())).thenReturn(true);
-    when(accessChecker.isAccessControlEnabled()).thenReturn(false);
+    when(accessChecker.isAccessControlEnabled()).thenReturn(true);
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/AuthResourceTestFixtures.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/AuthResourceTestFixtures.java
@@ -71,7 +71,7 @@ final class AuthResourceTestFixtures {
   }
 
   static void wirePermissiveAccess(DashboardAccessChecker accessChecker) {
-    when(accessChecker.hasAccess(anyString())).thenReturn(true);
-    when(accessChecker.isAccessControlEnabled()).thenReturn(true);
+    when(accessChecker.checkAccess(anyString()))
+        .thenReturn(DashboardAccessChecker.AccessDecision.ALLOWED);
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
@@ -62,12 +62,12 @@ class DashboardAccessCheckerTest {
         .thenThrow(new RuntimeException("GitHub App unavailable"));
     // Fail closed: an unresolvable owner must lock the dashboard, not open it to everyone.
     assertFalse(checker.hasAccess("random-user"));
-    assertFalse(checker.isAccessControlEnabled());
+    assertEquals(
+        DashboardAccessChecker.AccessDecision.NOT_CONFIGURED, checker.checkAccess("random-user"));
   }
 
   @Test
   void shouldResolveOwnerFromGitHubApp() {
-    assertTrue(checker.isAccessControlEnabled());
     assertTrue(checker.hasAccess("myowner"));
     verify(installationClient).getApp(eq("Bearer jwt"), anyString());
   }
@@ -222,7 +222,8 @@ class DashboardAccessCheckerTest {
   void shouldReturnEmptyOwnerWhenAppHasNullOwner() {
     when(installationClient.getApp(anyString(), anyString()))
         .thenReturn(new GitHubInstallationClient.AppInfo(null));
-    assertFalse(checker.isAccessControlEnabled());
+    assertEquals(
+        DashboardAccessChecker.AccessDecision.NOT_CONFIGURED, checker.checkAccess("anyone"));
     assertFalse(checker.hasAccess("anyone"));
   }
 
@@ -232,7 +233,8 @@ class DashboardAccessCheckerTest {
         .thenReturn(
             new GitHubInstallationClient.AppInfo(
                 new GitHubInstallationClient.AppInfo.Owner("", "User")));
-    assertFalse(checker.isAccessControlEnabled());
+    assertEquals(
+        DashboardAccessChecker.AccessDecision.NOT_CONFIGURED, checker.checkAccess("anyone"));
     assertFalse(checker.hasAccess("anyone"));
   }
 
@@ -248,7 +250,6 @@ class DashboardAccessCheckerTest {
   void shouldReturnConfiguredAccountOwnerWithoutCallingGitHubApp() {
     when(dashboardConfig.accountOwner()).thenReturn(Optional.of("configured-owner"));
 
-    assertTrue(checker.isAccessControlEnabled());
     assertTrue(checker.hasAccess("configured-owner"));
 
     verify(installationClient, never()).getApp(anyString(), anyString());
@@ -258,7 +259,6 @@ class DashboardAccessCheckerTest {
   void shouldIgnoreBlankConfiguredAccountOwner() {
     when(dashboardConfig.accountOwner()).thenReturn(Optional.of("   "));
 
-    assertTrue(checker.isAccessControlEnabled());
     assertTrue(checker.hasAccess("myowner"));
     verify(installationClient).getApp(eq("Bearer jwt"), anyString());
   }
@@ -354,5 +354,61 @@ class DashboardAccessCheckerTest {
     assertTrue(checker.hasAccess("myowner"));
 
     verify(installationClient, times(2)).getApp(eq("Bearer jwt"), anyString());
+  }
+
+  @Test
+  void shouldNotReResolveOwnerWithinNegativeCacheTtl() {
+    when(installationClient.getApp(anyString(), anyString()))
+        .thenThrow(new RuntimeException("GitHub App unavailable"));
+
+    // A failed resolution is cached briefly so repeated requests do not hammer the App endpoint.
+    assertFalse(checker.hasAccess("random-user"));
+    assertFalse(checker.hasAccess("another-user"));
+    assertEquals(
+        DashboardAccessChecker.AccessDecision.NOT_CONFIGURED, checker.checkAccess("third-user"));
+
+    verify(installationClient, times(1)).getApp(eq("Bearer jwt"), anyString());
+  }
+
+  @Test
+  void shouldRecoverAfterNegativeCacheTtlExpires() {
+    when(installationClient.getApp(anyString(), anyString()))
+        .thenThrow(new RuntimeException("GitHub App unavailable"));
+    assertFalse(checker.hasAccess("myowner"));
+
+    // Once the negative cache lapses and the App becomes resolvable again, access is restored.
+    now.set(now.get().plus(java.time.Duration.ofMinutes(2)));
+    reset(installationClient);
+    when(installationClient.getApp(eq("Bearer jwt"), anyString()))
+        .thenReturn(
+            new GitHubInstallationClient.AppInfo(
+                new GitHubInstallationClient.AppInfo.Owner("myowner", "User")));
+
+    assertEquals(DashboardAccessChecker.AccessDecision.ALLOWED, checker.checkAccess("myowner"));
+  }
+
+  @Test
+  void checkAccessShouldDistinguishAllowedDeniedAndNotConfigured() {
+    assertEquals(DashboardAccessChecker.AccessDecision.ALLOWED, checker.checkAccess("myowner"));
+
+    stubInstalledRepo("myowner", "demo");
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+    Response notCollaborator = mock(Response.class);
+    when(notCollaborator.getStatus()).thenReturn(404);
+    when(installationClient.checkCollaborator(
+            eq("Bearer inst-token"), anyString(), eq("myowner"), eq("demo"), eq("outsider")))
+        .thenReturn(notCollaborator);
+    assertEquals(DashboardAccessChecker.AccessDecision.DENIED, checker.checkAccess("outsider"));
+
+    assertEquals(DashboardAccessChecker.AccessDecision.DENIED, checker.checkAccess("  "));
+  }
+
+  @Test
+  void checkAccessShouldReturnNotConfiguredWhenOwnerUnresolvable() {
+    when(installationClient.getApp(anyString(), anyString()))
+        .thenThrow(new RuntimeException("GitHub App unavailable"));
+
+    assertEquals(
+        DashboardAccessChecker.AccessDecision.NOT_CONFIGURED, checker.checkAccess("anyone"));
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
@@ -57,10 +57,11 @@ class DashboardAccessCheckerTest {
   }
 
   @Test
-  void shouldAllowAnyUserWhenOwnerCannotBeResolved() {
+  void shouldDenyEveryUserWhenOwnerCannotBeResolved() {
     when(installationClient.getApp(anyString(), anyString()))
         .thenThrow(new RuntimeException("GitHub App unavailable"));
-    assertTrue(checker.hasAccess("random-user"));
+    // Fail closed: an unresolvable owner must lock the dashboard, not open it to everyone.
+    assertFalse(checker.hasAccess("random-user"));
     assertFalse(checker.isAccessControlEnabled());
   }
 
@@ -222,7 +223,7 @@ class DashboardAccessCheckerTest {
     when(installationClient.getApp(anyString(), anyString()))
         .thenReturn(new GitHubInstallationClient.AppInfo(null));
     assertFalse(checker.isAccessControlEnabled());
-    assertTrue(checker.hasAccess("anyone"));
+    assertFalse(checker.hasAccess("anyone"));
   }
 
   @Test
@@ -232,7 +233,7 @@ class DashboardAccessCheckerTest {
             new GitHubInstallationClient.AppInfo(
                 new GitHubInstallationClient.AppInfo.Owner("", "User")));
     assertFalse(checker.isAccessControlEnabled());
-    assertTrue(checker.hasAccess("anyone"));
+    assertFalse(checker.hasAccess("anyone"));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
@@ -159,6 +159,16 @@ class DashboardAccessCheckerTest {
   }
 
   @Test
+  void shouldReturnCachedDenial() {
+    // A fresh denied cache entry is served from cache without re-evaluating access.
+    checker.seedAccessCache("outsider", false, now.get());
+
+    assertEquals(DashboardAccessChecker.AccessDecision.DENIED, checker.checkAccess("outsider"));
+    assertFalse(checker.hasAccess("outsider"));
+    verify(installationClient, never()).listInstallations(anyString(), anyString(), anyInt());
+  }
+
+  @Test
   void shouldWarnOnUnexpectedCollaboratorCheckStatus() {
     stubInstalledRepo("myowner", "demo");
     when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [x] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Dashboard access control **failed open**. When the GitHub App owner could not be resolved and `thrillhousebot.dashboard.github.account-owner` was unset, `DashboardAccessChecker.hasAccess()` returned `true` for every authenticated GitHub user — exposing cost, token, and session data to anyone who could complete a GitHub login.

This PR makes access control **fail closed**:

- **`DashboardAccessChecker.hasAccess()`** now returns `false` (with a warning that names the `thrillhousebot.dashboard.github.account-owner` key) when the owner is empty, instead of `true`. This locks down both the OAuth callback path and the WebSocket / `DashboardSessionValidator` path.
- **`AuthResource`** surfaces a clear, distinct message through a new `accessDenial()` helper:
  - Unresolved/unconfigured owner → **503 Service Unavailable** with `"Dashboard access control is not configured: the GitHub App owner could not be resolved. Set thrillhousebot.dashboard.github.account-owner to enable access."` (instead of a misleading 403).
  - Known owner + non-collaborator login → **403 Forbidden** (unchanged behaviour).
  - No session is created when access control cannot be enforced.

## Related Issues

Fixes #17

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

- Updated `DashboardAccessCheckerTest` so the three empty-owner cases now assert denial (`shouldDenyEveryUserWhenOwnerCannotBeResolved` + the null/blank App-owner cases).
- Added `callbackShouldReturn503WhenOwnerNotConfigured` and `meShouldReturn503WhenOwnerNotConfigured` (both verify no session is created and `hasAccess` is never called once the owner gate fails).
- Updated the shared `AuthResourceTestFixtures.wirePermissiveAccess` baseline to reflect the new reality (access control enabled + user allowed).
- Full dashboard suite green; `spotless:check` and `spotbugs:check` both clean (0 bugs).

```
[INFO] Tests run: 86, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

**Behavioural change for operators:** a deployment with no `account-owner` configured **and** an unresolvable GitHub App owner now locks the dashboard (503 on `/api/auth/callback` and `/api/auth/me`) instead of granting open access. Setting `thrillhousebot.dashboard.github.account-owner` (or restoring App owner resolution) restores access. There is intentionally no longer an "open to everyone" mode.
