### PR TITLE
fix(review): gate the APPROVE verdict on CI status (#95)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import java.util.List;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 @RegisterRestClient(configKey = "github-api")
@@ -45,6 +46,60 @@ public interface GitHubCheckRunClient {
       @PathParam("repo") String repo,
       @PathParam("checkRunId") long checkRunId,
       UpdateCheckRunRequest request);
+
+  @GET
+  @Path("/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks")
+  @Produces(MediaType.APPLICATION_JSON)
+  RequiredStatusChecks getRequiredStatusChecks(
+      @HeaderParam("Authorization") String auth,
+      @HeaderParam("Accept") String accept,
+      @PathParam("owner") String owner,
+      @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
+
+  @GET
+  @Path("/repos/{owner}/{repo}/commits/{ref}/check-runs")
+  @Produces(MediaType.APPLICATION_JSON)
+  CheckRunsResponse getCheckRuns(
+      @HeaderParam("Authorization") String auth,
+      @HeaderParam("Accept") String accept,
+      @PathParam("owner") String owner,
+      @PathParam("repo") String repo,
+      @PathParam("ref") String ref);
+
+  @GET
+  @Path("/repos/{owner}/{repo}/commits/{ref}/status")
+  @Produces(MediaType.APPLICATION_JSON)
+  CombinedStatus getCombinedStatus(
+      @HeaderParam("Authorization") String auth,
+      @HeaderParam("Accept") String accept,
+      @PathParam("owner") String owner,
+      @PathParam("repo") String repo,
+      @PathParam("ref") String ref);
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  record RequiredStatusChecks(List<String> contexts, List<Check> checks) {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Check(String context, @JsonProperty("app_id") Long appId) {}
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  record CheckRunsResponse(
+      @JsonProperty("total_count") int totalCount,
+      @JsonProperty("check_runs") List<CheckRun> checkRuns) {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record CheckRun(long id, String name, String status, String conclusion, App app) {
+      @JsonInclude(JsonInclude.Include.NON_NULL)
+      public record App(@JsonProperty("id") Long id, String slug, String name) {}
+    }
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  record CombinedStatus(
+      String state, @JsonProperty("total_count") int totalCount, List<StatusDetail> statuses) {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record StatusDetail(long id, String state, String context, String description) {}
+  }
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   record CreateCheckRunRequest(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
@@ -79,6 +79,14 @@ public interface GitHubCheckRunClient {
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   record RequiredStatusChecks(List<String> contexts, List<Check> checks) {
+    public List<String> contexts() {
+      return contexts == null ? List.of() : List.copyOf(contexts);
+    }
+
+    public List<Check> checks() {
+      return checks == null ? List.of() : List.copyOf(checks);
+    }
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record Check(String context, @JsonProperty("app_id") Long appId) {}
   }
@@ -87,6 +95,10 @@ public interface GitHubCheckRunClient {
   record CheckRunsResponse(
       @JsonProperty("total_count") int totalCount,
       @JsonProperty("check_runs") List<CheckRun> checkRuns) {
+    public List<CheckRun> checkRuns() {
+      return checkRuns == null ? List.of() : List.copyOf(checkRuns);
+    }
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record CheckRun(long id, String name, String status, String conclusion, App app) {
       @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -97,6 +109,10 @@ public interface GitHubCheckRunClient {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   record CombinedStatus(
       String state, @JsonProperty("total_count") int totalCount, List<StatusDetail> statuses) {
+    public List<StatusDetail> statuses() {
+      return statuses == null ? List.of() : List.copyOf(statuses);
+    }
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record StatusDetail(long id, String state, String context, String description) {}
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
@@ -65,7 +65,9 @@ public interface GitHubCheckRunClient {
       @HeaderParam("Accept") String accept,
       @PathParam("owner") String owner,
       @PathParam("repo") String repo,
-      @PathParam("ref") String ref);
+      @PathParam("ref") String ref,
+      @QueryParam("per_page") @DefaultValue("100") int perPage,
+      @QueryParam("page") @DefaultValue("1") int page);
 
   @GET
   @Path("/repos/{owner}/{repo}/commits/{ref}/status")
@@ -75,7 +77,9 @@ public interface GitHubCheckRunClient {
       @HeaderParam("Accept") String accept,
       @PathParam("owner") String owner,
       @PathParam("repo") String repo,
-      @PathParam("ref") String ref);
+      @PathParam("ref") String ref,
+      @QueryParam("per_page") @DefaultValue("100") int perPage,
+      @QueryParam("page") @DefaultValue("1") int page);
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   record RequiredStatusChecks(List<String> contexts, List<Check> checks) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubPullRequestClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubPullRequestClient.java
@@ -67,7 +67,11 @@ public interface GitHubPullRequestClient {
 
   record PullRequestDetails(String title, String body, Ref head, Ref base) {}
 
-  record Ref(String sha) {}
+  record Ref(String sha, String ref) {
+    public Ref(String sha) {
+      this(sha, null);
+    }
+  }
 
   record FileDiff(
       String filename,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -52,21 +52,36 @@ public class PrSummaryGenerator {
     sb.append("| 🟡 Medium | ").append(result.mediumCount()).append(" |\n");
     sb.append("| 🔵 Low | ").append(result.lowCount()).append(" |\n\n");
 
-    if (result.previousStatuses() != null && !result.previousStatuses().isEmpty()) {
-      sb.append("### Previous Findings Status\n");
-      sb.append("| Status | Count |\n");
-      sb.append("|--------|-------|\n");
-      var resolved =
-          result.previousStatuses().stream().filter(s -> "resolved".equals(s.status())).count();
-      var unresolved =
-          result.previousStatuses().stream().filter(s -> "unresolved".equals(s.status())).count();
-      var justified =
-          result.previousStatuses().stream().filter(s -> "justified".equals(s.status())).count();
-      sb.append("| ✅ Resolved | ").append(resolved).append(" |\n");
-      sb.append("| ⚠️ Still present | ").append(unresolved).append(" |\n");
-      sb.append("| 💬 Justified | ").append(justified).append(" |\n\n");
-    }
+    appendPreviousFindings(sb, result);
+    appendFindingsOrCelebration(sb, result);
+    appendCiChecks(sb, result);
 
+    sb.append("---\n");
+    sb.append("*Automated review by ThrillhouseBot. Reply with `/review` to re-run.*\n");
+
+    return sb.toString();
+  }
+
+  private static void appendPreviousFindings(StringBuilder sb, ReviewResult result) {
+    // The record constructor guarantees a non-null status list.
+    if (result.previousStatuses().isEmpty()) {
+      return;
+    }
+    var resolved =
+        result.previousStatuses().stream().filter(s -> "resolved".equals(s.status())).count();
+    var unresolved =
+        result.previousStatuses().stream().filter(s -> "unresolved".equals(s.status())).count();
+    var justified =
+        result.previousStatuses().stream().filter(s -> "justified".equals(s.status())).count();
+    sb.append("### Previous Findings Status\n");
+    sb.append("| Status | Count |\n");
+    sb.append("|--------|-------|\n");
+    sb.append("| ✅ Resolved | ").append(resolved).append(" |\n");
+    sb.append("| ⚠️ Still present | ").append(unresolved).append(" |\n");
+    sb.append("| 💬 Justified | ").append(justified).append(" |\n\n");
+  }
+
+  private static void appendFindingsOrCelebration(StringBuilder sb, ReviewResult result) {
     if (result.hasIssues()) {
       sb.append("### Key Findings\n");
       List<Finding> topFindings =
@@ -94,32 +109,30 @@ public class PrSummaryGenerator {
             "No new issues found in this PR, but the review cannot be approved until the required checks are passing.\n\n");
       }
     }
+  }
 
-    if (!result.offendingCiChecks().isEmpty()) {
-      sb.append("### ⚠️ Required CI Checks Status\n");
-      sb.append("Some required checks are still pending or have failed:\n\n");
-      sb.append("| Check | Type | Status | Detail |\n");
-      sb.append("|-------|------|--------|--------|\n");
-      for (var check : result.offendingCiChecks()) {
-        String statusEmoji = check.isFailing() ? "❌ Failed" : "⏳ Pending";
-        String detail = check.conclusion() != null ? check.conclusion() : "-";
-        sb.append("| **")
-            .append(check.name())
-            .append("** | ")
-            .append(check.type())
-            .append(" | ")
-            .append(statusEmoji)
-            .append(" | ")
-            .append(detail)
-            .append(" |\n");
-      }
-      sb.append("\n");
+  private static void appendCiChecks(StringBuilder sb, ReviewResult result) {
+    if (result.offendingCiChecks().isEmpty()) {
+      return;
     }
-
-    sb.append("---\n");
-    sb.append("*Automated review by ThrillhouseBot. Reply with `/review` to re-run.*\n");
-
-    return sb.toString();
+    sb.append("### ⚠️ Required CI Checks Status\n");
+    sb.append("Some required checks are still pending or have failed:\n\n");
+    sb.append("| Check | Type | Status | Detail |\n");
+    sb.append("|-------|------|--------|--------|\n");
+    for (var check : result.offendingCiChecks()) {
+      String statusEmoji = check.isFailing() ? "❌ Failed" : "⏳ Pending";
+      String detail = check.conclusion() != null ? check.conclusion() : "-";
+      sb.append("| **")
+          .append(escapeTableCell(check.name()))
+          .append("** | ")
+          .append(escapeTableCell(check.type()))
+          .append(" | ")
+          .append(statusEmoji)
+          .append(" | ")
+          .append(escapeTableCell(detail))
+          .append(" |\n");
+    }
+    sb.append("\n");
   }
 
   /** A clean review celebrates only when nothing from earlier rounds is still unresolved. */
@@ -157,5 +170,13 @@ public class PrSummaryGenerator {
   /** Renders a signed line count, avoiding the awkward "+0"/"-0". */
   private static String signed(char sign, int count) {
     return count == 0 ? "0" : sign + Integer.toString(count);
+  }
+
+  /** Escapes a value for a single Markdown table cell so a literal '|' cannot break the layout. */
+  private static String escapeTableCell(String value) {
+    if (value == null) {
+      return "-";
+    }
+    return value.replace("\\", "\\\\").replace("|", "\\|");
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -95,7 +95,7 @@ public class PrSummaryGenerator {
       }
     }
 
-    if (result.offendingCiChecks() != null && !result.offendingCiChecks().isEmpty()) {
+    if (!result.offendingCiChecks().isEmpty()) {
       sb.append("### ⚠️ Required CI Checks Status\n");
       sb.append("Some required checks are still pending or have failed:\n\n");
       sb.append("| Check | Type | Status | Detail |\n");

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -87,7 +87,33 @@ public class PrSummaryGenerator {
       }
       sb.append("\n");
     } else if (hasNoUnresolvedPrevious(result)) {
-      sb.append(ZERO_ISSUES_MESSAGE).append("\n\n");
+      if (result.offendingCiChecks().isEmpty()) {
+        sb.append(ZERO_ISSUES_MESSAGE).append("\n\n");
+      } else {
+        sb.append(
+            "No new issues found in this PR, but the review cannot be approved until the required checks are passing.\n\n");
+      }
+    }
+
+    if (result.offendingCiChecks() != null && !result.offendingCiChecks().isEmpty()) {
+      sb.append("### ⚠️ Required CI Checks Status\n");
+      sb.append("Some required checks are still pending or have failed:\n\n");
+      sb.append("| Check | Type | Status | Detail |\n");
+      sb.append("|-------|------|--------|--------|\n");
+      for (var check : result.offendingCiChecks()) {
+        String statusEmoji = check.isFailing() ? "❌ Failed" : "⏳ Pending";
+        String detail = check.conclusion() != null ? check.conclusion() : "-";
+        sb.append("| **")
+            .append(check.name())
+            .append("** | ")
+            .append(check.type())
+            .append(" | ")
+            .append(statusEmoji)
+            .append(" | ")
+            .append(detail)
+            .append(" |\n");
+      }
+      sb.append("\n");
     }
 
     sb.append("---\n");

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -34,8 +34,14 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.IntFunction;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 @ApplicationScoped
@@ -52,6 +58,22 @@ public class ReviewOrchestrator {
 
   // Check run conclusion constants
   private static final String CONCLUSION_FAILURE = "failure";
+
+  // CI check evaluation constants
+  private static final String CI_SUCCESS = "success";
+  private static final String CI_PENDING = "pending";
+  private static final String CI_FAILING = "failing";
+
+  // Lowercased token identifying ThrillhouseBot's own checks/apps among CI results.
+  private static final String THRILLHOUSEBOT_TOKEN = "thrillhousebot";
+
+  // Check-run conclusions that count as a passing check (everything else is a failure)
+  private static final Set<String> PASSING_CONCLUSIONS = Set.of(CI_SUCCESS, "skipped", "neutral");
+
+  // CI status pagination: GitHub serves at most 100 rows per page; the loop stops on a short page.
+  // Package-private so the pagination guard can be exercised in tests without 5000 mock rows.
+  static final int CI_PER_PAGE = 100;
+  static final int CI_MAX_PAGES = 50;
 
   private final ThrillhouseConfig config;
   private final GitHubAuthClient authClient;
@@ -251,25 +273,9 @@ public class ReviewOrchestrator {
               aiResponse, priorAiResponseJsons, inlineComments, BOT_LOGIN);
       persistAiResponse(session, aiResponse);
 
-      // Fetch required status checks and evaluate CI checks on the head SHA
-      List<String> requiredContexts = null;
-      try {
-        var prDetails =
-            prClient.getPullRequest(auth, ACCEPT, req.owner(), req.repo(), req.prNumber());
-        if (prDetails != null && prDetails.base() != null && prDetails.base().ref() != null) {
-          var targetBranch = prDetails.base().ref();
-          var protection =
-              checkRunClient.getRequiredStatusChecks(
-                  auth, ACCEPT, req.owner(), req.repo(), targetBranch);
-          if (protection != null) {
-            requiredContexts = protection.contexts();
-          }
-        }
-      } catch (Exception e) {
-        Log.warnf(
-            e, "Could not fetch required status checks for branch, falling back to all checks");
-      }
-
+      // Fetch required status checks and evaluate CI checks on the head SHA. An absent result means
+      // "could not determine required checks" — evaluateCiChecks then gates on all checks (null).
+      List<String> requiredContexts = resolveRequiredContexts(auth, req).orElse(null);
       List<ReviewResult.CiCheck> offendingCiChecks =
           evaluateCiChecks(auth, req.owner(), req.repo(), req.commitSha(), requiredContexts);
 
@@ -662,27 +668,35 @@ public class ReviewOrchestrator {
   }
 
   static String checkTitleForResult(ReviewResult result) {
-    if (!result.hasIssues() && unresolvedPreviousCount(result) == 0) {
+    if (!result.hasIssues()
+        && unresolvedPreviousCount(result) == 0
+        && result.offendingCiChecks().isEmpty()) {
       return CHECK_NAME + " ✅";
     }
     return CHECK_NAME;
   }
 
   static String checkSummaryForResult(ReviewResult result) {
-    if (!result.hasIssues()) {
-      var unresolved = unresolvedPreviousCount(result);
-      if (unresolved == 0) {
-        return ZERO_ISSUES_MESSAGE;
-      }
-      return unresolvedPreviousMessage(unresolved);
+    if (result.hasIssues()) {
+      return String.format(
+          "%d findings: %d critical, %d high, %d medium, %d low",
+          result.totalFindings(),
+          result.criticalCount(),
+          result.highCount(),
+          result.mediumCount(),
+          result.lowCount());
     }
-    return String.format(
-        "%d findings: %d critical, %d high, %d medium, %d low",
-        result.totalFindings(),
-        result.criticalCount(),
-        result.highCount(),
-        result.mediumCount(),
-        result.lowCount());
+    // No new findings — surface CI gating first, since it also holds approval back.
+    if (!result.offendingCiChecks().isEmpty()) {
+      return String.format(
+          "No new issues found, but %d required CI check(s) are still pending or failing.",
+          result.offendingCiChecks().size());
+    }
+    var unresolved = unresolvedPreviousCount(result);
+    if (unresolved == 0) {
+      return ZERO_ISSUES_MESSAGE;
+    }
+    return unresolvedPreviousMessage(unresolved);
   }
 
   static long unresolvedPreviousCount(ReviewResult result) {
@@ -810,51 +824,11 @@ public class ReviewOrchestrator {
     dismissPendingBotReviews(auth, owner, repo, prNumber);
 
     if (!result.hasIssues()) {
-      if (result.reviewState() == ReviewState.APPROVE) {
-        // On a first review the celebration is part of the summary comment, so the approval
-        // itself carries no body; follow-ups post no summary and keep the message here
-        var req =
-            new GitHubReviewClient.CreateReviewRequest(
-                commitSha, result.isFirstReview() ? "" : ZERO_ISSUES_MESSAGE, "APPROVE", List.of());
-        createReviewWithFallback(auth, owner, repo, prNumber, req);
-        return;
-      }
-      // No new findings, but previous ones are still unresolved or CI checks are pending/failed —
-      // never claim a clean review
-      String body;
-      if (!result.offendingCiChecks().isEmpty()) {
-        var sb = new StringBuilder();
-        sb.append(
-            "ThrillhouseBot found no issues in this PR, but some checks are still pending or failed:\n");
-        for (var check : result.offendingCiChecks()) {
-          String status = check.isFailing() ? "failed" : "pending";
-          sb.append("- Check **").append(check.name()).append("** is ").append(status).append("\n");
-        }
-        long unresolved = unresolvedPreviousCount(result);
-        if (unresolved > 0) {
-          sb.append("\nAdditionally, ").append(unresolvedPreviousMessage(unresolved));
-        }
-        body = sb.toString();
-      } else {
-        body = unresolvedPreviousMessage(unresolvedPreviousCount(result));
-      }
-      var req =
-          new GitHubReviewClient.CreateReviewRequest(
-              commitSha,
-              body,
-              result.reviewState() == ReviewState.REQUEST_CHANGES ? "REQUEST_CHANGES" : "COMMENT",
-              List.of());
-      createReviewWithFallback(auth, owner, repo, prNumber, req);
+      postNoIssuesReview(auth, owner, repo, prNumber, commitSha, result);
       return;
     }
 
-    var patchesByFile = new HashMap<String, String>();
-    for (var file : diffFormatter.reviewableFiles(files)) {
-      if (file.patch() != null && !file.patch().isBlank()) {
-        patchesByFile.put(file.filename(), file.patch());
-      }
-    }
-    var lineResolver = new DiffLineResolver(patchesByFile);
+    var lineResolver = new DiffLineResolver(patchesByFile(files));
     var posted = postInlineComments(auth, owner, repo, prNumber, commitSha, result, lineResolver);
 
     if (result.reviewState() == ReviewState.REQUEST_CHANGES && posted > 0) {
@@ -873,6 +847,62 @@ public class ReviewOrchestrator {
           "No inline comments posted for %s/%s #%d — findings are in the PR summary comment only",
           owner, repo, prNumber);
     }
+  }
+
+  /**
+   * Posts the review when there are no new findings: a bare APPROVE, or a COMMENT explaining why.
+   */
+  private void postNoIssuesReview(
+      String auth, String owner, String repo, int prNumber, String commitSha, ReviewResult result) {
+    if (result.reviewState() == ReviewState.APPROVE) {
+      // On a first review the celebration is part of the summary comment, so the approval itself
+      // carries no body; follow-ups post no summary and keep the message here.
+      var req =
+          new GitHubReviewClient.CreateReviewRequest(
+              commitSha, result.isFirstReview() ? "" : ZERO_ISSUES_MESSAGE, "APPROVE", List.of());
+      createReviewWithFallback(auth, owner, repo, prNumber, req);
+      return;
+    }
+    // No new findings, but previous ones are still unresolved or CI checks are pending/failed —
+    // never claim a clean review.
+    var req =
+        new GitHubReviewClient.CreateReviewRequest(
+            commitSha,
+            noIssuesBody(result),
+            result.reviewState() == ReviewState.REQUEST_CHANGES ? "REQUEST_CHANGES" : "COMMENT",
+            List.of());
+    createReviewWithFallback(auth, owner, repo, prNumber, req);
+  }
+
+  /**
+   * Body for a no-new-findings COMMENT review: failing/pending CI checks and/or unresolved items.
+   */
+  private String noIssuesBody(ReviewResult result) {
+    long unresolved = unresolvedPreviousCount(result);
+    if (result.offendingCiChecks().isEmpty()) {
+      return unresolvedPreviousMessage(unresolved);
+    }
+    var sb = new StringBuilder();
+    sb.append(
+        "ThrillhouseBot found no issues in this PR, but some checks are still pending or failed:\n");
+    for (var check : result.offendingCiChecks()) {
+      String status = check.isFailing() ? "failed" : CI_PENDING;
+      sb.append("- Check **").append(check.name()).append("** is ").append(status).append("\n");
+    }
+    if (unresolved > 0) {
+      sb.append("\nAdditionally, ").append(unresolvedPreviousMessage(unresolved));
+    }
+    return sb.toString();
+  }
+
+  private Map<String, String> patchesByFile(List<GitHubPullRequestClient.FileDiff> files) {
+    var patchesByFile = new HashMap<String, String>();
+    for (var file : diffFormatter.reviewableFiles(files)) {
+      if (file.patch() != null && !file.patch().isBlank()) {
+        patchesByFile.put(file.filename(), file.patch());
+      }
+    }
+    return patchesByFile;
   }
 
   /**
@@ -1004,112 +1034,171 @@ public class ReviewOrchestrator {
     }
   }
 
+  /**
+   * Resolves the required status-check contexts for the PR's target branch, returning {@code null}
+   * (gate on all checks) when the branch is unprotected or the lookup fails.
+   */
+  private Optional<List<String>> resolveRequiredContexts(String auth, ReviewRequest req) {
+    try {
+      var prDetails =
+          prClient.getPullRequest(auth, ACCEPT, req.owner(), req.repo(), req.prNumber());
+      if (prDetails == null || prDetails.base() == null || prDetails.base().ref() == null) {
+        return Optional.empty();
+      }
+      var protection =
+          checkRunClient.getRequiredStatusChecks(
+              auth, ACCEPT, req.owner(), req.repo(), prDetails.base().ref());
+      return protection == null ? Optional.empty() : Optional.of(protection.contexts());
+    } catch (Exception e) {
+      Log.warnf(e, "Could not fetch required status checks for branch, falling back to all checks");
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Returns only the <em>offending</em> CI checks on {@code commitSha} — those that are pending,
+   * failing, or (when required) missing entirely. Passing checks are deliberately excluded so the
+   * caller can gate APPROVE on a non-empty result; a successful required check is recorded in
+   * {@code seen} so it is not later mistaken for a missing one.
+   */
   List<ReviewResult.CiCheck> evaluateCiChecks(
       String auth, String owner, String repo, String commitSha, List<String> requiredContexts) {
-    List<ReviewResult.CiCheck> checks = new ArrayList<>();
+    var offending = new ArrayList<ReviewResult.CiCheck>();
+    // Required contexts that reported in any state, so the missing-check pass does not re-flag a
+    // green check as pending.
+    var seen = new HashSet<String>();
+    // Contexts already recorded as offending, so a check reported through BOTH the Check Runs API
+    // and the Commit Status API is not listed twice.
+    var offendingNames = new HashSet<String>();
 
-    // 1. Get Check Runs
     try {
-      var checkRunsResponse = checkRunClient.getCheckRuns(auth, ACCEPT, owner, repo, commitSha);
-      if (checkRunsResponse != null && checkRunsResponse.checkRuns() != null) {
-        for (var run : checkRunsResponse.checkRuns()) {
-          // Ignore ThrillhouseBot's own check runs
-          if (isThrillhouseBotCheck(run.name(), run.app())) {
-            continue;
-          }
-
-          // If requiredContexts is provided, check if this run is in it
-          if (requiredContexts != null && !requiredContexts.contains(run.name())) {
-            continue;
-          }
-
-          String ciStatus = "success";
-          if (!"completed".equalsIgnoreCase(run.status())) {
-            ciStatus = "pending";
-          } else if (run.conclusion() == null
-              || !List.of("success", "skipped", "neutral")
-                  .contains(run.conclusion().toLowerCase(java.util.Locale.ROOT))) {
-            ciStatus = "failing";
-          }
-
-          checks.add(new ReviewResult.CiCheck(run.name(), "check-run", ciStatus, run.conclusion()));
-        }
-      }
+      collectPaged(
+          page -> {
+            var resp =
+                checkRunClient.getCheckRuns(
+                    auth, ACCEPT, owner, repo, commitSha, CI_PER_PAGE, page);
+            return resp == null ? null : resp.checkRuns();
+          },
+          run -> addOffendingCheckRun(run, requiredContexts, seen, offendingNames, offending));
     } catch (Exception e) {
       Log.warnf(e, "Failed to fetch check runs for commit %s", commitSha);
     }
 
-    // 2. Get Combined Statuses
     try {
-      var combinedStatus = checkRunClient.getCombinedStatus(auth, ACCEPT, owner, repo, commitSha);
-      if (combinedStatus != null && combinedStatus.statuses() != null) {
-        for (var status : combinedStatus.statuses()) {
-          if (isThrillhouseBotCheck(status.context(), null)) {
-            continue;
-          }
-
-          if (requiredContexts != null && !requiredContexts.contains(status.context())) {
-            continue;
-          }
-
-          String ciStatus = "success";
-          if ("pending".equalsIgnoreCase(status.state())) {
-            ciStatus = "pending";
-          } else if ("failure".equalsIgnoreCase(status.state())
-              || "error".equalsIgnoreCase(status.state())) {
-            ciStatus = "failing";
-          }
-
-          checks.add(
-              new ReviewResult.CiCheck(status.context(), "status", ciStatus, status.state()));
-        }
-      }
+      collectPaged(
+          page -> {
+            var resp =
+                checkRunClient.getCombinedStatus(
+                    auth, ACCEPT, owner, repo, commitSha, CI_PER_PAGE, page);
+            return resp == null ? null : resp.statuses();
+          },
+          status -> addOffendingStatus(status, requiredContexts, seen, offendingNames, offending));
     } catch (Exception e) {
       Log.warnf(e, "Failed to fetch combined status for commit %s", commitSha);
     }
 
-    // 3. If requiredContexts is provided, check if any required contexts are missing entirely
-    if (requiredContexts != null) {
-      for (String required : requiredContexts) {
-        // ThrillhouseBot itself must never be added as missing/pending
-        if (isThrillhouseBotCheck(required, null)) {
-          continue;
-        }
-        boolean found = false;
-        for (var check : checks) {
-          if (required.equals(check.name())) {
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          // A required check that hasn't reported anything is implicitly pending
-          checks.add(new ReviewResult.CiCheck(required, "missing", "pending", null));
-        }
+    addMissingRequiredChecks(requiredContexts, seen, offending);
+    return offending;
+  }
+
+  /**
+   * Pages through a GitHub list endpoint, applying {@code consume} to every row. Stops on an empty
+   * or short page (GitHub's last-page marker) or once {@link #CI_MAX_PAGES} is reached.
+   */
+  private static <T> void collectPaged(IntFunction<List<T>> fetchPage, Consumer<T> consume) {
+    List<T> page = null;
+    for (int p = 1; p <= CI_MAX_PAGES && (page == null || page.size() == CI_PER_PAGE); p++) {
+      page = fetchPage.apply(p);
+      if (page == null) {
+        page = List.of();
+      }
+      page.forEach(consume);
+    }
+  }
+
+  private void addOffendingCheckRun(
+      GitHubCheckRunClient.CheckRunsResponse.CheckRun run,
+      List<String> requiredContexts,
+      Set<String> seen,
+      Set<String> offendingNames,
+      List<ReviewResult.CiCheck> offending) {
+    if (isThrillhouseBotCheck(run.name(), run.app())
+        || isNotRequired(run.name(), requiredContexts)) {
+      return;
+    }
+    seen.add(run.name());
+    String ciStatus = classifyCheckRun(run.status(), run.conclusion());
+    if (!CI_SUCCESS.equals(ciStatus) && offendingNames.add(run.name())) {
+      offending.add(new ReviewResult.CiCheck(run.name(), "check-run", ciStatus, run.conclusion()));
+    }
+  }
+
+  private void addOffendingStatus(
+      GitHubCheckRunClient.CombinedStatus.StatusDetail status,
+      List<String> requiredContexts,
+      Set<String> seen,
+      Set<String> offendingNames,
+      List<ReviewResult.CiCheck> offending) {
+    if (isThrillhouseBotCheck(status.context(), null)
+        || isNotRequired(status.context(), requiredContexts)) {
+      return;
+    }
+    seen.add(status.context());
+    String ciStatus = classifyStatus(status.state());
+    if (!CI_SUCCESS.equals(ciStatus) && offendingNames.add(status.context())) {
+      offending.add(new ReviewResult.CiCheck(status.context(), "status", ciStatus, status.state()));
+    }
+  }
+
+  /** Required contexts that never reported are implicitly pending. */
+  private void addMissingRequiredChecks(
+      List<String> requiredContexts, Set<String> seen, List<ReviewResult.CiCheck> offending) {
+    if (requiredContexts == null) {
+      return;
+    }
+    for (String required : requiredContexts) {
+      // seen.add is false when the context already reported (or is a duplicate entry) — skip those.
+      if (!isThrillhouseBotCheck(required, null) && seen.add(required)) {
+        offending.add(new ReviewResult.CiCheck(required, "missing", CI_PENDING, null));
       }
     }
+  }
 
-    return checks;
+  private static boolean isNotRequired(String name, List<String> requiredContexts) {
+    return requiredContexts != null && !requiredContexts.contains(name);
+  }
+
+  /** Maps a check-run status/conclusion pair to one of success/pending/failing. */
+  private static String classifyCheckRun(String status, String conclusion) {
+    if (!CHECK_STATUS_COMPLETED.equalsIgnoreCase(status)) {
+      return CI_PENDING;
+    }
+    if (conclusion == null || !PASSING_CONCLUSIONS.contains(conclusion.toLowerCase(Locale.ROOT))) {
+      return CI_FAILING;
+    }
+    return CI_SUCCESS;
+  }
+
+  /** Maps a commit-status state to one of success/pending/failing. */
+  private static String classifyStatus(String state) {
+    if (CI_PENDING.equalsIgnoreCase(state)) {
+      return CI_PENDING;
+    }
+    if (CONCLUSION_FAILURE.equalsIgnoreCase(state) || "error".equalsIgnoreCase(state)) {
+      return CI_FAILING;
+    }
+    return CI_SUCCESS;
   }
 
   private boolean isThrillhouseBotCheck(
       String name, GitHubCheckRunClient.CheckRunsResponse.CheckRun.App app) {
-    if (name != null) {
-      if (name.equalsIgnoreCase(CHECK_NAME)
-          || name.toLowerCase(java.util.Locale.ROOT).contains("thrillhousebot")) {
-        return true;
-      }
+    if (name != null && (name.equalsIgnoreCase(CHECK_NAME) || containsBotToken(name))) {
+      return true;
     }
-    if (app != null) {
-      if (app.slug() != null
-          && app.slug().toLowerCase(java.util.Locale.ROOT).contains("thrillhousebot")) {
-        return true;
-      }
-      if (app.name() != null
-          && app.name().toLowerCase(java.util.Locale.ROOT).contains("thrillhousebot")) {
-        return true;
-      }
-    }
-    return false;
+    return app != null && (containsBotToken(app.slug()) || containsBotToken(app.name()));
+  }
+
+  private static boolean containsBotToken(String value) {
+    return value != null && value.toLowerCase(Locale.ROOT).contains(THRILLHOUSEBOT_TOKEN);
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -1028,7 +1028,7 @@ public class ReviewOrchestrator {
             ciStatus = "pending";
           } else if (run.conclusion() == null
               || !List.of("success", "skipped", "neutral")
-                  .contains(run.conclusion().toLowerCase())) {
+                  .contains(run.conclusion().toLowerCase(java.util.Locale.ROOT))) {
             ciStatus = "failing";
           }
 
@@ -1095,15 +1095,18 @@ public class ReviewOrchestrator {
   private boolean isThrillhouseBotCheck(
       String name, GitHubCheckRunClient.CheckRunsResponse.CheckRun.App app) {
     if (name != null) {
-      if (name.equalsIgnoreCase(CHECK_NAME) || name.toLowerCase().contains("thrillhousebot")) {
+      if (name.equalsIgnoreCase(CHECK_NAME)
+          || name.toLowerCase(java.util.Locale.ROOT).contains("thrillhousebot")) {
         return true;
       }
     }
     if (app != null) {
-      if (app.slug() != null && app.slug().toLowerCase().contains("thrillhousebot")) {
+      if (app.slug() != null
+          && app.slug().toLowerCase(java.util.Locale.ROOT).contains("thrillhousebot")) {
         return true;
       }
-      if (app.name() != null && app.name().toLowerCase().contains("thrillhousebot")) {
+      if (app.name() != null
+          && app.name().toLowerCase(java.util.Locale.ROOT).contains("thrillhousebot")) {
         return true;
       }
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -251,11 +251,34 @@ public class ReviewOrchestrator {
               aiResponse, priorAiResponseJsons, inlineComments, BOT_LOGIN);
       persistAiResponse(session, aiResponse);
 
+      // Fetch required status checks and evaluate CI checks on the head SHA
+      List<String> requiredContexts = null;
+      try {
+        var prDetails =
+            prClient.getPullRequest(auth, ACCEPT, req.owner(), req.repo(), req.prNumber());
+        if (prDetails != null && prDetails.base() != null && prDetails.base().ref() != null) {
+          var targetBranch = prDetails.base().ref();
+          var protection =
+              checkRunClient.getRequiredStatusChecks(
+                  auth, ACCEPT, req.owner(), req.repo(), targetBranch);
+          if (protection != null) {
+            requiredContexts = protection.contexts();
+          }
+        }
+      } catch (Exception e) {
+        Log.warnf(
+            e, "Could not fetch required status checks for branch, falling back to all checks");
+      }
+
+      List<ReviewResult.CiCheck> offendingCiChecks =
+          evaluateCiChecks(auth, req.owner(), req.repo(), req.commitSha(), requiredContexts);
+
       DiffStats diffStats = DiffStats.fromFiles(diffFormatter.reviewableFiles(files));
       var unresolvedPrevious =
           followUpAnalyzer.unresolvedFindings(
               previousAiResponseJson, aiResponse.previousFindingsStatus());
-      var result = buildResult(aiResponse, isFirstReview, diffStats, unresolvedPrevious);
+      var result =
+          buildResult(aiResponse, isFirstReview, diffStats, unresolvedPrevious, offendingCiChecks);
 
       // Finalize check run before posting PR review — avoid approving then failing later
       String conclusion = conclusionForResult(result);
@@ -691,7 +714,8 @@ public class ReviewOrchestrator {
       ReviewResponse aiResponse,
       boolean isFirstReview,
       DiffStats diffStats,
-      List<Finding> unresolvedPrevious) {
+      List<Finding> unresolvedPrevious,
+      List<ReviewResult.CiCheck> offendingCiChecks) {
     var findings = new ArrayList<Finding>();
     var critical = 0;
     var high = 0;
@@ -727,6 +751,11 @@ public class ReviewOrchestrator {
       state = ReviewState.COMMENT;
     }
 
+    // Gating approval verdict on CI status:
+    if (state == ReviewState.APPROVE && !offendingCiChecks.isEmpty()) {
+      state = ReviewState.COMMENT;
+    }
+
     // The summary is generated for clean reviews too: a zero-findings result still reports the
     // change overview and carries the celebration line inside the same comment
     var summaryMarkdown =
@@ -745,7 +774,8 @@ public class ReviewOrchestrator {
                 state,
                 isFirstReview,
                 "",
-                previousStatuses));
+                previousStatuses,
+                offendingCiChecks));
 
     return new ReviewResult(
         findings,
@@ -757,7 +787,16 @@ public class ReviewOrchestrator {
         state,
         isFirstReview,
         summaryMarkdown,
-        previousStatuses);
+        previousStatuses,
+        offendingCiChecks);
+  }
+
+  ReviewResult buildResult(
+      ReviewResponse aiResponse,
+      boolean isFirstReview,
+      DiffStats diffStats,
+      List<Finding> unresolvedPrevious) {
+    return buildResult(aiResponse, isFirstReview, diffStats, unresolvedPrevious, List.of());
   }
 
   void postReview(
@@ -780,11 +819,29 @@ public class ReviewOrchestrator {
         createReviewWithFallback(auth, owner, repo, prNumber, req);
         return;
       }
-      // No new findings, but previous ones are still unresolved — never claim a clean review
+      // No new findings, but previous ones are still unresolved or CI checks are pending/failed —
+      // never claim a clean review
+      String body;
+      if (!result.offendingCiChecks().isEmpty()) {
+        var sb = new StringBuilder();
+        sb.append(
+            "ThrillhouseBot found no issues in this PR, but some checks are still pending or failed:\n");
+        for (var check : result.offendingCiChecks()) {
+          String status = check.isFailing() ? "failed" : "pending";
+          sb.append("- Check **").append(check.name()).append("** is ").append(status).append("\n");
+        }
+        long unresolved = unresolvedPreviousCount(result);
+        if (unresolved > 0) {
+          sb.append("\nAdditionally, ").append(unresolvedPreviousMessage(unresolved));
+        }
+        body = sb.toString();
+      } else {
+        body = unresolvedPreviousMessage(unresolvedPreviousCount(result));
+      }
       var req =
           new GitHubReviewClient.CreateReviewRequest(
               commitSha,
-              unresolvedPreviousMessage(unresolvedPreviousCount(result)),
+              body,
               result.reviewState() == ReviewState.REQUEST_CHANGES ? "REQUEST_CHANGES" : "COMMENT",
               List.of());
       createReviewWithFallback(auth, owner, repo, prNumber, req);
@@ -945,5 +1002,111 @@ public class ReviewOrchestrator {
               req.commitId(), req.body(), req.event(), List.of());
       reviewClient.createReview(auth, ACCEPT, owner, repo, prNumber, fallback);
     }
+  }
+
+  List<ReviewResult.CiCheck> evaluateCiChecks(
+      String auth, String owner, String repo, String commitSha, List<String> requiredContexts) {
+    List<ReviewResult.CiCheck> checks = new ArrayList<>();
+
+    // 1. Get Check Runs
+    try {
+      var checkRunsResponse = checkRunClient.getCheckRuns(auth, ACCEPT, owner, repo, commitSha);
+      if (checkRunsResponse != null && checkRunsResponse.checkRuns() != null) {
+        for (var run : checkRunsResponse.checkRuns()) {
+          // Ignore ThrillhouseBot's own check runs
+          if (isThrillhouseBotCheck(run.name(), run.app())) {
+            continue;
+          }
+
+          // If requiredContexts is provided, check if this run is in it
+          if (requiredContexts != null && !requiredContexts.contains(run.name())) {
+            continue;
+          }
+
+          String ciStatus = "success";
+          if (!"completed".equalsIgnoreCase(run.status())) {
+            ciStatus = "pending";
+          } else if (run.conclusion() == null
+              || !List.of("success", "skipped", "neutral")
+                  .contains(run.conclusion().toLowerCase())) {
+            ciStatus = "failing";
+          }
+
+          checks.add(new ReviewResult.CiCheck(run.name(), "check-run", ciStatus, run.conclusion()));
+        }
+      }
+    } catch (Exception e) {
+      Log.warnf(e, "Failed to fetch check runs for commit %s", commitSha);
+    }
+
+    // 2. Get Combined Statuses
+    try {
+      var combinedStatus = checkRunClient.getCombinedStatus(auth, ACCEPT, owner, repo, commitSha);
+      if (combinedStatus != null && combinedStatus.statuses() != null) {
+        for (var status : combinedStatus.statuses()) {
+          if (isThrillhouseBotCheck(status.context(), null)) {
+            continue;
+          }
+
+          if (requiredContexts != null && !requiredContexts.contains(status.context())) {
+            continue;
+          }
+
+          String ciStatus = "success";
+          if ("pending".equalsIgnoreCase(status.state())) {
+            ciStatus = "pending";
+          } else if ("failure".equalsIgnoreCase(status.state())
+              || "error".equalsIgnoreCase(status.state())) {
+            ciStatus = "failing";
+          }
+
+          checks.add(
+              new ReviewResult.CiCheck(status.context(), "status", ciStatus, status.state()));
+        }
+      }
+    } catch (Exception e) {
+      Log.warnf(e, "Failed to fetch combined status for commit %s", commitSha);
+    }
+
+    // 3. If requiredContexts is provided, check if any required contexts are missing entirely
+    if (requiredContexts != null) {
+      for (String required : requiredContexts) {
+        // ThrillhouseBot itself must never be added as missing/pending
+        if (isThrillhouseBotCheck(required, null)) {
+          continue;
+        }
+        boolean found = false;
+        for (var check : checks) {
+          if (required.equals(check.name())) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          // A required check that hasn't reported anything is implicitly pending
+          checks.add(new ReviewResult.CiCheck(required, "missing", "pending", null));
+        }
+      }
+    }
+
+    return checks;
+  }
+
+  private boolean isThrillhouseBotCheck(
+      String name, GitHubCheckRunClient.CheckRunsResponse.CheckRun.App app) {
+    if (name != null) {
+      if (name.equalsIgnoreCase(CHECK_NAME) || name.toLowerCase().contains("thrillhousebot")) {
+        return true;
+      }
+    }
+    if (app != null) {
+      if (app.slug() != null && app.slug().toLowerCase().contains("thrillhousebot")) {
+        return true;
+      }
+      if (app.name() != null && app.name().toLowerCase().contains("thrillhousebot")) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -30,15 +30,42 @@ public record ReviewResult(
     ReviewState reviewState,
     boolean isFirstReview,
     String summaryMarkdown,
-    List<PreviousFindingStatus> previousStatuses) {
+    List<PreviousFindingStatus> previousStatuses,
+    List<CiCheck> offendingCiChecks) {
   public ReviewResult {
     findings = List.copyOf(findings);
     previousStatuses = List.copyOf(previousStatuses);
+    offendingCiChecks = offendingCiChecks == null ? List.of() : List.copyOf(offendingCiChecks);
     // Check-run conclusion derivation relies on a non-null state; fall back to the
     // canonical risk mapping rather than NPE on an inconsistent record
     if (reviewState == null) {
       reviewState = ReviewState.fromHighestRisk(highestRisk);
     }
+  }
+
+  public ReviewResult(
+      List<Finding> findings,
+      int criticalCount,
+      int highCount,
+      int mediumCount,
+      int lowCount,
+      RiskLevel highestRisk,
+      ReviewState reviewState,
+      boolean isFirstReview,
+      String summaryMarkdown,
+      List<PreviousFindingStatus> previousStatuses) {
+    this(
+        findings,
+        criticalCount,
+        highCount,
+        mediumCount,
+        lowCount,
+        highestRisk,
+        reviewState,
+        isFirstReview,
+        summaryMarkdown,
+        previousStatuses,
+        List.of());
   }
 
   public boolean hasIssues() {
@@ -54,4 +81,15 @@ public record ReviewResult(
       int id,
       String status, // resolved, unresolved, justified
       String note) {}
+
+  @RegisterForReflection
+  public record CiCheck(String name, String type, String status, String conclusion) {
+    public boolean isPending() {
+      return "pending".equalsIgnoreCase(status);
+    }
+
+    public boolean isFailing() {
+      return "failing".equalsIgnoreCase(status);
+    }
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -226,7 +226,7 @@ class PrSummaryGeneratorTest {
   void shouldShowRequiredCiChecksStatusWhenNotEmpty() {
     var checks =
         List.of(
-            new ReviewResult.CiCheck("build", "check-run", "failing", "failure"),
+            new ReviewResult.CiCheck("build", "check-run", "failing", null),
             new ReviewResult.CiCheck("test", "status", "pending", "pending"));
     var result =
         new ReviewResult(
@@ -242,5 +242,22 @@ class PrSummaryGeneratorTest {
     assertTrue(summary.contains("⏳ Pending"));
     assertTrue(summary.contains("**build**"));
     assertTrue(summary.contains("**test**"));
+  }
+
+  @Test
+  void shouldShowRequiredCiChecksStatusWhenFindingsExist() {
+    var findings = List.of(new Finding(RiskLevel.LOW, "src/A.java", 1, "Nit", "d", null, null));
+    var checks = List.of(new ReviewResult.CiCheck("lint", "status", "failing", "failure"));
+    var result =
+        new ReviewResult(
+            findings, 0, 0, 0, 1, RiskLevel.LOW, ReviewState.COMMENT, true, "", List.of(), checks);
+
+    var summary = generator.generate(1, 10, 2, null, result);
+
+    assertFalse(summary.contains("Everything's coming up Thrillhouse"));
+    assertTrue(summary.contains("Key Findings"));
+    assertTrue(summary.contains("Required CI Checks Status"));
+    assertTrue(summary.contains("❌ Failed"));
+    assertTrue(summary.contains("**lint**"));
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -221,4 +221,26 @@ class PrSummaryGeneratorTest {
     assertTrue(summary.contains("M1"));
     assertFalse(summary.contains("L1")); // 6th should be excluded
   }
+
+  @Test
+  void shouldShowRequiredCiChecksStatusWhenNotEmpty() {
+    var checks =
+        List.of(
+            new ReviewResult.CiCheck("build", "check-run", "failing", "failure"),
+            new ReviewResult.CiCheck("test", "status", "pending", "pending"));
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), checks);
+
+    var summary = generator.generate(1, 10, 2, null, result);
+
+    assertFalse(summary.contains("Everything's coming up Thrillhouse"));
+    assertTrue(
+        summary.contains("No new issues found in this PR, but the review cannot be approved"));
+    assertTrue(summary.contains("Required CI Checks Status"));
+    assertTrue(summary.contains("❌ Failed"));
+    assertTrue(summary.contains("⏳ Pending"));
+    assertTrue(summary.contains("**build**"));
+    assertTrue(summary.contains("**test**"));
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -260,4 +260,33 @@ class PrSummaryGeneratorTest {
     assertTrue(summary.contains("❌ Failed"));
     assertTrue(summary.contains("**lint**"));
   }
+
+  @Test
+  void shouldEscapePipesInCiCheckTableCells() {
+    // A check name containing '|' must be escaped so it cannot break the Markdown table layout.
+    var checks =
+        List.of(new ReviewResult.CiCheck("build | strict", "check-run", "failing", "failure"));
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), checks);
+
+    var summary = generator.generate(1, 10, 2, null, result);
+
+    assertTrue(summary.contains("build \\| strict"));
+    assertFalse(summary.contains("build | strict"));
+  }
+
+  @Test
+  void shouldRenderDashForNullCheckNameInCiTable() {
+    var checks = List.of(new ReviewResult.CiCheck(null, "missing", "pending", null));
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), checks);
+
+    var summary = generator.generate(1, 10, 2, null, result);
+
+    // A null name/conclusion renders as "-" rather than throwing.
+    assertTrue(summary.contains("Required CI Checks Status"));
+    assertTrue(summary.contains("⏳ Pending"));
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -780,6 +780,21 @@ class ReviewOrchestratorTest {
 
       assertEquals("ThrillhouseBot Review ✅", title);
     }
+
+    @Test
+    void shouldNotCelebrateWhenCiChecksAreOffendingDespiteNoFindings() {
+      // No findings and nothing unresolved, but a required check is failing: the bot's own check
+      // run must not show the green ✅ title nor the zero-issues celebration summary.
+      var offending = List.of(new ReviewResult.CiCheck("build", "check-run", "failing", "failure"));
+      var result =
+          new ReviewResult(
+              List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), offending);
+
+      assertFalse(ReviewOrchestrator.checkTitleForResult(result).contains("✅"));
+      String summary = ReviewOrchestrator.checkSummaryForResult(result);
+      assertFalse(summary.contains("Everything's coming up Thrillhouse"));
+      assertTrue(summary.contains("required CI check(s) are still pending or failing"));
+    }
   }
 
   // ─────────────────────────────────────────────────────────────
@@ -2627,6 +2642,13 @@ class ReviewOrchestratorTest {
         orchestrator.review(
             new ReviewOrchestrator.ReviewRequest(
                 "owner", "repo", 7, "", "(manual review)", "", "", "main", 123L, true));
+
+        // The thrown getRequiredStatusChecks must be swallowed: the review still finalizes its
+        // check run and posts a review rather than failing the whole run.
+        verify(checkRunClient)
+            .updateCheckRun(anyString(), anyString(), anyString(), anyString(), anyLong(), any());
+        verify(reviewClient)
+            .createReview(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
       }
     }
   }
@@ -2916,31 +2938,32 @@ class ReviewOrchestratorTest {
 
     @Test
     void shouldIgnoreThrillhouseBotChecks() {
-      // Setup check runs
+      // All checks below are failing; only the genuinely-non-bot ones must surface as offending,
+      // proving the ThrillhouseBot checks are dropped by bot-detection rather than by being green.
       var app =
           new GitHubCheckRunClient.CheckRunsResponse.CheckRun.App(
               1L, "thrillhousebot", "ThrillhouseBot");
       var tbRun =
           new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
-              1L, "ThrillhouseBot Review", "completed", "success", app);
+              1L, "ThrillhouseBot Review", "completed", "failure", app);
       var appSlugRun =
           new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
               10L,
               "Some Checks",
               "completed",
-              "success",
+              "failure",
               new GitHubCheckRunClient.CheckRunsResponse.CheckRun.App(2L, "thrillhousebot", null));
       var appNameRun =
           new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
               11L,
               "Other Checks",
               "completed",
-              "success",
+              "failure",
               new GitHubCheckRunClient.CheckRunsResponse.CheckRun.App(3L, null, "ThrillhouseBot"));
       var otherRun =
           new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
-              2L, "build", "completed", "success", null);
-      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any()))
+              2L, "build", "completed", "failure", null);
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
           .thenReturn(
               new GitHubCheckRunClient.CheckRunsResponse(
                   4, List.of(tbRun, appSlugRun, appNameRun, otherRun)));
@@ -2948,13 +2971,13 @@ class ReviewOrchestratorTest {
       // Setup statuses
       var tbStatus =
           new GitHubCheckRunClient.CombinedStatus.StatusDetail(
-              1L, "success", "thrillhousebot-status", "desc");
+              1L, "failure", "thrillhousebot-status", "desc");
       var otherStatus =
-          new GitHubCheckRunClient.CombinedStatus.StatusDetail(2L, "success", "lint", "desc");
-      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any()))
+          new GitHubCheckRunClient.CombinedStatus.StatusDetail(2L, "failure", "lint", "desc");
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
           .thenReturn(
               new GitHubCheckRunClient.CombinedStatus(
-                  "success", 2, List.of(tbStatus, otherStatus)));
+                  "failure", 2, List.of(tbStatus, otherStatus)));
 
       var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
 
@@ -2965,23 +2988,48 @@ class ReviewOrchestratorTest {
     }
 
     @Test
-    void shouldFilterByRequiredContextsWhenProvided() {
-      var run1 =
+    void shouldExcludePassingChecksFromOffendingList() {
+      // Every check is green — the offending list must come back empty so APPROVE is not gated.
+      var passRun =
           new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
               1L, "build", "completed", "success", null);
+      var skippedRun =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              2L, "docs", "completed", "skipped", null);
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(2, List.of(passRun, skippedRun)));
+      var passStatus =
+          new GitHubCheckRunClient.CombinedStatus.StatusDetail(1L, "success", "lint", "desc");
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CombinedStatus("success", 1, List.of(passStatus)));
+
+      // requiredContexts lists checks that are all green and already reported — none is missing.
+      var result =
+          orchestrator.evaluateCiChecks(
+              "auth", "owner", "repo", "sha", List.of("build", "docs", "lint"));
+
+      assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldFilterByRequiredContextsWhenProvided() {
+      // All four checks are failing; only the two in requiredContexts must surface as offending.
+      var run1 =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              1L, "build", "completed", "failure", null);
       var run2 =
           new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
-              2L, "test", "completed", "success", null);
-      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any()))
+              2L, "test", "completed", "failure", null);
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
           .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(2, List.of(run1, run2)));
 
       var status1 =
-          new GitHubCheckRunClient.CombinedStatus.StatusDetail(1L, "success", "lint", "desc");
+          new GitHubCheckRunClient.CombinedStatus.StatusDetail(1L, "failure", "lint", "desc");
       var status2 =
-          new GitHubCheckRunClient.CombinedStatus.StatusDetail(2L, "success", "deploy", "desc");
-      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any()))
+          new GitHubCheckRunClient.CombinedStatus.StatusDetail(2L, "failure", "deploy", "desc");
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
           .thenReturn(
-              new GitHubCheckRunClient.CombinedStatus("success", 2, List.of(status1, status2)));
+              new GitHubCheckRunClient.CombinedStatus("failure", 2, List.of(status1, status2)));
 
       var result =
           orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", List.of("build", "lint"));
@@ -2995,9 +3043,9 @@ class ReviewOrchestratorTest {
 
     @Test
     void shouldMarkMissingRequiredChecksAsPending() {
-      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any()))
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
           .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(0, List.of()));
-      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any()))
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
           .thenReturn(new GitHubCheckRunClient.CombinedStatus("success", 0, List.of()));
 
       var result =
@@ -3026,7 +3074,7 @@ class ReviewOrchestratorTest {
       var runSkipped =
           new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
               3L, "docs", "completed", "skipped", null);
-      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any()))
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
           .thenReturn(
               new GitHubCheckRunClient.CheckRunsResponse(
                   3, List.of(runPending, runFailed, runSkipped)));
@@ -3037,14 +3085,15 @@ class ReviewOrchestratorTest {
       // 5. Error status
       var statusError =
           new GitHubCheckRunClient.CombinedStatus.StatusDetail(2L, "error", "security", "desc");
-      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any()))
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
           .thenReturn(
               new GitHubCheckRunClient.CombinedStatus(
                   "pending", 2, List.of(statusPending, statusError)));
 
       var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
 
-      assertEquals(5, result.size());
+      // docs (skipped → passing) is excluded; only the four offending checks remain.
+      assertEquals(4, result.size());
 
       var build = result.stream().filter(c -> "build".equals(c.name())).findFirst().orElseThrow();
       assertEquals("pending", build.status());
@@ -3052,8 +3101,7 @@ class ReviewOrchestratorTest {
       var test = result.stream().filter(c -> "test".equals(c.name())).findFirst().orElseThrow();
       assertEquals("failing", test.status());
 
-      var docs = result.stream().filter(c -> "docs".equals(c.name())).findFirst().orElseThrow();
-      assertEquals("success", docs.status());
+      assertFalse(result.stream().anyMatch(c -> "docs".equals(c.name())));
 
       var lint = result.stream().filter(c -> "lint".equals(c.name())).findFirst().orElseThrow();
       assertEquals("pending", lint.status());
@@ -3064,10 +3112,170 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void shouldPageThroughCheckRunsUntilAShortPageIsReturned() {
+      // A full first page (100 rows) must trigger a second fetch; the short second page stops it.
+      var fullPage = new java.util.ArrayList<GitHubCheckRunClient.CheckRunsResponse.CheckRun>();
+      for (int i = 0; i < 100; i++) {
+        fullPage.add(
+            new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                i, "check-" + i, "completed", "failure", null));
+      }
+      var lastPage =
+          List.of(
+              new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                  100L, "check-100", "completed", "failure", null));
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(101, fullPage))
+          .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(101, lastPage));
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CombinedStatus("success", 0, List.of()));
+
+      var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
+
+      // Both pages were consumed: 100 + 1 failing check runs.
+      assertEquals(101, result.size());
+      verify(checkRunClient).getCheckRuns(any(), any(), any(), any(), any(), eq(100), eq(1));
+      verify(checkRunClient).getCheckRuns(any(), any(), any(), any(), any(), eq(100), eq(2));
+    }
+
+    @Test
+    void shouldPageThroughCombinedStatusUntilAShortPageIsReturned() {
+      var fullStatusPage =
+          new java.util.ArrayList<GitHubCheckRunClient.CombinedStatus.StatusDetail>();
+      for (int i = 0; i < 100; i++) {
+        fullStatusPage.add(
+            new GitHubCheckRunClient.CombinedStatus.StatusDetail(i, "failure", "ctx-" + i, "d"));
+      }
+      var lastStatusPage =
+          List.of(
+              new GitHubCheckRunClient.CombinedStatus.StatusDetail(
+                  100L, "failure", "ctx-100", "d"));
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(0, List.of()));
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CombinedStatus("failure", 101, fullStatusPage))
+          .thenReturn(new GitHubCheckRunClient.CombinedStatus("failure", 101, lastStatusPage));
+
+      var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
+
+      assertEquals(101, result.size());
+      verify(checkRunClient).getCombinedStatus(any(), any(), any(), any(), any(), eq(100), eq(2));
+    }
+
+    @Test
+    void shouldStopPagingAtTheMaxPagesGuard() {
+      // Every page is full (CI_PER_PAGE rows) so the short-page break never fires; the loop must
+      // terminate at the CI_MAX_PAGES guard rather than run forever.
+      var fullRuns = new java.util.ArrayList<GitHubCheckRunClient.CheckRunsResponse.CheckRun>();
+      var fullStatuses =
+          new java.util.ArrayList<GitHubCheckRunClient.CombinedStatus.StatusDetail>();
+      for (int i = 0; i < ReviewOrchestrator.CI_PER_PAGE; i++) {
+        fullRuns.add(
+            new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                i, "run-" + i, "completed", "failure", null));
+        fullStatuses.add(
+            new GitHubCheckRunClient.CombinedStatus.StatusDetail(i, "failure", "status-" + i, "d"));
+      }
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(
+              new GitHubCheckRunClient.CheckRunsResponse(ReviewOrchestrator.CI_PER_PAGE, fullRuns));
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(
+              new GitHubCheckRunClient.CombinedStatus(
+                  "failure", ReviewOrchestrator.CI_PER_PAGE, fullStatuses));
+
+      var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
+
+      // Deduped to the distinct names across the repeated pages.
+      assertEquals(2 * ReviewOrchestrator.CI_PER_PAGE, result.size());
+      verify(checkRunClient, times(ReviewOrchestrator.CI_MAX_PAGES))
+          .getCheckRuns(
+              any(), any(), any(), any(), any(), eq(ReviewOrchestrator.CI_PER_PAGE), anyInt());
+      verify(checkRunClient, times(ReviewOrchestrator.CI_MAX_PAGES))
+          .getCombinedStatus(
+              any(), any(), any(), any(), any(), eq(ReviewOrchestrator.CI_PER_PAGE), anyInt());
+    }
+
+    @Test
+    void shouldBreakWhenCheckRunsAndStatusResponsesAreNull() {
+      // Unmocked endpoints return null; the page loops must break immediately without error.
+      var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
+      assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldTreatCompletedRunWithNullConclusionAsFailing() {
+      var run =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(1L, "build", "completed", null, null);
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(1, List.of(run)));
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CombinedStatus("success", 0, List.of()));
+
+      var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
+
+      assertEquals(1, result.size());
+      assertEquals("failing", result.get(0).status());
+    }
+
+    @Test
+    void shouldDeduplicateContextReportedAsBothCheckRunAndStatus() {
+      // The same failing context reported twice via check runs and once via status → listed once.
+      var run =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              1L, "build", "completed", "failure", null);
+      var dupRun =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              2L, "build", "completed", "failure", null);
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(2, List.of(run, dupRun)));
+      var status =
+          new GitHubCheckRunClient.CombinedStatus.StatusDetail(1L, "failure", "build", "d");
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CombinedStatus("failure", 1, List.of(status)));
+
+      var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
+
+      assertEquals(1, result.size());
+      assertEquals("build", result.get(0).name());
+      assertEquals("check-run", result.get(0).type());
+    }
+
+    @Test
+    void shouldKeepNonBotChecksWhoseAppAndNameDoNotMatch() {
+      // Apps present but not ThrillhouseBot (one with a name, one without), plus a null-named run.
+      var appWithName =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun.App(
+              9L, "github-actions", "GitHub Actions");
+      var appNoName = new GitHubCheckRunClient.CheckRunsResponse.CheckRun.App(8L, "circleci", null);
+      var named =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              1L, "build", "completed", "failure", appWithName);
+      var namelessApp =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              3L, "deploy", "completed", "failure", appNoName);
+      var nullNamed =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              2L, null, "completed", "failure", null);
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(
+              new GitHubCheckRunClient.CheckRunsResponse(
+                  3, List.of(named, namelessApp, nullNamed)));
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CombinedStatus("success", 0, List.of()));
+
+      var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
+
+      assertEquals(3, result.size());
+      assertTrue(result.stream().anyMatch(c -> "build".equals(c.name())));
+      assertTrue(result.stream().anyMatch(c -> "deploy".equals(c.name())));
+    }
+
+    @Test
     void shouldHandleNullChecksAndStatusesGracefully() {
-      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any()))
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
           .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(0, null));
