### PR TITLE
docs: document new config keys (WEBHOOK_DEDUP_TTL, manual-trigger-allowed-logins)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@
 GITHUB_APP_ID=your_app_id
 GITHUB_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
 GITHUB_WEBHOOK_SECRET=your_webhook_secret
+# Optional: webhook deduplication window for GitHub redeliveries
+#WEBHOOK_DEDUP_TTL=24h
+# Optional: comma-separated allowlist of logins permitted to trigger manual /review without repo access
+#THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS=alice,bob
 
 # AI — any OpenAI-compatible API. Set AI_BASE_URL/AI_MODEL for your provider.
 # Defaults below use DeepSeek; e.g. Alibaba Cloud Model Studio would be:

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ variables are the ones you will change per provider:
 | `GITHUB_APP_ID` | GitHub App ID | _(required)_ |
 | `GITHUB_PRIVATE_KEY` | GitHub App private key (PEM) | _(required)_ |
 | `GITHUB_WEBHOOK_SECRET` | Webhook HMAC secret | _(required)_ |
+| `WEBHOOK_DEDUP_TTL` | Webhook deduplication time-to-live for GitHub redeliveries | `24h` |
+| `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` | Comma-separated allowlist of logins permitted to trigger manual `/review` without repo access | _(empty)_ |
 | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | OAuth credentials for dashboard login | _(required for dashboard)_ |
 | `DASHBOARD_URL` | Public dashboard URL (OAuth callback base) | `http://localhost:8080` |
 | `DATASOURCE_DB_KIND` | `h2` or `postgresql` | `h2` (dev), `postgresql` (`%prod`) |


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [x] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

This PR documents two configuration keys introduced in v0.1.1 that were missing from the user-facing documentation:
- `WEBHOOK_DEDUP_TTL`: The time-to-live for deduplicating GitHub redeliveries (defaults to 24h).
- `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS`: The allowlist of GitHub logins permitted to trigger manual `/review` comments without needing write access to the repository.

Both keys have been added to the configuration table in `README.md` and included as commented-out examples in `.env.example`.

## Related Issues

Fixes #94

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (verified markdown table formatting)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

N/A
