### PR TITLE
fix(review): description-citation matcher mis-handles wrapped lines, Unicode whitespace, and intra-literal spacing (#122)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 /**
  * Deterministic guard against findings that quote code which is not in the diff. The model
@@ -57,8 +56,6 @@ public class FindingQuoteValidator {
 
   /** Shared tail of every log line that strips a suggestion and caps confidence. */
   private static final String DEMOTION_SUFFIX = " dropping its suggestion and capping confidence";
-
-  private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 
   public record DiffLine(String normalizedText, int rightLineNum, char marker) {}
 
@@ -158,8 +155,9 @@ public class FindingQuoteValidator {
    * one never demotes (#121, mechanism b). <b>The proposed fix is not a citation:</b> among chains
    * <em>absent</em> from the diff, one whose compacted form the compacted {@code suggestion_new}
    * restates is the hypothetical fix — absent by definition — and is not counted as fabrication
-   * (#121, mechanism a). The match is whitespace-insensitive so reformatting can't hide a real
-   * citation.
+   * (#121, mechanism a). The match ignores all whitespace — Unicode-aware, and over a scope joined
+   * across diff lines — so reformatting or a wrapped citation can't hide a real one (see {@link
+   * #stripWhitespace}).
    */
   private static boolean descriptionCitesAbsentCode(
       ReviewResponse.Finding finding, DiffIndex index) {
@@ -167,12 +165,12 @@ public class FindingQuoteValidator {
     if (cited.isEmpty()) {
       return false;
     }
-    List<String> compactedScope = compactedLines(index.diffLinesFor(finding.file()));
+    String compactedScope = compactScope(index.diffLinesFor(finding.file()));
     String compactedSuggestion =
-        finding.suggestionNew() == null ? "" : compact(finding.suggestionNew());
+        finding.suggestionNew() == null ? "" : stripWhitespace(finding.suggestionNew());
     boolean fabricated = false;
     for (String expression : cited) {
-      String needle = compact(expression);
+      String needle = stripWhitespace(expression);
       if (appearsIn(needle, compactedScope)) {
         // Present verbatim in the diff: the finding is grounded — keep it, whatever else it cites.
         return false;
@@ -347,32 +345,51 @@ public class FindingQuoteValidator {
   }
 
   /**
-   * The scoped diff lines with all whitespace removed, compacted once for reuse across citations.
+   * The scoped diff lines stripped of whitespace and concatenated in diff order. Joining the lines
+   * — rather than testing each in isolation — lets a citation the source wraps across two physical
+   * diff lines (e.g. {@code obj.method()} then {@code .chain(null)}) still be found.
    */
-  private static List<String> compactedLines(List<DiffLine> scope) {
-    var compacted = new ArrayList<String>(scope.size());
+  private static String compactScope(List<DiffLine> scope) {
+    var joined = new StringBuilder();
     for (DiffLine line : scope) {
-      compacted.add(compact(line.normalizedText()));
+      joined.append(stripWhitespace(line.normalizedText()));
     }
-    return compacted;
+    return joined.toString();
   }
 
   /**
    * Whether {@code needle} — an already-compacted call chain (see {@link #citedCallExpressions}) —
-   * occurs within any already-compacted diff line. Both sides are whitespace-stripped so
-   * indentation or reformatting can't hide a citation.
+   * occurs within the compacted, joined diff scope. Both sides are whitespace-stripped so
+   * indentation or reformatting can't hide a citation, and joining the scope lets a citation the
+   * source wraps across two diff lines still be found.
    */
-  private static boolean appearsIn(String needle, List<String> compactedScope) {
-    for (String line : compactedScope) {
-      if (line.contains(needle)) {
-        return true;
-      }
-    }
-    return false;
+  private static boolean appearsIn(String needle, String compactedScope) {
+    return compactedScope.contains(needle);
   }
 
-  private static String compact(String text) {
-    return WHITESPACE.matcher(text).replaceAll("");
+  /**
+   * Removes every whitespace character so a citation matches the diff regardless of reformatting.
+   * The strip is Unicode-aware: {@link Character#isSpaceChar} catches the non-breaking spaces
+   * (U+00A0, U+2007, U+202F) that {@link Character#isWhitespace} omits, so even an exotic space
+   * can't hide a real citation.
+   *
+   * <p>Whitespace inside string/char literals is stripped too, so a phantom that differs from real
+   * code only by intra-literal spacing (e.g. {@code put("a b")} vs {@code put("ab")}) reads as
+   * present and is not demoted. That residual false negative is deliberate: telling a real literal
+   * interior from an incidental quote (a comment apostrophe, a string the source splits across diff
+   * lines) can't be done reliably on diff text alone, and demoting on a misread would drop a
+   * genuinely present finding — the costly direction this guard exists to avoid. Catching that
+   * phantom needs the cross-file context tracked separately in #55.
+   */
+  private static String stripWhitespace(String text) {
+    var out = new StringBuilder(text.length());
+    for (int i = 0; i < text.length(); i++) {
+      char c = text.charAt(i);
+      if (!Character.isWhitespace(c) && !Character.isSpaceChar(c)) {
+        out.append(c);
+      }
+    }
+    return out.toString();
   }
 
   static QuoteMatch matchQuote(List<String> quoted, Set<String> diffLines) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -836,6 +836,145 @@ class FindingQuoteValidatorTest {
     assertEquals("low", result.findings().get(0).confidence());
   }
 
+  /**
+   * (a) The cited chain {@code obj.method().chain(null)} is present, but the source wraps it across
+   * two physical diff lines. Matching each line in isolation would miss it and wrongly demote;
+   * because the compacted scope is joined in diff order, the wrapped chain is still found and the
+   * finding is kept intact.
+   */
+  @Test
+  void keepsFindingWhenDescriptionCitesAChainTheSourceWrapsAcrossLines() {
+    var diff =
+        """
+        ### Wrap.java (modified, +1 -1)
+        ```diff
+        @@ -1,5 +1,5 @@
+         public class Wrap {
+             var x = obj.method()
+                 .chain(null);
+        -    int unrelated = 1;
+        +    int unrelated = 2;
+         }
+        ```
+        """;
+    var finding =
+        new ReviewResponse.Finding(
+            "medium",
+            "high",
+            "Wrap.java",
+            4,
+            "Title",
+            "The result of `obj.method().chain(null)` is dereferenced without a guard.",
+            "int unrelated = 1;",
+            "fixed");
+    var response = response(finding);
+
+    assertSame(response, validator.validate(response, diff));
+  }
+
+  /**
+   * (b) The cited chain carries a non-breaking space (U+00A0) inside its argument list. An
+   * ASCII-only {@code \\s} would leave the space in place so the needle no longer matched its
+   * ASCII-spaced source, wrongly demoting the finding; Unicode-aware compaction normalizes it and
+   * the finding is kept.
+   */
+  @Test
+  void keepsFindingWhenDescriptionCitesAChainWithUnicodeWhitespace() {
+    var diff =
+        """
+        ### Config.java (modified, +1 -1)
+        ```diff
+        @@ -1,3 +1,3 @@
+         public class Config {
+        -    return config.value().orElse(null);
+        +    return config.value().orElseGet(Config::fallback);
+         }
+        ```
+        """;
+    var finding =
+        new ReviewResponse.Finding(
+            "medium",
+            "high",
+            "Config.java",
+            2,
+            "Title",
+            "The expression `config.value().orElse(\u00A0null)` can return null here.",
+            "return config.value().orElse(null);",
+            "fixed");
+    var response = response(finding);
+
+    assertSame(response, validator.validate(response, diff));
+  }
+
+  /**
+   * The conservative trade for issue #122: a description that cites a string/char literal differing
+   * from the real code only by spacing <em>inside</em> the literal ({@code cache.put("a b")} vs the
+   * source's {@code cache.put("ab")}) is kept, not demoted. Distinguishing a genuine literal
+   * interior from an incidental quote can't be done reliably on diff text alone, so the guard never
+   * demotes on intra-literal spacing — a deliberate false negative in the safe direction.
+   */
+  @Test
+  void keepsFindingWhoseCitedLiteralDiffersOnlyByIntraLiteralSpacing() {
+    var diff =
+        """
+        ### Cache.java (modified, +1 -1)
+        ```diff
+        @@ -1,3 +1,3 @@
+         public class Cache {
+        -    int unrelated = 1;
+        +    cache.put("ab");
+         }
+        ```
+        """;
+    var finding =
+        new ReviewResponse.Finding(
+            "medium",
+            "high",
+            "Cache.java",
+            2,
+            "Title",
+            "The entry from `cache.put(\"a b\")` is overwritten on the next call.",
+            "int unrelated = 1;",
+            "fixed");
+    var response = response(finding);
+
+    assertSame(response, validator.validate(response, diff));
+  }
+
+  /**
+   * An apostrophe or stray quote in a comment near the cited chain must not break the match. The
+   * whole scope is compared with all whitespace removed, so the comment's punctuation is
+   * irrelevant: the cited {@code config.value().orElse(null)} is found and the finding is kept.
+   */
+  @Test
+  void keepsFindingWhenScopeHasCommentApostropheNearCitedChain() {
+    var diff =
+        """
+        ### Foo.java (modified, +1 -1)
+        ```diff
+        @@ -1,4 +1,4 @@
+         public class Foo {
+             // can't fix config.value() .orElse(null) but here's why
+        -    int unrelated = 1;
+        +    int unrelated = 2;
+         }
+        ```
+        """;
+    var finding =
+        new ReviewResponse.Finding(
+            "medium",
+            "high",
+            "Foo.java",
+            3,
+            "Title",
+            "The value `config.value().orElse(null)` can be null here.",
+            "int unrelated = 1;",
+            "fixed");
+    var response = response(finding);
+
+    assertSame(response, validator.validate(response, diff));
+  }
+
   @Test
   void noNewlineIndicatorIsNotQuotableContent() {
     var diff =


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] ✅ Test

## Description

The description-citation guard (#106 / PR #114) demotes a finding when a chained-call expression cited in its `description` is absent from the file-scoped diff. The whitespace-insensitive matcher (`appearsIn` → `stripWhitespace`) had two matcher-mechanics edges that wrongly demoted **present** findings:

- **(a) Wrapped lines.** `appearsIn` tested the compacted citation against each diff line individually, so an expression the source wraps across two physical diff lines (e.g. `obj.method()` then `.chain(null)`) matched neither line and was demoted. Now the compacted scope is joined once per file (`compactScope`) and the citation is searched against the concatenation.
- **(b) Unicode whitespace.** `compact` used `Pattern.compile("\\s+")` (ASCII-only), so a non-breaking space (U+00A0) inside a citation survived and defeated the match. The strip is now Unicode-aware (`Character.isWhitespace || isSpaceChar`, which catches the NBSP family `\s` omits).

The previously-overstated `descriptionCitesAbsentCode` Javadoc is corrected, and the now-unused `WHITESPACE` pattern is removed.

### On part (c) of #122 (intra-literal spacing) — intentionally deferred

The issue also asked to make whitespace **inside string/char literals** significant, so a phantom like `put("a b")` (vs real `put("ab")`) is demoted. An initial literal-aware implementation was added and then **removed after adversarial multi-agent review**: every literal-aware variant reintroduced the costly false positive it set out to avoid — an incidental quote in the scope (a comment apostrophe `can't … here's`, or a string the source splits across diff lines) is misread as a literal delimiter and demotes a genuinely-present finding.

The `(c)` phantom is *whitespace-free-indistinguishable* from such a present finding, so any detection that fires on the phantom also fires on real findings. Per #122's own conservative rule (**an uncertain match must keep the finding**), and because the phantom is the acceptable *false-negative* direction, `(c)` is dropped. The matcher reduces to a single Unicode-aware whitespace-free match with no false positives. Catching the intra-literal phantom needs the cross-file context tracked in #55.

## Related Issues

Fixes #122

## How Has This Been Tested?

- [x] Unit tests

`FindingQuoteValidatorTest` covers: (a) wrapped-line keep, (b) NBSP keep, the deliberate conservative trade (intra-literal phantom **kept**, not demoted), and comment-quote robustness. The (a) and (b) tests were each verified to **fail on the pre-fix code**.

- `./mvnw spotless:check` ✅
- `./mvnw clean test spotbugs:check` ✅ — 697 tests, 0 failures, SpotBugs clean
- JaCoCo: 100% coverage on changed lines (the one remaining partial branch is pre-existing `validate()` code)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
