### PR TITLE
fix(webhook): dedupe redelivered events to prevent duplicate reviews

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -45,6 +45,8 @@ public interface ThrillhouseConfig {
 
   GitHubConfig github();
 
+  WebhookConfig webhook();
+
   ReviewConfig review();
 
   DashboardConfig dashboard();
@@ -60,6 +62,17 @@ public interface ThrillhouseConfig {
 
     @WithName("webhook-secret")
     String webhookSecret();
+  }
+
+  interface WebhookConfig {
+    /**
+     * How long a processed {@code X-GitHub-Delivery} id is remembered so GitHub redeliveries
+     * (manual redelivery or automatic retries) within this window are dropped instead of triggering
+     * a duplicate review. State is in-memory per replica.
+     */
+    @WithDefault("24h")
+    @WithName("dedup-ttl")
+    Duration dedupTtl();
   }
 
   interface ReviewConfig {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -38,6 +38,7 @@ public class WebhookController {
   private final WebhookVerifier verifier;
   private final TriggerDetector triggerDetector;
   private final ReviewDispatcher reviewDispatcher;
+  private final WebhookDeduplicator deduplicator;
   private final ObjectMapper mapper;
 
   @Inject
@@ -46,11 +47,13 @@ public class WebhookController {
       WebhookVerifier verifier,
       TriggerDetector triggerDetector,
       ReviewDispatcher reviewDispatcher,
+      WebhookDeduplicator deduplicator,
       ObjectMapper mapper) {
     this.config = config;
     this.verifier = verifier;
     this.triggerDetector = triggerDetector;
     this.reviewDispatcher = reviewDispatcher;
+    this.deduplicator = deduplicator;
     this.mapper = mapper;
   }
 
@@ -59,6 +62,7 @@ public class WebhookController {
       @HeaderParam("X-Hub-Signature-256") String signature,
       @HeaderParam("X-GitHub-Event") String eventType,
       @HeaderParam("X-GitHub-Hook-Installation-Target-Type") String targetType,
+      @HeaderParam("X-GitHub-Delivery") String deliveryId,
       byte[] body) {
     if (!verifier.verify(signature, body, config.github().webhookSecret())) {
       return Response.status(Response.Status.UNAUTHORIZED)
@@ -76,7 +80,15 @@ public class WebhookController {
           .build();
     }
 
-    log.info("Received {} event (action: {})", eventType, payload.action());
+    log.info(
+        "Received {} event (action: {}, delivery: {})", eventType, payload.action(), deliveryId);
+
+    // GitHub redelivers webhooks — manual redelivery or an automatic retry — reusing the same
+    // delivery id, so drop repeats to avoid a duplicate review and duplicate AI cost.
+    if (deduplicator.isDuplicate(deliveryId)) {
+      log.info("Ignoring redelivered {} event (delivery: {})", eventType, deliveryId);
+      return Response.ok("{\"status\":\"ignored\"}").build();
+    }
 
     routeEvent(eventType, payload);
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookDeduplicator.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.webhook;
+
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+
+/**
+ * Remembers recently processed {@code X-GitHub-Delivery} ids so redelivered webhooks — manual
+ * redelivery from the GitHub App's Advanced settings, or GitHub's automatic retries — are dropped
+ * instead of starting a second review.
+ *
+ * <p>Each sighting records an expiry {@code ttlMillis} into the future via a single atomic {@code
+ * put}; a sighting is a duplicate only while an earlier, unexpired record already exists. State is
+ * in-memory per replica, like {@link dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher}.
+ */
+@ApplicationScoped
+public class WebhookDeduplicator {
+
+  /** Sweep expired ids once the map reaches this size, mirroring the other in-memory TTL caches. */
+  static final int SWEEP_THRESHOLD = 10_000;
+
+  /** Delivery id → epoch-millis deadline after which the redelivery window has lapsed. */
+  final ConcurrentHashMap<String, Long> seen = new ConcurrentHashMap<>();
+
+  private final long ttlMillis;
+  private final int sweepThreshold;
+  private final LongSupplier clock;
+
+  @Inject
+  public WebhookDeduplicator(ThrillhouseConfig config) {
+    this(config.webhook().dedupTtl().toMillis(), SWEEP_THRESHOLD, System::currentTimeMillis);
+  }
+
+  /** Visible for tests: allows controlling the dedup clock and sweep threshold. */
+  WebhookDeduplicator(long ttlMillis, int sweepThreshold, LongSupplier clock) {
+    this.ttlMillis = ttlMillis;
+    this.sweepThreshold = Math.max(1, sweepThreshold);
+    this.clock = clock;
+  }
+
+  /**
+   * Records {@code deliveryId} as processed and reports whether an unexpired record already
+   * existed. The record-and-read is a single atomic {@code put}, so concurrent sightings of the
+   * same id yield exactly one "not duplicate".
+   *
+   * @return {@code true} if this delivery was already processed within the TTL (a redelivery to
+   *     drop); {@code false} if it is newly recorded or its prior record had expired. A null or
+   *     blank id is never treated as a duplicate, so deliveries missing the header fail open.
+   */
+  public boolean isDuplicate(String deliveryId) {
+    if (deliveryId == null || deliveryId.isBlank()) {
+      return false;
+    }
+    long now = clock.getAsLong();
+    Long previousDeadline = seen.put(deliveryId, now + ttlMillis);
+    boolean duplicate = previousDeadline != null && previousDeadline > now;
+    if (!duplicate) {
+      sweepExpired(now);
+    }
+    return duplicate;
+  }
+
+  /**
+   * {@link #isDuplicate} refreshes an existing key's deadline but never shrinks the map, so ids
+   * that are never redelivered would accumulate forever. Sweep expired entries once the map is
+   * large enough that the scan is worthwhile; live entries are never removed, so a still-remembered
+   * redelivery can never be reprocessed.
+   */
+  void sweepExpired(long now) {
+    if (seen.size() < sweepThreshold) {
+      return;
+    }
+    seen.values().removeIf(deadline -> deadline <= now);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,6 +18,10 @@ thrillhousebot.github.app-id=${GITHUB_APP_ID}
 thrillhousebot.github.private-key=${GITHUB_PRIVATE_KEY}
 thrillhousebot.github.webhook-secret=${GITHUB_WEBHOOK_SECRET}
 
+# Webhook redelivery dedup — drop repeat X-GitHub-Delivery ids within the TTL so GitHub
+# redeliveries/retries do not trigger duplicate reviews (in-memory, per replica).
+thrillhousebot.webhook.dedup-ttl=${WEBHOOK_DEDUP_TTL:24h}
+
 # LangChain4j over any OpenAI-compatible API (set AI_BASE_URL/AI_MODEL; DeepSeek is the default)
 quarkus.langchain4j.openai.api-key=${AI_API_KEY}
 quarkus.langchain4j.openai.base-url=${AI_BASE_URL:https://api.deepseek.com/v1}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -41,7 +41,12 @@ class WebhookControllerTest {
 
   @Mock private ReviewDispatcher reviewDispatcher;
 
+  @Mock private WebhookDeduplicator deduplicator;
+
   private final ObjectMapper mapper = new ObjectMapper();
+
+  /** A non-null delivery id; the mocked deduplicator reports it unseen unless a test overrides. */
+  private static final String DELIVERY = "00000000-0000-0000-0000-000000000001";
 
   private WebhookController controller;
 
@@ -50,7 +55,9 @@ class WebhookControllerTest {
     MockitoAnnotations.openMocks(this);
     when(config.github()).thenReturn(githubConfig);
     when(githubConfig.webhookSecret()).thenReturn("test-secret");
-    controller = new WebhookController(config, verifier, triggerDetector, reviewDispatcher, mapper);
+    controller =
+        new WebhookController(
+            config, verifier, triggerDetector, reviewDispatcher, deduplicator, mapper);
   }
 
   // ── handleWebhook tests ────────────────────────────────────────────────
@@ -63,7 +70,7 @@ class WebhookControllerTest {
         buildPullRequestPayload("opened", 42, "owner/repo", "abc123", "main")
             .getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "pull_request", null, body);
+    var response = controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
 
     assertEquals(200, response.getStatus());
   }
@@ -74,7 +81,7 @@ class WebhookControllerTest {
 
     var body = "{}".getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=invalid", "pull_request", null, body);
+    var response = controller.handleWebhook("sha256=invalid", "pull_request", null, DELIVERY, body);
 
     assertEquals(401, response.getStatus());
     var entity = (String) response.getEntity();
@@ -87,11 +94,60 @@ class WebhookControllerTest {
 
     var body = "not-valid-json".getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "pull_request", null, body);
+    var response = controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
 
     assertEquals(400, response.getStatus());
     var entity = (String) response.getEntity();
     assertTrue(entity.contains("Invalid payload"));
+  }
+
+  // ── delivery dedup tests ───────────────────────────────────────────────
+
+  @Test
+  void shouldDropRedeliveredWebhookWithoutDispatching() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(deduplicator.isDuplicate("redelivered-id")).thenReturn(true);
+
+    var body =
+        buildPullRequestPayload("opened", 7, "owner/repo", "sha7", "main")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response =
+        controller.handleWebhook("sha256=valid", "pull_request", null, "redelivered-id", body);
+
+    assertEquals(200, response.getStatus());
+    assertTrue(((String) response.getEntity()).contains("ignored"));
+    // A redelivery must not start a second review.
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+  }
+
+  @Test
+  void shouldProcessFirstDeliveryAndPassIdToDeduplicator() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+
+    var body =
+        buildPullRequestPayload("opened", 8, "owner/repo", "sha8", "main")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response =
+        controller.handleWebhook("sha256=valid", "pull_request", null, "delivery-xyz", body);
+
+    assertEquals(200, response.getStatus());
+    verify(deduplicator).isDuplicate("delivery-xyz");
+    verify(reviewDispatcher).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+  }
+
+  @Test
+  void shouldNotConsultDeduplicatorWhenSignatureInvalid() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(false);
+
+    var body = "{}".getBytes(StandardCharsets.UTF_8);
+
+    var response = controller.handleWebhook("sha256=bad", "pull_request", null, "any-id", body);
+
+    assertEquals(401, response.getStatus());
+    // Dedup happens only after the signature is verified, so forged ids cannot poison the cache.
+    verifyNoInteractions(deduplicator);
   }
 
   // ── pull_request routing tests ─────────────────────────────────────────
@@ -104,7 +160,7 @@ class WebhookControllerTest {
         buildPullRequestPayload("opened", 99, "owner/myrepo", "headsha123", "default")
             .getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "pull_request", null, body);
+    var response = controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     verify(reviewDispatcher)
@@ -130,7 +186,7 @@ class WebhookControllerTest {
         buildPullRequestPayload("synchronize", 55, "org/app", "newsha", "develop")
             .getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "pull_request", null, body);
+    var response = controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     verify(reviewDispatcher)
@@ -156,7 +212,7 @@ class WebhookControllerTest {
         buildPullRequestPayload("reopened", 10, "a/b", "sha10", "main")
             .getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "pull_request", null, body);
+    var response = controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     verify(reviewDispatcher)
@@ -182,7 +238,7 @@ class WebhookControllerTest {
         buildPullRequestPayload("opened", 12, "a/b", "sha12", "main", false)
             .getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "pull_request", null, body);
+    var response = controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     verify(reviewDispatcher)
@@ -198,7 +254,7 @@ class WebhookControllerTest {
     var body =
         buildPullRequestPayload("closed", 1, "x/y", "sha", "main").getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "pull_request", null, body);
+    var response = controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     // Orchestrator should NOT be called for "closed" action
@@ -218,7 +274,7 @@ class WebhookControllerTest {
         buildIssueCommentPayload("created", 77, "owner/repo", "octocat", "/review")
             .getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, body);
+    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     verify(reviewDispatcher)
@@ -255,7 +311,7 @@ class WebhookControllerTest {
         buildIssueCommentPayload("created", 1, "a/b", "octocat", "Nice PR!")
             .getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, body);
+    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     // Orchestrator should NOT be called when trigger not detected
@@ -272,7 +328,7 @@ class WebhookControllerTest {
         buildIssueCommentPayload("created", 1, "a/b", "thrillhousebot[bot]", "/review")
             .getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, body);
+    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     // Orchestrator should NOT be called for bot comments
@@ -287,7 +343,7 @@ class WebhookControllerTest {
 
     var body = buildInstallationPayload("created", 12345L).getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "installation", null, body);
+    var response = controller.handleWebhook("sha256=valid", "installation", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
@@ -300,7 +356,7 @@ class WebhookControllerTest {
     var body = buildInstallationPayload("added", 42L).getBytes(StandardCharsets.UTF_8);
 
     var response =
-        controller.handleWebhook("sha256=valid", "installation_repositories", null, body);
+        controller.handleWebhook("sha256=valid", "installation_repositories", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
@@ -313,7 +369,7 @@ class WebhookControllerTest {
     // Payload with action but no installation field
     var body = "{\"action\":\"created\"}".getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "installation", null, body);
+    var response = controller.handleWebhook("sha256=valid", "installation", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
@@ -325,7 +381,7 @@ class WebhookControllerTest {
 
     var body = "{}".getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "ping", null, body);
+    var response = controller.handleWebhook("sha256=valid", "ping", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
@@ -340,7 +396,7 @@ class WebhookControllerTest {
     var body =
         buildPullRequestPayload("opened", 1, "a/b", "sha", "main").getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "push", null, body);
+    var response = controller.handleWebhook("sha256=valid", "push", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     // Orchestrator should NOT be called for unknown event types
@@ -357,7 +413,7 @@ class WebhookControllerTest {
     var body =
         buildPullRequestPayload("opened", 1, "a/b", "sha", "main").getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "pull_request", null, body);
+    var response = controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     // The async routeEvent should have caught the RuntimeException and logged it
@@ -379,7 +435,7 @@ class WebhookControllerTest {
 
     var response =
         controller.handleWebhook(
-            "sha256=valid", "issue_comment", null, body.getBytes(StandardCharsets.UTF_8));
+            "sha256=valid", "issue_comment", null, DELIVERY, body.getBytes(StandardCharsets.UTF_8));
     assertEquals(200, response.getStatus());
 
     verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
@@ -402,7 +458,7 @@ class WebhookControllerTest {
 
     var response =
         controller.handleWebhook(
-            "sha256=valid", "issue_comment", null, body.getBytes(StandardCharsets.UTF_8));
+            "sha256=valid", "issue_comment", null, DELIVERY, body.getBytes(StandardCharsets.UTF_8));
     assertEquals(200, response.getStatus());
 
     verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -294,7 +294,7 @@ class WebhookControllerTest {
         buildIssueCommentPayload("created", 88, "owner/repo", "stranger", "/review", "NONE")
             .getBytes(StandardCharsets.UTF_8);
 
-    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, body);
+    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
     // A non-collaborator must not be able to spend the operator's API budget.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookDeduplicatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookDeduplicatorTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.webhook;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+import org.junit.jupiter.api.Test;
+
+class WebhookDeduplicatorTest {
+
+  private static final long TTL_MS = 60_000L;
+  private static final int BIG_THRESHOLD = 10_000;
+
+  @Test
+  void injectionConstructorReadsTtlFromConfig() {
+    var config = mock(ThrillhouseConfig.class);
+    var webhookConfig = mock(ThrillhouseConfig.WebhookConfig.class);
+    when(config.webhook()).thenReturn(webhookConfig);
+    when(webhookConfig.dedupTtl()).thenReturn(Duration.ofHours(24));
+
+    var dedup = new WebhookDeduplicator(config);
+
+    // The config-wired bean behaves like any other: a first sighting is new, an immediate repeat
+    // (well within the 24h TTL) is a duplicate.
+    assertFalse(dedup.isDuplicate("delivery-1"));
+    assertTrue(dedup.isDuplicate("delivery-1"));
+  }
+
+  @Test
+  void firstDeliveryIsNotDuplicate() {
+    var dedup = new WebhookDeduplicator(TTL_MS, BIG_THRESHOLD, new MutableClock(0));
+
+    assertFalse(dedup.isDuplicate("delivery-1"));
+  }
+
+  @Test
+  void repeatDeliveryWithinTtlIsDuplicate() {
+    var dedup = new WebhookDeduplicator(TTL_MS, BIG_THRESHOLD, new MutableClock(0));
+
+    assertFalse(dedup.isDuplicate("delivery-1"));
+    assertTrue(dedup.isDuplicate("delivery-1"));
+    assertTrue(dedup.isDuplicate("delivery-1"));
+  }
+
+  @Test
+  void distinctDeliveriesAreIndependent() {
+    var dedup = new WebhookDeduplicator(TTL_MS, BIG_THRESHOLD, new MutableClock(0));
+
+    assertFalse(dedup.isDuplicate("a"));
+    assertFalse(dedup.isDuplicate("b"));
+    assertTrue(dedup.isDuplicate("a"));
+    assertTrue(dedup.isDuplicate("b"));
+  }
+
+  @Test
+  void deliveryIsForgottenAfterTtlExpires() {
+    var clock = new MutableClock(0);
+    var dedup = new WebhookDeduplicator(TTL_MS, BIG_THRESHOLD, clock);
+
+    assertFalse(dedup.isDuplicate("delivery-1"));
+    assertTrue(dedup.isDuplicate("delivery-1"));
+
+    // Step past the TTL: the prior record has lapsed and the next sighting is first-seen again...
+    clock.advance(TTL_MS + 1);
+    assertFalse(dedup.isDuplicate("delivery-1"));
+    // ...and is remembered again from that point.
+    assertTrue(dedup.isDuplicate("delivery-1"));
+  }
+
+  @Test
+  void deliveryStillDeduplicatedJustBeforeTtl() {
+    var clock = new MutableClock(0);
+    var dedup = new WebhookDeduplicator(TTL_MS, BIG_THRESHOLD, clock);
+
+    assertFalse(dedup.isDuplicate("delivery-1"));
+    // One tick before the deadline the record is still live.
+    clock.advance(TTL_MS - 1);
+    assertTrue(dedup.isDuplicate("delivery-1"));
+  }
+
+  @Test
+  void deliveryExpiresExactlyAtTtlBoundary() {
+    var clock = new MutableClock(0);
+    var dedup = new WebhookDeduplicator(TTL_MS, BIG_THRESHOLD, clock);
+
+    assertFalse(dedup.isDuplicate("delivery-1"));
+    // At exactly the deadline the record has expired (deadline is the first lapsed instant), so the
+    // sighting is treated as first-seen — this pins the `previousDeadline > now` boundary.
+    clock.advance(TTL_MS);
+    assertFalse(dedup.isDuplicate("delivery-1"));
+  }
+
+  @Test
+  void nullOrBlankDeliveryIdFailsOpen() {
+    var dedup = new WebhookDeduplicator(TTL_MS, BIG_THRESHOLD, new MutableClock(0));
+
+    // Missing/blank ids are never deduped (and never stored), so they always process.
+    assertFalse(dedup.isDuplicate(null));
+    assertFalse(dedup.isDuplicate(null));
+    assertFalse(dedup.isDuplicate(""));
+    assertFalse(dedup.isDuplicate("   "));
+    assertEquals(0, dedup.seen.size());
+  }
+
+  @Test
+  void expiredEntriesAreReclaimedOnceThresholdReached() {
+    var clock = new MutableClock(0);
+    int threshold = 4;
+    var dedup = new WebhookDeduplicator(TTL_MS, threshold, clock);
+
+    // Fill exactly to the sweep threshold; nothing has expired yet so nothing is reclaimed.
+    for (int i = 0; i < threshold; i++) {
+      dedup.isDuplicate("old-" + i);
+    }
+    assertEquals(threshold, dedup.seen.size());
+
+    // Let every recorded id lapse, then record one more id: that sighting crosses the threshold and
+    // triggers the sweep, which must reclaim all four expired ids and leave only the new one.
+    clock.advance(TTL_MS + 1);
+    dedup.isDuplicate("new-0");
+
+    // Fails if the expired sweep is removed — the 4 stale ids would still be in the map.
+    assertEquals(1, dedup.seen.size());
+  }
+
+  @Test
+  void liveEntriesAreNeverSweptAndStayDeduplicated() {
+    var clock = new MutableClock(0);
+    int threshold = 10;
+    var dedup = new WebhookDeduplicator(TTL_MS, threshold, clock);
+
+    // Record far more than the threshold of distinct, still-live ids within the TTL window.
+    int count = threshold * 3;
+    for (int i = 0; i < count; i++) {
+      assertFalse(dedup.isDuplicate("id-" + i));
+    }
+
+    // Sweep-on-expiry set, not a hard cap: live ids are retained past the threshold (no forced
+    // eviction), so a redelivery of any of them is still recognised as a duplicate.
+    assertEquals(count, dedup.seen.size());
+    for (int i = 0; i < count; i++) {
+      assertTrue(dedup.isDuplicate("id-" + i), "live id-" + i + " was forgotten");
+    }
+  }
+
+  @Test
+  void concurrentFirstSightingOfSameDeliveryHappensExactlyOnce() throws InterruptedException {
+    var dedup = new WebhookDeduplicator(TTL_MS, BIG_THRESHOLD, new MutableClock(0));
+
+    // Exactly one of many threads may observe a brand-new id as new; the rest see a duplicate.
+    assertEquals(1, raceFirstSightings(dedup, "racing-id", 32));
+  }
+
+  @Test
+  void concurrentRedeliveryOfExpiredIdReprocessesExactlyOnce() throws InterruptedException {
+    var clock = new MutableClock(0);
+    var dedup = new WebhookDeduplicator(TTL_MS, BIG_THRESHOLD, clock);
+
+    dedup.isDuplicate("id"); // record it...
+    clock.advance(TTL_MS + 1); // ...then let it expire.
+
+    // Many threads redeliver the expired id at once: exactly one may reprocess it, never two.
+    assertEquals(1, raceFirstSightings(dedup, "id", 32));
+  }
+
+  /**
+   * Runs {@code threads} concurrent {@code isDuplicate(id)} calls and returns how many observed the
+   * id as new. Any throwable from a worker is surfaced as a test failure rather than silently
+   * skewing the count.
+   */
+  private long raceFirstSightings(WebhookDeduplicator dedup, String id, int threads)
+      throws InterruptedException {
+    var start = new CountDownLatch(1);
+    var done = new CountDownLatch(threads);
+    var firstSightings = new AtomicLong(0);
+    var error = new AtomicReference<Throwable>();
+
+    for (int t = 0; t < threads; t++) {
+      Thread thread =
+          new Thread(
+              () -> {
+                try {
+                  start.await();
+                  if (!dedup.isDuplicate(id)) {
+                    firstSightings.incrementAndGet();
+                  }
+                } catch (InterruptedException _) {
+                  Thread.currentThread().interrupt();
+                } catch (Throwable t2) {
+                  error.compareAndSet(null, t2);
+                } finally {
+                  done.countDown();
+                }
+              });
+      thread.start();
+    }
+    start.countDown();
+    assertTrue(done.await(10, TimeUnit.SECONDS), "threads did not finish");
+    if (error.get() != null) {
+      throw new AssertionError("isDuplicate threw on a worker thread", error.get());
+    }
+    return firstSightings.get();
+  }
+
+  /** A {@link LongSupplier} clock whose epoch-millis value can be advanced by tests. */
+  private static final class MutableClock implements LongSupplier {
+    private final AtomicLong millis;
+
+    MutableClock(long startMillis) {
+      this.millis = new AtomicLong(startMillis);
+    }
+
+    void advance(long byMillis) {
+      millis.addAndGet(byMillis);
+    }
+
+    @Override
+    public long getAsLong() {
+      return millis.get();
+    }
+  }
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`WebhookController` routed every accepted delivery to `ReviewDispatcher` with no idempotency check, and the `X-GitHub-Delivery` header was never read. When GitHub redelivers a webhook — manual redelivery from the App's Advanced settings, or an automatic retry on a slow/failed response — it reuses the same delivery id, so each redelivery started a **full second review**, posting duplicate comments and incurring duplicate AI cost.

This PR makes delivery handling idempotent:

- **New `WebhookDeduplicator`** — an in-memory dedup set keyed on `X-GitHub-Delivery`. `isDuplicate` records an expiry TTL into the future with a single atomic `put` and reports whether an earlier, unexpired record already existed, so concurrent sightings of the same id yield exactly one "not duplicate" with no read-then-write races. The map is bounded by a threshold-gated sweep of **expired** entries only — live ids are never evicted, so a still-remembered redelivery can never be reprocessed. This mirrors the project's existing in-memory TTL caches (`InstructionsResolver.sweepExpiredEntries`, `DashboardSessionStore.sweepExpired`) rather than introducing a third bespoke shape.
- **`WebhookController`** now reads `X-GitHub-Delivery` and drops repeats with `200 {"status":"ignored"}`. The dedup check runs **after** signature verification, so forged ids can't poison the set. A missing/blank id fails open (processed normally), since real GitHub deliveries always carry the header.
- **Config** — `thrillhousebot.webhook.dedup-ttl` (default `24h`, overridable via `WEBHOOK_DEDUP_TTL`). The sweep threshold is an internal constant, consistent with the sibling caches.

### Design notes

- Dedup state is **in-memory, per replica**, matching the existing in-memory `ReviewDispatcher` (whose per-PR coalescing already assumes a single replica). Cross-replica idempotency would need shared state (DB/Redis); adding it for dedup alone while review serialization stays in-memory would be inconsistent.
- The id is recorded at receipt (before the async review completes). This robustly dedupes concurrent/rapid redeliveries; the tradeoff is that re-driving a *failed* review via manual redelivery within the TTL is suppressed — the supported re-trigger is a `/review` comment (a distinct delivery id).

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

`WebhookDeduplicatorTest` (11 tests): first-sighting vs. duplicate, distinct ids, TTL expiry, just-before-TTL and exact-deadline boundary, null/blank fail-open, expired entries reclaimed once the threshold is reached (fails if the sweep is removed), live entries retained past the threshold and still deduplicated (proves no live eviction), and two concurrency tests — a fresh id and an expired id — each asserting exactly one reprocess and surfacing any worker-thread throwable.

`WebhookControllerTest`: redelivery dropped without dispatching, first delivery processed with the id passed through, and the deduplicator not consulted on an invalid signature.

Full suite green locally: **734 tests, 0 failures**; `spotless:check` clean.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No breaking changes. The one new config key is optional with a sensible default (`24h`).