### PR TITLE
ci: honor severity filter in Trivy SARIF fs scan gate (#76)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
           severity: CRITICAL
           exit-code: "1"
           format: sarif
+          limit-severities-for-sarif: true
           output: trivy-fs.sarif
       - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
         if: always() && github.event_name == 'push'


### PR DESCRIPTION
## What type of PR is this?

- [x] 🏗️ CI/CD

## Description

The `trivy` filesystem job in `.github/workflows/ci.yml` (`scan-type: fs`) uses `format: sarif` with `severity: CRITICAL` and `exit-code: "1"`, but was missing `limit-severities-for-sarif: true`.

With `format: sarif`, `aquasecurity/trivy-action` scans **all** severities by default, so the `severity` filter is ignored for both the SARIF report and the exit code unless `limit-severities-for-sarif: true` is set ([trivy-action#309](https://github.com/aquasecurity/trivy-action/issues/309)).

Because this step **gates** CI (`exit-code: "1"`), it would fail the build on **any** severity finding (including LOW/MEDIUM) rather than only `CRITICAL` as declared. It passes today only because there are no findings; a future non-CRITICAL CVE would break `main`/PR CI inconsistently with the stated gate.

The fix adds the flag directly after `format: sarif`, matching the convention already used in `release.yml` and the `trivy-image` job. The `severity: CRITICAL` filter is kept as-is so the gate matches its declared intent.

```diff
           scan-type: fs
           version: v0.70.0
           scanners: vuln
           severity: CRITICAL
           exit-code: "1"
           format: sarif
+          limit-severities-for-sarif: true
           output: trivy-fs.sarif
```

## Related Issues

Fixes #76

Same root cause as #8 (release gate) and #12 / #75 (report-only image scans); the fs job was the last gating step missing the flag.

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

- `ci.yml` parses as valid YAML after the change.
- Audited every `trivy-action` SARIF step across all workflows (`ci.yml`, `release.yml`, `security-scan.yml`) — all now set `limit-severities-for-sarif: true`.
- The `trivy` CI job (the job modified here) passes green on this PR.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

<!-- N/A: automated tests do not apply to a one-line CI workflow config change; no docs reference this gate. -->

## Screenshots / Logs

```
$ grep -nE "scan-type|severity:|format:|limit-severities-for-sarif|exit-code" .github/workflows/ci.yml
201:          scan-type: fs
204:          severity: CRITICAL
205:          exit-code: "1"
206:          format: sarif
207:          limit-severities-for-sarif: true   # <-- added
208:          output: trivy-fs.sarif
```

## Additional Notes

#82 proposes consolidating the duplicated Trivy scan + upload-SARIF steps into a reusable workflow/composite action; if that lands first it would subsume this change. This PR is the minimal targeted fix in the meantime.