-      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any()))
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
           .thenReturn(new GitHubCheckRunClient.CombinedStatus("pending", 0, null));
 
       var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
@@ -3076,13 +3284,244 @@ class ReviewOrchestratorTest {
 
     @Test
     void shouldHandleExceptionsGracefully() {
-      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any()))
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
           .thenThrow(new RuntimeException("failed"));
-      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any()))
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
           .thenThrow(new RuntimeException("failed"));
 
       var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
       assertTrue(result.isEmpty());
+    }
+  }
+
+  @Nested
+  class CiGatingThroughReview {
+
+    private void stubCommonReviewMocks(GitHubCheckRunClient.CheckRunsResponse checkRuns) {
+      when(authClient.getAuthHeader(123L)).thenReturn("Bearer test");
+      when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(42)))
+          .thenReturn(
+              new GitHubPullRequestClient.PullRequestDetails(
+                  "Test PR",
+                  "",
+                  new GitHubPullRequestClient.Ref("abcdefgh", "feature"),
+                  new GitHubPullRequestClient.Ref("base1234567", "main")));
+      when(checkRunClient.createCheckRun(anyString(), anyString(), anyString(), anyString(), any()))
+          .thenReturn(new GitHubCheckRunClient.CheckRunResponse(1L, "http://check"));
+      doNothing()
+          .when(checkRunClient)
+          .updateCheckRun(anyString(), anyString(), anyString(), anyString(), anyLong(), any());
+      when(prClient.getPullRequestFiles(
+              anyString(), anyString(), anyString(), anyString(), anyInt()))
+          .thenReturn(List.of());
+      when(checkRunClient.getRequiredStatusChecks(
+              anyString(), anyString(), anyString(), anyString(), anyString()))
+          .thenReturn(new GitHubCheckRunClient.RequiredStatusChecks(List.of("build"), List.of()));
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(checkRuns);
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CombinedStatus("success", 0, List.of()));
+      when(prClient.compareCommits(
+              anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
+          .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
+      when(reviewClient.listReviews(anyString(), anyString(), anyString(), anyString(), anyInt()))
+          .thenReturn(List.of());
+      when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
+          .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
+      when(aiReviewService.review(any(ReviewSession.class), any()))
+          .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+    }
+
+    private ReviewOrchestrator.ReviewRequest request() {
+      return new ReviewOrchestrator.ReviewRequest(
+          "owner", "repo", 42, "abcdefgh", "Test PR", "", "base1234567", "main", 123L, false);
+    }
+
+    @Test
+    void reviewShouldApproveWhenRequiredChecksPass() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        // The single required check ("build") has already succeeded — APPROVE must stand.
+        stubCommonReviewMocks(
+            new GitHubCheckRunClient.CheckRunsResponse(
+                1,
+                List.of(
+                    new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                        1L, "build", "completed", "success", null))));
+
+        orchestrator.review(request());
+
+        verify(reviewClient)
+            .createReview(
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyInt(),
+                argThat(req -> "APPROVE".equals(req.event())));
+      }
+    }
+
+    @Test
+    void reviewShouldDowngradeToCommentWhenRequiredCheckFails() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        // The required check ("build") is failing — a would-be APPROVE must become COMMENT.
+        stubCommonReviewMocks(
+            new GitHubCheckRunClient.CheckRunsResponse(
+                1,
+                List.of(
+                    new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                        1L, "build", "completed", "failure", null))));
+
+        orchestrator.review(request());
+
+        var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+        verify(reviewClient)
+            .createReview(
+                anyString(), anyString(), anyString(), anyString(), anyInt(), captor.capture());
+        var req = captor.getValue();
+        assertEquals("COMMENT", req.event());
+        assertTrue(req.body().contains("**build**"));
+        assertTrue(req.body().contains("failed"));
+      }
+    }
+
+    @Test
+    void reviewShouldFallBackWhenBaseRefMissing() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        stubCommonReviewMocks(
+            new GitHubCheckRunClient.CheckRunsResponse(
+                1,
+                List.of(
+                    new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                        1L, "build", "completed", "success", null))));
+        // Base ref is null: required-status-checks must not be fetched and gating falls back to
+        // all checks (which are green here), so the review still approves.
+        when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(42)))
+            .thenReturn(
+                new GitHubPullRequestClient.PullRequestDetails(
+                    "Test PR",
+                    "",
+                    new GitHubPullRequestClient.Ref("abcdefgh", "feature"),
+                    new GitHubPullRequestClient.Ref("base1234567", null)));
+
+        orchestrator.review(request());
+
+        verify(checkRunClient, never())
+            .getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString());
+        verify(reviewClient)
+            .createReview(
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyInt(),
+                argThat(req -> "APPROVE".equals(req.event())));
+      }
+    }
+
+    @Test
+    void reviewShouldHandleNullProtectionResponse() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        stubCommonReviewMocks(
+            new GitHubCheckRunClient.CheckRunsResponse(
+                1,
+                List.of(
+                    new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                        1L, "build", "completed", "success", null))));
+        // Branch protection lookup returns null (e.g. unprotected branch) — gating falls back to
+        // all checks; all green here, so the review approves.
+        when(checkRunClient.getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(null);
+
+        orchestrator.review(request());
+
+        verify(reviewClient)
+            .createReview(
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyInt(),
+                argThat(req -> "APPROVE".equals(req.event())));
+      }
+    }
+
+    @Test
+    void reviewShouldFallBackWhenBaseIsNull() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        stubCommonReviewMocks(
+            new GitHubCheckRunClient.CheckRunsResponse(
+                1,
+                List.of(
+                    new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                        1L, "build", "completed", "success", null))));
+        // The PR has no base ref object at all — required checks are not fetched.
+        when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(42)))
+            .thenReturn(
+                new GitHubPullRequestClient.PullRequestDetails(
+                    "Test PR", "", new GitHubPullRequestClient.Ref("abcdefgh", "feature"), null));
+
+        orchestrator.review(request());
+
+        verify(checkRunClient, never())
+            .getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString());
+        verify(reviewClient)
+            .createReview(
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyInt(),
+                argThat(req -> "APPROVE".equals(req.event())));
+      }
     }
   }
 
