### PR TITLE
fix: close diff fences during truncation

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
@@ -325,8 +325,13 @@ public class ReviewDiffFormatter {
   private static boolean isInsideCodeFence(String[] lines, int lineCount) {
     var insideFence = false;
     for (var i = 0; i < lineCount; i++) {
-      if (lines[i].trim().startsWith("```")) {
-        insideFence = !insideFence;
+      var line = lines[i].trim();
+      if (line.startsWith("```")) {
+        if (!insideFence) {
+          insideFence = true;
+        } else if (line.substring(3).trim().isEmpty()) {
+          insideFence = false;
+        }
       }
     }
     return insideFence;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
@@ -303,15 +303,33 @@ public class ReviewDiffFormatter {
       return "(patch truncated)\n";
     }
 
-    var sb = new StringBuilder();
     var contentLines = maxLines - 1;
+    if (isInsideCodeFence(lines, contentLines)) {
+      contentLines = Math.max(0, maxLines - 2);
+    }
+
+    var closesFence = isInsideCodeFence(lines, contentLines);
+    var sb = new StringBuilder();
     for (var i = 0; i < contentLines; i++) {
       sb.append(lines[i]).append('\n');
+    }
+    if (closesFence) {
+      sb.append("```\n");
     }
     sb.append("(patch truncated — ")
         .append(lines.length - contentLines)
         .append(" lines omitted)\n");
     return sb.toString();
+  }
+
+  private static boolean isInsideCodeFence(String[] lines, int lineCount) {
+    var insideFence = false;
+    for (var i = 0; i < lineCount; i++) {
+      if (lines[i].trim().startsWith("```")) {
+        insideFence = !insideFence;
+      }
+    }
+    return insideFence;
   }
 
   static int lineCount(String text) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
@@ -186,6 +186,25 @@ class ReviewDiffFormatterTest {
     }
 
     @Test
+    void shouldCloseDiffFenceWhenTruncatingInsidePatch() {
+      var section = "### a.java\n```diff\n@@\n+one\n+two\n```\n\n";
+
+      var result = ReviewDiffFormatter.truncateSection(section, 5);
+
+      assertEquals("### a.java\n```diff\n@@\n```\n(patch truncated — 5 lines omitted)\n", result);
+    }
+
+    @Test
+    void shouldKeepTruncatedFenceWithinLineBudget() {
+      var section = "```diff\n+one\n+two\n```\n";
+
+      var result = ReviewDiffFormatter.truncateSection(section, 2);
+
+      assertEquals("(patch truncated — 5 lines omitted)\n", result);
+      assertEquals(1, ReviewDiffFormatter.lineCount(result));
+    }
+
+    @Test
     void shouldCountLinesForNullEmptyAndNewlineOnlyText() {
       assertEquals(0, ReviewDiffFormatter.lineCount(null));
       assertEquals(0, ReviewDiffFormatter.lineCount(""));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
@@ -205,6 +205,15 @@ class ReviewDiffFormatterTest {
     }
 
     @Test
+    void shouldNotTreatFencedPatchContentAsClosingFence() {
+      var section = "### docs.md\n```diff\n+```js\n+console.log('hi')\n```\n\n";
+
+      var result = ReviewDiffFormatter.truncateSection(section, 5);
+
+      assertEquals("### docs.md\n```diff\n+```js\n```\n(patch truncated — 5 lines omitted)\n", result);
+    }
+
+    @Test
     void shouldCountLinesForNullEmptyAndNewlineOnlyText() {
       assertEquals(0, ReviewDiffFormatter.lineCount(null));
       assertEquals(0, ReviewDiffFormatter.lineCount(""));


### PR DESCRIPTION
Fixes #21.

This keeps truncated diff sections from leaving an open Markdown code fence when the line budget cuts through a patch. If the retained lines are inside a fence, the formatter now reserves space to close it before adding the truncation marker.

I also added regression coverage for truncating inside a ```diff block and for the tight-budget helper case.

Check run locally:
- `git diff --check`

I could not run `./mvnw -Dtest=ReviewDiffFormatterTest test` on this machine because there is no Java runtime installed.