### PR TITLE
fix(manifest): request actions read permissions for CI gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to ThrillhouseBot.
 ### Changed
 
 - **CI**: consolidated the seven duplicated Trivy scan + SARIF-upload steps across `ci.yml`, `release.yml`, and `security-scan.yml` into a single `.github/actions/trivy-scan` composite action, centralizing the pinned action SHA, Trivy version, `format: sarif`, and the `limit-severities-for-sarif` flag. The CI filesystem scan now applies `limit-severities-for-sarif` like every other scan (closes the gap tracked in #76).
+- **GitHub App Permissions**: Added `actions: read` permission to `manifest.json` (and documented in `README.md`). This is required to read GitHub Actions workflow runs and check suite statuses to evaluate CI status for PR approval gating (introduced in PR #95).
 
 ## [0.1.0] — 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Create a GitHub App before starting the bot; you'll need its credentials for `.e
 |---|---|
 | Webhook URL | `https://<your-host>/api/webhook` |
 | Webhook Secret | Random string |
-| Repository Permissions | Pull Requests: R/W, Checks: R/W, Contents: Read, Issues: R/W |
+| Repository Permissions | Pull Requests: R/W, Checks: R/W, Contents: Read, Issues: R/W, Actions: Read |
 | Subscribe to Events | Pull Request, Issue comment |
 | Identifying & authorizing users | Enabled (for dashboard login) |
 | Callback URL | `https://<your-host>/api/auth/callback` |

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,8 @@
     "checks": "write",
     "pull_requests": "write",
     "contents": "read",
-    "issues": "write"
+    "issues": "write",
+    "actions": "read"
   },
   "request_oauth_on_install": false
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor / Configuration
- [x] 📝 Documentation

## Description

This PR adds the `actions: read` permission to `manifest.json` so that newly created installations of ThrillhouseBot automatically receive the required permissions to query GitHub Actions workflow statuses. This permission is necessary for the PR approval gating feature introduced in PR #95.

We also updated the manual installation instructions in `README.md` and detailed the rationale under the unreleased version `0.1.1` in `CHANGELOG.md`.

## Related Issues

Fixes #125
Relates to PR #95

## How Has This Been Tested?

- [x] Manual testing (verified file structures, Spotless linting, and Maven tests pass locally)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors