### PR TITLE
docs(readme): clarify fail-closed behavior for dashboard access

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Early v0.1.0 release:
   Multiple replicas are unsupported.
 - **Dashboard access** — GitHub OAuth required. Only the app account owner and
   collaborators on installed repos can use the dashboard; no admin UI or guest mode.
-  If the app owner cannot be resolved from GitHub, access control is off until
+  If the app owner cannot be resolved from GitHub, the dashboard fails closed (denies all access) until
   `thrillhousebot.dashboard.github.account-owner` is set.
 - **Production database** — container and native production builds use PostgreSQL
   (`%prod`). H2 is for local `quarkus:dev` only.


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [x] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

This PR updates the `README.md` to accurately document the current access control behavior. Specifically, it clarifies that if the app owner cannot be resolved from GitHub, the dashboard **fails closed** (denying all access) until `thrillhousebot.dashboard.github.account-owner` is explicitly configured. This aligns the documentation with the actual behavior implemented in PR #17, removing the outdated description of the former fail-open behavior.

## Related Issues

Fixes #90

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

N/A
