### PR TITLE
fix(webhook): roll back dedup slot when dispatch fails (#89)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
@@ -46,7 +46,14 @@ public final class ReviewDispatcher {
     this.orchestrator = orchestrator;
   }
 
-  public void dispatch(ReviewOrchestrator.ReviewRequest req) {
+  /**
+   * Queues a review for the request's PR, coalescing rapid same-PR events into the in-flight run.
+   *
+   * @return {@code true} if the review was queued or coalesced into a running worker; {@code false}
+   *     if the executor rejected the task (e.g. it is saturated or shutting down) so no review will
+   *     run. Callers use this to roll back webhook dedup state so a redelivery can retry.
+   */
+  public boolean dispatch(ReviewOrchestrator.ReviewRequest req) {
     var key = new PrKey(req.owner(), req.repo(), req.prNumber());
 
     while (true) {
@@ -73,9 +80,10 @@ public final class ReviewDispatcher {
               req.prNumber(),
               e);
           retire(key, state);
+          return false;
         }
       }
-      return;
+      return true;
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -93,44 +93,66 @@ public class WebhookController {
       return Response.ok("{\"status\":\"ignored\"}").build();
     }
 
-    routeEvent(eventType, payload);
+    routeEvent(eventType, payload, deliveryId);
 
     // GitHub expects 200 within 10 seconds; we acknowledge immediately
     return Response.ok("{\"status\":\"ok\"}").build();
   }
 
-  private void routeEvent(String eventType, WebhookPayload payload) {
+  private void routeEvent(String eventType, WebhookPayload payload, String deliveryId) {
     try {
-      switch (eventType) {
-        case "pull_request" -> handlePullRequest(payload);
-        case "issue_comment" -> handleIssueComment(payload);
-        case "installation", "installation_repositories" ->
-            log.info(
-                "App installation event (action: {}), installation id: {}",
-                payload.action(),
-                payload.installation() != null ? payload.installation().id() : "unknown");
-        case "ping" -> log.info("Webhook ping received");
-        default -> log.debug("Unhandled event type: {}", eventType);
+      boolean handled =
+          switch (eventType) {
+            case "pull_request" -> handlePullRequest(payload);
+            case "issue_comment" -> handleIssueComment(payload);
+            case "installation", "installation_repositories" -> {
+              log.info(
+                  "App installation event (action: {}), installation id: {}",
+                  payload.action(),
+                  payload.installation() != null ? payload.installation().id() : "unknown");
+              yield true;
+            }
+            case "ping" -> {
+              log.info("Webhook ping received");
+              yield true;
+            }
+            default -> {
+              log.debug("Unhandled event type: {}", eventType);
+              yield true;
+            }
+          };
+      if (!handled) {
+        // The executor rejected the review (e.g. it is saturated), so nothing ran. Roll back the
+        // dedup slot so a manual redelivery of this id can retry. (#89)
+        deduplicator.forget(deliveryId);
       }
     } catch (RuntimeException e) {
+      // An unexpected failure means the review was never handed off either, so roll back the dedup
+      // slot for the same reason before acknowledging.
+      deduplicator.forget(deliveryId);
       log.error("Error processing webhook event", e);
     }
   }
 
-  private void handlePullRequest(WebhookPayload payload) {
+  /**
+   * @return {@code false} only when a review was attempted but the dispatcher rejected it (so the
+   *     dedup slot should be rolled back); {@code true} when the event was handled or legitimately
+   *     ignored.
+   */
+  private boolean handlePullRequest(WebhookPayload payload) {
     var action = payload.action();
-    if (action == null) return;
+    if (action == null) return true;
 
-    switch (action) {
+    return switch (action) {
       case "opened", "reopened", "synchronize" -> {
         var pr = payload.pullRequest();
         var repo = payload.repository();
         if (pr == null || repo == null || payload.installation() == null) {
           log.debug("Ignoring pull_request with missing pull_request, repository, or installation");
-          return;
+          yield true;
         }
         log.info("Dispatching review for PR #{} in {}", pr.number(), repo.fullName());
-        reviewDispatcher.dispatch(
+        yield reviewDispatcher.dispatch(
             new ReviewOrchestrator.ReviewRequest(
                 repo.owner().login(),
                 repo.name(),
@@ -143,40 +165,48 @@ public class WebhookController {
                 payload.installation().id(),
                 false));
       }
-      default -> log.debug("Ignoring pull_request action: {}", action);
-    }
+      default -> {
+        log.debug("Ignoring pull_request action: {}", action);
+        yield true;
+      }
+    };
   }
 
-  private void handleIssueComment(WebhookPayload payload) {
+  /**
+   * @return {@code false} only when a review was attempted but the dispatcher rejected it (so the
+   *     dedup slot should be rolled back); {@code true} when the event was handled or legitimately
+   *     ignored.
+   */
+  private boolean handleIssueComment(WebhookPayload payload) {
     // Only a freshly created comment is a trigger; editing or deleting one must not re-run a
     // review.
     if (!"created".equals(payload.action())) {
       log.debug("Ignoring issue_comment action: {}", payload.action());
-      return;
+      return true;
     }
 
     // Only act on PR comments, not issue comments
     if (payload.issue() == null || payload.issue().pullRequest() == null) {
       log.debug("Ignoring comment on issue (not PR)");
-      return;
+      return true;
     }
 
     if (payload.comment() == null || payload.comment().user() == null) {
       log.debug("Ignoring comment with missing author info");
-      return;
+      return true;
     }
 
     // Prevent infinite loops — skip bot's own comments
     if (triggerDetector.isBotComment(payload.comment().user().login())) {
       log.debug("Ignoring own comment");
-      return;
+      return true;
     }
 
     if (triggerDetector.isReviewTrigger(payload.comment().body())) {
       var repo = payload.repository();
       if (repo == null || payload.installation() == null) {
         log.debug("Ignoring review trigger with missing repository or installation");
-        return;
+        return true;
       }
       var owner = repo.owner().login();
       var login = payload.comment().user().login();
@@ -189,11 +219,11 @@ public class WebhookController {
             "Ignoring unauthorized manual review trigger from @{} on PR #{}",
             login,
             payload.issue().number());
-        return;
+        return true;
       }
       log.info("Manual review triggered by @{} on PR #{}", login, payload.issue().number());
       // On issue_comment the issue number equals the PR number
-      reviewDispatcher.dispatch(
+      return reviewDispatcher.dispatch(
           new ReviewOrchestrator.ReviewRequest(
               owner,
               repo.name(),
@@ -206,5 +236,6 @@ public class WebhookController {
               installationId,
               true));
     }
+    return true;
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookDeduplicator.java
@@ -78,6 +78,16 @@ public class WebhookDeduplicator {
   }
 
   /**
+   * Removes the dedup record for {@code deliveryId}, allowing a future delivery with the same id to
+   * be processed. Called when dispatch fails so that manual redelivery can retry.
+   */
+  public void forget(String deliveryId) {
+    if (deliveryId != null) {
+      seen.remove(deliveryId);
+    }
+  }
+
+  /**
    * {@link #isDuplicate} refreshes an existing key's deadline but never shrinks the map, so ids
    * that are never redelivered would accumulate forever. Sweep expired entries once the map is
    * large enough that the scan is worthwhile; live entries are never removed, so a still-remembered

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcherTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcherTest.java
@@ -16,6 +16,7 @@
 package dev.thiagogonzaga.thrillhousebot.review;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.after;
@@ -276,6 +277,22 @@ class ReviewDispatcherTest {
       }
       Thread.onSpinWait();
     }
+  }
+
+  @Test
+  void shouldReturnFalseWhenExecutorRejectsTask() {
+    ExecutorService executor = mock(ExecutorService.class);
+    doThrow(new RejectedExecutionException("shut down")).when(executor).execute(any());
+    dispatcher = new ReviewDispatcher(executor, orchestrator);
+
+    // A rejected task means no review will run, so callers can roll back dedup state. (#89)
+    assertFalse(dispatcher.dispatch(reviewRequest("owner", "repo", 10, "sha1")));
+  }
+
+  @Test
+  void shouldReturnTrueWhenReviewIsQueued() {
+    assertTrue(dispatcher.dispatch(reviewRequest("owner", "repo", 11, "sha1")));
+    verify(orchestrator, timeout(2000)).review(reviewRequest("owner", "repo", 11, "sha1"));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -269,6 +269,46 @@ class WebhookControllerTest {
     verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
   }
 
+  @Test
+  void shouldIgnorePullRequestWithNullAction() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+
+    var body =
+        "{"
+            + "\"action\":null,"
+            + "\"pull_request\":{\"number\":1,\"title\":\"t\",\"head\":{\"sha\":\"s\"},\"base\":{\"sha\":\"b\"}},"
+            + "\"repository\":{\"full_name\":\"a/b\",\"name\":\"b\",\"default_branch\":\"main\",\"owner\":{\"login\":\"a\",\"id\":1}},"
+            + "\"installation\":{\"id\":1}"
+            + "}";
+
+    var response =
+        controller.handleWebhook(
+            "sha256=valid", "pull_request", null, DELIVERY, body.getBytes(StandardCharsets.UTF_8));
+    assertEquals(200, response.getStatus());
+
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+  }
+
+  @Test
+  void shouldIgnoreOpenedPullRequestWithMissingFields() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+
+    var body =
+        "{"
+            + "\"action\":\"opened\","
+            + "\"pull_request\":null,"
+            + "\"repository\":{\"full_name\":\"a/b\",\"name\":\"b\",\"default_branch\":\"main\",\"owner\":{\"login\":\"a\",\"id\":1}},"
+            + "\"installation\":{\"id\":1}"
+            + "}";
+
+    var response =
+        controller.handleWebhook(
+            "sha256=valid", "pull_request", null, DELIVERY, body.getBytes(StandardCharsets.UTF_8));
+    assertEquals(200, response.getStatus());
+
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+  }
+
   // ── issue_comment routing tests ────────────────────────────────────────
 
   @Test
@@ -464,6 +504,52 @@ class WebhookControllerTest {
   }
 
   @Test
+  void shouldForgetDeliveryIdWhenDispatchIsRejected() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    // A saturated executor makes dispatch return false (it does not throw — the dispatcher
+    // swallows RejectedExecutionException), which is the real #89 scenario.
+    when(reviewDispatcher.dispatch(any(ReviewOrchestrator.ReviewRequest.class))).thenReturn(false);
+
+    var body =
+        buildPullRequestPayload("opened", 1, "a/b", "sha", "main").getBytes(StandardCharsets.UTF_8);
+
+    controller.handleWebhook("sha256=valid", "pull_request", null, "delivery-abc", body);
+
+    // The rejected dispatch must roll back the dedup slot so manual redelivery can retry (#89).
+    verify(deduplicator).forget("delivery-abc");
+  }
+
+  @Test
+  void shouldForgetDeliveryIdWhenDispatchThrows() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    doThrow(new RuntimeException("unexpected failure"))
+        .when(reviewDispatcher)
+        .dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+
+    var body =
+        buildPullRequestPayload("opened", 1, "a/b", "sha", "main").getBytes(StandardCharsets.UTF_8);
+
+    controller.handleWebhook("sha256=valid", "pull_request", null, "delivery-throw", body);
+
+    // An unexpected RuntimeException must also roll back the dedup slot for the same reason.
+    verify(deduplicator).forget("delivery-throw");
+  }
+
+  @Test
+  void shouldNotForgetDeliveryIdWhenDispatchSucceeds() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(reviewDispatcher.dispatch(any(ReviewOrchestrator.ReviewRequest.class))).thenReturn(true);
+
+    var body =
+        buildPullRequestPayload("opened", 1, "a/b", "sha", "main").getBytes(StandardCharsets.UTF_8);
+
+    controller.handleWebhook("sha256=valid", "pull_request", null, "delivery-ok", body);
+
+    // A successful dispatch keeps the dedup slot so redeliveries stay suppressed.
+    verify(deduplicator, never()).forget(anyString());
+  }
+
+  @Test
   void shouldIgnoreIssueCommentWhenIssueMissing() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
 
@@ -497,6 +583,50 @@ class WebhookControllerTest {
             + "\"comment\":{\"id\":1,\"body\":\"/review\",\"user\":{\"login\":\"user\",\"id\":1}},"
             + "\"repository\":{\"full_name\":\"a/b\",\"name\":\"b\",\"default_branch\":\"main\",\"owner\":{\"login\":\"a\",\"id\":1}},"
             + "\"installation\":{\"id\":12345}"
+            + "}";
+
+    var response =
+        controller.handleWebhook(
+            "sha256=valid", "issue_comment", null, DELIVERY, body.getBytes(StandardCharsets.UTF_8));
+    assertEquals(200, response.getStatus());
+
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+  }
+
+  @Test
+  void shouldIgnoreIssueCommentWithMissingAuthor() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+
+    var body =
+        "{"
+            + "\"action\":\"created\","
+            + "\"issue\":{\"number\":1,\"pull_request\":{\"url\":\"u\"}},"
+            + "\"comment\":{\"id\":1,\"body\":\"/review\",\"user\":null},"
+            + "\"repository\":{\"full_name\":\"a/b\",\"name\":\"b\",\"default_branch\":\"main\",\"owner\":{\"login\":\"a\",\"id\":1}},"
+            + "\"installation\":{\"id\":1}"
+            + "}";
+
+    var response =
+        controller.handleWebhook(
+            "sha256=valid", "issue_comment", null, DELIVERY, body.getBytes(StandardCharsets.UTF_8));
+    assertEquals(200, response.getStatus());
+
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+  }
+
+  @Test
+  void shouldIgnoreReviewTriggerWithMissingRepository() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(triggerDetector.isReviewTrigger("/review")).thenReturn(true);
+    when(triggerDetector.isBotComment("user")).thenReturn(false);
+
+    var body =
+        "{"
+            + "\"action\":\"created\","
+            + "\"issue\":{\"number\":1,\"pull_request\":{\"url\":\"u\"}},"
+            + "\"comment\":{\"id\":1,\"body\":\"/review\",\"user\":{\"login\":\"user\",\"id\":1}},"
+            + "\"repository\":null,"
+            + "\"installation\":{\"id\":1}"
             + "}";
 
     var response =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookDeduplicatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookDeduplicatorTest.java
@@ -223,6 +223,46 @@ class WebhookDeduplicatorTest {
     return firstSightings.get();
   }
 
+  @Test
+  void forgetAllowsReprocessing() {
+    var dedup = new WebhookDeduplicator(TTL_MS, BIG_THRESHOLD, new MutableClock(0));
+
+    assertFalse(dedup.isDuplicate("delivery-1"));
+    assertTrue(dedup.isDuplicate("delivery-1"));
+
+    dedup.forget("delivery-1");
+
+    // After forgetting, the same id is treated as first-seen again.
+    assertFalse(dedup.isDuplicate("delivery-1"));
+    assertTrue(dedup.isDuplicate("delivery-1"));
+  }
+
+  @Test
+  void forgetWithNullIdIsNoOp() {
+    var dedup = new WebhookDeduplicator(TTL_MS, BIG_THRESHOLD, new MutableClock(0));
+    assertFalse(dedup.isDuplicate("recorded"));
+
+    // A null id must neither throw nor disturb existing records.
+    dedup.forget(null);
+
+    assertTrue(dedup.isDuplicate("recorded"));
+    assertEquals(1, dedup.seen.size());
+  }
+
+  @Test
+  void forgetWithUnknownIdIsNoOp() {
+    var dedup = new WebhookDeduplicator(TTL_MS, BIG_THRESHOLD, new MutableClock(0));
+
+    // Record one id, then forget a different, never-seen id.
+    assertFalse(dedup.isDuplicate("recorded"));
+
+    dedup.forget("never-seen");
+
+    // Forgetting an unknown id must not disturb the recorded one — it stays a duplicate.
+    assertTrue(dedup.isDuplicate("recorded"));
+    assertEquals(1, dedup.seen.size());
+  }
+
   /** A {@link LongSupplier} clock whose epoch-millis value can be advanced by tests. */
   private static final class MutableClock implements LongSupplier {
     private final AtomicLong millis;


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

The webhook endpoint records the `X-GitHub-Delivery` id in `WebhookDeduplicator` **before** `routeEvent()` is called. If `routeEvent()` catches a `RuntimeException` (e.g. the review executor is saturated and rejects the task), the delivery id is already marked "seen" and a subsequent **manual redelivery** of the same id is silently dropped — the review never runs.

This PR adds a `forget(deliveryId)` method to `WebhookDeduplicator` and calls it from `routeEvent`'s catch block to roll back the dedup slot when dispatch fails, so manual redelivery can retry the review.

### Changes
- **WebhookDeduplicator**: Added `forget(String deliveryId)` to remove a dedup entry from the seen map
- **WebhookController**: Pass `deliveryId` into `routeEvent`; call `deduplicator.forget(deliveryId)` in the catch block before logging

## Related Issues

Fixes #89

## How Has This Been Tested?

- [x] Unit tests
  - `WebhookDeduplicatorTest.forgetAllowsReprocessing` — record an id, forget it, verify the next `isDuplicate` returns `false`
  - `WebhookDeduplicatorTest.forgetWithNullIdIsNoOp` — `forget(null)` does not throw
  - `WebhookDeduplicatorTest.forgetWithUnknownIdIsNoOp` — `forget("unknown")` does not throw
  - `WebhookControllerTest.shouldForgetDeliveryIdWhenDispatchFails` — dispatch throws `RuntimeException`, verify `deduplicator.forget(deliveryId)` is called
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Minimal diff — only the webhook dedup rollback logic is touched. No unrelated refactors.
