### PR TITLE
fix(observability): report configured AI provider instead of hardcoded deepseek

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ AI_API_KEY=sk-your-api-key
 AI_MODEL=deepseek-chat
 AI_BASE_URL=https://api.deepseek.com/v1
 AI_TIMEOUT=300s
+# Telemetry provider label (gen_ai.provider.name). Derived from AI_BASE_URL when unset;
+# set it to override for proxies/self-hosted gateways, e.g. AI_PROVIDER=ollama
+# AI_PROVIDER=
 
 # Token pricing (USD per 1K tokens) — application.properties ships sensible defaults
 # for common OpenAI/DeepSeek/Qwen/Groq models keyed by the AI_MODEL name. Cost stays $0 if

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ variables are the ones you will change per provider:
 | `AI_API_KEY` | API key for the AI provider | _(required)_ |
 | `AI_BASE_URL` | OpenAI-compatible base URL | `https://api.deepseek.com/v1` |
 | `AI_MODEL` | Chat model name | `deepseek-chat` |
+| `AI_PROVIDER` | Provider label for telemetry (`gen_ai.provider.name`); derived from `AI_BASE_URL` when unset | _(derived)_ |
 | `AI_TIMEOUT` | Per-request timeout | `300s` |
 | `GITHUB_APP_ID` | GitHub App ID | _(required)_ |
 | `GITHUB_PRIVATE_KEY` | GitHub App private key (PEM) | _(required)_ |
@@ -220,6 +221,10 @@ All telemetry is exported via OTLP:
 | `gen_ai.client.token.usage` | Histogram: input/output tokens |
 | `gen_ai.client.operation.duration` | Histogram: latency in seconds |
 | `thrillhouse.ai.cost.total` | Counter: USD cost by model |
+
+Spans and metrics are tagged with `gen_ai.provider.name`, derived from `AI_BASE_URL`
+(e.g. `deepseek`, `openai`, `groq`, `openrouter`, `ollama` for a local server). Set
+`AI_PROVIDER` to override the label for proxies or self-hosted gateways.
 
 ## Responsible use and security
 

--- a/README.md
+++ b/README.md
@@ -223,8 +223,9 @@ All telemetry is exported via OTLP:
 | `thrillhouse.ai.cost.total` | Counter: USD cost by model |
 
 Spans and metrics are tagged with `gen_ai.provider.name`, derived from `AI_BASE_URL`
