### PR TITLE
fix(review): hold APPROVE over silently dropped prior findings (#118)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -38,6 +38,40 @@ public final class DiffLineResolver {
         (file, patch) -> rightSideLinesByFile.put(file, parseRightSideLines(patch)));
   }
 
+  /**
+   * Whether {@code line} — or a line within {@code tolerance} of it — is an actual right-side line
+   * of the file's diff. Unlike {@link #resolveRightSideLine}, this never snaps to an arbitrarily
+   * distant line: it answers "is the flagged line genuinely still in this diff", which the approve
+   * backstop relies on to tell a still-open finding from one whose code has been changed away. The
+   * file is matched with {@link FilePaths#same}, so a model path variant still resolves to the
+   * diff's filename.
+   */
+  public boolean isLineInDiff(String file, int line, int tolerance) {
+    if (file == null || line <= 0) {
+      return false;
+    }
+    TreeSet<Integer> lines = rightSideLinesByFile.get(file);
+    if (lines == null) {
+      lines = lookupByPathVariant(file);
+    }
+    if (lines == null || lines.isEmpty()) {
+      return false;
+    }
+    Integer floor = lines.floor(line);
+    Integer ceiling = lines.ceiling(line);
+    return (floor != null && line - floor <= tolerance)
+        || (ceiling != null && ceiling - line <= tolerance);
+  }
+
+  private TreeSet<Integer> lookupByPathVariant(String file) {
+    for (var entry : rightSideLinesByFile.entrySet()) {
+      if (FilePaths.same(file, entry.getKey())) {
+        return entry.getValue();
+      }
+    }
+    return null;
+  }
+
   /** Returns the requested line or the nearest commentable line in the same file diff. */
   public OptionalInt resolveRightSideLine(String file, int requestedLine) {
     if (file == null || requestedLine <= 0) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -15,8 +15,10 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.OptionalInt;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
@@ -50,11 +52,11 @@ public final class DiffLineResolver {
     if (file == null || line <= 0) {
       return false;
     }
-    TreeSet<Integer> lines = rightSideLinesByFile.get(file);
+    NavigableSet<Integer> lines = rightSideLinesByFile.get(file);
     if (lines == null) {
       lines = lookupByPathVariant(file);
     }
-    if (lines == null || lines.isEmpty()) {
+    if (lines.isEmpty()) {
       return false;
     }
     Integer floor = lines.floor(line);
@@ -63,13 +65,13 @@ public final class DiffLineResolver {
         || (ceiling != null && ceiling - line <= tolerance);
   }
 
-  private TreeSet<Integer> lookupByPathVariant(String file) {
+  private NavigableSet<Integer> lookupByPathVariant(String file) {
     for (var entry : rightSideLinesByFile.entrySet()) {
       if (FilePaths.same(file, entry.getKey())) {
         return entry.getValue();
       }
     }
-    return null;
+    return Collections.emptyNavigableSet();
   }
 
   /** Returns the requested line or the nearest commentable line in the same file diff. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -36,6 +36,8 @@ import java.util.stream.Stream;
 @ApplicationScoped
 public class FollowUpAnalyzer {
 
+  private static final String STATUS_UNRESOLVED = "unresolved";
+
   private final ObjectMapper mapper;
 
   @Inject
@@ -431,7 +433,7 @@ public class FollowUpAnalyzer {
     }
     var unresolvedIds = new HashSet<Integer>();
     for (var status : statuses) {
-      if ("unresolved".equalsIgnoreCase(status.status())) {
+      if (STATUS_UNRESOLVED.equalsIgnoreCase(status.status())) {
         unresolvedIds.add(status.id());
       }
     }
@@ -487,24 +489,33 @@ public class FollowUpAnalyzer {
     var held = new ArrayList<ReviewResult.PreviousFindingStatus>();
     for (var i = 0; i < previous.size(); i++) {
       var id = i + 1;
-      if (reportedIds.contains(id)) {
-        continue; // the model accounted for it (resolved/justified/unresolved) — not a silent drop
+      if (isUnreportedAndStillOpen(
+          previous.get(i), id, reportedIds, lineResolver, inlineComments, botLogin)) {
+        held.add(
+            new ReviewResult.PreviousFindingStatus(
+                id,
+                STATUS_UNRESOLVED,
+                "Flagged in an earlier round and still present; not addressed in this revision."));
       }
-      var finding = previous.get(i);
-      // isLineInDiff already rejects a null file, so no separate guard is needed here.
-      if (!lineResolver.isLineInDiff(finding.file(), finding.line(), DUPLICATE_LINE_TOLERANCE)) {
-        continue; // its code is no longer in this round's diff — cannot confirm it is still open
-      }
-      if (answeredRootComment(finding, inlineComments, botLogin) != null) {
-        continue; // a maintainer already engaged on the thread — defer to them, do not auto-hold
-      }
-      held.add(
-          new ReviewResult.PreviousFindingStatus(
-              id,
-              "unresolved",
-              "Flagged in an earlier round and still present; not addressed in this revision."));
     }
     return held;
+  }
+
+  /**
+   * A prior finding (1-based {@code id}) is a still-open silent drop when the model named it in no
+   * status entry, its flagged line is still in the current diff, and no maintainer has replied on
+   * its thread. {@link DiffLineResolver#isLineInDiff} already rejects a null file.
+   */
+  private static boolean isUnreportedAndStillOpen(
+      ReviewResponse.Finding finding,
+      int id,
+      Set<Integer> reportedIds,
+      DiffLineResolver lineResolver,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      String botLogin) {
+    return !reportedIds.contains(id)
+        && lineResolver.isLineInDiff(finding.file(), finding.line(), DUPLICATE_LINE_TOLERANCE)
+        && answeredRootComment(finding, inlineComments, botLogin) == null;
   }
 
   private List<ReviewResponse.Finding> parsePreviousFindings(String aiResponseJson) {
@@ -553,6 +564,6 @@ public class FollowUpAnalyzer {
 
   /** Checks if there are any unresolved findings that should be re-flagged. */
   public boolean hasUnresolved(List<ReviewResult.PreviousFindingStatus> statuses) {
-    return statuses.stream().anyMatch(s -> "unresolved".equalsIgnoreCase(s.status()));
+    return statuses.stream().anyMatch(s -> STATUS_UNRESOLVED.equalsIgnoreCase(s.status()));
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -444,6 +444,69 @@ public class FollowUpAnalyzer {
     return unresolved;
   }
 
+  /**
+   * Deterministic approve backstop for issue #118. Prior findings the model left OUT of
+   * previous_findings_status entirely — neither resolved, justified, nor even reported as
+   * unresolved — that are still present in the current diff and carry no maintainer reply, surfaced
+   * as synthetic {@code "unresolved"} statuses. Merging these into the result's previous-findings
+   * statuses makes the existing APPROVE → COMMENT gate hold over a silently dropped finding, and
+   * makes every downstream count and message truthful, without a separate code path.
+   *
+   * <p>The findings are reconstructed from the persisted previous response (keyed by repo+PR, so it
+   * survives a force-push/rebase), which means the backstop fires even when the model received the
+   * previous-findings context but ignored it — the exact PR #99 dogfood symptom.
+   *
+   * <p>Scoped to the newest prior round only ({@code previousAiResponseJson});
+   * previous_findings_status ids are 1-based positions over exactly that list, so iterating it
+   * keeps the id mapping aligned with {@link #unresolvedFindings} and rules the off-by-one out by
+   * construction. Findings the model <em>did</em> account for (any status id) are skipped, so this
+   * never double-counts the model-reported {@code unresolved} items the {@link #hasUnresolved} gate
+   * already holds.
+   *
+   * <p>It is downgrade-only — these statuses reach the APPROVE gate but never {@code outstanding},
+   * so they can turn APPROVE into COMMENT, never into REQUEST_CHANGES. A maintainer reply on the
+   * thread clears the hold (the human is engaged; defer to them, matching {@link
+   * #dropRepliedDuplicates}), as does the model marking the finding resolved/justified.
+   */
+  public List<ReviewResult.PreviousFindingStatus> unreportedUnresolvedStatuses(
+      String previousAiResponseJson,
+      List<ReviewResponse.PreviousFindingStatus> statuses,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      DiffLineResolver lineResolver,
+      String botLogin) {
+    var previous = parsePreviousFindings(previousAiResponseJson);
+    if (previous.isEmpty() || lineResolver == null) {
+      return List.of();
+    }
+    var reportedIds = new HashSet<Integer>();
+    if (statuses != null) {
+      for (var status : statuses) {
+        reportedIds.add(status.id());
+      }
+    }
+    var held = new ArrayList<ReviewResult.PreviousFindingStatus>();
+    for (var i = 0; i < previous.size(); i++) {
+      var id = i + 1;
+      if (reportedIds.contains(id)) {
+        continue; // the model accounted for it (resolved/justified/unresolved) — not a silent drop
+      }
+      var finding = previous.get(i);
+      // isLineInDiff already rejects a null file, so no separate guard is needed here.
+      if (!lineResolver.isLineInDiff(finding.file(), finding.line(), DUPLICATE_LINE_TOLERANCE)) {
+        continue; // its code is no longer in this round's diff — cannot confirm it is still open
+      }
+      if (answeredRootComment(finding, inlineComments, botLogin) != null) {
+        continue; // a maintainer already engaged on the thread — defer to them, do not auto-hold
+      }
+      held.add(
+          new ReviewResult.PreviousFindingStatus(
+              id,
+              "unresolved",
+              "Flagged in an earlier round and still present; not addressed in this revision."));
+    }
+    return held;
+  }
+
   private List<ReviewResponse.Finding> parsePreviousFindings(String aiResponseJson) {
     if (aiResponseJson == null || aiResponseJson.isBlank()) {
       return List.of();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -215,12 +215,14 @@ public class ReviewOrchestrator {
           buildBaseComparison(auth, req.owner(), req.repo(), req.baseSha(), req.commitSha());
 
       var priorReviews = fetchPriorReviews(auth, req.owner(), req.repo(), req.prNumber());
-      var isFirstReview = priorReviews.stream().noneMatch(r -> BOT_LOGIN.equals(r.user().login()));
+      // First-review detection consults the persisted prior responses, not just formal GitHub
+      // reviews: every completed round persists its AI response keyed by repo+PR (surviving a
+      // force-push/rebase), so the previous-findings context is reconstructed for every follow-up
+      // round even on the rare path where no formal review was emitted. (#118)
       List<String> priorAiResponseJsons =
-          isFirstReview
-              ? List.of()
-              : sessionPersistence.findAllPriorAiResponseJsons(
-                  repository, req.prNumber(), session.id);
+          sessionPersistence.findAllPriorAiResponseJsons(repository, req.prNumber(), session.id);
+      var hasBotReview = priorReviews.stream().anyMatch(r -> BOT_LOGIN.equals(r.user().login()));
+      var isFirstReview = !hasBotReview && priorAiResponseJsons.isEmpty();
       String previousAiResponseJson =
           priorAiResponseJsons.isEmpty() ? null : priorAiResponseJsons.get(0);
       List<String> olderAiResponseJsons =
@@ -283,8 +285,26 @@ public class ReviewOrchestrator {
       var unresolvedPrevious =
           followUpAnalyzer.unresolvedFindings(
               previousAiResponseJson, aiResponse.previousFindingsStatus());
+      // Deterministic backstop: reconstruct the bot's own prior findings the model silently dropped
+      // from previous_findings_status but that are still present in this diff, as unresolved
+      // statuses, so an APPROVE can never sail over them. (#118)
+      var backstopUnresolved =
+          isFirstReview
+              ? List.<ReviewResult.PreviousFindingStatus>of()
+              : followUpAnalyzer.unreportedUnresolvedStatuses(
+                  previousAiResponseJson,
+                  aiResponse.previousFindingsStatus(),
+                  inlineComments,
+                  new DiffLineResolver(patchesByFile(files)),
+                  BOT_LOGIN);
       var result =
-          buildResult(aiResponse, isFirstReview, diffStats, unresolvedPrevious, offendingCiChecks);
+          buildResult(
+              aiResponse,
+              isFirstReview,
+              diffStats,
+              unresolvedPrevious,
+              offendingCiChecks,
+              backstopUnresolved);
 
       // Finalize check run before posting PR review — avoid approving then failing later
       String conclusion = conclusionForResult(result);
@@ -729,7 +749,8 @@ public class ReviewOrchestrator {
       boolean isFirstReview,
       DiffStats diffStats,
       List<Finding> unresolvedPrevious,
-      List<ReviewResult.CiCheck> offendingCiChecks) {
+      List<ReviewResult.CiCheck> offendingCiChecks,
+      List<ReviewResult.PreviousFindingStatus> backstopUnresolved) {
     var findings = new ArrayList<Finding>();
     var critical = 0;
     var high = 0;
@@ -758,9 +779,17 @@ public class ReviewOrchestrator {
     var outstanding = new ArrayList<Finding>(findings);
     outstanding.addAll(unresolvedPrevious);
     ReviewState state = ReviewState.fromFindings(outstanding);
-    var previousStatuses = followUpAnalyzer.toStatuses(aiResponse.previousFindingsStatus());
+    // Merge the model's previous-findings statuses with the backstop's reconstructed unresolved
+    // ones (#118): the silently dropped findings then flow through the same gate, counts, and
+    // messages as any unresolved status, so no separate path is needed. Backstop statuses reach the
+    // gate but never `outstanding`, keeping the hold downgrade-only (APPROVE → COMMENT, never
+    // REQUEST_CHANGES).
+    var previousStatuses =
+        new ArrayList<ReviewResult.PreviousFindingStatus>(
+            followUpAnalyzer.toStatuses(aiResponse.previousFindingsStatus()));
+    previousStatuses.addAll(backstopUnresolved);
     // Unresolved statuses that could not be mapped back to stored findings (e.g. pre-persistence
-    // sessions) must still hold the approval back
+    // sessions), or that the model dropped but the backstop reconstructed, must still hold approval
     if (state == ReviewState.APPROVE && followUpAnalyzer.hasUnresolved(previousStatuses)) {
       state = ReviewState.COMMENT;
     }
@@ -803,6 +832,16 @@ public class ReviewOrchestrator {
         summaryMarkdown,
         previousStatuses,
         offendingCiChecks);
+  }
+
+  ReviewResult buildResult(
+      ReviewResponse aiResponse,
+      boolean isFirstReview,
+      DiffStats diffStats,
+      List<Finding> unresolvedPrevious,
+      List<ReviewResult.CiCheck> offendingCiChecks) {
+    return buildResult(
+        aiResponse, isFirstReview, diffStats, unresolvedPrevious, offendingCiChecks, List.of());
   }
 
   ReviewResult buildResult(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
@@ -132,6 +132,56 @@ class DiffLineResolverTest {
   }
 
   @Test
+  void isLineInDiffShouldAcceptExactLineAndLinesWithinTolerance() {
+    var resolver = new DiffLineResolver(Map.of("main.py", PATCH));
+
+    assertTrue(resolver.isLineInDiff("main.py", 11, 3)); // exact right-side line
+    assertTrue(resolver.isLineInDiff("main.py", 13, 3)); // one past line 12, within tolerance
+    assertTrue(resolver.isLineInDiff("main.py", 8, 3)); // two before line 10, within tolerance
+  }
+
+  @Test
+  void isLineInDiffShouldRejectLineFarFromDiffUnlikeResolveRightSideLine() {
+    var resolver = new DiffLineResolver(Map.of("main.py", PATCH));
+
+    // resolveRightSideLine snaps a far line onto the nearest hunk line; isLineInDiff must not, so
+    // the approve backstop never treats a merely-touched file as a still-present finding.
+    assertEquals(OptionalInt.of(12), resolver.resolveRightSideLine("main.py", 99));
+    assertFalse(resolver.isLineInDiff("main.py", 99, 3)); // only a floor exists, far below
+    assertFalse(resolver.isLineInDiff("main.py", 2, 3)); // only a ceiling exists, far above
+  }
+
+  @Test
+  void isLineInDiffShouldRejectWhenFileHasNoRightSideLines() {
+    var deletionOnly =
+        """
+        @@ -10,2 +10,0 @@
+        -removed_one
+        -removed_two
+        """;
+    var resolver = new DiffLineResolver(Map.of("main.py", deletionOnly));
+
+    assertFalse(resolver.isLineInDiff("main.py", 10, 3));
+  }
+
+  @Test
+  void isLineInDiffShouldRejectMissingFileAndInvalidInputs() {
+    var resolver = new DiffLineResolver(Map.of("main.py", PATCH));
+
+    assertFalse(resolver.isLineInDiff("other.py", 11, 3));
+    assertFalse(resolver.isLineInDiff(null, 11, 3));
+    assertFalse(resolver.isLineInDiff("main.py", 0, 3));
+  }
+
+  @Test
+  void isLineInDiffShouldMatchAcrossPathVariants() {
+    var resolver = new DiffLineResolver(Map.of("src/dir/Main.java", PATCH));
+
+    // The model may report a shorter path than GitHub's diff filename; FilePaths.same bridges them.
+    assertTrue(resolver.isLineInDiff("dir/Main.java", 11, 3));
+  }
+
+  @Test
   void shouldIgnoreDeletionOnlyLines() {
     var patch =
         """

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class FollowUpAnalyzerTest {
@@ -684,6 +685,103 @@ class FollowUpAnalyzerTest {
     assertTrue(analyzer.unresolvedFindings(PREVIOUS_JSON, List.of()).isEmpty());
     assertTrue(analyzer.unresolvedFindings(null, unresolvedStatus).isEmpty());
     assertTrue(analyzer.unresolvedFindings("not json", unresolvedStatus).isEmpty());
+  }
+
+  /** One-line patch whose only right-side line is {@code line}, for backstop presence tests. */
+  private static String patch(int line) {
+    return "@@ -" + line + ",1 +" + line + ",1 @@\n-old\n+new";
+  }
+
+  private static List<Integer> heldIds(List<ReviewResult.PreviousFindingStatus> held) {
+    return held.stream().map(ReviewResult.PreviousFindingStatus::id).toList();
+  }
+
+  @Test
+  void unreportedUnresolvedShouldHoldSilentlyDroppedFindingsStillInDiff() {
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(PREVIOUS_JSON, List.of(), List.of(), resolver, BOT);
+
+    assertEquals(List.of(1, 2), heldIds(held));
+    assertTrue(held.stream().allMatch(s -> "unresolved".equals(s.status())));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldSkipAnyFindingTheModelReported() {
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+
+    // Both accounted for (resolved + justified) → nothing held.
+    assertTrue(
+        analyzer
+            .unreportedUnresolvedStatuses(
+                PREVIOUS_JSON,
+                List.of(
+                    new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed"),
+                    new ReviewResponse.PreviousFindingStatus(2, "justified", "intentional")),
+                List.of(),
+                resolver,
+                BOT)
+            .isEmpty());
+
+    // id=1 reported (even as unresolved — the existing gate already holds it), id=2 omitted → only
+    // #2 is the silent drop the backstop must reconstruct. Pins the 1-based id mapping.
+    var held =
+        analyzer.unreportedUnresolvedStatuses(
+            PREVIOUS_JSON,
+            List.of(new ReviewResponse.PreviousFindingStatus(1, "unresolved", "still")),
+            List.of(),
+            resolver,
+            BOT);
+    assertEquals(List.of(2), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldExcludeFindingsWithMaintainerReply() {
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+    var comments =
+        List.of(
+            comment(100L, null, "src/A.java", "**CRITICAL — SQL injection**", BOT),
+            comment(101L, 100L, "src/A.java", "intentional, leaving as is", "maintainer"));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(PREVIOUS_JSON, List.of(), comments, resolver, BOT);
+
+    // Finding #1's thread carries a maintainer reply → defer to the human; only #2 is held.
+    assertEquals(List.of(2), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldExcludeFindingsNotInCurrentDiff() {
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+
+    // src/B.java is absent from this round's diff → finding #2's code is gone; only #1 is held.
+    var held =
+        analyzer.unreportedUnresolvedStatuses(PREVIOUS_JSON, List.of(), List.of(), resolver, BOT);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldReturnEmptyForMissingInputs() {
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+
+    assertTrue(
+        analyzer.unreportedUnresolvedStatuses(null, List.of(), List.of(), resolver, BOT).isEmpty());
+    assertTrue(
+        analyzer
+            .unreportedUnresolvedStatuses("not json", List.of(), List.of(), resolver, BOT)
+            .isEmpty());
+    assertTrue(
+        analyzer
+            .unreportedUnresolvedStatuses(PREVIOUS_JSON, List.of(), List.of(), null, BOT)
+            .isEmpty());
+    // Null statuses ⇒ the model reported nothing ⇒ every present finding is a silent drop.
+    assertEquals(
+        2,
+        analyzer
+            .unreportedUnresolvedStatuses(PREVIOUS_JSON, null, List.of(), resolver, BOT)
+            .size());
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -711,7 +711,7 @@ class FollowUpAnalyzerTest {
   void unreportedUnresolvedShouldSkipAnyFindingTheModelReported() {
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
 
-    // Both accounted for (resolved + justified) → nothing held.
+    // Both findings carry a status, one resolved and one justified, so nothing is held.
     assertTrue(
         analyzer
             .unreportedUnresolvedStatuses(
@@ -724,8 +724,8 @@ class FollowUpAnalyzerTest {
                 BOT)
             .isEmpty());
 
-    // id=1 reported (even as unresolved — the existing gate already holds it), id=2 omitted → only
-    // #2 is the silent drop the backstop must reconstruct. Pins the 1-based id mapping.
+    // Finding one is reported and the existing gate already holds it; finding two is omitted, so
+    // only finding two is the silent drop the backstop reconstructs. Pins the 1-based id mapping.
     var held =
         analyzer.unreportedUnresolvedStatuses(
             PREVIOUS_JSON,

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2800,6 +2800,181 @@ class ReviewOrchestratorTest {
   }
 
   @Nested
+  class ApproveBackstop {
+
+    private final FollowUpAnalyzer realAnalyzer = new FollowUpAnalyzer(new ObjectMapper());
+
+    private void delegateStatusGate() {
+      when(followUpAnalyzer.toStatuses(any()))
+          .thenAnswer(invocation -> realAnalyzer.toStatuses(invocation.getArgument(0)));
+      when(followUpAnalyzer.hasUnresolved(any()))
+          .thenAnswer(invocation -> realAnalyzer.hasUnresolved(invocation.getArgument(0)));
+    }
+
+    private ReviewResult buildWithBackstop(List<ReviewResult.PreviousFindingStatus> backstop) {
+      return orchestrator.buildResult(
+          new ReviewResponse(List.of(), List.of(), null),
+          false,
+          new ReviewOrchestrator.DiffStats(0, 0, 0),
+          List.of(),
+          List.of(),
+          backstop);
+    }
+
+    @Test
+    void shouldDowngradeApproveToCommentWhenBackstopHoldsUnresolved() {
+      delegateStatusGate();
+
+      var result =
+          buildWithBackstop(
+              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still present")));
+
+      assertEquals(ReviewState.COMMENT, result.reviewState());
+      assertFalse(ReviewOrchestrator.checkTitleForResult(result).contains("✅"));
+      // The message reflects the held finding — never the contradictory "0 previous finding(s)".
+      assertTrue(
+          ReviewOrchestrator.checkSummaryForResult(result)
+              .contains("1 previous finding(s) remain unresolved"));
+    }
+
+    @Test
+    void shouldApproveWhenBackstopHoldsNothing() {
+      delegateStatusGate();
+
+      var result = buildWithBackstop(List.of());
+
+      assertEquals(ReviewState.APPROVE, result.reviewState());
+      assertTrue(ReviewOrchestrator.checkTitleForResult(result).contains("✅"));
+      assertTrue(ReviewOrchestrator.checkSummaryForResult(result).contains("No issues found"));
+    }
+
+    @Test
+    void shouldNeverEscalateBackstopBeyondComment() {
+      delegateStatusGate();
+
+      // Even several silently dropped findings only neutralize approval — never REQUEST_CHANGES.
+      var result =
+          buildWithBackstop(
+              List.of(
+                  new ReviewResult.PreviousFindingStatus(1, "unresolved", "a"),
+                  new ReviewResult.PreviousFindingStatus(2, "unresolved", "b")));
+
+      assertEquals(ReviewState.COMMENT, result.reviewState());
+    }
+
+    @Test
+    void shouldPostCommentReviewWhenBackstopHolds() {
+      delegateStatusGate();
+      var result =
+          buildWithBackstop(
+              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still present")));
+
+      orchestrator.postReview("auth", "owner", "repo", 5, "sha", result, List.of());
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      assertEquals("COMMENT", captor.getValue().event());
+      assertTrue(captor.getValue().body().contains("remain unresolved"));
+    }
+
+    @Test
+    void shouldHoldApproveOverSilentlyDroppedPriorFindingThroughReview() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = followUpSession();
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+        delegateStatusGate();
+        when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
+            .thenReturn(List.of(PRIOR_FINDING_JSON));
+        when(followUpAnalyzer.buildPreviousFindingsContext(
+                any(), any(), any(), any(), eq("thrillhousebot[bot]")))
+            .thenReturn("1. [MEDIUM] src/Main.java:10 — Dropped finding");
+        // The model silently drops the still-open prior finding: no new findings, empty status.
+        when(aiReviewService.review(any(ReviewSession.class), any()))
+            .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+        // The deterministic backstop reconstructs it as unresolved from persistence.
+        when(followUpAnalyzer.unreportedUnresolvedStatuses(
+                any(), any(), any(), any(), eq("thrillhousebot[bot]")))
+            .thenReturn(
+                List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still present")));
+
+        orchestrator.review(followUpRequest());
+
+        var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+        verify(reviewClient)
+            .createReview(
+                anyString(), anyString(), anyString(), anyString(), anyInt(), captor.capture());
+        assertEquals("COMMENT", captor.getValue().event());
+        assertTrue(captor.getValue().body().contains("remain unresolved"));
+      }
+    }
+
+    @Test
+    void shouldTreatAsFollowUpWhenPersistenceHasPriorResponsesDespiteNoBotReview() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = followUpSession();
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+        // No formal bot review exists (listReviews defaults to empty), but a prior round persisted
+        // its findings — the review must still be treated as a follow-up. (#118 fix #1)
+        when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
+            .thenReturn(List.of(PRIOR_FINDING_JSON));
+        when(followUpAnalyzer.buildPreviousFindingsContext(
+                any(), any(), any(), any(), eq("thrillhousebot[bot]")))
+            .thenReturn("previous context");
+        when(aiReviewService.review(any(ReviewSession.class), any()))
+            .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+        orchestrator.review(followUpRequest());
+
+        // Previous-findings context IS reconstructed without any formal bot review...
+        verify(followUpAnalyzer)
+            .buildPreviousFindingsContext(any(), any(), any(), any(), eq("thrillhousebot[bot]"));
+        // ...and the first-review summary issue-comment is NOT posted.
+        verify(commentClient, never())
+            .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+      }
+    }
+
+    private static final String PRIOR_FINDING_JSON =
+        "{\"findings\":[{\"risk\":\"medium\",\"file\":\"src/Main.java\",\"line\":10,"
+            + "\"title\":\"Dropped finding\",\"description\":\"d\"}]}";
+
+    private ReviewSession followUpSession() {
+      var session = mock(ReviewSession.class);
+      session.id = 1L;
+      when(session.getRepository()).thenReturn("owner/repo");
+      when(session.getPrNumber()).thenReturn(42);
+      when(session.getPrTitle()).thenReturn("Test PR");
+      when(session.getCommitSha()).thenReturn("abcdefgh");
+      when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+      when(authClient.getAuthHeader(123L)).thenReturn("Bearer test");
+      when(checkRunClient.createCheckRun(anyString(), anyString(), anyString(), anyString(), any()))
+          .thenReturn(new GitHubCheckRunClient.CheckRunResponse(1L, "http://check"));
+      doNothing()
+          .when(checkRunClient)
+          .updateCheckRun(anyString(), anyString(), anyString(), anyString(), anyLong(), any());
+      when(prClient.getPullRequestFiles(
+              anyString(), anyString(), anyString(), anyString(), anyInt()))
+          .thenReturn(List.of());
+      when(prClient.compareCommits(
+              anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
+          .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
+      when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
+          .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
+      return session;
+    }
+
+    private ReviewOrchestrator.ReviewRequest followUpRequest() {
+      return new ReviewOrchestrator.ReviewRequest(
+          "owner", "repo", 42, "abcdefgh", "Test PR", "", "base1234567", "main", 123L, false);
+    }
+  }
+
+  @Nested
   class ResolveAddressedThreads {
 
     private static final String AUTH = "auth";


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Previous-findings tracking relied entirely on the model's self-reported `previous_findings_status`. The orchestrator already reconstructs the previous-findings context on every follow-up round (the persisted prior responses are keyed by `repository + prNumber`, so they survive a force-push/rebase). The residual defect is downstream: **both** APPROVE→COMMENT downgrade paths in `buildResult` depend on the model marking an item `unresolved`. When the model returns an empty/insufficient status array — a **silent drop**, observed dogfooding [#99](https://github.com/devops-thiago/ThrillhouseBot/pull/99) across a force-push — a still-open prior finding is approved over (and the same finding can be re-raised at a drifted severity).

This adds a **deterministic backstop** that does not trust the model's self-report:

- `FollowUpAnalyzer.unreportedUnresolvedStatuses(...)` reconstructs the bot's own prior findings from the persisted previous response and, for any the model left out of `previous_findings_status` entirely, that has **no maintainer reply**, and whose flagged line is **still present** in the current diff, returns a synthetic `"unresolved"` status.
- `ReviewOrchestrator.buildResult` merges those into the result's previous-finding statuses, so the **existing** gate holds APPROVE→COMMENT and every count/message stays truthful — no separate code path, no `"0 previous finding(s)"` contradiction.
- The hold is **downgrade-only** (APPROVE→COMMENT, never REQUEST_CHANGES): backstop statuses reach the gate but never the `outstanding` list that `ReviewState.fromFindings` could escalate.
- "Still present" is a new exact ±tolerance membership test, `DiffLineResolver.isLineInDiff`, **not** the snapping `resolveRightSideLine` — so a merely re-touched file does not over-block (the issue explicitly rejects "block on any prior finding regardless of resolution" as too strict).
- First-review detection now also consults persistence, so the previous-findings context is reconstructed for every follow-up round even on the rare path where no formal GitHub review was emitted.

Maps to the issue's three proposed-solution bullets: content/identity tracking (persistence-driven), context reconstructed every round regardless of head SHA, and the still-present APPROVE backstop. A maintainer reply or a model `resolved`/`justified` verdict clears the hold (an acknowledge-only reply is intentionally treated as "human engaged — defer to them", matching `dropRepliedDuplicates`).

## Related Issues

Fixes #118

## How Has This Been Tested?

- [x] Unit tests

New tests:
- `DiffLineResolverTest` — `isLineInDiff` accepts exact/within-tolerance lines, rejects far lines (the regression vs. snapping `resolveRightSideLine`), missing files, empty right-side sets, and matches across path variants.
- `FollowUpAnalyzerTest` — `unreportedUnresolvedStatuses` holds silently-dropped findings still in the diff, skips any finding the model reported (pins the 1-based id mapping), skips maintainer-replied threads, skips findings no longer in the diff, and is null-safe.
- `ReviewOrchestratorTest > ApproveBackstop` — backstop downgrades APPROVE→COMMENT with a truthful message, approves when nothing is held, never escalates beyond COMMENT, posts a COMMENT review citing the unresolved finding, holds approval over a silently-dropped prior finding end-to-end through `review()`, and treats a PR with persisted prior responses but no formal bot review as a follow-up.

Local verification (mirrors CI):
- `./mvnw spotless:check` ✅
- `./mvnw verify` ✅ — 887 tests pass, JaCoCo gate met, SpotBugs clean
- Patch coverage: 0 missed lines and 0 missed branches on all three new methods (`isLineInDiff`, `lookupByPathVariant`, `unreportedUnresolvedStatuses`)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No prompt change is required — the backstop is deterministic and independent of the model's `previous_findings_status`. Tightening the prompt contract is left as a possible follow-up.