@@ -3131,7 +3570,9 @@ class ReviewOrchestratorTest {
       assertTrue(body.contains("some checks are still pending or failed:"));
       assertTrue(body.contains("- Check **build** is failed"));
       assertTrue(body.contains("- Check **lint** is pending"));
-      assertTrue(body.contains("Additionally, 1 previous finding"));
+      assertTrue(
+          body.contains(
+              "Additionally, No new issues in this revision, but 1 previous finding(s) remain unresolved"));
     }
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -3128,7 +3128,9 @@ class ReviewOrchestratorTest {
   class DtoCoverage {
     @Test
     void shouldCoverCiCheckMethods() {
-      var nullChecksResult = new ReviewResult(List.of(), 0, 0, 0, 0, RiskLevel.LOW, ReviewState.APPROVE, true, "", List.of(), null);
+      var nullChecksResult =
+          new ReviewResult(
+              List.of(), 0, 0, 0, 0, RiskLevel.LOW, ReviewState.APPROVE, true, "", List.of(), null);
       assertTrue(nullChecksResult.offendingCiChecks().isEmpty());
       var failing = new ReviewResult.CiCheck("build", "check-run", "failing", "failure");
       var pending = new ReviewResult.CiCheck("lint", "status", "pending", "pending");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2546,8 +2546,8 @@ class ReviewOrchestratorTest {
                 new GitHubPullRequestClient.PullRequestDetails(
                     "add new API",
                     "Adds a new API endpoint",
-                    new GitHubPullRequestClient.Ref("headsha1234"),
-                    new GitHubPullRequestClient.Ref("basesha5678")));
+                    new GitHubPullRequestClient.Ref("headsha1234", "feature"),
+                    new GitHubPullRequestClient.Ref("basesha5678", "main")));
         when(checkRunClient.createCheckRun(
                 anyString(), anyString(), anyString(), anyString(), any()))
             .thenReturn(new GitHubCheckRunClient.CheckRunResponse(1L, "http://check"));
@@ -2603,8 +2603,8 @@ class ReviewOrchestratorTest {
                 new GitHubPullRequestClient.PullRequestDetails(
                     "add new API",
                     "Adds a new API endpoint",
-                    new GitHubPullRequestClient.Ref("headsha1234"),
-                    new GitHubPullRequestClient.Ref("basesha5678")));
+                    new GitHubPullRequestClient.Ref("headsha1234", "feature"),
+                    new GitHubPullRequestClient.Ref("basesha5678", "main")));
         when(prClient.getPullRequestFiles(
                 anyString(), anyString(), anyString(), anyString(), anyInt()))
             .thenReturn(List.of());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -810,6 +810,11 @@ class ReviewOrchestratorTest {
         when(prClient.getPullRequestFiles(
                 anyString(), anyString(), anyString(), anyString(), anyInt()))
             .thenReturn(List.of());
+        when(checkRunClient.getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(
+                new GitHubCheckRunClient.RequiredStatusChecks(
+                    List.of("required-build"), List.of()));
         when(prClient.compareCommits(
                 anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
             .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
@@ -979,6 +984,11 @@ class ReviewOrchestratorTest {
         when(prClient.getPullRequestFiles(
                 anyString(), anyString(), anyString(), anyString(), anyInt()))
             .thenReturn(List.of());
+        when(checkRunClient.getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(
+                new GitHubCheckRunClient.RequiredStatusChecks(
+                    List.of("required-build"), List.of()));
         when(prClient.compareCommits(
                 anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
             .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
@@ -1036,6 +1046,11 @@ class ReviewOrchestratorTest {
         when(prClient.getPullRequestFiles(
                 anyString(), anyString(), anyString(), anyString(), anyInt()))
             .thenReturn(List.of());
+        when(checkRunClient.getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(
+                new GitHubCheckRunClient.RequiredStatusChecks(
+                    List.of("required-build"), List.of()));
         when(prClient.compareCommits(
                 anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
             .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
@@ -1100,6 +1115,11 @@ class ReviewOrchestratorTest {
         when(prClient.getPullRequestFiles(
                 anyString(), anyString(), anyString(), anyString(), anyInt()))
             .thenReturn(List.of());
+        when(checkRunClient.getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(
+                new GitHubCheckRunClient.RequiredStatusChecks(
+                    List.of("required-build"), List.of()));
         when(prClient.compareCommits(
                 anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
             .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
@@ -1170,6 +1190,11 @@ class ReviewOrchestratorTest {
         when(prClient.getPullRequestFiles(
                 anyString(), anyString(), anyString(), anyString(), anyInt()))
             .thenReturn(List.of());
+        when(checkRunClient.getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(
+                new GitHubCheckRunClient.RequiredStatusChecks(
+                    List.of("required-build"), List.of()));
         when(prClient.compareCommits(
                 anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
             .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
@@ -1374,6 +1399,11 @@ class ReviewOrchestratorTest {
         when(prClient.getPullRequestFiles(
                 anyString(), anyString(), anyString(), anyString(), anyInt()))
             .thenReturn(List.of());
+        when(checkRunClient.getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(
+                new GitHubCheckRunClient.RequiredStatusChecks(
+                    List.of("required-build"), List.of()));
         when(prClient.compareCommits(
                 anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
             .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
@@ -2511,7 +2541,7 @@ class ReviewOrchestratorTest {
             .thenReturn(session);
 
         when(authClient.getAuthHeader(123L)).thenReturn("Bearer test");
-        when(prClient.getPullRequest(anyString(), anyString(), eq("owner"), eq("repo"), eq(7)))
+        when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(7)))
             .thenReturn(
                 new GitHubPullRequestClient.PullRequestDetails(
                     "add new API",
@@ -2524,6 +2554,11 @@ class ReviewOrchestratorTest {
         when(prClient.getPullRequestFiles(
                 anyString(), anyString(), anyString(), anyString(), anyInt()))
             .thenReturn(List.of());
+        when(checkRunClient.getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(
+                new GitHubCheckRunClient.RequiredStatusChecks(
+                    List.of("required-build"), List.of()));
         when(prClient.compareCommits(
                 anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
             .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
@@ -2545,6 +2580,53 @@ class ReviewOrchestratorTest {
             .createCheckRun(
                 anyString(), anyString(), eq("owner"), eq("repo"), checkRunCaptor.capture());
         assertEquals("headsha1234", checkRunCaptor.getValue().headSha());
+      }
+    }
+
+    @Test
+    void reviewShouldCatchExceptionWhenFetchingStatusChecks() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(7);
+        when(session.getPrTitle()).thenReturn("(manual review)");
+        when(session.getCommitSha()).thenReturn("");
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        when(authClient.getAuthHeader(123L)).thenReturn("Bearer test");
+        when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(7)))
+            .thenReturn(
+                new GitHubPullRequestClient.PullRequestDetails(
+                    "add new API",
+                    "Adds a new API endpoint",
+                    new GitHubPullRequestClient.Ref("headsha1234"),
+                    new GitHubPullRequestClient.Ref("basesha5678")));
+        when(prClient.getPullRequestFiles(
+                anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of());
+        when(checkRunClient.getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenThrow(new RuntimeException("failed"));
+        when(checkRunClient.createCheckRun(
+                anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(new GitHubCheckRunClient.CheckRunResponse(1L, "http://check"));
+        when(prClient.compareCommits(
+                anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
+        when(reviewClient.listReviews(anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of());
+        when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
+            .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
+        when(aiReviewService.review(any(ReviewSession.class), any()))
+            .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+        orchestrator.review(
+            new ReviewOrchestrator.ReviewRequest(
+                "owner", "repo", 7, "", "(manual review)", "", "", "main", 123L, true));
       }
     }
   }
@@ -2841,11 +2923,27 @@ class ReviewOrchestratorTest {
       var tbRun =
           new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
               1L, "ThrillhouseBot Review", "completed", "success", app);
+      var appSlugRun =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              10L,
+              "Some Checks",
+              "completed",
+              "success",
+              new GitHubCheckRunClient.CheckRunsResponse.CheckRun.App(2L, "thrillhousebot", null));
+      var appNameRun =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              11L,
+              "Other Checks",
+              "completed",
+              "success",
+              new GitHubCheckRunClient.CheckRunsResponse.CheckRun.App(3L, null, "ThrillhouseBot"));
       var otherRun =
           new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
               2L, "build", "completed", "success", null);
       when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any()))
-          .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(2, List.of(tbRun, otherRun)));
+          .thenReturn(
+              new GitHubCheckRunClient.CheckRunsResponse(
+                  4, List.of(tbRun, appSlugRun, appNameRun, otherRun)));
 
       // Setup statuses
       var tbStatus =
@@ -2963,6 +3061,117 @@ class ReviewOrchestratorTest {
       var security =
           result.stream().filter(c -> "security".equals(c.name())).findFirst().orElseThrow();
       assertEquals("failing", security.status());
+    }
+
+    @Test
+    void shouldHandleNullChecksAndStatusesGracefully() {
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any()))
+          .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(0, null));
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any()))
+          .thenReturn(new GitHubCheckRunClient.CombinedStatus("pending", 0, null));
+
+      var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
+      assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldHandleExceptionsGracefully() {
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any()))
+          .thenThrow(new RuntimeException("failed"));
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any()))
+          .thenThrow(new RuntimeException("failed"));
+
+      var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  @Nested
+  class CiChecksGating {
+
+    @Test
+    void shouldDowngradeApproveToCommentWhenOffendingCiChecksExist() {
+      var aiResponse = new ReviewResponse(List.of(), List.of(), null);
+      var offending = List.of(new ReviewResult.CiCheck("build", "check-run", "failing", "failure"));
+
+      var result =
+          orchestrator.buildResult(
+              aiResponse, false, new ReviewOrchestrator.DiffStats(0, 0, 0), List.of(), offending);
+
+      assertEquals(ReviewState.COMMENT, result.reviewState());
+    }
+
+    @Test
+    void shouldFormatPostReviewBodyWithOffendingCiChecks() {
+      var offending =
+          List.of(
+              new ReviewResult.CiCheck("build", "check-run", "failing", "failure"),
+              new ReviewResult.CiCheck("lint", "status", "pending", null));
+      var result =
+          new ReviewResult(
+              List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", List.of(), offending);
+
+      orchestrator.postReview("auth", "owner", "repo", 5, "sha", result, List.of());
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+
+      var body = captor.getValue().body();
+      assertTrue(body.contains("some checks are still pending or failed:"));
+      assertTrue(body.contains("- Check **build** is failed"));
+      assertTrue(body.contains("- Check **lint** is pending"));
+    }
+  }
+
+  @Nested
+  class DtoCoverage {
+    @Test
+    void shouldCoverCiCheckMethods() {
+      var nullChecksResult = new ReviewResult(List.of(), 0, 0, 0, 0, RiskLevel.LOW, ReviewState.APPROVE, true, "", List.of(), null);
+      assertTrue(nullChecksResult.offendingCiChecks().isEmpty());
+      var failing = new ReviewResult.CiCheck("build", "check-run", "failing", "failure");
+      var pending = new ReviewResult.CiCheck("lint", "status", "pending", "pending");
+
+      assertTrue(failing.isFailing());
+      assertFalse(failing.isPending());
+
+      assertTrue(pending.isPending());
+      assertFalse(pending.isFailing());
+    }
+
+    @Test
+    void shouldCoverGitHubCheckRunClientDTOs() {
+      var reqChecksNull = new GitHubCheckRunClient.RequiredStatusChecks(null, null);
+      assertTrue(reqChecksNull.contexts().isEmpty());
+      assertTrue(reqChecksNull.checks().isEmpty());
+
+      var reqChecksVal =
+          new GitHubCheckRunClient.RequiredStatusChecks(
+              List.of("ctx"),
+              List.of(new GitHubCheckRunClient.RequiredStatusChecks.Check("ctx", 1L)));
+      assertFalse(reqChecksVal.contexts().isEmpty());
+      assertFalse(reqChecksVal.checks().isEmpty());
+
+      var checkRunsNull = new GitHubCheckRunClient.CheckRunsResponse(0, null);
+      assertTrue(checkRunsNull.checkRuns().isEmpty());
+
+      var checkRunsVal =
+          new GitHubCheckRunClient.CheckRunsResponse(
+              1,
+              List.of(
+                  new GitHubCheckRunClient.CheckRunsResponse.CheckRun(1L, "n", "s", "c", null)));
+      assertFalse(checkRunsVal.checkRuns().isEmpty());
+
+      var statusNull = new GitHubCheckRunClient.CombinedStatus("pending", 0, null);
+      assertTrue(statusNull.statuses().isEmpty());
+
+      var statusVal =
+          new GitHubCheckRunClient.CombinedStatus(
+              "pending",
+              1,
+              List.of(new GitHubCheckRunClient.CombinedStatus.StatusDetail(1L, "s", "c", "d")));
+      assertFalse(statusVal.statuses().isEmpty());
     }
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2828,4 +2828,141 @@ class ReviewOrchestratorTest {
       assertEquals("", stack);
     }
   }
+
+  @Nested
+  class EvaluateCiChecks {
+
+    @Test
+    void shouldIgnoreThrillhouseBotChecks() {
+      // Setup check runs
+      var app =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun.App(
+              1L, "thrillhousebot", "ThrillhouseBot");
+      var tbRun =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              1L, "ThrillhouseBot Review", "completed", "success", app);
+      var otherRun =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              2L, "build", "completed", "success", null);
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any()))
+          .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(2, List.of(tbRun, otherRun)));
+
+      // Setup statuses
+      var tbStatus =
+          new GitHubCheckRunClient.CombinedStatus.StatusDetail(
+              1L, "success", "thrillhousebot-status", "desc");
+      var otherStatus =
+          new GitHubCheckRunClient.CombinedStatus.StatusDetail(2L, "success", "lint", "desc");
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any()))
+          .thenReturn(
+              new GitHubCheckRunClient.CombinedStatus(
+                  "success", 2, List.of(tbStatus, otherStatus)));
+
+      var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
+
+      assertEquals(2, result.size());
+      assertTrue(result.stream().anyMatch(c -> "build".equals(c.name())));
+      assertTrue(result.stream().anyMatch(c -> "lint".equals(c.name())));
+      assertFalse(result.stream().anyMatch(c -> c.name().contains("thrillhousebot")));
+    }
+
+    @Test
+    void shouldFilterByRequiredContextsWhenProvided() {
+      var run1 =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              1L, "build", "completed", "success", null);
+      var run2 =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              2L, "test", "completed", "success", null);
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any()))
+          .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(2, List.of(run1, run2)));
+
+      var status1 =
+          new GitHubCheckRunClient.CombinedStatus.StatusDetail(1L, "success", "lint", "desc");
+      var status2 =
+          new GitHubCheckRunClient.CombinedStatus.StatusDetail(2L, "success", "deploy", "desc");
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any()))
+          .thenReturn(
+              new GitHubCheckRunClient.CombinedStatus("success", 2, List.of(status1, status2)));
+
+      var result =
+          orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", List.of("build", "lint"));
+
+      assertEquals(2, result.size());
+      assertTrue(result.stream().anyMatch(c -> "build".equals(c.name())));
+      assertTrue(result.stream().anyMatch(c -> "lint".equals(c.name())));
+      assertFalse(result.stream().anyMatch(c -> "test".equals(c.name())));
+      assertFalse(result.stream().anyMatch(c -> "deploy".equals(c.name())));
+    }
+
+    @Test
+    void shouldMarkMissingRequiredChecksAsPending() {
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any()))
+          .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(0, List.of()));
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any()))
+          .thenReturn(new GitHubCheckRunClient.CombinedStatus("success", 0, List.of()));
+
+      var result =
+          orchestrator.evaluateCiChecks(
+              "auth", "owner", "repo", "sha", List.of("build", "thrillhousebot"));
+
+      // thrillhousebot is ignored, so only "build" is missing
+      assertEquals(1, result.size());
+      var check = result.get(0);
+      assertEquals("build", check.name());
+      assertEquals("missing", check.type());
+      assertEquals("pending", check.status());
+    }
+
+    @Test
+    void shouldEvaluateStatusesAndConclusionsCorrectly() {
+      // 1. Pending check run
+      var runPending =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              1L, "build", "in_progress", null, null);
+      // 2. Failed check run
+      var runFailed =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              2L, "test", "completed", "failure", null);
+      // 3. Skipped check run (success)
+      var runSkipped =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              3L, "docs", "completed", "skipped", null);
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any()))
+          .thenReturn(
+              new GitHubCheckRunClient.CheckRunsResponse(
+                  3, List.of(runPending, runFailed, runSkipped)));
+
+      // 4. Pending status
+      var statusPending =
+          new GitHubCheckRunClient.CombinedStatus.StatusDetail(1L, "pending", "lint", "desc");
+      // 5. Error status
+      var statusError =
+          new GitHubCheckRunClient.CombinedStatus.StatusDetail(2L, "error", "security", "desc");
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any()))
+          .thenReturn(
+              new GitHubCheckRunClient.CombinedStatus(
+                  "pending", 2, List.of(statusPending, statusError)));
+
+      var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
+
+      assertEquals(5, result.size());
+
+      var build = result.stream().filter(c -> "build".equals(c.name())).findFirst().orElseThrow();
+      assertEquals("pending", build.status());
+
+      var test = result.stream().filter(c -> "test".equals(c.name())).findFirst().orElseThrow();
+      assertEquals("failing", test.status());
+
+      var docs = result.stream().filter(c -> "docs".equals(c.name())).findFirst().orElseThrow();
+      assertEquals("success", docs.status());
+
+      var lint = result.stream().filter(c -> "lint".equals(c.name())).findFirst().orElseThrow();
+      assertEquals("pending", lint.status());
+
+      var security =
+          result.stream().filter(c -> "security".equals(c.name())).findFirst().orElseThrow();
+      assertEquals("failing", security.status());
+    }
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -3109,7 +3109,17 @@ class ReviewOrchestratorTest {
               new ReviewResult.CiCheck("lint", "status", "pending", null));
       var result =
           new ReviewResult(
-              List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", List.of(), offending);
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.COMMENT,
+              false,
+              "",
+              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "")),
+              offending);
 
       orchestrator.postReview("auth", "owner", "repo", 5, "sha", result, List.of());
 
