### PR TITLE
fix(review): FindingQuoteValidator can validate a finding misattributed among near-identical lines (#98)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -27,8 +27,8 @@ import java.util.regex.Pattern;
  */
 public final class DiffLineResolver {
 
-  private static final Pattern HUNK_HEADER =
-      Pattern.compile("@@ -\\d+(?:,\\d+)? \\+(\\d+)(?:,\\d+)? @@");
+  // Shared with FindingQuoteValidator, which tracks the same right-side line numbers.
+  static final Pattern HUNK_HEADER = Pattern.compile("@@ -\\d+(?:,\\d+)? \\+(\\d+)(?:,\\d+)? @@");
 
   private final Map<String, TreeSet<Integer>> rightSideLinesByFile;
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -43,6 +43,8 @@ public class FindingQuoteValidator {
 
   private static final String LOW_CONFIDENCE = "low";
 
+  public record DiffLine(String normalizedText, int rightLineNum, char marker) {}
+
   /** Validates each finding's quoted code against the raw (unescaped) diff text. */
   public ReviewResponse validate(ReviewResponse response, String diff) {
     if (response.findings().isEmpty() || diff == null || diff.isBlank()) {
@@ -52,12 +54,24 @@ public class FindingQuoteValidator {
     var kept = new ArrayList<ReviewResponse.Finding>(response.findings().size());
     var changed = false;
     for (ReviewResponse.Finding finding : response.findings()) {
-      QuoteMatch match = matchQuote(finding.suggestionOld(), index.linesFor(finding.file()));
+      List<String> quoted = normalizedLines(finding.suggestionOld());
+      QuoteMatch match = matchQuote(quoted, index.linesFor(finding.file()));
+      if (match == QuoteMatch.FULL) {
+        match = checkAmbiguity(quoted, finding.line(), index.diffLinesFor(finding.file()));
+      }
       switch (match) {
         case FULL, NO_QUOTE -> kept.add(finding);
         case PARTIAL -> {
           Log.infof(
               "Finding '%s' (%s:%d) quotes code only partially present in the diff —"
+                  + " dropping its suggestion and capping confidence",
+              finding.title(), finding.file(), finding.line());
+          kept.add(withoutSuggestion(finding));
+          changed = true;
+        }
+        case AMBIGUOUS -> {
+          Log.infof(
+              "Finding '%s' (%s:%d) quotes code that appears in multiple locations, but the finding's line is ambiguous —"
                   + " dropping its suggestion and capping confidence",
               finding.title(), finding.file(), finding.line());
           kept.add(withoutSuggestion(finding));
@@ -88,11 +102,14 @@ public class FindingQuoteValidator {
     /** Some quoted lines are present, others are not. */
     PARTIAL,
     /** No quoted line is present in the diff. */
-    NONE
+    NONE,
+    /**
+     * Quote is fully present in multiple locations, but finding line doesn't uniquely select one.
+     */
+    AMBIGUOUS
   }
 
-  static QuoteMatch matchQuote(String suggestionOld, Set<String> diffLines) {
-    List<String> quoted = normalizedLines(suggestionOld);
+  static QuoteMatch matchQuote(List<String> quoted, Set<String> diffLines) {
     if (quoted.isEmpty()) {
       return QuoteMatch.NO_QUOTE;
     }
@@ -104,37 +121,120 @@ public class FindingQuoteValidator {
   }
 
   /**
+   * Disambiguates a quote the {@link #matchQuote} gate already accepted as FULL. Only quotes that
+   * appear as a contiguous run over the retained (context/deleted) lines are scrutinized: additions
+   * are dropped because {@code suggestion_old} is original code, and a quote found in two or more
+   * such locations is AMBIGUOUS unless the finding's line uniquely selects one (within a 3-line
+   * tolerance). Anything not matched contiguously here stays FULL — the conservative direction.
+   */
+  private static QuoteMatch checkAmbiguity(
+      List<String> quoted, int findingLine, List<DiffLine> diffLines) {
+    List<DiffLine> filtered = retainedLines(diffLines);
+    List<Integer> matchIndices = contiguousMatchStarts(filtered, quoted);
+    if (matchIndices.size() <= 1) {
+      return QuoteMatch.FULL;
+    }
+
+    int k = quoted.size();
+    int selectedCount = 0;
+    for (int idx : matchIndices) {
+      int startLine = filtered.get(idx).rightLineNum();
+      int endLine = filtered.get(idx + k - 1).rightLineNum();
+      if (findingLine >= startLine - 3 && findingLine <= endLine + 3) {
+        selectedCount++;
+      }
+    }
+    return selectedCount == 1 ? QuoteMatch.FULL : QuoteMatch.AMBIGUOUS;
+  }
+
+  /**
+   * The diff lines that {@code suggestion_old} can match: context and deletions, never additions.
+   */
+  private static List<DiffLine> retainedLines(List<DiffLine> diffLines) {
+    var filtered = new ArrayList<DiffLine>();
+    for (DiffLine dl : diffLines) {
+      if (dl.marker() != '+') {
+        filtered.add(dl);
+      }
+    }
+    return filtered;
+  }
+
+  /** Start indices where {@code quoted} appears as a contiguous run in {@code lines}. */
+  private static List<Integer> contiguousMatchStarts(List<DiffLine> lines, List<String> quoted) {
+    var starts = new ArrayList<Integer>();
+    int k = quoted.size();
+    for (int i = 0; i <= lines.size() - k; i++) {
+      if (matchesAt(lines, i, quoted)) {
+        starts.add(i);
+      }
+    }
+    return starts;
+  }
+
+  private static boolean matchesAt(List<DiffLine> lines, int offset, List<String> quoted) {
+    for (int j = 0; j < quoted.size(); j++) {
+      if (!lines.get(offset + j).normalizedText().equals(quoted.get(j))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
    * The diff's normalized body lines, both as one union and scoped per file. A quote is checked
    * against its finding's own file when that file is identifiable in the diff — the same text
    * appearing in some other file's hunk must not validate a misattributed finding. The union is the
    * conservative fallback for findings whose file cannot be matched to a diff section.
    */
-  record DiffIndex(Map<String, Set<String>> byFile, Set<String> all) {
+  record DiffIndex(
+      Map<String, List<DiffLine>> fileLines,
+      List<DiffLine> allLines,
+      Map<String, Set<String>> byFile,
+      Set<String> all) {
 
     Set<String> linesFor(String file) {
-      if (file == null || file.isBlank()) {
-        return all;
-      }
-      Set<String> exact = byFile.get(file);
-      if (exact != null) {
-        return exact;
-      }
-      // The model sometimes shortens or expands paths; suffix matches still scope. An
-      // ambiguous name (Handler.java in several modules) scopes to the union of its
-      // candidates, never to the whole diff — a quote from an unrelated file must not
-      // validate just because the finding's path was ambiguous.
-      var candidates =
-          byFile.keySet().stream()
-              .filter(k -> k.endsWith("/" + file) || file.endsWith("/" + k))
-              .toList();
-      if (candidates.isEmpty()) {
+      var sections = sectionKeysFor(file);
+      if (sections.isEmpty()) {
         return all;
       }
       var scoped = new HashSet<String>();
-      for (String candidate : candidates) {
-        scoped.addAll(byFile.get(candidate));
+      for (String section : sections) {
+        scoped.addAll(byFile.get(section));
       }
       return scoped;
+    }
+
+    List<DiffLine> diffLinesFor(String file) {
+      var sections = sectionKeysFor(file);
+      if (sections.isEmpty()) {
+        return allLines;
+      }
+      var scoped = new ArrayList<DiffLine>();
+      for (String section : sections) {
+        scoped.addAll(fileLines.get(section));
+      }
+      return scoped;
+    }
+
+    /**
+     * The diff-section keys a finding's file resolves to, or an empty list when the file cannot be
+     * matched and the caller must fall back to the whole-diff union. An exact section match wins;
+     * otherwise the model sometimes shortens or expands paths, so suffix matches still scope. An
+     * ambiguous name (Handler.java in several modules) scopes to the union of its candidates, never
+     * to the whole diff — a quote from an unrelated file must not validate just because the
+     * finding's path was ambiguous.
+     */
+    private List<String> sectionKeysFor(String file) {
+      if (file == null || file.isBlank()) {
+        return List.of();
+      }
+      if (fileLines.containsKey(file)) {
+        return List.of(file);
+      }
+      return fileLines.keySet().stream()
+          .filter(k -> k.endsWith("/" + file) || file.endsWith("/" + k))
+          .toList();
     }
   }
 
@@ -146,31 +246,73 @@ public class FindingQuoteValidator {
    * File scoping follows the formatter's "### filename (status, +A -D)" section headers.
    */
   static DiffIndex indexDiff(String diff) {
-    var byFile = new HashMap<String, Set<String>>();
-    var all = new HashSet<String>();
-    Set<String> current = null;
+    var fileLines = new HashMap<String, List<DiffLine>>();
+    var allLines = new ArrayList<DiffLine>();
+    List<DiffLine> current = null;
+    int rightLine = 0;
+
     for (String raw : PromptTemplateEscaper.neutralizeMarkers(diff).split("\n", -1)) {
       if (raw.startsWith("### ")) {
-        current = byFile.computeIfAbsent(sectionFilename(raw), k -> new HashSet<>());
+        current = fileLines.computeIfAbsent(sectionFilename(raw), k -> new ArrayList<>());
+        // A new file section restarts right-side numbering; don't carry the previous file's
+        // counter forward in case its first hunk header is missing or unparseable.
+        rightLine = 0;
+      } else if (raw.startsWith("@@")) {
+        rightLine = hunkStartLine(raw, rightLine);
       } else if (!isDiffStructureLine(raw)) {
-        String normalized = bodyOf(raw).strip();
-        if (!normalized.isEmpty()) {
-          all.add(normalized);
-          if (current != null) {
-            current.add(normalized);
-          }
-        }
+        rightLine = appendBodyLine(raw, rightLine, allLines, current);
       }
     }
-    return new DiffIndex(byFile, all);
+
+    var byFile = new HashMap<String, Set<String>>();
+    fileLines.forEach((file, lines) -> byFile.put(file, textSet(lines)));
+    return new DiffIndex(fileLines, allLines, byFile, textSet(allLines));
   }
 
-  /** Hunk headers, file headers, and code fences are diff plumbing, never quotable content. */
+  /** The right-side start line of a hunk header, or {@code fallback} when it can't be parsed. */
+  private static int hunkStartLine(String raw, int fallback) {
+    var matcher = DiffLineResolver.HUNK_HEADER.matcher(raw);
+    return matcher.find() ? Integer.parseInt(matcher.group(1)) : fallback;
+  }
+
+  /**
+   * Records a normalized body line into the union and (when scoped) its file, then returns the
+   * advanced right-side line counter — additions and context advance it; deletions do not.
+   */
+  private static int appendBodyLine(
+      String raw, int rightLine, List<DiffLine> allLines, List<DiffLine> current) {
+    String normalized = bodyOf(raw).strip();
+    if (normalized.isEmpty()) {
+      return rightLine;
+    }
+    // A non-empty normalized body implies a non-empty raw line, so charAt(0) is safe.
+    char marker = raw.charAt(0);
+    var diffLine = new DiffLine(normalized, rightLine, marker);
+    allLines.add(diffLine);
+    if (current != null) {
+      current.add(diffLine);
+    }
+    return marker == '+' || marker == ' ' ? rightLine + 1 : rightLine;
+  }
+
+  private static Set<String> textSet(List<DiffLine> lines) {
+    var set = new HashSet<String>();
+    for (var dl : lines) {
+      set.add(dl.normalizedText());
+    }
+    return set;
+  }
+
+  /**
+   * File headers, code fences, and the {@code "\ No newline at end of file"} indicator are diff
+   * plumbing, never quotable content. Hunk headers ({@code @@}) are intercepted earlier for line
+   * tracking, so they never reach this check.
+   */
   private static boolean isDiffStructureLine(String raw) {
     return raw.startsWith("+++")
         || raw.startsWith("---")
-        || raw.startsWith("@@")
-        || raw.startsWith("```");
+        || raw.startsWith("```")
+        || raw.startsWith("\\ ");
   }
 
   /** The line without its unified-diff marker column (+, -, space). */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -18,12 +18,16 @@ package dev.thiagogonzaga.thrillhousebot.review;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -274,5 +278,254 @@ class FindingQuoteValidatorTest {
 
     assertEquals(0, result.findings().size());
     assertNull(result.summary());
+  }
+
+  @Test
+  void ambiguousQuoteCapsConfidenceAndDropsSuggestion() {
+    var diff =
+        """
+        ### src/Test.java (modified, +2 -2)
+        ```diff
+        @@ -10,6 +10,6 @@
+         public void testOne() {
+        -    assertEquals(1, val);
+        +    assertEquals(2, val);
+         }
+         public void testTwo() {
+        -    assertEquals(1, val);
+        +    assertEquals(2, val);
+         }
+        ```
+        """;
+    // The two occurrences sit at right-side lines 11 and 14, so their 3-line tolerance windows
+    // ([8,14] and [11,17]) overlap. The finding at line 12 falls inside both, uniquely selecting
+    // neither — so the outcome depends on correct right-side line tracking, not mere distance.
+    var finding =
+        new ReviewResponse.Finding(
+            "critical",
+            "high",
+            "src/Test.java",
+            12,
+            "Title",
+            "Description",
+            "assertEquals(1, val);",
+            "assertEquals(2, val);");
+    var response = response(finding);
+
+    var result = validator.validate(response, diff);
+
+    assertEquals(1, result.findings().size());
+    var kept = result.findings().get(0);
+    assertNull(kept.suggestionOld());
+    assertNull(kept.suggestionNew());
+    assertEquals("low", kept.confidence());
+  }
+
+  private static final String DUPLICATE_QUOTE_DIFF =
+      """
+      ### src/Test.java (modified, +2 -2)
+      ```diff
+      @@ -10,3 +10,3 @@
+       public void testOne() {
+      -    assertEquals(1, val);
+      +    assertEquals(2, val);
+       }
+      @@ -20,3 +20,3 @@
+       public void testTwo() {
+      -    assertEquals(1, val);
+      +    assertEquals(2, val);
+       }
+      ```
+      """;
+
+  // Same duplicate quote, but each hunk header carries git's trailing function-context suffix.
+  private static final String DUPLICATE_QUOTE_DIFF_TRAILING_HEADER =
+      """
+      ### src/Test.java (modified, +2 -2)
+      ```diff
+      @@ -10,3 +10,3 @@ public void testOne() {
+       public void testOne() {
+      -    assertEquals(1, val);
+      +    assertEquals(2, val);
+       }
+      @@ -20,3 +20,3 @@ public void testTwo() {
+       public void testTwo() {
+      -    assertEquals(1, val);
+      +    assertEquals(2, val);
+       }
+      ```
+      """;
+
+  static Stream<Arguments> uniquelySelectedDuplicateQuotes() {
+    return Stream.of(
+        // line 21 uniquely selects testTwo — the upper occurrence's tolerance window
+        arguments(DUPLICATE_QUOTE_DIFF, 21),
+        // line 11 selects the earlier testOne — exercises the lower-bound edge of the window
+        arguments(DUPLICATE_QUOTE_DIFF, 11),
+        // trailing context after @@ must still parse the +start, so line 21 selects testTwo
+        arguments(DUPLICATE_QUOTE_DIFF_TRAILING_HEADER, 21));
+  }
+
+  /**
+   * When a quote appears in multiple locations but the finding's line uniquely selects one (within
+   * the 3-line tolerance), the finding is kept intact regardless of the hunk-header form.
+   */
+  @ParameterizedTest
+  @MethodSource("uniquelySelectedDuplicateQuotes")
+  void uniqueQuoteAmongDuplicatesIsKept(String diff, int line) {
+    var finding =
+        new ReviewResponse.Finding(
+            "critical",
+            "high",
+            "src/Test.java",
+            line,
+            "Title",
+            "Description",
+            "assertEquals(1, val);",
+            "assertEquals(2, val);");
+
+    var result = validator.validate(response(finding), diff);
+
+    assertEquals(1, result.findings().size());
+    var kept = result.findings().get(0);
+    assertEquals("assertEquals(1, val);", kept.suggestionOld());
+    assertEquals("high", kept.confidence());
+  }
+
+  @Test
+  void quoteWithInterleavedAdditionsIsKept() {
+    var diff =
+        """
+        ### src/Test.java (modified, +1 -0)
+        ```diff
+        @@ -10,4 +10,5 @@
+         public void run() {
+             stepOne();
+        +    insertedStep();
+             stepTwo();
+         }
+        ```
+        """;
+    // The quote has "stepOne();" and "stepTwo();" which are separated by "+    insertedStep();" in
+    // the diff.
+    // Since "+    insertedStep();" is an addition, it should be ignored when matching
+    // suggestionOld.
+    var quote = "stepOne();\nstepTwo();";
+    var finding =
+        new ReviewResponse.Finding(
+            "critical", "high", "src/Test.java", 11, "Title", "Description", quote, "replacement");
+    var response = response(finding);
+
+    var result = validator.validate(response, diff);
+
+    assertEquals(1, result.findings().size());
+    var kept = result.findings().get(0);
+    assertEquals(quote, kept.suggestionOld());
+    assertEquals("high", kept.confidence());
+  }
+
+  @Test
+  void ambiguousAcrossFilesWhenFindingFileUnresolved() {
+    var diff =
+        """
+        ### src/A.java (modified, +1 -1)
+        ```diff
+        @@ -10,3 +10,3 @@
+         public void a() {
+        -    doThing();
+        +    doThingElse();
+         }
+        ```
+        ### src/B.java (modified, +1 -1)
+        ```diff
+        @@ -10,3 +10,3 @@
+         public void b() {
+        -    doThing();
+        +    doThingElse();
+         }
+        ```
+        """;
+    // The finding's file matches no section, so scoping falls back to the whole-diff union where
+    // "doThing();" appears in both files at right-side line 11 (each file restarts its own
+    // numbering). Line 11 sits in both tolerance windows, so neither is uniquely selected.
+    var finding =
+        new ReviewResponse.Finding(
+            "critical",
+            "high",
+            "src/Unknown.java",
+            11,
+            "Title",
+            "Description",
+            "doThing();",
+            "doThingElse();");
+    var response = response(finding);
+
+    var result = validator.validate(response, diff);
+
+    assertEquals(1, result.findings().size());
+    var kept = result.findings().get(0);
+    assertNull(kept.suggestionOld());
+    assertEquals("low", kept.confidence());
+  }
+
+  @Test
+  void unparseableHunkHeaderIsIgnored() {
+    var diff =
+        """
+        ### src/Test.java (modified, +1 -1)
+        ```diff
+        @@ this is not a valid hunk header @@
+         public void run() {
+        -    doThing();
+        +    doThingElse();
+         }
+        ```
+        """;
+    // A line that starts with @@ but carries no parseable +start leaves right-side numbering at its
+    // default; the single quoted occurrence has no duplicate to disambiguate and is kept.
+    var finding =
+        new ReviewResponse.Finding(
+            "critical",
+            "high",
+            "src/Test.java",
+            1,
+            "Title",
+            "Description",
+            "doThing();",
+            "doThingElse();");
+    var response = response(finding);
+
+    var result = validator.validate(response, diff);
+
+    assertEquals(1, result.findings().size());
+    assertEquals("doThing();", result.findings().get(0).suggestionOld());
+  }
+
+  @Test
+  void blankFileFallsBackToTheWholeDiff() {
+    var response = response(findingOn("   ", "int onlyInB = 2;"));
+
+    assertSame(response, validator.validate(response, MULTI_FILE_DIFF));
+  }
+
+  @Test
+  void noNewlineIndicatorIsNotQuotableContent() {
+    var diff =
+        """
+        ### src/Test.java (modified, +1 -1)
+        ```diff
+        @@ -1,1 +1,1 @@
+        -oldValue
+        +newValue
+        \\ No newline at end of file
+        ```
+        """;
+    // The "\\ No newline at end of file" indicator is diff plumbing; a finding quoting it must not
+    // validate against the diff.
+    var response = response(findingOn("src/Test.java", "\\ No newline at end of file"));
+
+    var result = validator.validate(response, diff);
+
+    assertEquals(0, result.findings().size());
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [x] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`FindingQuoteValidator` could validate a finding that was misattributed among near-identical
lines: when a quoted `suggestion_old` appears in several places in the diff, the original check
accepted it as long as the text existed *somewhere*, so a finding pointing at the wrong occurrence
slipped through with a suggestion anchored to the wrong line.

This PR makes the check position-aware:

- `indexDiff` now tracks the **right-side line number** of every diff line (parsing hunk headers,
  advancing on additions/context, holding on deletions).
- When a quote matches as `FULL`, `checkAmbiguity` finds every contiguous occurrence over the
  retained (context/deleted) lines — additions are filtered out since `suggestion_old` is original
  code — and checks whether the finding's line uniquely selects one (within a 3-line tolerance).
- If it does not, the match is treated as `AMBIGUOUS`: the unreliable suggestion is dropped and
  confidence is capped to `low`, so the finding can still surface but cannot block.

## Related Issues

Fixes #98

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Added/updated unit tests in `FindingQuoteValidatorTest.java`, covering: ambiguous quotes (suggestion
dropped, confidence capped), uniquely-selected quotes among duplicates kept intact (parameterized
across line position and hunk-header form), interleaved additions, the whole-diff union fallback for
unresolved/blank files, unparseable hunk headers, and the `\ No newline at end of file` indicator.
Ran `./mvnw verify` locally: Spotless, SpotBugs, and all unit tests pass; JaCoCo coverage gate met
and patch coverage is 100% on changed lines.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Beyond the core fix, this branch incorporates review-driven hardening:

- Shares the hunk-header regex with `DiffLineResolver` (`HUNK_HEADER`) instead of duplicating it,
  and resets right-side numbering at each file section.
- Consolidates the per-file path scoping (`linesFor`/`diffLinesFor`) behind a single
  `sectionKeysFor` helper.
- Extracts helpers in `indexDiff`/`checkAmbiguity` to bring both methods under the cognitive-complexity limit.
- Removes dead branches and parameterizes structurally-identical tests.

No breaking changes; the validator stays conservative — it only ever drops a suggestion or caps
confidence, never fabricates one.
