### PR TITLE
fix(webhook): verify real write access for manual /review triggers

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -108,6 +108,13 @@ public interface ThrillhouseConfig {
     @WithDefault("**/pom.xml,**/package-lock.json,**/*.lock,**/*.generated.*,**/target/**")
     @WithName("ignored-files")
     List<String> ignoredFiles();
+
+    /**
+     * GitHub logins permitted to manually trigger reviews regardless of repository permission. When
+     * empty, only users with write access to the repository may trigger a manual review.
+     */
+    @WithName("manual-trigger-allowed-logins")
+    Optional<List<String>> manualTriggerAllowedLogins();
   }
 
   interface DashboardConfig {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubInstallationClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubInstallationClient.java
@@ -58,9 +58,21 @@ public interface GitHubInstallationClient {
       @PathParam("repo") String repo,
       @PathParam("username") String username);
 
+  @GET
+  @Path("/repos/{owner}/{repo}/collaborators/{username}/permission")
+  @Produces(MediaType.APPLICATION_JSON)
+  CollaboratorPermission collaboratorPermission(
+      @HeaderParam("Authorization") String authorization,
+      @HeaderParam("Accept") String accept,
+      @PathParam("owner") String owner,
+      @PathParam("repo") String repo,
+      @PathParam("username") String username);
+
   record Installation(long id, Account account) {
     public record Account(String login, String type) {}
   }
+
+  record CollaboratorPermission(String permission, @JsonProperty("role_name") String roleName) {}
 
   record AppInfo(Owner owner) {
     public record Owner(String login, String type) {}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizer.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.webhook;
+
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubInstallationClient;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Decides whether a commenter may manually trigger a paid review. Org membership or a bare
+ * collaborator relationship is not sufficient: the commenter must actually hold write access to the
+ * specific repository — verified authoritatively against the GitHub API — or be named in the
+ * operator's explicit allowlist.
+ */
+@ApplicationScoped
+public class ManualReviewAuthorizer {
+
+  private static final Logger log = LoggerFactory.getLogger(ManualReviewAuthorizer.class);
+  private static final String ACCEPT = "application/vnd.github+json";
+
+  /**
+   * GitHub {@code author_association} values that a write-access holder can present. Any other
+   * value ({@code CONTRIBUTOR}, {@code FIRST_TIME_CONTRIBUTOR}, {@code NONE}, ...) provably lacks
+   * write access — association precedence guarantees a collaborator/member is never reported as one
+   * of those — so it is rejected without an API round-trip, keeping public-repo trigger spam from
+   * consuming the app's GitHub rate limit. Write access is then confirmed authoritatively for the
+   * remaining cases.
+   */
+  private static final Set<String> WRITE_CAPABLE_ASSOCIATIONS =
+      Set.of("OWNER", "MEMBER", "COLLABORATOR");
+
+  /** GitHub collaborator-permission levels that include push (write) access. */
+  private static final Set<String> WRITE_PERMISSIONS = Set.of("admin", "write");
+
+  private final ThrillhouseConfig config;
+  private final GitHubAuthClient authClient;
+  private final GitHubInstallationClient installationClient;
+
+  @Inject
+  public ManualReviewAuthorizer(
+      ThrillhouseConfig config,
+      GitHubAuthClient authClient,
+      @RestClient GitHubInstallationClient installationClient) {
+    this.config = config;
+    this.authClient = authClient;
+    this.installationClient = installationClient;
+  }
+
+  /**
+   * Returns {@code true} only if {@code login} may spend the operator's API budget on a manual
+   * review of {@code owner/repo}: either the login is allowlisted, or it holds write access to the
+   * repository. {@code authorAssociation} is used solely as a cheap rejection of commenters who
+   * cannot possibly have write access; it never grants access on its own.
+   */
+  public boolean isAuthorized(
+      String owner, String repo, long installationId, String login, String authorAssociation) {
+    if (login == null || login.isBlank()) {
+      return false;
+    }
+    if (isAllowlisted(login)) {
+      return true;
+    }
+    if (!mayHoldWriteAccess(authorAssociation)) {
+      return false;
+    }
+    return hasWriteAccess(owner, repo, installationId, login);
+  }
+
+  private boolean isAllowlisted(String login) {
+    for (String allowed : config.review().manualTriggerAllowedLogins().orElse(List.of())) {
+      if (allowed.trim().equalsIgnoreCase(login.trim())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean mayHoldWriteAccess(String authorAssociation) {
+    return authorAssociation != null
+        && WRITE_CAPABLE_ASSOCIATIONS.contains(authorAssociation.trim().toUpperCase(Locale.ROOT));
+  }
+
+  private boolean hasWriteAccess(String owner, String repo, long installationId, String login) {
+    try {
+      var permission =
+          installationClient.collaboratorPermission(
+              authClient.getAuthHeader(installationId), ACCEPT, owner, repo, login);
+      var level = permission == null ? null : permission.permission();
+      return level != null && WRITE_PERMISSIONS.contains(level.trim().toLowerCase(Locale.ROOT));
+    } catch (RuntimeException e) {
+      log.warn(
+          "Permission check failed for {}/{} user {}: {} — denying manual review",
+          owner,
+          repo,
+          login,
+          e.getMessage());
+      return false;
+    }
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
@@ -16,7 +16,6 @@
 package dev.thiagogonzaga.thrillhousebot.webhook;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -29,13 +28,6 @@ public class TriggerDetector {
               ".*(?:^|\\s)/review(?:\\s|$).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL),
           Pattern.compile(
               ".*@thrillhousebot\\s+review\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
-
-  /**
-   * GitHub {@code author_association} values that grant write access to the repository and are
-   * therefore allowed to spend the operator's API budget on a manual review.
-   */
-  private static final Set<String> AUTHORIZED_ASSOCIATIONS =
-      Set.of("OWNER", "MEMBER", "COLLABORATOR");
 
   /**
    * Checks whether a comment body contains a review trigger keyword. Triggers: "/review" or
@@ -53,17 +45,5 @@ public class TriggerDetector {
     if (authorLogin == null) return false;
     return ("thrillhousebot[bot]".equalsIgnoreCase(authorLogin)
         || "thrillhouse-bot[bot]".equalsIgnoreCase(authorLogin));
-  }
-
-  /**
-   * Checks whether a commenter is authorized to manually trigger a review based on their GitHub
-   * {@code author_association}. Only owners, organization members, and collaborators (users with
-   * write access) may run a manual review; everyone else — {@code CONTRIBUTOR}, {@code
-   * FIRST_TIME_CONTRIBUTOR}, {@code NONE}, etc. — is rejected so that arbitrary users on public
-   * repositories cannot spend the operator's API budget.
-   */
-  public boolean isAuthorizedToTrigger(String authorAssociation) {
-    if (authorAssociation == null) return false;
-    return AUTHORIZED_ASSOCIATIONS.contains(authorAssociation.trim().toUpperCase(Locale.ROOT));
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -39,6 +39,7 @@ public class WebhookController {
   private final TriggerDetector triggerDetector;
   private final ReviewDispatcher reviewDispatcher;
   private final WebhookDeduplicator deduplicator;
+  private final ManualReviewAuthorizer manualReviewAuthorizer;
   private final ObjectMapper mapper;
 
   @Inject
@@ -48,12 +49,14 @@ public class WebhookController {
       TriggerDetector triggerDetector,
       ReviewDispatcher reviewDispatcher,
       WebhookDeduplicator deduplicator,
+      ManualReviewAuthorizer manualReviewAuthorizer,
       ObjectMapper mapper) {
     this.config = config;
     this.verifier = verifier;
     this.triggerDetector = triggerDetector;
     this.reviewDispatcher = reviewDispatcher;
     this.deduplicator = deduplicator;
+    this.manualReviewAuthorizer = manualReviewAuthorizer;
     this.mapper = mapper;
   }
 
@@ -145,6 +148,13 @@ public class WebhookController {
   }
 
   private void handleIssueComment(WebhookPayload payload) {
+    // Only a freshly created comment is a trigger; editing or deleting one must not re-run a
+    // review.
+    if (!"created".equals(payload.action())) {
+      log.debug("Ignoring issue_comment action: {}", payload.action());
+      return;
+    }
+
     // Only act on PR comments, not issue comments
     if (payload.issue() == null || payload.issue().pullRequest() == null) {
       log.debug("Ignoring comment on issue (not PR)");
@@ -163,29 +173,29 @@ public class WebhookController {
     }
 
     if (triggerDetector.isReviewTrigger(payload.comment().body())) {
-      // Manual triggers spend the operator's API budget, so restrict them to users with write
-      // access (owner/member/collaborator). Otherwise anyone could repeatedly trigger paid reviews.
-      if (!triggerDetector.isAuthorizedToTrigger(payload.comment().authorAssociation())) {
-        log.info(
-            "Ignoring unauthorized manual review trigger from @{} (association: {}) on PR #{}",
-            payload.comment().user().login(),
-            payload.comment().authorAssociation(),
-            payload.issue().number());
-        return;
-      }
       var repo = payload.repository();
       if (repo == null || payload.installation() == null) {
         log.debug("Ignoring review trigger with missing repository or installation");
         return;
       }
-      log.info(
-          "Manual review triggered by @{} on PR #{}",
-          payload.comment().user().login(),
-          payload.issue().number());
+      var owner = repo.owner().login();
+      var login = payload.comment().user().login();
+      var installationId = payload.installation().id();
+      // Manual triggers spend the operator's API budget, so restrict them to users who actually
+      // hold write access to the repository (or are explicitly allowlisted).
+      if (!manualReviewAuthorizer.isAuthorized(
+          owner, repo.name(), installationId, login, payload.comment().authorAssociation())) {
+        log.info(
+            "Ignoring unauthorized manual review trigger from @{} on PR #{}",
+            login,
+            payload.issue().number());
+        return;
+      }
+      log.info("Manual review triggered by @{} on PR #{}", login, payload.issue().number());
       // On issue_comment the issue number equals the PR number
       reviewDispatcher.dispatch(
           new ReviewOrchestrator.ReviewRequest(
-              repo.owner().login(),
+              owner,
               repo.name(),
               payload.issue().number(),
               "",
@@ -193,7 +203,7 @@ public class WebhookController {
               "",
               "",
               repo.defaultBranch(),
-              payload.installation().id(),
+              installationId,
               true));
     }
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.webhook;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubInstallationClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubInstallationClient.CollaboratorPermission;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class ManualReviewAuthorizerTest {
+
+  @Mock private ThrillhouseConfig config;
+
+  @Mock private ThrillhouseConfig.ReviewConfig reviewConfig;
+
+  @Mock private GitHubAuthClient authClient;
+
+  @Mock private GitHubInstallationClient installationClient;
+
+  private ManualReviewAuthorizer authorizer;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    when(config.review()).thenReturn(reviewConfig);
+    when(reviewConfig.manualTriggerAllowedLogins()).thenReturn(Optional.empty());
+    authorizer = new ManualReviewAuthorizer(config, authClient, installationClient);
+  }
+
+  private void stubPermission(String permission) {
+    when(authClient.getAuthHeader(anyLong())).thenReturn("Bearer token");
+    when(installationClient.collaboratorPermission(
+            anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(new CollaboratorPermission(permission, permission));
+  }
+
+  @Test
+  void shouldRejectBlankOrNullLogin() {
+    assertFalse(authorizer.isAuthorized("o", "r", 1L, null, "OWNER"));
+    assertFalse(authorizer.isAuthorized("o", "r", 1L, "   ", "OWNER"));
+    verifyNoInteractions(installationClient);
+  }
+
+  @Test
+  void shouldAllowAllowlistedLoginWithoutApiCall() {
+    when(reviewConfig.manualTriggerAllowedLogins()).thenReturn(Optional.of(List.of("Trusted-Bot")));
+
+    // Allowlist match is case-insensitive and short-circuits before any GitHub call.
+    assertTrue(authorizer.isAuthorized("o", "r", 1L, "trusted-bot", "NONE"));
+    verifyNoInteractions(installationClient);
+    verifyNoInteractions(authClient);
+  }
+
+  @Test
+  void shouldNotMatchDifferentAllowlistedLogin() {
+    when(reviewConfig.manualTriggerAllowedLogins())
+        .thenReturn(Optional.of(List.of("someone-else")));
+
+    // A non-matching allowlist entry is skipped; with a non-write association the user is then
+    // rejected without an API call.
+    assertFalse(authorizer.isAuthorized("o", "r", 1L, "stranger", "NONE"));
+    verifyNoInteractions(installationClient);
+  }
+
+  @Test
+  void shouldRejectNonWriteCapableAssociationWithoutApiCall() {
+    assertFalse(authorizer.isAuthorized("o", "r", 1L, "stranger", "NONE"));
+    assertFalse(authorizer.isAuthorized("o", "r", 1L, "drive-by", "CONTRIBUTOR"));
+    assertFalse(authorizer.isAuthorized("o", "r", 1L, "newcomer", "FIRST_TIME_CONTRIBUTOR"));
+    assertFalse(authorizer.isAuthorized("o", "r", 1L, "puppet", "MANNEQUIN"));
+    assertFalse(authorizer.isAuthorized("o", "r", 1L, "unknown", null));
+    verifyNoInteractions(installationClient);
+  }
+
+  @Test
+  void shouldRejectReadOnlyOrgMember() {
+    stubPermission("read");
+    assertFalse(authorizer.isAuthorized("o", "r", 1L, "member", "MEMBER"));
+  }
+
+  @Test
+  void shouldAuthorizeMemberWithWritePermission() {
+    stubPermission("write");
+    assertTrue(authorizer.isAuthorized("o", "r", 1L, "maintainer", "MEMBER"));
+  }
+
+  @Test
+  void shouldAuthorizeCollaboratorWithAdminPermission() {
+    stubPermission("admin");
+    assertTrue(authorizer.isAuthorized("o", "r", 1L, "collab", "COLLABORATOR"));
+  }
+
+  @Test
+  void shouldVerifyPermissionEvenForOwnerAssociation() {
+    stubPermission("admin");
+
+    // A mixed-case association still passes the pre-filter, and OWNER is confirmed via the API
+    // rather than trusted on the association alone.
+    assertTrue(authorizer.isAuthorized("acme", "widgets", 7L, "boss", "owner"));
+    verify(installationClient)
+        .collaboratorPermission(anyString(), anyString(), eq("acme"), eq("widgets"), eq("boss"));
+  }
+
+  @Test
+  void shouldFailClosedWhenPermissionCheckThrows() {
+    when(authClient.getAuthHeader(anyLong())).thenReturn("Bearer token");
+    when(installationClient.collaboratorPermission(
+            anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenThrow(new RuntimeException("github unavailable"));
+
+    assertFalse(authorizer.isAuthorized("o", "r", 1L, "member", "MEMBER"));
+  }
+
+  @Test
+  void shouldFailClosedWhenPermissionResponseNull() {
+    when(authClient.getAuthHeader(anyLong())).thenReturn("Bearer token");
+    when(installationClient.collaboratorPermission(
+            anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(null);
+
+    assertFalse(authorizer.isAuthorized("o", "r", 1L, "member", "MEMBER"));
+  }
+
+  @Test
+  void shouldFailClosedWhenPermissionMissing() {
+    when(authClient.getAuthHeader(anyLong())).thenReturn("Bearer token");
+    when(installationClient.collaboratorPermission(
+            anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(new CollaboratorPermission(null, null));
+
+    assertFalse(authorizer.isAuthorized("o", "r", 1L, "member", "MEMBER"));
+  }
+
+  @Test
+  void shouldTreatPermissionLevelCaseInsensitively() {
+    stubPermission("WRITE");
+    assertTrue(authorizer.isAuthorized("o", "r", 1L, "member", "MEMBER"));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
@@ -59,29 +59,4 @@ class TriggerDetectorTest {
     assertFalse(detector.isBotComment("thrillhousebot"));
     assertFalse(detector.isBotComment(""));
   }
-
-  @Test
-  void shouldAuthorizeWriteAccessAssociations() {
-    assertTrue(detector.isAuthorizedToTrigger("OWNER"));
-    assertTrue(detector.isAuthorizedToTrigger("MEMBER"));
-    assertTrue(detector.isAuthorizedToTrigger("COLLABORATOR"));
-  }
-
-  @Test
-  void shouldAuthorizeRegardlessOfCaseAndWhitespace() {
-    assertTrue(detector.isAuthorizedToTrigger("owner"));
-    assertTrue(detector.isAuthorizedToTrigger("Collaborator"));
-    assertTrue(detector.isAuthorizedToTrigger("  MEMBER  "));
-  }
-
-  @Test
-  void shouldRejectNonWriteAssociations() {
-    assertFalse(detector.isAuthorizedToTrigger("CONTRIBUTOR"));
-    assertFalse(detector.isAuthorizedToTrigger("FIRST_TIME_CONTRIBUTOR"));
-    assertFalse(detector.isAuthorizedToTrigger("FIRST_TIMER"));
-    assertFalse(detector.isAuthorizedToTrigger("MANNEQUIN"));
-    assertFalse(detector.isAuthorizedToTrigger("NONE"));
-    assertFalse(detector.isAuthorizedToTrigger(""));
-    assertFalse(detector.isAuthorizedToTrigger(null));
-  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -43,6 +43,8 @@ class WebhookControllerTest {
 
   @Mock private WebhookDeduplicator deduplicator;
 
+  @Mock private ManualReviewAuthorizer manualReviewAuthorizer;
+
   private final ObjectMapper mapper = new ObjectMapper();
 
   /** A non-null delivery id; the mocked deduplicator reports it unseen unless a test overrides. */
@@ -57,7 +59,13 @@ class WebhookControllerTest {
     when(githubConfig.webhookSecret()).thenReturn("test-secret");
     controller =
         new WebhookController(
-            config, verifier, triggerDetector, reviewDispatcher, deduplicator, mapper);
+            config,
+            verifier,
+            triggerDetector,
+            reviewDispatcher,
+            deduplicator,
+            manualReviewAuthorizer,
+            mapper);
   }
 
   // ── handleWebhook tests ────────────────────────────────────────────────
@@ -268,7 +276,8 @@ class WebhookControllerTest {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
     when(triggerDetector.isReviewTrigger("/review")).thenReturn(true);
     when(triggerDetector.isBotComment("octocat")).thenReturn(false);
-    when(triggerDetector.isAuthorizedToTrigger("OWNER")).thenReturn(true);
+    when(manualReviewAuthorizer.isAuthorized("owner", "repo", 12345L, "octocat", "OWNER"))
+        .thenReturn(true);
 
     var body =
         buildIssueCommentPayload("created", 77, "owner/repo", "octocat", "/review")
@@ -288,7 +297,9 @@ class WebhookControllerTest {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
     when(triggerDetector.isReviewTrigger("/review")).thenReturn(true);
     when(triggerDetector.isBotComment("stranger")).thenReturn(false);
-    when(triggerDetector.isAuthorizedToTrigger("NONE")).thenReturn(false);
+    when(manualReviewAuthorizer.isAuthorized(
+            anyString(), anyString(), anyLong(), anyString(), any()))
+        .thenReturn(false);
 
     var body =
         buildIssueCommentPayload("created", 88, "owner/repo", "stranger", "/review", "NONE")
@@ -297,8 +308,40 @@ class WebhookControllerTest {
     var response = controller.handleWebhook("sha256=valid", "issue_comment", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
-    // A non-collaborator must not be able to spend the operator's API budget.
+    // A user without write access must not be able to spend the operator's API budget.
     verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+  }
+
+  @Test
+  void shouldIgnoreEditedIssueComment() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+
+    var body =
+        buildIssueCommentPayload("edited", 88, "owner/repo", "octocat", "/review")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, DELIVERY, body);
+    assertEquals(200, response.getStatus());
+
+    // Editing a comment must not re-dispatch a review, and authorization is never consulted.
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+    verifyNoInteractions(manualReviewAuthorizer);
+  }
+
+  @Test
+  void shouldIgnoreDeletedIssueComment() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+
+    var body =
+        buildIssueCommentPayload("deleted", 88, "owner/repo", "octocat", "/review")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, DELIVERY, body);
+    assertEquals(200, response.getStatus());
+
+    // Deleting a comment must not re-dispatch a review.
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+    verifyNoInteractions(manualReviewAuthorizer);
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [x] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [x] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Follow-up that hardens the manual-review authorization shipped in #78.

#78 limited manual `/review` triggers to commenters whose GitHub `author_association` is `OWNER`/`MEMBER`/`COLLABORATOR`. A review of that change surfaced three issues:

1. **`author_association` is not a reliable proxy for write access.** `MEMBER` only means membership in the owning organization, so a **read-only org member** could still trigger paid reviews and spend the operator's API budget. It also duplicated authorization logic the project already owns (`DashboardAccessChecker` resolves real repo access via the GitHub API).
2. **No `action` filter.** `issue_comment` fires for `created`, `edited`, and `deleted`; an authorized user editing or deleting a `/review` comment re-dispatched a paid review.
3. The association set was hardcoded with no operator override.

### What this PR does

- Adds **`ManualReviewAuthorizer`**, which confirms the commenter holds **admin/write** permission on the specific repository via the GitHub collaborator-permission API (`GET /repos/{owner}/{repo}/collaborators/{username}/permission`), reusing the existing installation-token flow (`GitHubAuthClient`) and REST client (`GitHubInstallationClient`). `TriggerDetector` goes back to recognizing trigger text only.
- Keeps `author_association` **only as a cheap negative pre-filter**: values that provably cannot hold write access (`CONTRIBUTOR`, `NONE`, …) are rejected without an API round-trip, so public-repo trigger spam cannot exhaust the app's GitHub rate limit. It never grants access on its own.
- Restricts `issue_comment` handling to the **`created`** action.
- Adds a configurable **`thrillhousebot.review.manual-trigger-allowed-logins`** allowlist for explicitly trusted users.
- Fails **closed** on missing permission or any API error. Automatic `pull_request` reviews are unaffected.

## Related Issues

Refs #70, #78

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- New `ManualReviewAuthorizerTest`: read-only `MEMBER` rejected (the over-permit regression), `MEMBER`/`COLLABORATOR`/`OWNER` with write/admin authorized, `OWNER` verified via API rather than trusted on association, non-write associations and blank login rejected without any API call, allowlist match (case-insensitive), case-insensitive permission level, and fail-closed on exception / missing permission.
- `WebhookControllerTest`: updated to the new authorizer; added `edited`/`deleted` action-filter cases (no dispatch, authorizer never consulted).
- Full suite: `./mvnw test` → **733 tests, 0 failures**. `./mvnw spotless:check` passes.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

A read-only org member is now rejected even though their association is `MEMBER`:

```
INFO  Ignoring unauthorized manual review trigger from @member on PR #88
```

## Additional Notes

The write-permission check is a synchronous call on the webhook acknowledgement path; installation tokens are cached by `GitHubAuthClient`, and the negative pre-filter avoids the call entirely for non-collaborators, so the common abuse path makes no API request.