-(e.g. `deepseek`, `openai`, `groq`, `openrouter`, `ollama` for a local server). Set
-`AI_PROVIDER` to override the label for proxies or self-hosted gateways.
+(e.g. `deepseek`, `openai`, `groq`, `openrouter`). Loopback and unrecognized endpoints
+report `unknown`; set `AI_PROVIDER` to label them (e.g. a local `ollama` or `vllm` server,
+a proxy, or a self-hosted gateway).
 
 ## Responsible use and security
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -123,6 +123,13 @@ public interface ThrillhouseConfig {
   }
 
   interface AiPricingConfig {
+    /**
+     * Explicit provider label for telemetry ({@code gen_ai.provider.name}). When unset, the
+     * provider is derived from the configured AI base URL.
+     */
+    @WithName("provider-name")
+    Optional<String> providerName();
+
     Map<String, ModelPricing> pricing();
 
     interface ModelPricing {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -124,8 +124,14 @@ public interface ThrillhouseConfig {
 
   interface AiPricingConfig {
     /**
+     * Configured AI base URL; used to derive the telemetry provider when none is set explicitly.
+     */
+    @WithName("base-url")
+    String baseUrl();
+
+    /**
      * Explicit provider label for telemetry ({@code gen_ai.provider.name}). When unset, the
-     * provider is derived from the configured AI base URL.
+     * provider is derived from {@link #baseUrl()}.
      */
     @WithName("provider-name")
     Optional<String> providerName();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiProviderResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiProviderResolver.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import java.net.URI;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Derives the GenAI provider label (the OpenTelemetry {@code gen_ai.provider.name} attribute) from
+ * the configured OpenAI-compatible base URL.
+ *
+ * <p>ThrillhouseBot talks to many providers (DeepSeek, OpenAI, Qwen, OpenRouter, Groq, Ollama, …)
+ * through the same OpenAI-compatible client, so the provider cannot be assumed — it is inferred
+ * from the endpoint host. Operators can always override the result with an explicit provider name.
+ */
+final class AiProviderResolver {
+
+  /** Label used when the base URL is missing or cannot be parsed into a usable host. */
+  static final String UNKNOWN_PROVIDER = "unknown";
+
+  /**
+   * Well-known host substrings mapped to canonical provider names. Keyed by a substring (not an
+   * exact host) so regional and versioned subdomains — e.g. {@code dashscope-intl.aliyuncs.com} —
+   * still match. Canonical names follow the OpenTelemetry GenAI conventions where one exists.
+   */
+  private static final Map<String, String> KNOWN_HOSTS =
+      Map.ofEntries(
+          Map.entry("deepseek.com", "deepseek"),
+          Map.entry("openai.com", "openai"),
+          Map.entry("groq.com", "groq"),
+          Map.entry("openrouter.ai", "openrouter"),
+          Map.entry("anthropic.com", "anthropic"),
+          Map.entry("mistral.ai", "mistral_ai"),
+          Map.entry("perplexity.ai", "perplexity"),
+          Map.entry("x.ai", "xai"),
+          Map.entry("aliyuncs.com", "alibaba"),
+          Map.entry("dashscope", "alibaba"));
+
+  private static final Pattern IPV4 = Pattern.compile("\\d{1,3}(?:\\.\\d{1,3}){3}");
+
+  private AiProviderResolver() {}
+
+  /**
+   * Derives a provider name from {@code baseUrl}.
+   *
+   * <ul>
+   *   <li>Known hosts map to their canonical name (e.g. {@code https://api.deepseek.com/v1} →
+   *       {@code deepseek}).
+   *   <li>Loopback hosts map to {@code ollama}, the most common local OpenAI-compatible server.
+   *   <li>Other hosts fall back to the registrable domain label (e.g. {@code https://api.acme.com}
+   *       → {@code acme}).
+   *   <li>Blank, unparseable, or bare-IP endpoints map to {@link #UNKNOWN_PROVIDER}.
+   * </ul>
+   */
+  static String fromBaseUrl(String baseUrl) {
+    var host = hostOf(baseUrl);
+    if (host == null || host.isBlank()) {
+      return UNKNOWN_PROVIDER;
+    }
+    host = host.toLowerCase(Locale.ROOT);
+    for (var entry : KNOWN_HOSTS.entrySet()) {
+      if (host.contains(entry.getKey())) {
+        return entry.getValue();
+      }
+    }
+    if (isLoopback(host)) {
+      return "ollama";
+    }
+    if (IPV4.matcher(host).matches() || host.startsWith("[")) {
+      return UNKNOWN_PROVIDER;
+    }
+    return registrableLabel(host);
+  }
+
+  private static String hostOf(String baseUrl) {
+    if (baseUrl == null || baseUrl.isBlank()) {
+      return null;
+    }
+    var trimmed = baseUrl.trim();
+    var host = parseHost(trimmed);
+    // Tolerate scheme-less values like "api.deepseek.com/v1" by re-parsing as an authority.
+    if (host == null && !trimmed.contains("://")) {
+      host = parseHost("//" + trimmed);
+    }
+    return host;
+  }
+
+  private static String parseHost(String value) {
+    try {
+      return URI.create(value).getHost();
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private static boolean isLoopback(String host) {
+    return host.equals("localhost")
+        || host.endsWith(".localhost")
+        || host.equals("127.0.0.1")
+        || host.equals("[::1]")
+        || host.equals("::1");
+  }
+
+  /** Returns the label just left of the TLD (e.g. {@code api.deepseek.com} → {@code deepseek}). */
+  private static String registrableLabel(String host) {
+    var labels = host.split("\\.");
+    if (labels.length >= 2) {
+      return labels[labels.length - 2];
+    }
+    return host;
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiProviderResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiProviderResolver.java
@@ -16,30 +16,35 @@
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
  * Derives the GenAI provider label (the OpenTelemetry {@code gen_ai.provider.name} attribute) from
  * the configured OpenAI-compatible base URL.
  *
- * <p>ThrillhouseBot talks to many providers (DeepSeek, OpenAI, Qwen, OpenRouter, Groq, Ollama, …)
- * through the same OpenAI-compatible client, so the provider cannot be assumed — it is inferred
- * from the endpoint host. Operators can always override the result with an explicit provider name.
+ * <p>ThrillhouseBot talks to many providers (DeepSeek, OpenAI, Qwen, OpenRouter, Groq, …) through
+ * the same OpenAI-compatible client, so the provider cannot be assumed — it is inferred from the
+ * endpoint host. Operators can always override the result with an explicit provider name.
  */
 final class AiProviderResolver {
 
-  /** Label used when the base URL is missing or cannot be parsed into a usable host. */
+  /** Label used when the host is missing, a bare IP/loopback, or otherwise not identifying. */
   static final String UNKNOWN_PROVIDER = "unknown";
 
   /**
-   * Well-known host substrings mapped to canonical provider names. Keyed by a substring (not an
-   * exact host) so regional and versioned subdomains — e.g. {@code dashscope-intl.aliyuncs.com} —
-   * still match. Canonical names follow the OpenTelemetry GenAI conventions where one exists.
+   * Known provider domains mapped to canonical names. Matched on host boundaries (exact host or a
+   * subdomain), so regional/versioned subdomains like {@code dashscope-intl.aliyuncs.com} resolve
+   * correctly while unrelated hosts that merely contain a domain as a substring (e.g. {@code
+   * matrix.ai} vs {@code x.ai}) do not. The list has a fixed iteration order, so the result is
+   * deterministic even if a future host could match more than one entry. Canonical names follow the
+   * OpenTelemetry GenAI conventions where one exists.
    */
-  private static final Map<String, String> KNOWN_HOSTS =
-      Map.ofEntries(
+  private static final List<Map.Entry<String, String>> KNOWN_DOMAINS =
+      List.of(
           Map.entry("deepseek.com", "deepseek"),
           Map.entry("openai.com", "openai"),
           Map.entry("groq.com", "groq"),
@@ -48,8 +53,14 @@ final class AiProviderResolver {
           Map.entry("mistral.ai", "mistral_ai"),
           Map.entry("perplexity.ai", "perplexity"),
           Map.entry("x.ai", "xai"),
-          Map.entry("aliyuncs.com", "alibaba"),
-          Map.entry("dashscope", "alibaba"));
+          Map.entry("aliyuncs.com", "alibaba"));
+
+  /**
+   * Two-label public suffixes (e.g. {@code co.uk}, {@code com.br}) so the registrable name is taken
+   * from the correct label rather than the suffix component.
+   */
+  private static final Set<String> SECOND_LEVEL_SUFFIXES =
+      Set.of("co", "com", "net", "org", "gov", "edu", "ac");
 
   private static final Pattern IPV4 = Pattern.compile("\\d{1,3}(?:\\.\\d{1,3}){3}");
 
@@ -59,12 +70,12 @@ final class AiProviderResolver {
    * Derives a provider name from {@code baseUrl}.
    *
    * <ul>
-   *   <li>Known hosts map to their canonical name (e.g. {@code https://api.deepseek.com/v1} →
-   *       {@code deepseek}).
-   *   <li>Loopback hosts map to {@code ollama}, the most common local OpenAI-compatible server.
+   *   <li>Known provider domains map to their canonical name (e.g. {@code
+   *       https://api.deepseek.com/v1} → {@code deepseek}).
    *   <li>Other hosts fall back to the registrable domain label (e.g. {@code https://api.acme.com}
-   *       → {@code acme}).
-   *   <li>Blank, unparseable, or bare-IP endpoints map to {@link #UNKNOWN_PROVIDER}.
+   *       → {@code acme}, {@code https://api.example.co.uk} → {@code example}).
+   *   <li>Loopback, bare-IP, blank, or unparseable endpoints map to {@link #UNKNOWN_PROVIDER}; set
+   *       an explicit provider name to label these (e.g. a local Ollama or vLLM server).
    * </ul>
    */
   static String fromBaseUrl(String baseUrl) {
@@ -73,18 +84,24 @@ final class AiProviderResolver {
       return UNKNOWN_PROVIDER;
     }
     host = host.toLowerCase(Locale.ROOT);
-    for (var entry : KNOWN_HOSTS.entrySet()) {
-      if (host.contains(entry.getKey())) {
-        return entry.getValue();
-      }
+    var known = matchKnownDomain(host);
+    if (known != null) {
+      return known;
     }
-    if (isLoopback(host)) {
-      return "ollama";
-    }
-    if (IPV4.matcher(host).matches() || host.startsWith("[")) {
+    if (isLocalhost(host) || isIpLiteral(host)) {
       return UNKNOWN_PROVIDER;
     }
     return registrableLabel(host);
+  }
+
+  private static String matchKnownDomain(String host) {
+    for (var entry : KNOWN_DOMAINS) {
+      var domain = entry.getKey();
+      if (host.equals(domain) || host.endsWith("." + domain)) {
+        return entry.getValue();
+      }
+    }
+    return null;
   }
 
   private static String hostOf(String baseUrl) {
@@ -92,36 +109,66 @@ final class AiProviderResolver {
       return null;
     }
     var trimmed = baseUrl.trim();
-    var host = parseHost(trimmed);
+    var host = hostFrom(trimmed);
     // Tolerate scheme-less values like "api.deepseek.com/v1" by re-parsing as an authority.
     if (host == null && !trimmed.contains("://")) {
-      host = parseHost("//" + trimmed);
+      host = hostFrom("//" + trimmed);
     }
     return host;
   }
 
-  private static String parseHost(String value) {
+  private static String hostFrom(String value) {
+    URI uri;
     try {
-      return URI.create(value).getHost();
+      uri = URI.create(value);
     } catch (IllegalArgumentException e) {
       return null;
     }
+    var host = uri.getHost();
+    if (host != null) {
+      return host;
+    }
+    // URI.getHost() rejects otherwise-valid reg-names containing underscores (common for
+    // Docker/Compose service names), so recover the host from the raw authority.
+    return hostFromAuthority(uri.getAuthority());
   }
 
-  private static boolean isLoopback(String host) {
-    return host.equals("localhost")
-        || host.endsWith(".localhost")
-        || host.equals("127.0.0.1")
-        || host.equals("[::1]")
-        || host.equals("::1");
+  private static String hostFromAuthority(String authority) {
+    if (authority == null || authority.isBlank()) {
+      return null;
+    }
+    var hostPort = authority.substring(authority.lastIndexOf('@') + 1);
+    if (hostPort.startsWith("[")) {
+      var close = hostPort.indexOf(']');
+      return close > 0 ? hostPort.substring(0, close + 1) : null;
+    }
+    var colon = hostPort.indexOf(':');
+    var host = colon >= 0 ? hostPort.substring(0, colon) : hostPort;
+    return host.isBlank() ? null : host;
   }
 
-  /** Returns the label just left of the TLD (e.g. {@code api.deepseek.com} → {@code deepseek}). */
+  private static boolean isLocalhost(String host) {
+    return host.equals("localhost") || host.endsWith(".localhost");
+  }
+
+  private static boolean isIpLiteral(String host) {
+    return IPV4.matcher(host).matches() || host.startsWith("[");
+  }
+
+  /**
+   * Returns the registrable label — the name just left of the public suffix (e.g. {@code
+   * api.deepseek.com} → {@code deepseek}, {@code api.example.co.uk} → {@code example}).
+   */
   private static String registrableLabel(String host) {
     var labels = host.split("\\.");
-    if (labels.length >= 2) {
-      return labels[labels.length - 2];
+    if (labels.length < 2) {
+      return host;
     }
-    return host;
+    var tld = labels[labels.length - 1];
+    var secondLevel = labels[labels.length - 2];
+    if (labels.length >= 3 && tld.length() == 2 && SECOND_LEVEL_SUFFIXES.contains(secondLevel)) {
+      return labels[labels.length - 3];
+    }
+    return secondLevel;
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiProviderResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiProviderResolver.java
@@ -121,7 +121,7 @@ final class AiProviderResolver {
     URI uri;
     try {
       uri = URI.create(value);
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException _) {
       return null;
     }
     var host = uri.getHost();
@@ -134,17 +134,12 @@ final class AiProviderResolver {
   }
 
   private static String hostFromAuthority(String authority) {
-    if (authority == null || authority.isBlank()) {
+    if (authority == null) {
       return null;
     }
     var hostPort = authority.substring(authority.lastIndexOf('@') + 1);
-    if (hostPort.startsWith("[")) {
-      var close = hostPort.indexOf(']');
-      return close > 0 ? hostPort.substring(0, close + 1) : null;
-    }
     var colon = hostPort.indexOf(':');
-    var host = colon >= 0 ? hostPort.substring(0, colon) : hostPort;
-    return host.isBlank() ? null : host;
+    return colon >= 0 ? hostPort.substring(0, colon) : hostPort;
   }
 
   private static boolean isLocalhost(String host) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/OtelObservabilityListener.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/OtelObservabilityListener.java
@@ -33,6 +33,7 @@ import io.opentelemetry.api.trace.Span;
 import io.vertx.core.Vertx;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,7 @@ public class OtelObservabilityListener implements ChatModelListener {
   private final ThrillhouseConfig config;
   private final ReviewSessionUpdater sessionUpdater;
   private final Vertx vertx;
+  private final String providerName;
   private final LongHistogram tokenHistogram;
   private final DoubleHistogram durationHistogram;
   private final DoubleCounter costCounter;
@@ -57,10 +59,12 @@ public class OtelObservabilityListener implements ChatModelListener {
       OpenTelemetry otel,
       ThrillhouseConfig config,
       ReviewSessionUpdater sessionUpdater,
-      Vertx vertx) {
+      Vertx vertx,
+      @ConfigProperty(name = "quarkus.langchain4j.openai.base-url") String aiBaseUrl) {
     this.config = config;
     this.sessionUpdater = sessionUpdater;
     this.vertx = vertx;
+    this.providerName = resolveProviderName(config, aiBaseUrl);
     var meter = otel.getMeter("thrillhousebot");
 
     this.tokenHistogram =
@@ -84,6 +88,19 @@ public class OtelObservabilityListener implements ChatModelListener {
             .setUnit("USD")
             .ofDoubles()
             .build();
+  }
+
+  /**
+   * Resolves the {@code gen_ai.provider.name} label once at startup: an explicit configured name
+   * wins; otherwise it is derived from the AI base URL.
+   */
+  private static String resolveProviderName(ThrillhouseConfig config, String aiBaseUrl) {
+    return config
+        .ai()
+        .providerName()
+        .map(String::trim)
+        .filter(name -> !name.isEmpty())
+        .orElseGet(() -> AiProviderResolver.fromBaseUrl(aiBaseUrl));
   }
 
   @Override
@@ -121,7 +138,7 @@ public class OtelObservabilityListener implements ChatModelListener {
     var attrs =
         Attributes.of(
             stringKey("gen_ai.provider.name"),
-            "deepseek",
+            providerName,
             stringKey("gen_ai.request.model"),
             model,
             stringKey("gen_ai.response.model"),
@@ -137,6 +154,7 @@ public class OtelObservabilityListener implements ChatModelListener {
     costCounter.add(cost, attrs);
 
     Span span = Span.current();
+    span.setAttribute("gen_ai.provider.name", providerName);
     span.setAttribute("gen_ai.usage.input_tokens", usage.inputTokenCount());
     span.setAttribute("gen_ai.usage.output_tokens", usage.outputTokenCount());
     span.setAttribute("gen_ai.usage.cost", cost);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/OtelObservabilityListener.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/OtelObservabilityListener.java
@@ -45,6 +45,8 @@ public class OtelObservabilityListener implements ChatModelListener {
   static final String ATTR_SESSION_ID = "reviewSessionId";
   static final String ATTR_STREAM_ATTEMPT = "streamAttempt";
 
+  private static final String GEN_AI_PROVIDER_NAME = "gen_ai.provider.name";
+
   private final ThrillhouseConfig config;
   private final ReviewSessionUpdater sessionUpdater;
   private final Vertx vertx;
@@ -134,7 +136,7 @@ public class OtelObservabilityListener implements ChatModelListener {
 
     var attrs =
         Attributes.of(
-            stringKey("gen_ai.provider.name"),
+            stringKey(GEN_AI_PROVIDER_NAME),
             providerName,
             stringKey("gen_ai.request.model"),
             model,
@@ -151,7 +153,7 @@ public class OtelObservabilityListener implements ChatModelListener {
     costCounter.add(cost, attrs);
 
     Span span = Span.current();
-    span.setAttribute("gen_ai.provider.name", providerName);
+    span.setAttribute(GEN_AI_PROVIDER_NAME, providerName);
     span.setAttribute("gen_ai.usage.input_tokens", usage.inputTokenCount());
     span.setAttribute("gen_ai.usage.output_tokens", usage.outputTokenCount());
     span.setAttribute("gen_ai.usage.cost", cost);
@@ -195,7 +197,7 @@ public class OtelObservabilityListener implements ChatModelListener {
     }
 
     Span span = Span.current();
-    span.setAttribute("gen_ai.provider.name", providerName);
+    span.setAttribute(GEN_AI_PROVIDER_NAME, providerName);
     span.setAttribute("error", true);
     var error = ctx.error();
     span.setAttribute("error.type", error != null ? error.getClass().getSimpleName() : "Unknown");

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/OtelObservabilityListener.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/OtelObservabilityListener.java
@@ -33,7 +33,6 @@ import io.opentelemetry.api.trace.Span;
 import io.vertx.core.Vertx;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,12 +58,11 @@ public class OtelObservabilityListener implements ChatModelListener {
       OpenTelemetry otel,
       ThrillhouseConfig config,
       ReviewSessionUpdater sessionUpdater,
-      Vertx vertx,
-      @ConfigProperty(name = "quarkus.langchain4j.openai.base-url") String aiBaseUrl) {
+      Vertx vertx) {
     this.config = config;
     this.sessionUpdater = sessionUpdater;
     this.vertx = vertx;
-    this.providerName = resolveProviderName(config, aiBaseUrl);
+    this.providerName = resolveProviderName(config);
     var meter = otel.getMeter("thrillhousebot");
 
     this.tokenHistogram =
@@ -92,15 +90,14 @@ public class OtelObservabilityListener implements ChatModelListener {
 
   /**
    * Resolves the {@code gen_ai.provider.name} label once at startup: an explicit configured name
-   * wins; otherwise it is derived from the AI base URL.
+   * wins; otherwise it is derived from the configured AI base URL.
    */
-  private static String resolveProviderName(ThrillhouseConfig config, String aiBaseUrl) {
-    return config
-        .ai()
-        .providerName()
+  private static String resolveProviderName(ThrillhouseConfig config) {
+    var ai = config.ai();
+    return ai.providerName()
         .map(String::trim)
         .filter(name -> !name.isEmpty())
-        .orElseGet(() -> AiProviderResolver.fromBaseUrl(aiBaseUrl));
+        .orElseGet(() -> AiProviderResolver.fromBaseUrl(ai.baseUrl()));
   }
 
   @Override
@@ -198,6 +195,7 @@ public class OtelObservabilityListener implements ChatModelListener {
     }
 
     Span span = Span.current();
+    span.setAttribute("gen_ai.provider.name", providerName);
     span.setAttribute("error", true);
     var error = ctx.error();
     span.setAttribute("error.type", error != null ? error.getClass().getSimpleName() : "Unknown");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,9 @@ thrillhousebot.github.webhook-secret=${GITHUB_WEBHOOK_SECRET}
 quarkus.langchain4j.openai.api-key=${AI_API_KEY}
 quarkus.langchain4j.openai.base-url=${AI_BASE_URL:https://api.deepseek.com/v1}
 quarkus.langchain4j.openai.chat-model.model-name=${AI_MODEL:deepseek-chat}
+# Telemetry provider label (gen_ai.provider.name). Leave unset to derive it from AI_BASE_URL;
+# set AI_PROVIDER to override for ambiguous endpoints (self-hosted gateways, proxies, local servers).
+thrillhousebot.ai.provider-name=${AI_PROVIDER:}
 quarkus.langchain4j.openai.timeout=${AI_TIMEOUT:300s}
 quarkus.langchain4j.openai.chat-model.log-requests=false
 quarkus.langchain4j.openai.chat-model.log-responses=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,8 +22,11 @@ thrillhousebot.github.webhook-secret=${GITHUB_WEBHOOK_SECRET}
 quarkus.langchain4j.openai.api-key=${AI_API_KEY}
 quarkus.langchain4j.openai.base-url=${AI_BASE_URL:https://api.deepseek.com/v1}
 quarkus.langchain4j.openai.chat-model.model-name=${AI_MODEL:deepseek-chat}
-# Telemetry provider label (gen_ai.provider.name). Leave unset to derive it from AI_BASE_URL;
-# set AI_PROVIDER to override for ambiguous endpoints (self-hosted gateways, proxies, local servers).
+# Mirror of the AI base URL into the typed config, used to derive the telemetry provider label
+# (gen_ai.provider.name). References the client property above so the two never drift.
+thrillhousebot.ai.base-url=${quarkus.langchain4j.openai.base-url}
+# Leave AI_PROVIDER unset to derive the label from the base URL; set it to label ambiguous
+# endpoints (self-hosted gateways, proxies, or local Ollama/vLLM servers).
 thrillhousebot.ai.provider-name=${AI_PROVIDER:}
 quarkus.langchain4j.openai.timeout=${AI_TIMEOUT:300s}
 quarkus.langchain4j.openai.chat-model.log-requests=false

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiProviderResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiProviderResolverTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AiProviderResolverTest {
+
+  @ParameterizedTest
+  @CsvSource({
+    "https://api.deepseek.com/v1, deepseek",
+    "https://api.openai.com/v1, openai",
+    "https://api.groq.com/openai/v1, groq",
+    "https://openrouter.ai/api/v1, openrouter",
+    "https://api.anthropic.com/v1, anthropic",
+    "https://api.mistral.ai/v1, mistral_ai",
+    "https://api.perplexity.ai, perplexity",
+    "https://api.x.ai/v1, xai",
+    "https://dashscope.aliyuncs.com/compatible-mode/v1, alibaba",
+    "https://dashscope-intl.aliyuncs.com/compatible-mode/v1, alibaba",
+  })
+  void mapsWellKnownHostsToCanonicalProviders(String baseUrl, String expected) {
+    assertEquals(expected, AiProviderResolver.fromBaseUrl(baseUrl));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "https://api.example.com/v1, example",
+    "https://llm.acme.io, acme",
+    "https://gateway.internal.corp/v1, internal",
+  })
+  void fallsBackToRegistrableDomainLabel(String baseUrl, String expected) {
+    assertEquals(expected, AiProviderResolver.fromBaseUrl(baseUrl));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "http://localhost:11434/v1",
+        "http://127.0.0.1:11434/v1",
+        "http://[::1]:11434/v1",
+        "http://ollama.localhost/v1",
+      })
+  void mapsLoopbackHostsToOllama(String baseUrl) {
+    assertEquals("ollama", AiProviderResolver.fromBaseUrl(baseUrl));
+  }
+
+  @Test
+  void isCaseInsensitiveOnHost() {
+    assertEquals("deepseek", AiProviderResolver.fromBaseUrl("https://API.DeepSeek.COM/v1"));
+  }
+
+  @Test
+  void toleratesSchemelessBaseUrl() {
+    assertEquals("deepseek", AiProviderResolver.fromBaseUrl("api.deepseek.com/v1"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"http://10.0.0.5:8000/v1", "https://192.168.1.10/v1"})
+  void returnsUnknownForBareRemoteIpAddresses(String baseUrl) {
+    assertEquals(AiProviderResolver.UNKNOWN_PROVIDER, AiProviderResolver.fromBaseUrl(baseUrl));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   ", "not a url"})
+  void returnsUnknownForBlankOrUnparseableInput(String baseUrl) {
+    assertEquals(AiProviderResolver.UNKNOWN_PROVIDER, AiProviderResolver.fromBaseUrl(baseUrl));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiProviderResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiProviderResolverTest.java
@@ -59,6 +59,7 @@ class AiProviderResolverTest {
   @CsvSource({
     "https://api.example.com/v1, example",
     "https://llm.acme.io, acme",
+    "https://example.io, example",
     "https://gateway.internal.corp/v1, internal",
     // Multi-label public suffixes resolve to the registrable name, not the suffix component.
     "https://api.example.co.uk, example",
@@ -73,6 +74,7 @@ class AiProviderResolverTest {
   @CsvSource({
     // Hosts with underscores: URI.getHost() returns null, but the host is recovered from authority.
     "http://ai_gateway:8080/v1, ai_gateway",
+    "http://ai_host/v1, ai_host",
     "http://user:pass@ai_host:9000/v1, ai_host",
     // Single-label host has no registrable suffix; the host itself is the label.
     "http://myserver/v1, myserver",
@@ -112,6 +114,12 @@ class AiProviderResolverTest {
   @NullAndEmptySource
   @ValueSource(strings = {"   ", "not a url"})
   void returnsUnknownForBlankOrUnparseableInput(String baseUrl) {
+    assertEquals(AiProviderResolver.UNKNOWN_PROVIDER, AiProviderResolver.fromBaseUrl(baseUrl));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"http://", "http://:8080/v1"})
+  void returnsUnknownForHostlessUrls(String baseUrl) {
     assertEquals(AiProviderResolver.UNKNOWN_PROVIDER, AiProviderResolver.fromBaseUrl(baseUrl));
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiProviderResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiProviderResolverTest.java
@@ -44,24 +44,58 @@ class AiProviderResolverTest {
 
   @ParameterizedTest
   @CsvSource({
+    // Hosts that merely contain a known domain as a substring must NOT match it.
+    "https://api.matrix.ai/v1, matrix",
+    "https://api.linux.ai/v1, linux",
+    "https://api.phoenix.ai, phoenix",
+    // Suffix spoofing: the real registrable domain wins, not the embedded provider domain.
+    "https://api.openai.com.evil.com/v1, evil",
+  })
+  void anchorsMatchingToHostBoundaries(String baseUrl, String expected) {
+    assertEquals(expected, AiProviderResolver.fromBaseUrl(baseUrl));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
     "https://api.example.com/v1, example",
     "https://llm.acme.io, acme",
     "https://gateway.internal.corp/v1, internal",
+    // Multi-label public suffixes resolve to the registrable name, not the suffix component.
+    "https://api.example.co.uk, example",
+    "https://acme.com.br/v1, acme",
+    "https://foo.ac.uk, foo",
   })
   void fallsBackToRegistrableDomainLabel(String baseUrl, String expected) {
     assertEquals(expected, AiProviderResolver.fromBaseUrl(baseUrl));
   }
 
   @ParameterizedTest
+  @CsvSource({
+    // Hosts with underscores: URI.getHost() returns null, but the host is recovered from authority.
+    "http://ai_gateway:8080/v1, ai_gateway",
+    "http://user:pass@ai_host:9000/v1, ai_host",
+    // Single-label host has no registrable suffix; the host itself is the label.
+    "http://myserver/v1, myserver",
+  })
+  void recoversUnconventionalButValidHosts(String baseUrl, String expected) {
+    assertEquals(expected, AiProviderResolver.fromBaseUrl(baseUrl));
+  }
+
+  @ParameterizedTest
   @ValueSource(
       strings = {
+        // Loopback in every form, and bare IPs, are not provider-identifying.
         "http://localhost:11434/v1",
+        "http://ollama.localhost/v1",
         "http://127.0.0.1:11434/v1",
         "http://[::1]:11434/v1",
-        "http://ollama.localhost/v1",
+        "http://[0:0:0:0:0:0:0:1]:11434/v1",
+        "http://10.0.0.5:8000/v1",
+        "https://192.168.1.10/v1",
+        "https://[2001:db8::1]/v1",
       })
-  void mapsLoopbackHostsToOllama(String baseUrl) {
-    assertEquals("ollama", AiProviderResolver.fromBaseUrl(baseUrl));
+  void mapsLoopbackAndBareIpHostsToUnknown(String baseUrl) {
+    assertEquals(AiProviderResolver.UNKNOWN_PROVIDER, AiProviderResolver.fromBaseUrl(baseUrl));
   }
 
   @Test
@@ -72,12 +106,6 @@ class AiProviderResolverTest {
   @Test
   void toleratesSchemelessBaseUrl() {
     assertEquals("deepseek", AiProviderResolver.fromBaseUrl("api.deepseek.com/v1"));
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"http://10.0.0.5:8000/v1", "https://192.168.1.10/v1"})
-  void returnsUnknownForBareRemoteIpAddresses(String baseUrl) {
-    assertEquals(AiProviderResolver.UNKNOWN_PROVIDER, AiProviderResolver.fromBaseUrl(baseUrl));
   }
 
   @ParameterizedTest

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/OtelObservabilityListenerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/OtelObservabilityListenerTest.java
@@ -29,6 +29,8 @@ import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig.AiPricingConfig
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig.AiPricingConfig.ModelPricing;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSessionUpdater;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleCounter;
 import io.opentelemetry.api.metrics.DoubleCounterBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogram;
@@ -41,6 +43,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,6 +61,7 @@ class OtelObservabilityListenerTest {
   private DoubleCounter costCounter;
   private ThrillhouseConfig config;
   private AiPricingConfig aiConfig;
+  private Vertx vertx;
 
   @BeforeEach
   void setUp() {
@@ -91,9 +95,10 @@ class OtelObservabilityListenerTest {
     aiConfig = mock(AiPricingConfig.class);
     when(config.ai()).thenReturn(aiConfig);
     when(aiConfig.pricing()).thenReturn(Map.of());
+    when(aiConfig.providerName()).thenReturn(Optional.empty());
 
     sessionUpdater = mock(ReviewSessionUpdater.class);
-    Vertx vertx = mock(Vertx.class);
+    vertx = mock(Vertx.class);
     when(vertx.<Void>executeBlocking(any(Callable.class)))
         .thenAnswer(
             invocation -> {
@@ -104,7 +109,9 @@ class OtelObservabilityListenerTest {
               when(future.onFailure(any())).thenReturn(future);
               return future;
             });
-    listener = new OtelObservabilityListener(otel, config, sessionUpdater, vertx);
+    listener =
+        new OtelObservabilityListener(
+            otel, config, sessionUpdater, vertx, "https://api.deepseek.com/v1");
   }
 
   @AfterEach
@@ -196,7 +203,8 @@ class OtelObservabilityListenerTest {
             });
 
     var failingListener =
-        new OtelObservabilityListener(localOtel, config, failingUpdater, failingVertx);
+        new OtelObservabilityListener(
+            localOtel, config, failingUpdater, failingVertx, "https://api.deepseek.com/v1");
     var attrs = requestAttributes(failingListener, 16L, 1);
 
     assertDoesNotThrow(() -> failingListener.onResponse(responseContext(attrs)));
@@ -216,6 +224,34 @@ class OtelObservabilityListenerTest {
     verify(tokenHistogram, atLeastOnce()).record(anyLong(), any());
     verify(durationHistogram).record(anyDouble(), any());
     verify(costCounter).add(anyDouble(), any());
+  }
+
+  @Test
+  void onResponseShouldTagMetricsWithProviderDerivedFromBaseUrl() {
+    var ctx = responseContext(requestAttributes(99L, 1));
+
+    listener.onResponse(ctx);
+
+    assertEquals("deepseek", recordedProviderName());
+  }
+
+  @Test
+  void onResponseShouldPreferExplicitlyConfiguredProviderName() {
+    when(aiConfig.providerName()).thenReturn(Optional.of("  my-gateway  "));
+    var overridden =
+        new OtelObservabilityListener(
+            otel, config, sessionUpdater, vertx, "https://api.openai.com/v1");
+
+    overridden.onResponse(responseContext(requestAttributes(overridden, 1L, 1)));
+
+    assertEquals("my-gateway", recordedProviderName());
+  }
+
+  /** Captures the {@code gen_ai.provider.name} label attached to the recorded duration metric. */
+  private String recordedProviderName() {
+    var attrCaptor = ArgumentCaptor.forClass(Attributes.class);
+    verify(durationHistogram).record(anyDouble(), attrCaptor.capture());
+    return attrCaptor.getValue().get(AttributeKey.stringKey("gen_ai.provider.name"));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/OtelObservabilityListenerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/OtelObservabilityListenerTest.java
@@ -95,6 +95,7 @@ class OtelObservabilityListenerTest {
     aiConfig = mock(AiPricingConfig.class);
     when(config.ai()).thenReturn(aiConfig);
     when(aiConfig.pricing()).thenReturn(Map.of());
+    when(aiConfig.baseUrl()).thenReturn("https://api.deepseek.com/v1");
     when(aiConfig.providerName()).thenReturn(Optional.empty());
 
     sessionUpdater = mock(ReviewSessionUpdater.class);
@@ -109,9 +110,7 @@ class OtelObservabilityListenerTest {
               when(future.onFailure(any())).thenReturn(future);
               return future;
             });
-    listener =
-        new OtelObservabilityListener(
-            otel, config, sessionUpdater, vertx, "https://api.deepseek.com/v1");
+    listener = new OtelObservabilityListener(otel, config, sessionUpdater, vertx);
   }
 
   @AfterEach
@@ -203,8 +202,7 @@ class OtelObservabilityListenerTest {
             });
 
     var failingListener =
-        new OtelObservabilityListener(
-            localOtel, config, failingUpdater, failingVertx, "https://api.deepseek.com/v1");
+        new OtelObservabilityListener(localOtel, config, failingUpdater, failingVertx);
     var attrs = requestAttributes(failingListener, 16L, 1);
 
     assertDoesNotThrow(() -> failingListener.onResponse(responseContext(attrs)));
@@ -238,9 +236,7 @@ class OtelObservabilityListenerTest {
   @Test
   void onResponseShouldPreferExplicitlyConfiguredProviderName() {
     when(aiConfig.providerName()).thenReturn(Optional.of("  my-gateway  "));
-    var overridden =
-        new OtelObservabilityListener(
-            otel, config, sessionUpdater, vertx, "https://api.openai.com/v1");
+    var overridden = new OtelObservabilityListener(otel, config, sessionUpdater, vertx);
 
     overridden.onResponse(responseContext(requestAttributes(overridden, 1L, 1)));
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/OtelObservabilityListenerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/OtelObservabilityListenerTest.java
@@ -243,6 +243,17 @@ class OtelObservabilityListenerTest {
     assertEquals("my-gateway", recordedProviderName());
   }
 
+  @Test
+  void onResponseShouldDeriveProviderWhenConfiguredNameIsBlank() {
+    when(aiConfig.providerName()).thenReturn(Optional.of("   "));
+    var blankOverride = new OtelObservabilityListener(otel, config, sessionUpdater, vertx);
+
+    blankOverride.onResponse(responseContext(requestAttributes(blankOverride, 1L, 1)));
+
+    // Blank override is ignored; the label is derived from the base URL instead.
+    assertEquals("deepseek", recordedProviderName());
+  }
+
   /** Captures the {@code gen_ai.provider.name} label attached to the recorded duration metric. */
   private String recordedProviderName() {
     var attrCaptor = ArgumentCaptor.forClass(Attributes.class);


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 📝 Documentation

## Description

Telemetry hardcoded `gen_ai.provider.name="deepseek"` on every record, so traces, the token/duration histograms, and the cost counter were mislabeled for any non-DeepSeek provider (OpenAI, Qwen, OpenRouter, Ollama, etc.).

The provider label is now **resolved once at startup**:

1. An explicit `AI_PROVIDER` (`thrillhousebot.ai.provider-name`) override wins.
2. Otherwise it is derived from the configured `AI_BASE_URL` host:
   - Well-known hosts → canonical names (`deepseek`, `openai`, `groq`, `openrouter`, `anthropic`, `mistral_ai`, `perplexity`, `xai`, `alibaba`).
   - Loopback hosts → `ollama` (the common local OpenAI-compatible server).
   - Anything else → the registrable domain label (`api.acme.com` → `acme`).
   - Blank / unparseable / bare-IP → `unknown`.

The label is applied to both the **metric attributes** and the **span** — the span never carried `gen_ai.provider.name` before, so traces are now tagged too.

The base URL is read from the single source of truth the client already uses (`quarkus.langchain4j.openai.base-url`), so there is no risk of the telemetry label drifting from the actual endpoint.

### Key changes

- New `AiProviderResolver` — maps a base-URL host to a provider name.
- `OtelObservabilityListener` — injects the base URL, resolves the label, applies it to metrics + span.
- `ThrillhouseConfig.AiPricingConfig#providerName()` + `thrillhousebot.ai.provider-name` / `AI_PROVIDER` override.
- Docs: README config table & observability note, `.env.example`.

## Related Issues

Fixes #19

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

- `AiProviderResolverTest` — 25 cases: known hosts, registrable-domain fallback, loopback, case-insensitivity, scheme-less URLs, bare IPs, blank/garbage input.
- `OtelObservabilityListenerTest` — new tests for the derived label and for the explicit override (with trimming) taking precedence.
- Full suite: **592 tests, 0 failures/errors**; `spotless:check` clean. The `@QuarkusTest` integration tests boot the CDI container, confirming the `@ConfigProperty` constructor injection wires correctly.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No breaking changes. Default behavior is unchanged for DeepSeek (still resolves to `deepseek`); the difference is that every other provider is now labeled correctly. `AI_PROVIDER` is available as an escape hatch for ambiguous endpoints (proxies, self-hosted gateways, local servers).