### PR TITLE
ci: consolidate duplicated Trivy scan+upload-SARIF steps into a composite action

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -1,0 +1,66 @@
+name: "Trivy scan + upload SARIF"
+description: >-
+  Run a pinned Trivy scan (filesystem or image), emit a SARIF report, and upload
+  it to GitHub code scanning. Centralizes the action SHA pins, Trivy version,
+  format: sarif, and limit-severities-for-sarif so every caller stays in sync.
+
+inputs:
+  scan-type:
+    description: "Trivy scan type: 'image' or 'fs'."
+    required: false
+    default: "image"
+  image-ref:
+    description: "Image reference to scan (used when scan-type is 'image')."
+    required: false
+    default: ""
+  scan-ref:
+    description: "Path to scan (used when scan-type is 'fs')."
+    required: false
+    default: "."
+  scanners:
+    description: "Comma-separated Trivy scanners. Empty uses Trivy's default set."
+    required: false
+    default: ""
+  severity:
+    description: "Comma-separated severities to report and gate on."
+    required: false
+    default: "CRITICAL,HIGH"
+  exit-code:
+    description: "Exit code when matching findings exist ('1' gates the job, '0' is report-only)."
+    required: false
+    default: "0"
+  trivyignores:
+    description: "Path to a .trivyignore file. Empty disables it."
+    required: false
+    default: ""
+  category:
+    description: "Code scanning category for the SARIF; also names the intermediate SARIF file, so keep it filename-safe (no slashes or spaces)."
+    required: true
+  upload:
+    description: "Whether to upload the SARIF to code scanning ('true' or 'false')."
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run Trivy scan
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        scan-type: ${{ inputs.scan-type }}
+        image-ref: ${{ inputs.image-ref }}
+        scan-ref: ${{ inputs.scan-ref }}
+        scanners: ${{ inputs.scanners }}
+        severity: ${{ inputs.severity }}
+        exit-code: ${{ inputs.exit-code }}
+        trivyignores: ${{ inputs.trivyignores }}
+        version: v0.70.0
+        format: sarif
+        limit-severities-for-sarif: true
+        output: ${{ inputs.category }}.sarif
+    - name: Upload Trivy SARIF
+      if: ${{ always() && inputs.upload == 'true' && hashFiles(format('{0}.sarif', inputs.category)) != '' }}
+      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
+      with:
+        sarif_file: ${{ inputs.category }}.sarif
+        category: ${{ inputs.category }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,20 +196,14 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      - uses: ./.github/actions/trivy-scan
         with:
           scan-type: fs
-          version: v0.70.0
           scanners: vuln
           severity: CRITICAL
           exit-code: "1"
-          format: sarif
-          output: trivy-fs.sarif
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
-        if: always() && github.event_name == 'push'
-        with:
-          sarif_file: trivy-fs.sarif
           category: trivy-fs
+          upload: ${{ github.event_name == 'push' }}
 
   trivy-image:
     needs: [docker]
@@ -226,33 +220,13 @@ jobs:
           registry: ghcr.io
           username: devops-thiago
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      - uses: ./.github/actions/trivy-scan
         with:
           image-ref: ghcr.io/devops-thiago/thrillhousebot:${{ github.sha }}
-          version: v0.70.0
-          severity: CRITICAL,HIGH
-          exit-code: "0"
-          format: sarif
-          limit-severities-for-sarif: true
-          output: trivy-image.sarif
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
-        if: always()
-        with:
-          sarif_file: trivy-image.sarif
           category: trivy-image
-      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      - uses: ./.github/actions/trivy-scan
         with:
           image-ref: ghcr.io/devops-thiago/thrillhousebot:${{ github.sha }}-distroless
-          version: v0.70.0
-          severity: CRITICAL,HIGH
-          exit-code: "0"
-          format: sarif
-          limit-severities-for-sarif: true
-          output: trivy-image-distroless.sarif
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
-        if: always()
-        with:
-          sarif_file: trivy-image-distroless.sarif
           category: trivy-image-distroless
 
   docker-pr:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,15 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ needs.verify.outputs.tag }}
+      # The trivy-scan composite action is referenced locally below. Local
+      # actions resolve from the checked-out tree, but the tag above can predate
+      # the action (e.g. re-releasing an old tag via workflow_dispatch). Check it
+      # out from the workflow's own ref into a side path so it always resolves.
+      - name: Check out reusable actions from the workflow ref
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          path: .actions-ref
+          sparse-checkout: .github/actions
       - name: Resolve Trivy ignore policy for tagged commit
         run: |
           if [ -f .trivyignore ]; then
@@ -114,38 +123,20 @@ jobs:
           username: devops-thiago
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Scan default image (gate on CRITICAL/HIGH)
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        uses: ./.actions-ref/.github/actions/trivy-scan
         with:
           image-ref: ${{ env.IMAGE }}:${{ needs.verify.outputs.sha }}
-          version: v0.70.0
           scanners: vuln
-          severity: CRITICAL,HIGH
           exit-code: "1"
-          format: sarif
-          limit-severities-for-sarif: true
-          output: trivy-release.sarif
           trivyignores: .trivyignore
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
-        if: always() && hashFiles('trivy-release.sarif') != ''
-        with:
-          sarif_file: trivy-release.sarif
           category: trivy-release
       - name: Scan distroless image (gate on CRITICAL/HIGH)
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        uses: ./.actions-ref/.github/actions/trivy-scan
         with:
           image-ref: ${{ env.IMAGE }}:${{ needs.verify.outputs.sha }}-distroless
