### PR TITLE
fix(dashboard): key repo-snapshot cache by owner to prevent cross-owner reuse (#91)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
@@ -74,13 +74,14 @@ public class DashboardAccessChecker {
   private record OwnerCache(String owner, Instant cachedAt) {}
 
   private final AtomicReference<RepoSnapshot> cachedSnapshot =
-      new AtomicReference<>(new RepoSnapshot(List.of(), null, Instant.EPOCH));
+      new AtomicReference<>(new RepoSnapshot(null, List.of(), null, Instant.EPOCH));
   private final AtomicReference<OwnerCache> ownerCache =
       new AtomicReference<>(new OwnerCache(null, Instant.EPOCH));
 
   static record AccessCacheEntry(boolean allowed, Instant cachedAt) {}
 
-  private record RepoSnapshot(List<RepoRef> repos, String installationAuth, Instant cachedAt) {}
+  private record RepoSnapshot(
+      String owner, List<RepoRef> repos, String installationAuth, Instant cachedAt) {}
 
   private record RepoRef(String owner, String name) {}
 
@@ -220,7 +221,8 @@ public class DashboardAccessChecker {
   private RepoSnapshot installedRepos(String accountOwner) {
     var snapshot = cachedSnapshot.get();
     if (snapshot.cachedAt().isAfter(clock.get().minus(REPO_CACHE_TTL))
-        && snapshot.installationAuth() != null) {
+        && snapshot.installationAuth() != null
+        && accountOwner.equalsIgnoreCase(snapshot.owner())) {
       return snapshot;
     }
 
@@ -238,7 +240,7 @@ public class DashboardAccessChecker {
       return cachedSnapshot.get();
     }
 
-    var updated = new RepoSnapshot(List.copyOf(repos), installationAuth, clock.get());
+    var updated = new RepoSnapshot(accountOwner, List.copyOf(repos), installationAuth, clock.get());
     cachedSnapshot.set(updated);
     log.info("Loaded {} installed repos for dashboard access control", repos.size());
     return updated;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
@@ -237,7 +237,14 @@ public class DashboardAccessChecker {
       }
     } catch (RuntimeException e) {
       log.warn("Failed to list installed repositories for {}: {}", accountOwner, e.getMessage());
-      return cachedSnapshot.get();
+      // Fail closed on owner mismatch: the cached snapshot may belong to a previous owner, so
+      // returning it here would re-introduce the cross-owner reuse this cache is keyed to prevent.
+      // Only fall back to it when it was resolved for the same owner (graceful degradation during a
+      // transient GitHub outage); otherwise deny by returning an empty snapshot for this owner.
+      var previous = cachedSnapshot.get();
+      return accountOwner.equalsIgnoreCase(previous.owner())
+          ? previous
+          : new RepoSnapshot(accountOwner, List.of(), null, Instant.EPOCH);
     }
 
     var updated = new RepoSnapshot(accountOwner, List.copyOf(repos), installationAuth, clock.get());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
@@ -550,6 +550,89 @@ class DashboardAccessCheckerTest {
         .listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1));
   }
 
+  @Test
+  void shouldFailClosedWhenRefetchForNewOwnerFails() {
+    // First access check caches a usable RepoSnapshot for "myowner" (auth + repos present).
+    stubInstalledRepo("myowner", "demo");
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+    Response collab = mock(Response.class);
+    when(collab.getStatus()).thenReturn(204);
+    when(installationClient.checkCollaborator(
+            anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(collab);
+
+    assertTrue(checker.hasAccess("collab-user"));
+
+    // Owner changes to "newowner", but resolving its installation token fails transiently.
+    when(dashboardConfig.accountOwner()).thenReturn(Optional.of("newowner"));
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
+        .thenReturn(List.of(installationFor("newowner", 200L)));
+    when(authClient.getAuthHeader(200L)).thenThrow(new RuntimeException("GitHub unavailable"));
+
+    // Advance past access cache TTL so the per-login result expires and access is re-evaluated.
+    now.set(now.get().plus(java.time.Duration.ofMinutes(6)));
+
+    // The error fallback must NOT serve "myowner"'s cached repos/token for "newowner": a
+    // collaborator of the previous owner must be denied, not authorized against the wrong repos.
+    assertFalse(checker.hasAccess("collab-user"));
+    // "myowner"'s repos are checked only during the first evaluation, never again via the fallback.
+    verify(installationClient, times(1))
+        .checkCollaborator(
+            eq("Bearer inst-token"), anyString(), eq("myowner"), anyString(), eq("collab-user"));
+  }
+
+  @Test
+  void shouldReuseCachedSnapshotForSameOwnerWhenRefreshFails() {
+    // First check caches a usable snapshot for "myowner"; the refresh token fails on the next call.
+    stubInstalledRepo("myowner", "demo");
+    when(authClient.getAuthHeader(99L))
+        .thenReturn("Bearer inst-token")
+        .thenThrow(new RuntimeException("GitHub unavailable"));
+    Response collab = mock(Response.class);
+    when(collab.getStatus()).thenReturn(204);
+    when(installationClient.checkCollaborator(
+            anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(collab);
+
+    assertTrue(checker.hasAccess("collab-user"));
+
+    // Advance past both the access cache (5 min) and the repo cache (10 min) so the snapshot is
+    // re-fetched; the re-fetch then fails transiently while the owner is unchanged.
+    now.set(now.get().plus(java.time.Duration.ofMinutes(11)));
+
+    // Graceful degradation: the cached snapshot belongs to the same owner, so it is reused rather
+    // than locking everyone out during a transient GitHub outage.
+    assertTrue(checker.hasAccess("collab-user"));
+  }
+
+  @Test
+  void shouldNotCacheMissingInstallationAndRetryWhenItAppears() {
+    // No matching installation exists yet, so the first lookup resolves no repos.
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
+        .thenReturn(List.of());
+
+    assertFalse(checker.hasAccess("collab-user"));
+    verify(installationClient, times(1))
+        .listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1));
+
+    // The installation now appears for "myowner" with the collaborator's repo.
+    stubInstalledRepo("myowner", "demo");
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+    Response collab = mock(Response.class);
+    when(collab.getStatus()).thenReturn(204);
+    when(installationClient.checkCollaborator(
+            anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(collab);
+
+    // Advance past access cache TTL (5 min) but within repo cache TTL (10 min): the prior negative
+    // (null-auth) snapshot must not be reused — the installation lookup must be retried.
+    now.set(now.get().plus(java.time.Duration.ofMinutes(6)));
+
+    assertTrue(checker.hasAccess("collab-user"));
+    verify(installationClient, times(2))
+        .listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1));
+  }
+
   private void stubInstalledRepo(String owner, String repo) {
     when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
         .thenReturn(List.of(installationFor(owner, 99L)));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
@@ -514,6 +514,42 @@ class DashboardAccessCheckerTest {
         .listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1));
   }
 
+  @Test
+  void shouldInvalidateRepoSnapshotCacheWhenOwnerChanges() {
+    // First access check caches a RepoSnapshot for "myowner"
+    stubInstalledRepo("myowner", "demo");
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+    Response collab = mock(Response.class);
+    when(collab.getStatus()).thenReturn(204);
+    when(installationClient.checkCollaborator(
+            anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(collab);
+
+    assertTrue(checker.hasAccess("collab-user"));
+    verify(installationClient, times(1))
+        .listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1));
+
+    // Switch the resolved owner to "newowner" (within repo cache TTL)
+    when(dashboardConfig.accountOwner()).thenReturn(Optional.of("newowner"));
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
+        .thenReturn(List.of(installationFor("newowner", 200L)));
+    when(authClient.getAuthHeader(200L)).thenReturn("Bearer new-inst-token");
+    when(installationClient.listInstallationRepositories(
+            eq("Bearer new-inst-token"), anyString(), eq(100), eq(1)))
+        .thenReturn(
+            new GitHubInstallationClient.InstallationRepositoriesResponse(
+                1, ownerRepos("newowner", "new-repo")));
+
+    // Advance past access cache TTL (5 min) but within repo cache TTL (10 min)
+    // so the per-login result expires and evaluateAccess re-enters installedRepos().
+    now.set(now.get().plus(java.time.Duration.ofMinutes(6)));
+
+    // The snapshot must NOT be reused — repos must be re-fetched for "newowner"
+    assertTrue(checker.hasAccess("collab-user"));
+    verify(installationClient, times(2))
+        .listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1));
+  }
+
   private void stubInstalledRepo(String owner, String repo) {
     when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
         .thenReturn(List.of(installationFor(owner, 99L)));


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

The `RepoSnapshot` cache in `DashboardAccessChecker` was a single `AtomicReference` with no owner identity. If the resolved account owner changed within the 10-minute TTL (e.g. config edit or App re-resolution), `installedRepos()` would return the stale snapshot for the previous owner, evaluating collaborator access against the wrong repositories and installation token.

### Changes

- **`RepoSnapshot` record**: Added `owner` field to carry the identity of the account owner the snapshot was fetched for.
- **Cache validation in `installedRepos()`**: Added `accountOwner.equalsIgnoreCase(snapshot.owner())` check so a snapshot resolved for one owner is never reused for a different owner.
- **Snapshot construction**: Passes `accountOwner` when creating the updated snapshot.

## Related Issues

Fixes #91

## How Has This Been Tested?

- [x] Unit tests - New unit test `shouldInvalidateRepoSnapshotCacheWhenOwnerChanges` — verifies that when the resolved owner changes within the repo cache TTL (but past the access cache TTL), the snapshot is re-fetched for the new owner instead of reusing the stale one.
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

N/A