@@ -3121,6 +3131,7 @@ class ReviewOrchestratorTest {
       assertTrue(body.contains("some checks are still pending or failed:"));
       assertTrue(body.contains("- Check **build** is failed"));
       assertTrue(body.contains("- Check **lint** is pending"));
+      assertTrue(body.contains("Additionally, 1 previous finding"));
     }
   }
 


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

ThrillhouseBot could post a green **APPROVE** review while the PR's CI was still red or pending. This change gates the APPROVE verdict on the CI status of the head commit.

On each review the bot now:

- Resolves the **required status checks** for the PR's target branch (falling back to evaluating *all* checks when the branch is unprotected or the lookup fails).
- Evaluates both **check-runs** and **commit statuses** on the head SHA, paginating through every page, ignoring ThrillhouseBot's own check, and de-duplicating a context reported through both APIs.
- Treats a check as **offending** when it is failing, pending, or a required check that never reported (implicitly pending); passing/skipped/neutral checks are excluded.
- **Downgrades a would-be APPROVE to COMMENT** when any offending check exists, and surfaces the offending checks in the PR summary comment, the review body, and the bot's own check-run title/summary (no more false "✅ / Everything's coming up Thrillhouse" while CI is red).

## Related Issues

Fixes #95

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- CI status evaluation logic — `EvaluateCiChecks` suite: bot-check filtering, required-context filtering, missing-required detection, status/conclusion classification, pagination (short-page and `CI_MAX_PAGES` guard), and cross-API de-duplication.
- End-to-end review gating — `CiGatingThroughReview`: `reviewShouldApproveWhenRequiredChecksPass` (green → APPROVE) and `reviewShouldDowngradeToCommentWhenRequiredCheckFails` (red → COMMENT with the offending check in the body), plus the unprotected-branch / null-protection fallbacks.
- Summary + check-run rendering — `PrSummaryGeneratorTest`: offending-checks table, no false celebration, and Markdown cell escaping.
- `./mvnw test` passes locally (871 tests); Spotless, SpotBugs, SonarCloud (0 issues), and Codecov patch (100%) are green in CI.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A — behaviour is covered by unit tests; the offending checks render as a "⚠️ Required CI Checks Status" table in the PR summary comment.

## Additional Notes

- No breaking changes; when CI is fully green the verdict is unchanged.
- `null` required-contexts is intentional and means "could not determine required checks → gate on all checks", distinct from an empty list ("no required checks").
- New GitHub API calls (`required_status_checks`, `commits/{ref}/check-runs`, `commits/{ref}/status`) are best-effort: any failure is logged and falls back rather than failing the review.
