### PR TITLE
fix(review): close diff fence and cut at hunk boundary when truncating

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
@@ -305,7 +305,7 @@ public class ReviewDiffFormatter {
 
     int fenceStart = diffFenceStart(lines);
     return fenceStart < 0
-        ? truncatePlain(lines, maxLines)
+        ? truncatePlain(section, lines, maxLines)
         : truncateFenced(lines, fenceStart, maxLines);
   }
 
@@ -321,15 +321,17 @@ public class ReviewDiffFormatter {
 
   /**
    * Raw line-count truncation for sections without a fenced patch (skipped or patch-less files).
+   * The omitted count is measured with {@link #lineCount} so it ignores the trailing empty elements
+   * {@code split("\n", -1)} produces for a section's {@code \n}-terminated tail.
    */
-  private static String truncatePlain(String[] lines, int maxLines) {
+  private static String truncatePlain(String section, String[] lines, int maxLines) {
     var sb = new StringBuilder();
     var contentLines = maxLines - 1;
     for (var i = 0; i < contentLines; i++) {
       sb.append(lines[i]).append('\n');
     }
     sb.append("(patch truncated — ")
-        .append(lines.length - contentLines)
+        .append(lineCount(section) - contentLines)
         .append(" lines omitted)\n");
     return sb.toString();
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
@@ -330,10 +330,13 @@ public class ReviewDiffFormatter {
     for (var i = 0; i < contentLines; i++) {
       sb.append(lines[i]).append('\n');
     }
-    sb.append("(patch truncated — ")
-        .append(lineCount(section) - contentLines)
-        .append(" lines omitted)\n");
+    sb.append(patchTruncatedNotice(lineCount(section) - contentLines));
     return sb.toString();
+  }
+
+  /** The shared "(patch truncated — N lines omitted)" notice appended by every truncation path. */
+  private static String patchTruncatedNotice(int omittedLines) {
+    return "(patch truncated — " + omittedLines + " lines omitted)\n";
   }
 
   /**
@@ -367,7 +370,7 @@ public class ReviewDiffFormatter {
     for (var i = 0; i < keep; i++) {
       sb.append(lines[patchStart + i]).append('\n');
     }
-    sb.append("(patch truncated — ").append(patchCount - keep).append(" lines omitted)\n");
+    sb.append(patchTruncatedNotice(patchCount - keep));
     sb.append("```\n");
     return sb.toString();
   }
@@ -408,7 +411,7 @@ public class ReviewDiffFormatter {
     for (var i = 0; i < headerLines; i++) {
       sb.append(lines[i]).append('\n');
     }
-    sb.append("(patch truncated — ").append(patchCount).append(" lines omitted)\n");
+    sb.append(patchTruncatedNotice(patchCount));
     return sb.toString();
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
@@ -303,6 +303,26 @@ public class ReviewDiffFormatter {
       return "(patch truncated)\n";
     }
 
+    int fenceStart = diffFenceStart(lines);
+    return fenceStart < 0
+        ? truncatePlain(lines, maxLines)
+        : truncateFenced(lines, fenceStart, maxLines);
+  }
+
+  /** Index of the opening ```` ```diff ```` fence, or -1 when the section has no fenced patch. */
+  private static int diffFenceStart(String[] lines) {
+    for (var i = 0; i < lines.length; i++) {
+      if (lines[i].startsWith("```")) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Raw line-count truncation for sections without a fenced patch (skipped or patch-less files).
+   */
+  private static String truncatePlain(String[] lines, int maxLines) {
     var sb = new StringBuilder();
     var contentLines = maxLines - 1;
     for (var i = 0; i < contentLines; i++) {
@@ -311,6 +331,82 @@ public class ReviewDiffFormatter {
     sb.append("(patch truncated — ")
         .append(lines.length - contentLines)
         .append(" lines omitted)\n");
+    return sb.toString();
+  }
+
+  /**
+   * Truncates a section whose patch is wrapped in a ```` ```diff ```` fence. Prefers to cut at a
+   * hunk boundary so no partial hunk is shown, and always re-closes the fence so the surrounding
+   * prompt never carries an open code block. The result stays within {@code maxLines}.
+   *
+   * <p>Assumes the section was produced by {@link #formatFileSection}: a single {@code
+   * \n}-delimited ```` ```diff ```` block whose body is a GitHub unified-diff patch (lines prefixed
+   * with a space, {@code +}, {@code -}, or {@code @@}), so the only bare {@code ```} line is the
+   * closing fence.
+   */
+  private static String truncateFenced(String[] lines, int fenceStart, int maxLines) {
+    int patchStart = fenceStart + 1;
+    int fenceEnd = closingFence(lines, patchStart);
+    int patchCount = Math.max(0, fenceEnd - patchStart);
+
+    // Reserve lines for the prefix (header + opening fence), the notice, and the closing fence.
+    int patchBudget = maxLines - patchStart - 2;
+    if (patchBudget < 1) {
+      return truncateWithoutFence(lines, fenceStart, patchCount, maxLines);
+    }
+
+    int keep =
+        alignToHunkBoundary(lines, patchStart, patchCount, Math.min(patchBudget, patchCount));
+
+    var sb = new StringBuilder();
+    for (var i = 0; i < patchStart; i++) {
+      sb.append(lines[i]).append('\n');
+    }
+    for (var i = 0; i < keep; i++) {
+      sb.append(lines[patchStart + i]).append('\n');
+    }
+    sb.append("(patch truncated — ").append(patchCount - keep).append(" lines omitted)\n");
+    sb.append("```\n");
+    return sb.toString();
+  }
+
+  /**
+   * Index of the closing ```` ``` ```` fence at or after {@code from}, or end-of-array if absent.
+   */
+  private static int closingFence(String[] lines, int from) {
+    for (var i = from; i < lines.length; i++) {
+      if (lines[i].equals("```")) {
+        return i;
+      }
+    }
+    return lines.length;
+  }
+
+  /**
+   * Pulls the cut point back to the start of the hunk it lands in so a partial trailing hunk is
+   * dropped rather than shown half-formed. Falls back to the raw cut when even the first hunk
+   * overflows the budget — a partial hunk inside a closed fence still beats an empty one.
+   */
+  private static int alignToHunkBoundary(String[] lines, int patchStart, int patchCount, int keep) {
+    if (keep >= patchCount) {
+      return keep;
+    }
+    int aligned = keep;
+    while (aligned > 0 && !lines[patchStart + aligned].startsWith("@@")) {
+      aligned--;
+    }
+    return aligned > 0 ? aligned : keep;
+  }
+
+  /** Degrades a fenced section to header + notice (no fence) when the budget is too small. */
+  private static String truncateWithoutFence(
+      String[] lines, int fenceStart, int patchCount, int maxLines) {
+    var sb = new StringBuilder();
+    int headerLines = Math.min(fenceStart, maxLines - 1);
+    for (var i = 0; i < headerLines; i++) {
+      sb.append(lines[i]).append('\n');
+    }
+    sb.append("(patch truncated — ").append(patchCount).append(" lines omitted)\n");
     return sb.toString();
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
@@ -186,6 +186,15 @@ class ReviewDiffFormatterTest {
     }
 
     @Test
+    void shouldTruncateFencelessSectionWithEmDashNoticeWhenBudgetAboveOne() {
+      // Sections without a ```diff fence (ignored / patch-less files) keep the original raw-line
+      // behavior: keep the first maxLines-1 lines, then an em-dash notice with the omitted count.
+      assertEquals(
+          "a\nb\n(patch truncated — 4 lines omitted)\n",
+          ReviewDiffFormatter.truncateSection("a\nb\nc\nd\ne\n", 3));
+    }
+
+    @Test
     void shouldCountLinesForNullEmptyAndNewlineOnlyText() {
       assertEquals(0, ReviewDiffFormatter.lineCount(null));
       assertEquals(0, ReviewDiffFormatter.lineCount(""));
@@ -270,6 +279,103 @@ class ReviewDiffFormatterTest {
       assertTrue(result.contains("(diff truncated at 10 lines — 2 files omitted)"));
       assertFalse(result.contains("```diff\nalpha"));
       assertFalse(result.contains("tail"));
+    }
+  }
+
+  @Nested
+  class FenceClosing {
+
+    private static final String TWO_HUNK_SECTION =
+        "### big.java (modified, +6 -0)\n"
+            + "```diff\n"
+            + "@@ -1,3 +1,6 @@\n"
+            + " a\n"
+            + "+b\n"
+            + "+c\n"
+            + "@@ -10,2 +13,4 @@\n"
+            + " d\n"
+            + "+e\n"
+            + "```\n\n";
+
+    private static long fenceCount(String text) {
+      return text.lines().filter(line -> line.startsWith("```")).count();
+    }
+
+    @Test
+    void shouldReCloseFenceWhenTruncatingMidHunk() {
+      // Budget 7: the first hunk (4 lines) does not fit, so the cut lands mid-hunk — the fence must
+      // still be closed rather than left open.
+      var truncated = ReviewDiffFormatter.truncateSection(TWO_HUNK_SECTION, 7);
+
+      assertEquals(2, fenceCount(truncated), "opening fence must be balanced by a closing fence");
+      assertTrue(truncated.endsWith("```\n"), "section must end with the closing fence");
+      assertTrue(truncated.contains("patch truncated"));
+      assertTrue(ReviewDiffFormatter.lineCount(truncated) <= 7, "must not exceed the line budget");
+    }
+
+    @Test
+    void shouldCutAtHunkBoundaryWhenWholeHunkFits() {
+      // Budget 8: the first hunk fits but the second does not, so the partial second hunk is
+      // dropped
+      // entirely at the @@ boundary.
+      var truncated = ReviewDiffFormatter.truncateSection(TWO_HUNK_SECTION, 8);
+
+      assertTrue(truncated.contains("@@ -1,3 +1,6 @@"), "first whole hunk is kept");
+      assertTrue(truncated.contains("+c"), "first hunk content is kept in full");
+      assertFalse(
+          truncated.contains("@@ -10,2 +13,4 @@"), "partial second hunk dropped at boundary");
+      assertFalse(truncated.contains("+e"), "no content leaks from the dropped hunk");
+      assertEquals(2, fenceCount(truncated), "fence must be re-closed");
+      assertTrue(truncated.endsWith("```\n"));
+      assertTrue(ReviewDiffFormatter.lineCount(truncated) <= 8);
+    }
+
+    @Test
+    void shouldCloseFenceForPatchWithNoHunkHeaders() {
+      // No @@ headers, so alignToHunkBoundary finds no boundary and falls back to a raw cut — the
+      // fence must still be re-closed (a partial patch inside a closed fence beats an open one).
+      var section = "### r.java (modified, +5 -0)\n```diff\n+l1\n+l2\n+l3\n+l4\n+l5\n```\n\n";
+      var truncated = ReviewDiffFormatter.truncateSection(section, 6);
+
+      assertEquals(2, fenceCount(truncated), "fence must be re-closed even with no @@ headers");
+      assertTrue(truncated.endsWith("```\n"));
+      assertTrue(truncated.contains("+l1"));
+      assertTrue(truncated.contains("+l2"));
+      assertFalse(truncated.contains("+l3"));
+      assertTrue(truncated.contains("patch truncated"));
+      assertEquals(6, ReviewDiffFormatter.lineCount(truncated));
+    }
+
+    @Test
+    void shouldNotOpenAFenceItCannotCloseWhenBudgetTooSmall() {
+      // Budget 3 cannot fit header + fence + notice + closing fence, so no fence is emitted at all.
+      var truncated = ReviewDiffFormatter.truncateSection(TWO_HUNK_SECTION, 3);
+
+      assertEquals(0, fenceCount(truncated), "must not emit an unbalanced fence");
+      assertTrue(truncated.contains("patch truncated"));
+      assertTrue(ReviewDiffFormatter.lineCount(truncated) <= 3);
+    }
+
+    @Test
+    void shouldKeepPromptFencesBalancedWhenLastFileIsTruncated() {
+      var formatter = new ReviewDiffFormatter(List.of(), 12);
+      var files =
+          List.of(
+              file(
+                  "big.java",
+                  "modified",
+                  6,
+                  0,
+                  "@@ -1,3 +1,6 @@\n a\n+b\n+c\n@@ -20,2 +24,5 @@\n d\n+e\n+f\n+g"),
+              file("small.java", "modified", 1, 0, "+x"));
+
+      var result = formatter.buildDiffString(files);
+
+      long fences = fenceCount(result);
+      assertTrue(fences >= 2, "the included file's fence must be present");
+      assertEquals(0, fences % 2, "every ```diff fence in the prompt must be closed");
+      assertTrue(result.contains("patch truncated"));
+      assertTrue(result.contains("(diff truncated at 12 lines — 1 files omitted)"));
     }
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
@@ -287,16 +287,19 @@ class ReviewDiffFormatterTest {
   class FenceClosing {
 
     private static final String TWO_HUNK_SECTION =
-        "### big.java (modified, +6 -0)\n"
-            + "```diff\n"
-            + "@@ -1,3 +1,6 @@\n"
-            + " a\n"
-            + "+b\n"
-            + "+c\n"
-            + "@@ -10,2 +13,4 @@\n"
-            + " d\n"
-            + "+e\n"
-            + "```\n\n";
+        """
+        ### big.java (modified, +6 -0)
+        ```diff
+        @@ -1,3 +1,6 @@
+         a
+        +b
+        +c
+        @@ -10,2 +13,4 @@
+         d
+        +e
+        ```
+
+        """;
 
     private static long fenceCount(String text) {
       return text.lines().filter(line -> line.startsWith("```")).count();

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
@@ -187,10 +187,11 @@ class ReviewDiffFormatterTest {
 
     @Test
     void shouldTruncateFencelessSectionWithEmDashNoticeWhenBudgetAboveOne() {
-      // Sections without a ```diff fence (ignored / patch-less files) keep the original raw-line
-      // behavior: keep the first maxLines-1 lines, then an em-dash notice with the omitted count.
+      // Sections without a ```diff fence (ignored / patch-less files): keep the first maxLines-1
+      // lines, then an em-dash notice. The omitted count is the real lines dropped (c, d, e = 3),
+      // not the split-array length, which would over-count the trailing empty element.
       assertEquals(
-          "a\nb\n(patch truncated — 4 lines omitted)\n",
+          "a\nb\n(patch truncated — 3 lines omitted)\n",
           ReviewDiffFormatter.truncateSection("a\nb\nc\nd\ne\n", 3));
     }
 
@@ -376,6 +377,33 @@ class ReviewDiffFormatterTest {
       assertEquals(0, fences % 2, "every ```diff fence in the prompt must be closed");
       assertTrue(result.contains("patch truncated"));
       assertTrue(result.contains("(diff truncated at 12 lines — 1 files omitted)"));
+    }
+
+    @Test
+    void shouldCloseFenceWhenSectionHasNoClosingFence() {
+      // Defensive: a fenced section missing its closing ``` (closingFence falls through to
+      // end-of-input) is still truncated with a freshly appended closing fence.
+      var section = "### a.java (modified, +5 -0)\n```diff\n@@ -1,5 +1,5 @@\n+a\n+b\n+c\n+d\n+e";
+      var truncated = ReviewDiffFormatter.truncateSection(section, 5);
+
+      assertEquals(2, fenceCount(truncated), "fence must be re-closed even when input had none");
+      assertTrue(truncated.endsWith("```\n"));
+      assertTrue(truncated.contains("patch truncated"));
+      assertTrue(ReviewDiffFormatter.lineCount(truncated) <= 5);
+    }
+
+    @Test
+    void shouldKeepWholePatchAndReCloseFenceWhenOnlyTrailingBlanksOverflow() {
+      // Budget equals the section's real line count: the entire patch body fits and only the
+      // trailing blank lines overflow, so the body is kept intact and the fence is still re-closed.
+      var section = "### a.java (modified, +2 -0)\n```diff\n@@ -1,1 +1,2 @@\n+x\n```\n\n";
+      var truncated = ReviewDiffFormatter.truncateSection(section, 6);
+
+      assertTrue(truncated.contains("@@ -1,1 +1,2 @@"), "hunk header kept");
+      assertTrue(truncated.contains("+x"), "patch body kept intact");
+      assertEquals(2, fenceCount(truncated), "fence re-closed");
+      assertTrue(truncated.endsWith("```\n"));
+      assertTrue(ReviewDiffFormatter.lineCount(truncated) <= 6);
     }
   }
 


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

When a diff exceeds `thrillhousebot.review.max-diff-lines`, `ReviewDiffFormatter.truncateSection()` truncated the last file's section by **raw line count**. That could cut in the middle of a hunk and drop the closing ` ``` ` fence of the ` ```diff ` block, so the prompt sent to the model carried an **unterminated code fence** — trailing prompt content could then be misread as diff.

`truncateSection()` now detects the ` ```diff ` fence and, when it has to truncate inside it:

- **Always re-closes the fence.** A line is reserved for the closing ` ``` ` up front (`truncateFenced`), so the prompt is never left with an open code block.
- **Cuts at a hunk boundary where possible.** `alignToHunkBoundary()` pulls the cut back to the last `@@` header so a partial trailing hunk is dropped whole; it falls back to a raw (still fenced) cut only when the first hunk alone exceeds the budget — a partial hunk inside a closed fence still beats an open one.
- **Preserves the `lineCount(out) <= maxLines` budget invariant**, so the downstream truncation footer keeps its line budget.
- **Leaves the non-fenced path unchanged** (`truncatePlain`) for ignored / patch-less file sections, and degrades tiny budgets to a header + notice with no unbalanced fence.

No behavior change for diffs that fit within the budget.

## Related Issues

Fixes #21

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Added 6 focused tests in `ReviewDiffFormatterTest`:

- `FenceClosing` — fence re-closed on a mid-hunk cut; cut aligned to the `@@` boundary when a whole hunk fits; no fence emitted when the budget is too small to close one; whole-prompt fences stay balanced when the last file is truncated; fence re-closed for a patch with no `@@` headers.
- `TruncationHelpers` — the fence-less em-dash notice path (`(patch truncated — N lines omitted)`) for `maxLines >= 2`.

Local verification:

- `./mvnw -Dtest=ReviewDiffFormatterTest test` → 43/43 pass
- Full `review` package → 146/146 pass
- `./mvnw spotless:check` → clean (google-java-format)
- `./mvnw compile spotbugs:check` → clean

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

A `truncateFenced` Javadoc note documents the precondition (sections come from `formatFileSection`: a single `\n`-delimited ` ```diff ` block whose body is a GitHub unified-diff patch), so the "first bare ` ``` ` line is the closing fence" assumption is explicit.

Out of scope: an adversarial self-review noted that the assembled prompt can run **~1 line over** `max-diff-lines` (the footer summary block costs 2 lines but only 1 is reserved). This is **pre-existing on `main`** and independent of this fix — the new fenced path always returns within its own budget — so it's left for a separate change.