### PR TITLE
fix(review): description-citation check over-demotes — ignores existing-vs-hypothetical and short-circuits on the first off-diff chain (#121)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -43,7 +43,11 @@ import java.util.regex.Pattern;
  * but its free-text {@code description} cites a chained call expression as existing source that
  * appears nowhere in scope — the fabricated mechanism is treated like a partial quote. Only
  * distinctive {@code receiver.member(...)} chains are checked, so bare method names that simply
- * fall outside the diff window are never penalized.
+ * fall outside the diff window are never penalized. Two further guards keep this from suppressing
+ * true positives: a chain that also appears in the finding's own {@code suggestion_new} is the
+ * proposed fix, not an existing-code citation, so it is excluded; and the demotion fires only when
+ * <em>every</em> remaining cited expression is absent — a finding grounded by even one
+ * verbatim-present chain keeps its suggestion and confidence.
  */
 @ApplicationScoped
 public class FindingQuoteValidator {
@@ -151,42 +155,62 @@ public class FindingQuoteValidator {
   }
 
   /**
-   * Whether the finding's description presents, as existing source, a chained call expression that
-   * cannot be found anywhere in the diff scoped to its file. This catches the failure mode where a
-   * genuine {@code suggestion_old} quote passes the gate but the supporting prose invents the
-   * mechanism (e.g. {@code dashboardConfig.accountOwner().orElse(null)} for a method parameter that
-   * is never derived that way). The match is whitespace-insensitive so reformatting can't hide a
-   * real citation — meaning the check only fires when the expression is genuinely absent.
+   * Whether the finding's description rests on a fabricated mechanism: it presents one or more
+   * chained call expressions as existing source and <em>none</em> of them can be found in the diff
+   * scoped to its file. This catches the failure mode where a genuine {@code suggestion_old} quote
+   * passes the gate but the supporting prose invents the mechanism (e.g. {@code
+   * dashboardConfig.accountOwner().orElse(null)} for a method parameter that is never derived that
+   * way). A chain that duplicates the finding's own {@code suggestion_new} is its proposed fix, not
+   * an existing-source citation, so it is excluded; and a single verbatim-present chain is enough
+   * to keep the finding — so restating the fix or naming an off-diff helper never demotes a
+   * grounded finding. The match is whitespace-insensitive so reformatting can't hide a real
+   * citation.
    */
   private static boolean descriptionCitesAbsentCode(
       ReviewResponse.Finding finding, DiffIndex index) {
-    List<String> cited = citedCallExpressions(finding.description());
+    List<String> cited =
+        citedExistingCodeExpressions(finding.description(), finding.suggestionNew());
     if (cited.isEmpty()) {
       return false;
     }
     List<String> compactedScope = compactedLines(index.diffLinesFor(finding.file()));
+    // Demote only when EVERY expression presented as existing source is absent from scope. A
+    // finding grounded by even one verbatim-present chain stays grounded even if it also names an
+    // off-diff helper — the guard targets a fabricated mechanism, not the first incidental chain
+    // that happens to fall outside the diff window (#121, mechanism b).
     for (String expression : cited) {
-      if (!appearsIn(expression, compactedScope)) {
-        return true;
+      if (appearsIn(expression, compactedScope)) {
+        return false;
       }
     }
-    return false;
+    return true;
   }
 
-  /** The chained call expressions a description presents as code, e.g. {@code a.b().c(null)}. */
-  private static List<String> citedCallExpressions(String description) {
+  /**
+   * The chained call expressions a description presents as <em>existing</em> source, e.g. {@code
+   * a.b().c(null)}. A chain that also appears (whitespace-insensitively) in the finding's own
+   * {@code suggestion_new} is excluded: it is the proposed fix, a hypothetical that is absent from
+   * the diff by definition, and demoting a finding for describing its own fix would violate #106's
+   * "existing code, not hypotheticals" scope (#121, mechanism a). A bare name or a dotted field
+   * chain without a call is never distinctive enough to flag against the diff's narrow window.
+   */
+  private static List<String> citedExistingCodeExpressions(
+      String description, String suggestionNew) {
     if (description == null || description.isBlank()) {
       return List.of();
     }
+    String compactedSuggestion = suggestionNew == null ? "" : compact(suggestionNew);
     var expressions = new ArrayList<String>();
     var matcher = CHAINED_CALL.matcher(description);
     while (matcher.find()) {
       String expression = matcher.group();
-      // Require an actual call: a dotted field chain (e.g. config.value) or a bare name is not
-      // distinctive enough to flag against the diff's narrow window.
-      if (expression.indexOf('(') >= 0) {
-        expressions.add(expression);
+      if (expression.indexOf('(') < 0) {
+        continue;
       }
+      if (!compactedSuggestion.isEmpty() && compactedSuggestion.contains(compact(expression))) {
+        continue;
+      }
+      expressions.add(expression);
     }
     return expressions;
   }
@@ -204,7 +228,7 @@ public class FindingQuoteValidator {
 
   /**
    * Whether {@code expression} occurs, ignoring whitespace, within any already-compacted diff line.
-   * The expression is always a non-empty call chain (see {@link #citedCallExpressions}).
+   * The expression is always a non-empty call chain (see {@link #citedExistingCodeExpressions}).
    */
   private static boolean appearsIn(String expression, List<String> compactedScope) {
     String needle = compact(expression);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -44,10 +44,11 @@ import java.util.regex.Pattern;
  * appears nowhere in scope — the fabricated mechanism is treated like a partial quote. Only
  * distinctive {@code receiver.member(...)} chains are checked, so bare method names that simply
  * fall outside the diff window are never penalized. Two further guards keep this from suppressing
- * true positives: a chain that also appears in the finding's own {@code suggestion_new} is the
- * proposed fix, not an existing-code citation, so it is excluded; and the demotion fires only when
- * <em>every</em> remaining cited expression is absent — a finding grounded by even one
- * verbatim-present chain keeps its suggestion and confidence.
+ * true positives: a chain found verbatim in the diff grounds the finding and keeps it (diff
+ * presence wins, even over a {@code suggestion_new} that wraps that same code); and among chains
+ * absent from the diff, one that merely restates the finding's own {@code suggestion_new} is the
+ * proposed fix, not a fabricated mechanism. A finding is demoted only when it cites an absent chain
+ * that is neither present in the diff nor a restatement of its own fix.
  */
 @ApplicationScoped
 public class FindingQuoteValidator {
@@ -155,62 +156,61 @@ public class FindingQuoteValidator {
   }
 
   /**
-   * Whether the finding's description rests on a fabricated mechanism: it presents one or more
-   * chained call expressions as existing source and <em>none</em> of them can be found in the diff
-   * scoped to its file. This catches the failure mode where a genuine {@code suggestion_old} quote
-   * passes the gate but the supporting prose invents the mechanism (e.g. {@code
-   * dashboardConfig.accountOwner().orElse(null)} for a method parameter that is never derived that
-   * way). A chain that duplicates the finding's own {@code suggestion_new} is its proposed fix, not
-   * an existing-source citation, so it is excluded; and a single verbatim-present chain is enough
-   * to keep the finding — so restating the fix or naming an off-diff helper never demotes a
-   * grounded finding. The match is whitespace-insensitive so reformatting can't hide a real
+   * Whether the finding's description rests on a fabricated mechanism: it cites at least one
+   * chained call expression as existing source that is absent from the diff scoped to its file and
+   * is not merely a restatement of the finding's own proposed fix. This catches the failure mode
+   * where a genuine {@code suggestion_old} quote passes the gate but the supporting prose invents
+   * the mechanism (e.g. {@code dashboardConfig.accountOwner().orElse(null)} for a method parameter
+   * that is never derived that way).
+   *
+   * <p>Two guards keep this from suppressing true positives. <b>Diff presence wins:</b> a chain
+   * found verbatim in the diff grounds the finding and keeps it immediately, before any
+   * fix-restatement is considered — so a {@code suggestion_new} that wraps the existing code it
+   * modifies can never strip the grounding chain, and naming an off-diff helper alongside a present
+   * one never demotes (#121, mechanism b). <b>The proposed fix is not a citation:</b> among chains
+   * <em>absent</em> from the diff, one whose compacted form the compacted {@code suggestion_new}
+   * restates is the hypothetical fix — absent by definition — and is not counted as fabrication
+   * (#121, mechanism a). The match is whitespace-insensitive so reformatting can't hide a real
    * citation.
    */
   private static boolean descriptionCitesAbsentCode(
       ReviewResponse.Finding finding, DiffIndex index) {
-    List<String> cited =
-        citedExistingCodeExpressions(finding.description(), finding.suggestionNew());
+    List<String> cited = citedCallExpressions(finding.description());
     if (cited.isEmpty()) {
       return false;
     }
     List<String> compactedScope = compactedLines(index.diffLinesFor(finding.file()));
-    // Demote only when EVERY expression presented as existing source is absent from scope. A
-    // finding grounded by even one verbatim-present chain stays grounded even if it also names an
-    // off-diff helper — the guard targets a fabricated mechanism, not the first incidental chain
-    // that happens to fall outside the diff window (#121, mechanism b).
+    String compactedSuggestion =
+        finding.suggestionNew() == null ? "" : compact(finding.suggestionNew());
+    boolean fabricated = false;
     for (String expression : cited) {
-      if (appearsIn(expression, compactedScope)) {
+      String needle = compact(expression);
+      if (appearsIn(needle, compactedScope)) {
+        // Present verbatim in the diff: the finding is grounded — keep it, whatever else it cites.
         return false;
       }
+      // Absent from the diff: a fabricated mechanism unless it merely restates the proposed fix.
+      if (!compactedSuggestion.contains(needle)) {
+        fabricated = true;
+      }
     }
-    return true;
+    return fabricated;
   }
 
-  /**
-   * The chained call expressions a description presents as <em>existing</em> source, e.g. {@code
-   * a.b().c(null)}. A chain that also appears (whitespace-insensitively) in the finding's own
-   * {@code suggestion_new} is excluded: it is the proposed fix, a hypothetical that is absent from
-   * the diff by definition, and demoting a finding for describing its own fix would violate #106's
-   * "existing code, not hypotheticals" scope (#121, mechanism a). A bare name or a dotted field
-   * chain without a call is never distinctive enough to flag against the diff's narrow window.
-   */
-  private static List<String> citedExistingCodeExpressions(
-      String description, String suggestionNew) {
+  /** The chained call expressions a description presents as code, e.g. {@code a.b().c(null)}. */
+  private static List<String> citedCallExpressions(String description) {
     if (description == null || description.isBlank()) {
       return List.of();
     }
-    String compactedSuggestion = suggestionNew == null ? "" : compact(suggestionNew);
     var expressions = new ArrayList<String>();
     var matcher = CHAINED_CALL.matcher(description);
     while (matcher.find()) {
       String expression = matcher.group();
-      if (expression.indexOf('(') < 0) {
-        continue;
+      // Require an actual call: a dotted field chain (e.g. config.value) or a bare name is not
+      // distinctive enough to flag against the diff's narrow window.
+      if (expression.indexOf('(') >= 0) {
+        expressions.add(expression);
       }
-      if (!compactedSuggestion.isEmpty() && compactedSuggestion.contains(compact(expression))) {
-        continue;
-      }
-      expressions.add(expression);
     }
     return expressions;
   }
@@ -227,11 +227,11 @@ public class FindingQuoteValidator {
   }
 
   /**
-   * Whether {@code expression} occurs, ignoring whitespace, within any already-compacted diff line.
-   * The expression is always a non-empty call chain (see {@link #citedExistingCodeExpressions}).
+   * Whether {@code needle} — an already-compacted call chain (see {@link #citedCallExpressions}) —
+   * occurs within any already-compacted diff line. Both sides are whitespace-stripped so
+   * indentation or reformatting can't hide a citation.
    */
-  private static boolean appearsIn(String expression, List<String> compactedScope) {
-    String needle = compact(expression);
+  private static boolean appearsIn(String needle, List<String> compactedScope) {
     for (String line : compactedScope) {
       if (line.contains(needle)) {
         return true;

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -620,10 +620,12 @@ class FindingQuoteValidatorTest {
 
   /**
    * Mechanism (a), #121: a chain the description cites that is also the finding's own {@code
-   * suggestion_new} is the proposed fix — a hypothetical, absent from the diff by definition.
-   * Subtracting it (the deterministic form of #106's "existing code, not the suggested fix") leaves
-   * no absent existing-source citation, so a finding that describes its own fix is not demoted. The
-   * chain is genuinely absent from {@code DESCRIPTION_DIFF}, so only the subtraction keeps it.
+   * suggestion_new} is the proposed fix — a hypothetical, absent from the diff by definition. The
+   * chain is still extracted, but since it is absent from {@code DESCRIPTION_DIFF} and restated in
+   * {@code suggestion_new}, it is not counted as a fabricated mechanism (the deterministic form of
+   * #106's "existing code, not the suggested fix"), so a finding that describes its own fix is not
+   * demoted. Its absence from the diff is what makes the {@code suggestion_new} restatement the
+   * only thing keeping it.
    */
   @ParameterizedTest
   @ValueSource(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -689,6 +689,31 @@ class FindingQuoteValidatorTest {
   }
 
   /**
+   * Mechanism (a)+(b) interaction, #121: a chain that is BOTH verbatim-present in the diff AND
+   * restated in {@code suggestion_new} (the common "the fix wraps the existing call" shape) must
+   * not be subtracted as the proposed fix — its diff presence grounds the finding. Naming a
+   * separate off-diff helper alongside it must not demote. Diff presence wins over fix-restatement.
+   */
+  @Test
+  void keepsFindingWhenPresentChainIsAlsoRestatedInSuggestionNew() {
+    var finding =
+        new ReviewResponse.Finding(
+            "medium",
+            "high",
+            "DashboardAccessChecker.java",
+            221,
+            "Potential NullPointerException when accountOwner is null",
+            // present core chain (verbatim in the diff) cited alongside an off-diff helper
+            "`r.owner().equals(accountOwner)` is case-sensitive; `cfg.opts().get()` set the owner.",
+            MATCHED_OLD,
+            // the proposed fix wraps the present chain, so it restates it verbatim
+            "r != null && r.owner().equals(accountOwner)");
+    var response = response(finding);
+
+    assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
+  }
+
+  /**
    * Mechanism (a), #121: a finding with no {@code suggestion_new} to subtract still demotes when
    * its only cited chain is a phantom. The null-suggestion path must be a no-op (nothing to
    * subtract), not an accidental keep — covering the {@code suggestionNew == null} branch.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -618,6 +618,101 @@ class FindingQuoteValidatorTest {
     assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
   }
 
+  /**
+   * Mechanism (a), #121: a chain the description cites that is also the finding's own {@code
+   * suggestion_new} is the proposed fix — a hypothetical, absent from the diff by definition.
+   * Subtracting it (the deterministic form of #106's "existing code, not the suggested fix") leaves
+   * no absent existing-source citation, so a finding that describes its own fix is not demoted. The
+   * chain is genuinely absent from {@code DESCRIPTION_DIFF}, so only the subtraction keeps it.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "The corrected expression is `%s`, which handles the null owner.",
+        "Guard the dereference; the fix is `%s` applied at the call site."
+      })
+  void keepsFindingWhenDescriptionRestatesItsSuggestionNew(String descriptionTemplate) {
+    var fix = "Optional.ofNullable(accountOwner).map(Owner::name).orElse(null)";
+    var finding =
+        new ReviewResponse.Finding(
+            "medium",
+            "high",
+            "DashboardAccessChecker.java",
+            221,
+            "Potential NullPointerException when accountOwner is null",
+            descriptionTemplate.formatted(fix),
+            MATCHED_OLD,
+            fix);
+    var response = response(finding);
+
+    assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
+  }
+
+  /**
+   * Mechanism (b), #121: a description that cites a present core mechanism keeps its suggestion
+   * even when an incidental off-diff helper is cited <em>first</em> — the guard must not
+   * short-circuit to a demotion on the first absent chain.
+   */
+  @Test
+  void keepsFindingWhenCoreCitedChainIsPresentDespiteOffDiffHelper() {
+    var finding =
+        describedFinding(
+            MATCHED_OLD,
+            "The off-diff helper `logger.atDebug().log()` traces it, but"
+                + " `r.owner().equals(accountOwner)` is the case-sensitive filter that misses"
+                + " matches.");
+    var response = response(finding);
+
+    assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
+  }
+
+  /**
+   * Mechanism (b), #121: when EVERY cited chain is absent the finding is still demoted — the
+   * all-absent semantics must not be inverted into "keep if any chain is absent".
+   */
+  @Test
+  void demotesFindingWhenEveryCitedChainIsAbsent() {
+    var finding =
+        describedFinding(
+            MATCHED_OLD,
+            "The mechanism `cfg.first().orElse(null)` and `cfg.second().get()` are both dereferenced"
+                + " unguarded.");
+    var response = response(finding);
+
+    var result = validator.validate(response, DESCRIPTION_DIFF);
+
+    assertEquals(1, result.findings().size());
+    var kept = result.findings().get(0);
+    assertNull(kept.suggestionOld());
+    assertNull(kept.suggestionNew());
+    assertEquals("low", kept.confidence());
+  }
+
+  /**
+   * Mechanism (a), #121: a finding with no {@code suggestion_new} to subtract still demotes when
+   * its only cited chain is a phantom. The null-suggestion path must be a no-op (nothing to
+   * subtract), not an accidental keep — covering the {@code suggestionNew == null} branch.
+   */
+  @Test
+  void demotesPhantomCitationWhenFindingHasNoSuggestionNew() {
+    var finding =
+        new ReviewResponse.Finding(
+            "medium",
+            "high",
+            "DashboardAccessChecker.java",
+            221,
+            "Potential NullPointerException when accountOwner is null",
+            "It dereferences `dashboardConfig.accountOwner().orElse(null)` unguarded.",
+            MATCHED_OLD,
+            null);
+    var response = response(finding);
+
+    var result = validator.validate(response, DESCRIPTION_DIFF);
+
+    assertEquals(1, result.findings().size());
+    assertEquals("low", result.findings().get(0).confidence());
+  }
+
   @Test
   void noNewlineIndicatorIsNotQuotableContent() {
     var diff =


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The description-citation guard added for #106 (PR #114) in `FindingQuoteValidator.descriptionCitesAbsentCode` **over-demotes legitimate findings** — it strips a finding's suggestion and caps confidence to `low` in two cases it shouldn't:

- **(a) No existing-vs-hypothetical distinction.** It extracted chained calls from the *whole* description, including the **proposed fix stated in prose**, and demoted the finding for citing its own suggested code (absent from the diff by definition). #106 explicitly scoped the check to *"only act on expressions presented as existing code, not on hypotheticals in the suggested fix."*
- **(b) Any-absent short-circuit.** It `return true`d on the **first** absent cited chain, so a finding whose **core mechanism is verbatim-present** was demoted just because it also named one incidental off-diff helper.

### Fix — two deterministic levers (no brittle prose NLP)

1. **Subtract the proposed fix.** Before the absence check, drop any cited chain that also appears (whitespace-insensitively) in the finding's `suggestion_new`. The fix code can never be mistaken for a fabricated mechanism — the literal, free implementation of #106's "not the suggested fix". Fixes **(a)**.
2. **Require *all* remaining citations absent, not any.** Demote only when every remaining existing-source chain is absent from scope. A grounded finding references the real code it's about, so at least one citation matches → it survives. Fixes **(b)**, and covers the residual of (a).

The dogfood case (PR #101 — the only chained call is the phantom `dashboardConfig.accountOwner().orElse(null)`) still demotes: all citations absent → demote.

**Honest tradeoff:** both levers trade a little recall — a phantom mechanism *mixed with* a genuine present chain no longer demotes. That's the same precision-for-recall trade #106 already chose; #55 (caller context) is the deep fix that later distinguishes "present but off-diff" from "truly fabricated". The all-absent rule also softens #120's lambda false-positive for free (the real outer chain is present).

## Related Issues

Fixes #121

## How Has This Been Tested?

- [x] Unit tests

New/changed tests in `FindingQuoteValidatorTest`:
- `keepsFindingWhenDescriptionRestatesItsSuggestionNew` (×2 phrasings) — mechanism (a): a cited chain that duplicates `suggestion_new` (and is genuinely absent from the diff) no longer demotes.
- `keepsFindingWhenCoreCitedChainIsPresentDespiteOffDiffHelper` — mechanism (b): an absent off-diff helper cited **first** + a present core chain → kept (no short-circuit demote).
- `demotesFindingWhenEveryCitedChainIsAbsent` — locks the all-absent semantics (not inverted to "keep if any absent").
- `demotesPhantomCitationWhenFindingHasNoSuggestionNew` — covers the `suggestion_new == null` subtraction branch.
- Pre-existing dogfood `demotesFindingWhenDescriptionCitesPhantomChainedCall` still passes unchanged.

Local gate: `./mvnw spotless:check verify` → **886 tests pass**, SpotBugs clean, JaCoCo coverage gate met.

## Scope

Strictly #121. **Untouched:** #120 (CHAINED_CALL nested-paren regex), #122 (compact/appearsIn whitespace mechanics), #55 (caller context), #105 (confidence-gated posting).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