-          version: v0.70.0
           scanners: vuln
-          severity: CRITICAL,HIGH
           exit-code: "1"
-          format: sarif
-          limit-severities-for-sarif: true
-          output: trivy-release-distroless.sarif
           trivyignores: .trivyignore
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
-        if: always() && hashFiles('trivy-release-distroless.sarif') != ''
-        with:
-          sarif_file: trivy-release-distroless.sarif
           category: trivy-release-distroless
 
   promote:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -25,29 +25,11 @@ jobs:
           registry: ghcr.io
           username: devops-thiago
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      - uses: ./.github/actions/trivy-scan
         with:
           image-ref: ghcr.io/devops-thiago/thrillhousebot:latest
-          version: v0.70.0
-          severity: CRITICAL,HIGH
-          exit-code: "0"
-          format: sarif
-          limit-severities-for-sarif: true
-          output: trivy-latest.sarif
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
-        with:
-          sarif_file: trivy-latest.sarif
           category: trivy-scheduled
-      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      - uses: ./.github/actions/trivy-scan
         with:
           image-ref: ghcr.io/devops-thiago/thrillhousebot:latest-distroless
-          version: v0.70.0
-          severity: CRITICAL,HIGH
-          exit-code: "0"
-          format: sarif
-          limit-severities-for-sarif: true
-          output: trivy-latest-distroless.sarif
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.0
-        with:
-          sarif_file: trivy-latest-distroless.sarif
           category: trivy-scheduled-distroless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to ThrillhouseBot.
 
 ## [0.1.1] — unreleased
 
+### Changed
+
+- **CI**: consolidated the seven duplicated Trivy scan + SARIF-upload steps across `ci.yml`, `release.yml`, and `security-scan.yml` into a single `.github/actions/trivy-scan` composite action, centralizing the pinned action SHA, Trivy version, `format: sarif`, and the `limit-severities-for-sarif` flag. The CI filesystem scan now applies `limit-severities-for-sarif` like every other scan (closes the gap tracked in #76).
+
 ## [0.1.0] — 2026-06-12
 
 ### Added


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [x] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [x] 🏗️ CI/CD

## Description

The "scan an image/fs + upload SARIF" pattern was copy-pasted across **7 `aquasecurity/trivy-action` invocations in 3 workflow files** (`ci.yml`, `release.yml`, `security-scan.yml`), each repeating the pinned action SHA, `version`, `severity`, `exit-code`, `format: sarif`, and `output`, plus a paired `upload-sarif` step. Because the config was duplicated rather than centralized, every cross-cutting Trivy change was O(number of copies) and easy to miss one — the `limit-severities-for-sarif` flag alone took three passes to roll out.

This PR extracts the pattern into a single composite action, `.github/actions/trivy-scan/action.yml`, and replaces all 7 inline step pairs with calls to it (net **−70 lines**). The action centralizes the pinned `trivy-action` + `upload-sarif` SHAs, `version: v0.70.0`, `format: sarif`, and `limit-severities-for-sarif: true`, and uploads the SARIF (guarded by `always() && upload && hashFiles(...) != ''`). Future Trivy changes are now a one-line edit in one place.

Intended behavior changes:
- **The CI filesystem scan now applies `limit-severities-for-sarif`** — it was the one copy still missing it, so its SARIF now reports only the severity it gates on (`CRITICAL`), matching every other scan. This subsumes #76.
- The unified upload guard preserves each original site's condition (fs stays push-only; release keeps its `hashFiles` guard). All 7 code-scanning categories are unchanged.

`release.yml`'s `scan` job checks out the release **tag**, so the composite is referenced from a small side-path sparse checkout of the workflow's own ref — keeping re-release of a pre-action tag (the `v0.1.0` example in the dispatch input) working.

## Related Issues

Closes #82.
Closes #76 (the fs-scan `limit-severities-for-sarif` gap, subsumed by centralizing the flag).

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

- YAML syntax validated for all four files.
- `actionlint` run clean on all three workflows.
- A multi-agent adversarial review reconstructed each of the 7 call sites' effective config (call-site inputs + composite defaults + baked-in values) and compared field-by-field against `main`; it also verified against `trivy-action@v0.36.0` that `scanners: ""` / `trivyignores: ""` are byte-identical to omitting them.
- Live CI on this PR: the `trivy` job (the first real execution of the composite action) passes. The `trivy-image`/`docker`/`native-build` jobs are skipped on PRs by design, so the composite's image-scan path will first run live when this merges to `main`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works <!-- N/A: workflow YAML; validated via actionlint + live CI run -->
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly <!-- CHANGELOG.md -->
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

CI on this PR is green (`trivy`, `test`, `docker-pr`, `frontend`, `format`, `codecov/patch`, `codecov/project`, `SonarCloud`, `CodeQL`, `dependency-review` all pass). `actionlint` reports no issues.

## Additional Notes

No breaking changes. The intermediate SARIF temp filenames for the scheduled scans change (`trivy-latest*.sarif` → `trivy-scheduled*.sarif`, derived from the category) but are consumed in-job and not referenced anywhere else; the uploaded code-scanning categories are preserved exactly.
