### PR TITLE
fix(review): validate description-cited code in FindingQuoteValidator (#106)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -50,6 +50,9 @@ public class FindingQuoteValidator {
 
   private static final String LOW_CONFIDENCE = "low";
 
+  /** Shared tail of every log line that strips a suggestion and caps confidence. */
+  private static final String DEMOTION_SUFFIX = " dropping its suggestion and capping confidence";
+
   /**
    * A chained call expression: a receiver followed by one or more {@code .member} segments, with
    * optional argument lists. Single names like {@code installedRepos()} are deliberately excluded —
@@ -85,8 +88,10 @@ public class FindingQuoteValidator {
           if (descriptionCitesAbsentCode(finding, index)) {
             Log.infof(
                 "Finding '%s' (%s:%d) cites code in its description that appears nowhere in the diff —"
-                    + " dropping its suggestion and capping confidence",
-                finding.title(), finding.file(), finding.line());
+                    + DEMOTION_SUFFIX,
+                finding.title(),
+                finding.file(),
+                finding.line());
             kept.add(withoutSuggestion(finding));
             changed = true;
           } else {
@@ -96,16 +101,20 @@ public class FindingQuoteValidator {
         case PARTIAL -> {
           Log.infof(
               "Finding '%s' (%s:%d) quotes code only partially present in the diff —"
-                  + " dropping its suggestion and capping confidence",
-              finding.title(), finding.file(), finding.line());
+                  + DEMOTION_SUFFIX,
+              finding.title(),
+              finding.file(),
+              finding.line());
           kept.add(withoutSuggestion(finding));
           changed = true;
         }
         case AMBIGUOUS -> {
           Log.infof(
               "Finding '%s' (%s:%d) quotes code that appears in multiple locations, but the finding's line is ambiguous —"
-                  + " dropping its suggestion and capping confidence",
-              finding.title(), finding.file(), finding.line());
+                  + DEMOTION_SUFFIX,
+              finding.title(),
+              finding.file(),
+              finding.line());
           kept.add(withoutSuggestion(finding));
           changed = true;
         }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Deterministic guard against findings that quote code which is not in the diff. The model
@@ -37,11 +38,29 @@ import java.util.Set;
  * <p>The check is conservative: a finding is dropped only when none of its quoted lines exist in
  * the diff (pure phantom). When the quote is partially wrong, the unreliable suggestion block is
  * removed and confidence is capped at "low" so the finding can still surface but cannot block.
+ *
+ * <p>The same demotion applies when a finding's {@code suggestion_old} genuinely matches the diff
+ * but its free-text {@code description} cites a chained call expression as existing source that
+ * appears nowhere in scope — the fabricated mechanism is treated like a partial quote. Only
+ * distinctive {@code receiver.member(...)} chains are checked, so bare method names that simply
+ * fall outside the diff window are never penalized.
  */
 @ApplicationScoped
 public class FindingQuoteValidator {
 
   private static final String LOW_CONFIDENCE = "low";
+
+  /**
+   * A chained call expression: a receiver followed by one or more {@code .member} segments, with
+   * optional argument lists. Single names like {@code installedRepos()} are deliberately excluded —
+   * they are too common to flag against the diff's narrow window. A match is only treated as a code
+   * citation when it actually contains a call ({@code '('}).
+   */
+  private static final Pattern CHAINED_CALL =
+      Pattern.compile(
+          "[A-Za-z_$][A-Za-z0-9_$]*(?:\\([^()]*\\))?(?:\\.[A-Za-z_$][A-Za-z0-9_$]*(?:\\([^()]*\\))?)+");
+
+  private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 
   public record DiffLine(String normalizedText, int rightLineNum, char marker) {}
 
@@ -60,7 +79,18 @@ public class FindingQuoteValidator {
         match = checkAmbiguity(quoted, finding.line(), index.diffLinesFor(finding.file()));
       }
       switch (match) {
-        case FULL, NO_QUOTE -> kept.add(finding);
+        case FULL, NO_QUOTE -> {
+          if (descriptionCitesAbsentCode(finding, index)) {
+            Log.infof(
+                "Finding '%s' (%s:%d) cites code in its description that appears nowhere in the diff —"
+                    + " dropping its suggestion and capping confidence",
+                finding.title(), finding.file(), finding.line());
+            kept.add(withoutSuggestion(finding));
+            changed = true;
+          } else {
+            kept.add(finding);
+          }
+        }
         case PARTIAL -> {
           Log.infof(
               "Finding '%s' (%s:%d) quotes code only partially present in the diff —"
@@ -107,6 +137,65 @@ public class FindingQuoteValidator {
      * Quote is fully present in multiple locations, but finding line doesn't uniquely select one.
      */
     AMBIGUOUS
+  }
+
+  /**
+   * Whether the finding's description presents, as existing source, a chained call expression that
+   * cannot be found anywhere in the diff scoped to its file. This catches the failure mode where a
+   * genuine {@code suggestion_old} quote passes the gate but the supporting prose invents the
+   * mechanism (e.g. {@code dashboardConfig.accountOwner().orElse(null)} for a method parameter that
+   * is never derived that way). The match is whitespace-insensitive so reformatting can't hide a
+   * real citation — meaning the check only fires when the expression is genuinely absent.
+   */
+  private static boolean descriptionCitesAbsentCode(
+      ReviewResponse.Finding finding, DiffIndex index) {
+    List<String> cited = citedCallExpressions(finding.description());
+    if (cited.isEmpty()) {
+      return false;
+    }
+    List<DiffLine> scope = index.diffLinesFor(finding.file());
+    for (String expression : cited) {
+      if (!appearsInDiff(expression, scope)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** The chained call expressions a description presents as code, e.g. {@code a.b().c(null)}. */
+  private static List<String> citedCallExpressions(String description) {
+    if (description == null || description.isBlank()) {
+      return List.of();
+    }
+    var expressions = new ArrayList<String>();
+    var matcher = CHAINED_CALL.matcher(description);
+    while (matcher.find()) {
+      String expression = matcher.group();
+      // Require an actual call: a dotted field chain (e.g. config.value) or a bare name is not
+      // distinctive enough to flag against the diff's narrow window.
+      if (expression.indexOf('(') >= 0) {
+        expressions.add(expression);
+      }
+    }
+    return expressions;
+  }
+
+  /**
+   * Whether {@code expression} occurs, ignoring whitespace, within any scoped diff line. The
+   * expression is always a non-empty call chain (see {@link #citedCallExpressions}).
+   */
+  private static boolean appearsInDiff(String expression, List<DiffLine> scope) {
+    String needle = compact(expression);
+    for (DiffLine line : scope) {
+      if (compact(line.normalizedText()).contains(needle)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String compact(String text) {
+    return WHITESPACE.matcher(text).replaceAll("");
   }
 
   static QuoteMatch matchQuote(List<String> quoted, Set<String> diffLines) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -164,9 +164,9 @@ public class FindingQuoteValidator {
     if (cited.isEmpty()) {
       return false;
     }
-    List<DiffLine> scope = index.diffLinesFor(finding.file());
+    List<String> compactedScope = compactedLines(index.diffLinesFor(finding.file()));
     for (String expression : cited) {
-      if (!appearsInDiff(expression, scope)) {
+      if (!appearsIn(expression, compactedScope)) {
         return true;
       }
     }
@@ -192,13 +192,24 @@ public class FindingQuoteValidator {
   }
 
   /**
-   * Whether {@code expression} occurs, ignoring whitespace, within any scoped diff line. The
-   * expression is always a non-empty call chain (see {@link #citedCallExpressions}).
+   * The scoped diff lines with all whitespace removed, compacted once for reuse across citations.
    */
-  private static boolean appearsInDiff(String expression, List<DiffLine> scope) {
-    String needle = compact(expression);
+  private static List<String> compactedLines(List<DiffLine> scope) {
+    var compacted = new ArrayList<String>(scope.size());
     for (DiffLine line : scope) {
-      if (compact(line.normalizedText()).contains(needle)) {
+      compacted.add(compact(line.normalizedText()));
+    }
+    return compacted;
+  }
+
+  /**
+   * Whether {@code expression} occurs, ignoring whitespace, within any already-compacted diff line.
+   * The expression is always a non-empty call chain (see {@link #citedCallExpressions}).
+   */
+  private static boolean appearsIn(String expression, List<String> compactedScope) {
+    String needle = compact(expression);
+    for (String line : compactedScope) {
+      if (line.contains(needle)) {
         return true;
       }
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -54,11 +54,13 @@ public class FindingQuoteValidator {
    * A chained call expression: a receiver followed by one or more {@code .member} segments, with
    * optional argument lists. Single names like {@code installedRepos()} are deliberately excluded —
    * they are too common to flag against the diff's narrow window. A match is only treated as a code
-   * citation when it actually contains a call ({@code '('}).
+   * citation when it actually contains a call ({@code '('}). Quantifiers are possessive: each class
+   * never overlaps the token that follows it, so no backtracking is ever needed and large inputs
+   * cannot trigger catastrophic backtracking.
    */
   private static final Pattern CHAINED_CALL =
       Pattern.compile(
-          "[A-Za-z_$][A-Za-z0-9_$]*(?:\\([^()]*\\))?(?:\\.[A-Za-z_$][A-Za-z0-9_$]*(?:\\([^()]*\\))?)+");
+          "[A-Za-z_$][A-Za-z0-9_$]*+(?:\\([^()]*+\\))?+(?:\\.[A-Za-z_$][A-Za-z0-9_$]*+(?:\\([^()]*+\\))?+)++");
 
   private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -508,6 +508,117 @@ class FindingQuoteValidatorTest {
     assertSame(response, validator.validate(response, MULTI_FILE_DIFF));
   }
 
+  private static final String DESCRIPTION_DIFF =
+      """
+      ### DashboardAccessChecker.java (modified, +1 -1)
+      ```diff
+      @@ -220,3 +220,3 @@
+       public List<RepoRef> installedRepos(String accountOwner) {
+      -    return repos.stream().filter(r -> r.owner().equals(accountOwner)).toList();
+      +    return repos.stream().filter(r -> r.owner().equalsIgnoreCase(accountOwner)).toList();
+       }
+      ```
+      """;
+
+  private static final String MATCHED_OLD =
+      "return repos.stream().filter(r -> r.owner().equals(accountOwner)).toList();";
+
+  private static ReviewResponse.Finding describedFinding(String suggestionOld, String description) {
+    return new ReviewResponse.Finding(
+        "medium",
+        "high",
+        "DashboardAccessChecker.java",
+        221,
+        "Potential NullPointerException when accountOwner is null",
+        description,
+        suggestionOld,
+        "fixed");
+  }
+
+  /**
+   * The PR #101 dogfood case: {@code suggestion_old} quotes the real changed line (a FULL match)
+   * but the description's supporting mechanism is a chained call that exists nowhere. The finding
+   * is kept but demoted — suggestion stripped, confidence capped — exactly like a partial quote.
+   */
+  @Test
+  void demotesFindingWhenDescriptionCitesPhantomChainedCall() {
+    var finding =
+        describedFinding(
+            MATCHED_OLD,
+            "accountOwner is obtained from `dashboardConfig.accountOwner().orElse(null)` in"
+                + " evaluateAccess(), so it can be null here.");
+    var response = response(finding);
+
+    var result = validator.validate(response, DESCRIPTION_DIFF);
+
+    assertEquals(1, result.findings().size());
+    var kept = result.findings().get(0);
+    assertNull(kept.suggestionOld());
+    assertNull(kept.suggestionNew());
+    assertEquals("low", kept.confidence());
+    assertEquals("medium", kept.risk());
+  }
+
+  /** A description whose chained call is genuinely present in the diff keeps the finding intact. */
+  @Test
+  void keepsFindingWhenDescriptionCitesPresentChainedCall() {
+    var finding =
+        describedFinding(
+            MATCHED_OLD,
+            "The filter `r.owner().equals(accountOwner)` is case-sensitive, which misses matches.");
+    var response = response(finding);
+
+    assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
+  }
+
+  /** Bare method names cited in the description must not be flagged just for being off-diff. */
+  @Test
+  void keepsFindingWhenDescriptionCitesOnlyBareMethodNames() {
+    var finding =
+        describedFinding(
+            MATCHED_OLD,
+            "accountOwner flows from installedRepos() and evaluateAccess(); it may be null.");
+    var response = response(finding);
+
+    assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
+  }
+
+  /** An absent description has no citations to check, so a matching quote passes through. */
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"   "})
+  void keepsFindingWithoutDescriptionAndMatchingQuote(String description) {
+    var response = response(describedFinding(MATCHED_OLD, description));
+
+    assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
+  }
+
+  /** A dotted field access without a call is not distinctive enough to flag, so it is ignored. */
+  @Test
+  void keepsFindingWhenDescriptionCitesOnlyDottedFieldAccess() {
+    var finding =
+        describedFinding(
+            MATCHED_OLD, "The configured `dashboardConfig.accountOwner` default is applied here.");
+    var response = response(finding);
+
+    assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
+  }
+
+  /** A phantom citation demotes even a finding that carries no suggestion_old of its own. */
+  @Test
+  void demotesQuotelessFindingWhenDescriptionCitesPhantomChainedCall() {
+    var finding =
+        describedFinding(
+            null,
+            "The value from `config.lookup().orElse(null)` is never null-checked before use.");
+    var response = response(finding);
+
+    var result = validator.validate(response, DESCRIPTION_DIFF);
+
+    assertEquals(1, result.findings().size());
+    assertEquals("low", result.findings().get(0).confidence());
+  }
+
   @Test
   void noNewlineIndicatorIsNotQuotableContent() {
     var diff =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -560,12 +560,16 @@ class FindingQuoteValidatorTest {
   }
 
   /**
-   * A description that cites no absent chained call leaves the finding untouched — whether the
-   * cited call is genuinely in the diff, only a bare method name, or only a dotted field access.
+   * A description that cites no absent chained call leaves the finding untouched: an absent (null
+   * or blank) description, a chained call genuinely in the diff, a bare method name, or a dotted
+   * field access without a call all pass through unchanged.
    */
   @ParameterizedTest
+  @NullSource
   @ValueSource(
       strings = {
+        // blank: no citations to check
+        "   ",
         // chained call genuinely present in the diff
         "The filter `r.owner().equals(accountOwner)` is case-sensitive, which misses matches.",
         // bare method names are not distinctive enough to flag against the diff window
@@ -573,17 +577,7 @@ class FindingQuoteValidatorTest {
         // a dotted field access without a call is ignored
         "The configured `dashboardConfig.accountOwner` default is applied here."
       })
-  void keepsFindingWhenDescriptionCitesNoAbsentChainedCall(String description) {
-    var response = response(describedFinding(MATCHED_OLD, description));
-
-    assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
-  }
-
-  /** An absent description has no citations to check, so a matching quote passes through. */
-  @ParameterizedTest
-  @NullSource
-  @ValueSource(strings = {"   "})
-  void keepsFindingWithoutDescriptionAndMatchingQuote(String description) {
+  void keepsFindingWhenDescriptionHasNoAbsentChainedCall(String description) {
     var response = response(describedFinding(MATCHED_OLD, description));
 
     assertSame(response, validator.validate(response, DESCRIPTION_DIFF));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -598,6 +598,26 @@ class FindingQuoteValidatorTest {
     assertEquals("low", result.findings().get(0).confidence());
   }
 
+  /**
+   * The NO_QUOTE keep-branch: a finding with no suggestion_old whose description cites no absent
+   * code (a present chained call, or none at all) passes through untouched — distinct from the
+   * FULL-arm keep tests, which all carry a matching suggestion_old.
+   */
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(
+      strings = {
+        // chained call genuinely present in the diff
+        "The filter `r.owner().equals(accountOwner)` is case-sensitive, which misses matches.",
+        // no chained call at all
+        "accountOwner may be null at this point."
+      })
+  void keepsQuotelessFindingWhenDescriptionHasNoAbsentChainedCall(String description) {
+    var response = response(describedFinding(null, description));
+
+    assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
+  }
+
   @Test
   void noNewlineIndicatorIsNotQuotableContent() {
     var diff =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -559,26 +559,22 @@ class FindingQuoteValidatorTest {
     assertEquals("medium", kept.risk());
   }
 
-  /** A description whose chained call is genuinely present in the diff keeps the finding intact. */
-  @Test
-  void keepsFindingWhenDescriptionCitesPresentChainedCall() {
-    var finding =
-        describedFinding(
-            MATCHED_OLD,
-            "The filter `r.owner().equals(accountOwner)` is case-sensitive, which misses matches.");
-    var response = response(finding);
-
-    assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
-  }
-
-  /** Bare method names cited in the description must not be flagged just for being off-diff. */
-  @Test
-  void keepsFindingWhenDescriptionCitesOnlyBareMethodNames() {
-    var finding =
-        describedFinding(
-            MATCHED_OLD,
-            "accountOwner flows from installedRepos() and evaluateAccess(); it may be null.");
-    var response = response(finding);
+  /**
+   * A description that cites no absent chained call leaves the finding untouched — whether the
+   * cited call is genuinely in the diff, only a bare method name, or only a dotted field access.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // chained call genuinely present in the diff
+        "The filter `r.owner().equals(accountOwner)` is case-sensitive, which misses matches.",
+        // bare method names are not distinctive enough to flag against the diff window
+        "accountOwner flows from installedRepos() and evaluateAccess(); it may be null.",
+        // a dotted field access without a call is ignored
+        "The configured `dashboardConfig.accountOwner` default is applied here."
+      })
+  void keepsFindingWhenDescriptionCitesNoAbsentChainedCall(String description) {
+    var response = response(describedFinding(MATCHED_OLD, description));
 
     assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
   }
@@ -589,17 +585,6 @@ class FindingQuoteValidatorTest {
   @ValueSource(strings = {"   "})
   void keepsFindingWithoutDescriptionAndMatchingQuote(String description) {
     var response = response(describedFinding(MATCHED_OLD, description));
-
-    assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
-  }
-
-  /** A dotted field access without a call is not distinctive enough to flag, so it is ignored. */
-  @Test
-  void keepsFindingWhenDescriptionCitesOnlyDottedFieldAccess() {
-    var finding =
-        describedFinding(
-            MATCHED_OLD, "The configured `dashboardConfig.accountOwner` default is applied here.");
-    var response = response(finding);
 
     assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
   }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`FindingQuoteValidator` only validated a finding's `suggestion_old` against the diff. When `suggestion_old` quoted the genuine changed lines (a `FULL` match) but the free-text `description` cited code that exists nowhere, the fabricated mechanism passed at full confidence — the hallucination just lived in the prose instead of the quote.

This PR extends the validator to also check the `description`:

- Extracts distinctive **chained call expressions** (`receiver.member(...)` patterns with an actual call) from the description.
- Tests each, whitespace-insensitively, against the diff lines scoped to the finding's file (same scoping `suggestion_old` already uses).
- When a cited expression appears nowhere in scope, routes the finding through the **existing `PARTIAL` handling**: strips the suggestion and caps confidence to `low`. No new outcome semantics — it reuses `withoutSuggestion`.

Conservatism guards (to avoid demoting legitimate findings):

- Bare method names (`installedRepos()`, `evaluateAccess()`) are **not** flagged — they are too common to test against the diff's narrow window.
- Dotted field access without a call (`config.value`) is ignored.
- Matching is whitespace-insensitive, so reformatting can never hide a real citation; the check only fires when an expression is genuinely absent.

**Dogfood reproduction (PR #101):** the MEDIUM finding on `DashboardAccessChecker.java` justified itself with `dashboardConfig.accountOwner().orElse(null)`, an expression that exists nowhere. That exact case is now covered by a unit test and is demoted instead of posting at full confidence.

## Related Issues

Fixes #106

## How Has This Been Tested?

- [x] Unit tests

Added tests in `FindingQuoteValidatorTest`:
- `demotesFindingWhenDescriptionCitesPhantomChainedCall` — the PR #101 reproduction (suggestion stripped, confidence capped, risk preserved).
- `keepsFindingWhenDescriptionCitesPresentChainedCall` — a chained call genuinely in the diff is untouched.
- `keepsFindingWhenDescriptionCitesOnlyBareMethodNames` / `keepsFindingWhenDescriptionCitesOnlyDottedFieldAccess` — conservatism guards.
- `demotesQuotelessFindingWhenDescriptionCitesPhantomChainedCall` — phantom demotes even without a `suggestion_old`.
- `keepsFindingWithoutDescriptionAndMatchingQuote` (null + blank) — absent description is a no-op.

Local gate: `./mvnw spotless:check test spotbugs:check` → 849 tests pass, SpotBugs clean. JaCoCo: all new lines/branches covered (only the pre-existing exhaustive-switch synthetic default remains partial).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors

## Additional Notes

Independent of #105 (confidence-gated posting): this fix reuses the existing cap-to-low + strip-suggestion demotion, which already removes the bad inline suggestion block today; once #105 lands, the low cap also routes the finding out of inline posting. Scope is the deterministic description check only.
