### PR TITLE
fix(review): CHAINED_CALL arg class can't span nested parens (#120)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -53,18 +53,6 @@ public class FindingQuoteValidator {
   /** Shared tail of every log line that strips a suggestion and caps confidence. */
   private static final String DEMOTION_SUFFIX = " dropping its suggestion and capping confidence";
 
-  /**
-   * A chained call expression: a receiver followed by one or more {@code .member} segments, with
-   * optional argument lists. Single names like {@code installedRepos()} are deliberately excluded —
-   * they are too common to flag against the diff's narrow window. A match is only treated as a code
-   * citation when it actually contains a call ({@code '('}). Quantifiers are possessive: each class
-   * never overlaps the token that follows it, so no backtracking is ever needed and large inputs
-   * cannot trigger catastrophic backtracking.
-   */
-  private static final Pattern CHAINED_CALL =
-      Pattern.compile(
-          "[A-Za-z_$][A-Za-z0-9_$]*+(?:\\([^()]*+\\))?+(?:\\.[A-Za-z_$][A-Za-z0-9_$]*+(?:\\([^()]*+\\))?+)++");
-
   private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 
   public record DiffLine(String normalizedText, int rightLineNum, char marker) {}
@@ -173,22 +161,150 @@ public class FindingQuoteValidator {
     return false;
   }
 
-  /** The chained call expressions a description presents as code, e.g. {@code a.b().c(null)}. */
+  /** The end index and shape of one chained-call scan: see {@link #scanChainedCall}. */
+  private record ChainSpan(int end, int memberSegments, boolean hasCall) {}
+
+  /**
+   * The chained call expressions a description presents as code, e.g. {@code a.b(c.d()).e(null)}.
+   *
+   * <p>Each candidate is consumed with a manual, bracket-matched walk rather than a regex. An
+   * argument list can itself hold a call or a lambda — i.e. nested parentheses — which a bounded
+   * character class cannot span; a balanced-paren regex could, but only by re-introducing the
+   * catastrophic-backtracking risk the possessive quantifiers were chosen to avoid. The walk spans
+   * a {@code receiver.member} chain in full, including nested-call and lambda arguments, so a
+   * nested expression surfaces as one whole citation and its inner sub-expressions are never
+   * emitted as standalone citations. Only chains with at least one {@code .member} segment and an
+   * actual call ({@code '('}) are kept; bare names like {@code installedRepos()} and dotted field
+   * access like {@code config.value} are deliberately excluded — they are not distinctive enough to
+   * flag against the diff's narrow window.
+   */
   private static List<String> citedCallExpressions(String description) {
     if (description == null || description.isBlank()) {
       return List.of();
     }
     var expressions = new ArrayList<String>();
-    var matcher = CHAINED_CALL.matcher(description);
-    while (matcher.find()) {
-      String expression = matcher.group();
-      // Require an actual call: a dotted field chain (e.g. config.value) or a bare name is not
-      // distinctive enough to flag against the diff's narrow window.
-      if (expression.indexOf('(') >= 0) {
-        expressions.add(expression);
+    int i = 0;
+    int n = description.length();
+    while (i < n) {
+      if (isIdentifierStart(description.charAt(i))) {
+        ChainSpan span = scanChainedCall(description, i);
+        if (span.memberSegments() >= 1 && span.hasCall()) {
+          expressions.add(description.substring(i, span.end()));
+        }
+        i = span.end();
+      } else {
+        i++;
       }
     }
     return expressions;
+  }
+
+  /**
+   * Consumes a chained-call expression starting at {@code start} (an identifier-start character): a
+   * receiver, an optional argument list, then zero or more {@code .member} segments each with an
+   * optional argument list. Argument lists are spanned with balanced-bracket counting (see {@link
+   * #skipBalancedParens}), so nested calls and lambdas are absorbed whole. The returned end index
+   * is always past the receiver, so the caller always makes progress.
+   */
+  private static ChainSpan scanChainedCall(String s, int start) {
+    int i = skipIdentifier(s, start);
+    boolean hasCall = false;
+    int afterArgs = skipBalancedParens(s, i);
+    if (afterArgs > i) {
+      hasCall = true;
+      i = afterArgs;
+    }
+    int segments = 0;
+    while (i < s.length() && s.charAt(i) == '.') {
+      int nameEnd = skipIdentifier(s, i + 1);
+      if (nameEnd == i + 1) {
+        break; // a '.' not followed by an identifier ends the chain
+      }
+      i = nameEnd;
+      afterArgs = skipBalancedParens(s, i);
+      if (afterArgs > i) {
+        hasCall = true;
+        i = afterArgs;
+      }
+      segments++;
+    }
+    return new ChainSpan(i, segments, hasCall);
+  }
+
+  /**
+   * Advances past an identifier at {@code start}, or returns {@code start} if none begins there.
+   */
+  private static int skipIdentifier(String s, int start) {
+    if (start >= s.length() || !isIdentifierStart(s.charAt(start))) {
+      return start;
+    }
+    int i = start + 1;
+    while (i < s.length() && isIdentifierPart(s.charAt(i))) {
+      i++;
+    }
+    return i;
+  }
+
+  /**
+   * If {@code start} is an opening parenthesis, returns the index just past its matching close,
+   * counting nesting depth and skipping string/char literals so parentheses inside a literal don't
+   * unbalance the count. Returns {@code start} unchanged when there is no argument list there or
+   * the parentheses are unbalanced — in which case the chain simply ends before the {@code '('}.
+   */
+  private static int skipBalancedParens(String s, int start) {
+    int n = s.length();
+    if (start >= n || s.charAt(start) != '(') {
+      return start;
+    }
+    int depth = 0;
+    int i = start;
+    while (i < n) {
+      char c = s.charAt(i);
+      if (c == '"' || c == '\'') {
+        i = skipLiteral(s, i);
+        continue;
+      }
+      if (c == '(') {
+        depth++;
+      } else if (c == ')') {
+        depth--;
+        if (depth == 0) {
+          return i + 1;
+        }
+      }
+      i++;
+    }
+    return start; // unbalanced — consume nothing
+  }
+
+  /**
+   * Advances past a string or char literal opened at {@code start}, honoring backslash escapes.
+   * Returns the index just past the closing quote, or the end of input for an unterminated literal.
+   */
+  private static int skipLiteral(String s, int start) {
+    char quote = s.charAt(start);
+    int n = s.length();
+    int i = start + 1;
+    while (i < n) {
+      char c = s.charAt(i);
+      if (c == '\\') {
+        i += 2; // skip the escaped character
+        continue;
+      }
+      if (c == quote) {
+        return i + 1;
+      }
+      i++;
+    }
+    return n; // unterminated literal
+  }
+
+  private static boolean isIdentifierStart(char c) {
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_' || c == '$';
+  }
+
+  private static boolean isIdentifierPart(char c) {
+    return isIdentifierStart(c) || (c >= '0' && c <= '9');
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -279,7 +279,11 @@ public class FindingQuoteValidator {
 
   /**
    * Advances past a string or char literal opened at {@code start}, honoring backslash escapes.
-   * Returns the index just past the closing quote, or the end of input for an unterminated literal.
+   * Returns the index just past the closing quote. For an unterminated literal it returns {@code
+   * start + 1}, treating the lone quote as an ordinary character rather than swallowing the rest of
+   * the input — the description is free-text prose where a bare apostrophe (a contraction or
+   * possessive) is far more common than a real char literal, and swallowing to end-of-input would
+   * unbalance the enclosing parentheses and silently drop an otherwise valid citation.
    */
   private static int skipLiteral(String s, int start) {
     char quote = s.charAt(start);
@@ -296,7 +300,7 @@ public class FindingQuoteValidator {
       }
       i++;
     }
-    return n; // unterminated literal
+    return start + 1; // unterminated literal: treat the lone quote as an ordinary character
   }
 
   private static boolean isIdentifierStart(char c) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -177,6 +177,12 @@ public class FindingQuoteValidator {
    * actual call ({@code '('}) are kept; bare names like {@code installedRepos()} and dotted field
    * access like {@code config.value} are deliberately excluded — they are not distinctive enough to
    * flag against the diff's narrow window.
+   *
+   * <p>A bare-name call (a receiver call with no following {@code .member}, e.g. {@code
+   * requireNonNull(user.getName())}) is itself excluded, but its argument list may wrap a real
+   * chain. Rather than skipping the whole wrapper, the walk descends past the bare receiver so the
+   * inner chain ({@code user.getName()}) is still extracted — otherwise a fabricated mechanism
+   * cited only inside such a wrapper would escape the guard.
    */
   private static List<String> citedCallExpressions(String description) {
     if (description == null || description.isBlank()) {
@@ -190,8 +196,13 @@ public class FindingQuoteValidator {
         ChainSpan span = scanChainedCall(description, i);
         if (span.memberSegments() >= 1 && span.hasCall()) {
           expressions.add(description.substring(i, span.end()));
+          i = span.end(); // a genuine chain: skip it whole, never surfacing its inner sub-exprs
+        } else if (span.hasCall()) {
+          // a bare-name call: descend past just the receiver so its argument list is re-scanned
+          i = skipIdentifier(description, i);
+        } else {
+          i = span.end(); // a bare name or dotted field access with no call: nothing to recover
         }
-        i = span.end();
       } else {
         i++;
       }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -588,7 +588,10 @@ class FindingQuoteValidatorTest {
         "It mentions `obj.run(\"oops` without ever closing the quote.",
         // a null-guard clause cites no call chain, so the present chain still matches and is kept
         "Guard `owner == null || accountOwner == null` before"
-            + " `r.owner().equals(accountOwner)`, which is present."
+            + " `r.owner().equals(accountOwner)`, which is present.",
+        // a present chain wrapped in a bare-name call: the inner chain is descended into and found
+        // in the diff, so the finding is not over-demoted
+        "The value `requireNonNull(r.owner().equals(accountOwner))` is recomputed each call."
       })
   void keepsFindingWhenDescriptionHasNoAbsentChainedCall(String description) {
     var response = response(describedFinding(MATCHED_OLD, description));
@@ -658,7 +661,11 @@ class FindingQuoteValidatorTest {
         "Two call sites exist. The `path.split('/')` output (the $tmp local) is never checked.",
         // a lone apostrophe inside the cited call's arguments must not swallow the rest of the
         // citation: the phantom chain is still extracted whole and, being absent, demoted
-        "accountOwner is `dashboardConfig.lookup(the user's key).orElse(null)`, which may be null."
+        "accountOwner is `dashboardConfig.lookup(the user's key).orElse(null)`, which may be null.",
+        // a phantom chain wrapped in a bare-name call must still be checked: the wrapper itself is
+        // not a citation, but the inner config.fetch(accountId) is extracted and, being absent,
+        // demoted
+        "It is wrapped as `requireNonNull(config.fetch(accountId))`, which can throw."
       })
   void demotesFindingWhenDescriptionCitesAbsentNestedCallChain(String description) {
     var result =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -562,7 +562,10 @@ class FindingQuoteValidatorTest {
   /**
    * A description that cites no absent chained call leaves the finding untouched: an absent (null
    * or blank) description, a chained call genuinely in the diff, a bare method name, or a dotted
-   * field access without a call all pass through unchanged.
+   * field access without a call all pass through unchanged. This also covers #120 face (b): a full
+   * nested lambda chain present in the diff is one whole citation (its inner predicate is not
+   * surfaced separately), and malformed candidates — unbalanced parentheses or an unterminated
+   * string literal — consume no argument list and are never flagged.
    */
   @ParameterizedTest
   @NullSource
@@ -575,7 +578,17 @@ class FindingQuoteValidatorTest {
         // bare method names are not distinctive enough to flag against the diff window
         "accountOwner flows from installedRepos() and evaluateAccess(); it may be null.",
         // a dotted field access without a call is ignored
-        "The configured `dashboardConfig.accountOwner` default is applied here."
+        "The configured `dashboardConfig.accountOwner` default is applied here.",
+        // face (b): the full lambda chain present in the diff is one citation, kept whole
+        "The filter `repos.stream().filter(r -> r.owner().equals(accountOwner)).toList()` is"
+            + " case-sensitive, which misses matches.",
+        // unbalanced parentheses consume no argument list, so nothing distinctive is flagged
+        "The incomplete call `obj.process(arg` appears only in the prose.",
+        // an unterminated string literal swallows the remainder, so no call chain is consumed
+        "It mentions `obj.run(\"oops` without ever closing the quote.",
+        // a null-guard clause cites no call chain, so the present chain still matches and is kept
+        "Guard `owner == null || accountOwner == null` before"
+            + " `r.owner().equals(accountOwner)`, which is present."
       })
   void keepsFindingWhenDescriptionHasNoAbsentChainedCall(String description) {
     var response = response(describedFinding(MATCHED_OLD, description));
@@ -616,6 +629,79 @@ class FindingQuoteValidatorTest {
     var response = response(describedFinding(null, description));
 
     assertSame(response, validator.validate(response, DESCRIPTION_DIFF));
+  }
+
+  /**
+   * #120 face (a): a citation whose argument is itself a call or a lambda (nested parentheses) used
+   * to be either truncated to a paren-less fragment and dropped unchecked, or split so the chain's
+   * fabricated tail was never seen — in both cases the phantom escaped at full confidence. The
+   * whole chain is now extracted as one citation and, being absent from the diff, is demoted.
+   * Covers a nested-call argument, a lambda chain sharing a real prefix but ending in an invented
+   * tail, a receiver that is itself a call, and a string literal whose escaped quote must not end
+   * it early.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // nested-call argument: was truncated to the paren-less "config.lookup" and dropped
+        "accountOwner comes from `config.lookup(getKey()).orElse(null)`, so it may be null.",
+        // lambda chain sharing a real prefix; the old split missed the invented .orElseThrow tail
+        "It evaluates `repos.stream().filter(r -> r.owner().equals(accountOwner))"
+            + ".orElseThrow(IllegalStateException::new)` on every request.",
+        // the receiver itself takes arguments
+        "The value `getConfig().lookup(key).orElse(null)` is never null-checked before use.",
+        // an escaped quote inside the string-literal argument must not terminate the literal early,
+        // and the receiver name exercises underscore/digit identifier characters
+        "It validates with `pattern_2.match(\"a\\\"b\").orElseThrow()` before continuing.",
+        // a char-literal slash holds no real bracket, a leading dollar sign is a valid identifier
+        // start, and the sentence break exercises a dot that is not followed by an identifier
+        "Two call sites exist. The `path.split('/')` output (the $tmp local) is never checked."
+      })
+  void demotesFindingWhenDescriptionCitesAbsentNestedCallChain(String description) {
+    var result =
+        validator.validate(response(describedFinding(MATCHED_OLD, description)), DESCRIPTION_DIFF);
+
+    assertEquals(1, result.findings().size());
+    var kept = result.findings().get(0);
+    assertNull(kept.suggestionOld());
+    assertNull(kept.suggestionNew());
+    assertEquals("low", kept.confidence());
+    assertEquals("medium", kept.risk());
+  }
+
+  private static final String LITERAL_DIFF =
+      """
+      ### src/Router.java (modified, +1 -1)
+      ```diff
+      @@ -3,3 +3,3 @@
+       void route() {
+      -    handlers.put(label(")"), fallback).register();
+      +    handlers.put(label(")"), primary).register();
+       }
+      ```
+      """;
+
+  /**
+   * A parenthesis inside a string literal must not be counted as a bracket: the {@code ")"} literal
+   * argument is spanned whole, so a present chain that embeds it matches the diff and is kept. A
+   * naive depth counter would truncate the citation at the literal's parenthesis and wrongly
+   * demote.
+   */
+  @Test
+  void keepsFindingWhenDescriptionCitesPresentChainWithLiteralParenArgument() {
+    var finding =
+        new ReviewResponse.Finding(
+            "medium",
+            "high",
+            "src/Router.java",
+            4,
+            "Title",
+            "It registers via `handlers.put(label(\")\"), fallback).register()` at startup.",
+            "handlers.put(label(\")\"), fallback).register();",
+            "fixed");
+    var response = response(finding);
+
+    assertSame(response, validator.validate(response, LITERAL_DIFF));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -655,7 +655,10 @@ class FindingQuoteValidatorTest {
         "It validates with `pattern_2.match(\"a\\\"b\").orElseThrow()` before continuing.",
         // a char-literal slash holds no real bracket, a leading dollar sign is a valid identifier
         // start, and the sentence break exercises a dot that is not followed by an identifier
-        "Two call sites exist. The `path.split('/')` output (the $tmp local) is never checked."
+        "Two call sites exist. The `path.split('/')` output (the $tmp local) is never checked.",
+        // a lone apostrophe inside the cited call's arguments must not swallow the rest of the
+        // citation: the phantom chain is still extracted whole and, being absent, demoted
+        "accountOwner is `dashboardConfig.lookup(the user's key).orElse(null)`, which may be null."
       })
   void demotesFindingWhenDescriptionCitesAbsentNestedCallChain(String description) {
     var result =


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The description-citation guard shipped by #106 (PR #114) extracted citations from a finding's `description` with the `CHAINED_CALL` regex, whose argument class `\([^()]*+\)` is possessive and excludes **both** parens — so it could not span an argument that is itself a call or a lambda. One root cause, two confirmed symptoms:

- **(a) Fabrication escapes (false negative).** A phantom citation whose argument is a nested call — `config.lookup(getKey()).orElse(null)` — matched only `config.lookup`. That fragment has no `(`, so it was dropped unvalidated and the fabricated mechanism posted at full confidence.
- **(b) Inner sub-expression synthesized (false positive risk).** A lambda chain — `repos.stream().filter(r -> r.owner().equals(accountOwner)).toList()` — was split, surfacing the lambda-internal `r.owner().equals(accountOwner)` as its own standalone citation rather than being absorbed into the one whole expression.

### Fix

Replace the regex with a small **manual, bracket-matched scan** (the issue's recommended "safer fix"). It spans a `receiver.member` chain in full — including nested-call and lambda arguments — so:

- `config.lookup(getKey()).orElse(null)` is now kept as **one whole citation**, validated, and (being absent) correctly demoted — the fabrication is caught.
- `repos.stream().filter(r -> r.owner().equals(accountOwner)).toList()` is treated as **one expression**; the lambda-internal predicate is no longer emitted as a standalone citation.

The scan is **literal-aware**: a parenthesis inside a string/char literal (e.g. `cache.put(")")`) cannot truncate a citation. A naive depth-only counter would truncate there and regress a present finding into a *false demotion* — exactly the failure mode #120 exists to reduce. A manual scan also sidesteps the catastrophic-backtracking risk a balanced-paren regex would re-introduce (Sonar **S5998** — the reason #114 made the quantifiers possessive).

Conservatism is unchanged: bare method names (`installedRepos()`) and dotted field access (`config.value`) are still not flagged.

**Scope:** the extraction defect only. The demotion/matching concerns filed separately as #121 (over-demotion) and #122 (compaction mechanics) are deliberately untouched — the literal-awareness here is about correct *bracket-matching during extraction*, distinct from #122's whitespace-compaction concern.

## Related Issues

Fixes #120

## How Has This Been Tested?

- [x] Unit tests

Added to `FindingQuoteValidatorTest` (per the issue's "add one per face"):

- `demotesFindingWhenDescriptionCitesAbsentNestedCallChain` (parameterized) — **face (a)**: a nested-call argument, a lambda chain sharing a real prefix but ending in an invented `.orElseThrow(...)` tail, a receiver that is itself a call, and an escaped quote inside a string literal — each now extracted whole and demoted. These **fail on the old regex** (the phantom was kept) and pass now.
- `keepsFindingWhenDescriptionHasNoAbsentNestedChain` (parameterized) — **face (b)**: the present full lambda chain is kept as one citation (inner predicate not surfaced); unbalanced parens and unterminated literals consume no argument list and are not flagged.
- `keepsFindingWhenDescriptionCitesPresentChainWithLiteralParenArgument` — a present chain embedding a `")"` literal is spanned whole and kept (a depth-only counter would falsely demote it).

Local gate (Java 25):

- `./mvnw spotless:check` ✅
- `./mvnw verify` → **889 tests pass**, JaCoCo coverage gate met ✅
- `./mvnw spotbugs:check` → 0 bugs ✅
- JaCoCo: every new line covered (100% line coverage on all new methods).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors

## Additional Notes

Empirically confirmed against the real `java.util.regex` engine that the old `CHAINED_CALL` produced `config.lookup` (no paren → dropped) for face (a) and split the lambda chain into `repos.stream().filter` + `r.owner().equals(accountOwner)` for face (b) — matching the issue's reported behavior exactly. The new scanner produces one whole citation in both cases.
