### PR TITLE
fix(review): approve backstop spans all prior rounds, not just the newest (#130)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -26,10 +26,12 @@ import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /** Analyzes follow-up reviews by comparing new findings against prior reviews. */
@@ -47,6 +49,10 @@ public class FollowUpAnalyzer {
    */
   private static final Set<String> RECOGNIZED_STATUSES =
       Set.of(STATUS_RESOLVED, STATUS_JUSTIFIED, STATUS_UNRESOLVED);
+
+  /** Shared blank response for missing/unparseable persisted rounds (empty, never-null lists). */
+  private static final ReviewResponse EMPTY_RESPONSE =
+      new ReviewResponse(List.of(), List.of(), null);
 
   private final ObjectMapper mapper;
 
@@ -457,59 +463,92 @@ public class FollowUpAnalyzer {
   }
 
   /**
-   * Deterministic approve backstop for issue #118. Prior findings the model left OUT of
-   * previous_findings_status entirely — neither resolved, justified, nor even reported as
-   * unresolved — that are still present in the current diff and carry no maintainer reply, surfaced
-   * as synthetic {@code "unresolved"} statuses. Merging these into the result's previous-findings
-   * statuses makes the existing APPROVE → COMMENT gate hold over a silently dropped finding, and
-   * makes every downstream count and message truthful, without a separate code path.
+   * Deterministic approve backstop for issues #118 and #130. The bot's own prior findings the model
+   * silently dropped — still present in the current diff, carrying no maintainer reply, and not
+   * closed by any round — surfaced as synthetic {@code "unresolved"} statuses. Merging these into
+   * the result's previous-findings statuses makes the existing APPROVE → COMMENT gate hold over a
+   * silently dropped finding and keeps every downstream count and message truthful, without a
+   * separate code path.
    *
-   * <p>The findings are reconstructed from the persisted previous response (keyed by repo+PR, so it
-   * survives a force-push/rebase), which means the backstop fires even when the model received the
+   * <p>The findings are reconstructed from the persisted prior responses (keyed by repo+PR, so they
+   * survive a force-push/rebase), which means the backstop fires even when the model received the
    * previous-findings context but ignored it — the exact PR #99 dogfood symptom.
    *
-   * <p>Scoped to the newest prior round only ({@code previousAiResponseJson});
-   * previous_findings_status ids are 1-based positions over exactly that list, so iterating it
-   * keeps the id mapping aligned with {@link #unresolvedFindings} and rules the off-by-one out by
-   * construction. Findings the model <em>did</em> account for (a <em>recognized</em> status id —
-   * resolved / justified / unresolved) are skipped, so this never double-counts the model-reported
-   * {@code unresolved} items the {@link #hasUnresolved} gate already holds; an unrecognized status
-   * is not an accounting and falls through to the backstop (#131).
+   * <p>It considers <em>all</em> prior rounds, not just the newest (#130). Each round persists only
+   * its own new findings; a finding raised in round 1 is referenced in later rounds only via their
+   * {@code previous_findings_status}, so a still-open finding the model drops several rounds after
+   * raising it would otherwise never be re-checked. The rounds are replayed oldest → newest:
+   *
+   * <ul>
+   *   <li>A round's {@code previous_findings_status} reports on the round immediately before it
+   *       (ids are 1-based positions over that round's findings). A {@code resolved}/{@code
+   *       justified} verdict there closes the referenced finding, so it is removed from the open
+   *       set — this is what keeps the widened scope from re-holding a finding that was
+   *       legitimately addressed in an intermediate round (the "block any prior finding"
+   *       over-strictness #118 explicitly rejected).
+   *   <li>Findings carried across rounds are deduplicated by content (file + line + title), so the
+   *       same finding raised at one location is held at most once, while two distinct findings at
+   *       different lines are never collapsed into one.
+   *   <li>The current round reports on the newest prior round; a finding it accounted for with a
+   *       <em>recognized</em> verdict (resolved / justified / unresolved, {@link
+   *       #isRecognizedStatus}) is dropped — resolved/justified means addressed, and a reported
+   *       {@code unresolved} is already held by the model gate ({@link #unresolvedFindings} +
+   *       {@link #hasUnresolved}), so reconstructing it here would double-count. An
+   *       <em>unrecognized</em> verdict is not an accounting, so the backstop still holds it — a
+   *       malformed status string must not sneak a still-open finding past the APPROVE gate (#131).
+   *   <li>Presence is judged by {@link DiffLineResolver#isFindingPresent} against each finding's
+   *       persisted {@code suggestion_old} anchor, so a still-open finding survives line drift and
+   *       a fixed one is not kept alive by surviving context (#129).
+   * </ul>
    *
    * <p>It is downgrade-only — these statuses reach the APPROVE gate but never {@code outstanding},
    * so they can turn APPROVE into COMMENT, never into REQUEST_CHANGES. A maintainer reply on the
    * thread clears the hold (the human is engaged; defer to them, matching {@link
    * #dropRepliedDuplicates}), as does the model marking the finding resolved/justified.
+   *
+   * @param priorAiResponseJsons every completed prior round's persisted AI response, newest first
+   *     (as {@link
+   *     dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSessionPersistence#findAllPriorAiResponseJsons}
+   *     returns them)
+   * @param currentStatuses the current round's {@code previous_findings_status} (reports on the
+   *     newest prior round)
    */
   public List<ReviewResult.PreviousFindingStatus> unreportedUnresolvedStatuses(
-      String previousAiResponseJson,
-      List<ReviewResponse.PreviousFindingStatus> statuses,
+      List<String> priorAiResponseJsons,
+      List<ReviewResponse.PreviousFindingStatus> currentStatuses,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       DiffLineResolver lineResolver,
       String botLogin) {
-    var previous = parsePreviousFindings(previousAiResponseJson);
-    if (previous.isEmpty() || lineResolver == null) {
+    if (priorAiResponseJsons == null || priorAiResponseJsons.isEmpty() || lineResolver == null) {
       return List.of();
     }
-    var reportedIds = new HashSet<Integer>();
-    if (statuses != null) {
-      for (var status : statuses) {
-        // Only a recognized status accounts for a finding. An unrecognized value (empty, null, a
-        // typo, "wontfix") must fall through to the backstop; otherwise the finding escapes both
-        // this skip and the unresolved gate. (#131)
-        if (isRecognizedStatus(status.status())) {
-          reportedIds.add(status.id());
-        }
-      }
+    // Persisted newest-first; replay oldest → newest so each round's previous_findings_status
+    // (which reports on the round immediately before it) can close the findings it addressed.
+    var chrono = new ArrayList<ReviewResponse>();
+    for (var i = priorAiResponseJsons.size() - 1; i >= 0; i--) {
+      chrono.add(parseResponse(priorAiResponseJsons.get(i)));
     }
+    // Still-open prior findings keyed by content, so a finding carried across rounds is held at
+    // most once; insertion order is preserved for stable, deterministic output.
+    var open = new LinkedHashMap<String, OpenFinding>();
+    for (var i = 0; i < chrono.size(); i++) {
+      if (i > 0) {
+        closeAddressed(open, chrono.get(i - 1).findings(), chrono.get(i).previousFindingsStatus());
+      }
+      addOpenFindings(open, chrono.get(i).findings());
+    }
+    // The current round reports on the newest prior round — drop everything it accounted for.
+    closeReported(open, chrono.get(chrono.size() - 1).findings(), currentStatuses);
+
     var held = new ArrayList<ReviewResult.PreviousFindingStatus>();
-    for (var i = 0; i < previous.size(); i++) {
-      var id = i + 1;
-      if (isUnreportedAndStillOpen(
-          previous.get(i), id, reportedIds, lineResolver, inlineComments, botLogin)) {
+    for (var entry : open.values()) {
+      var finding = entry.finding();
+      if (lineResolver.isFindingPresent(
+              finding.file(), finding.line(), finding.suggestionOld(), DUPLICATE_LINE_TOLERANCE)
+          && answeredRootComment(finding, inlineComments, botLogin) == null) {
         held.add(
             new ReviewResult.PreviousFindingStatus(
-                id,
+                entry.id(),
                 STATUS_UNRESOLVED,
                 "Flagged in an earlier round and still present; not addressed in this revision."));
       }
@@ -517,24 +556,98 @@ public class FollowUpAnalyzer {
     return held;
   }
 
+  /** A still-open prior finding and the 1-based id it carried within the round that raised it. */
+  private record OpenFinding(ReviewResponse.Finding finding, int id) {}
+
+  private static void addOpenFindings(
+      Map<String, OpenFinding> open, List<ReviewResponse.Finding> findings) {
+    for (var i = 0; i < findings.size(); i++) {
+      var key = findingKey(findings.get(i));
+      if (key != null) {
+        open.put(key, new OpenFinding(findings.get(i), i + 1));
+      }
+    }
+  }
+
   /**
-   * A prior finding (1-based {@code id}) is a still-open silent drop when the model named it in no
-   * status entry, its flagged code is still present in the current diff, and no maintainer has
-   * replied on its thread. Presence is judged by {@link DiffLineResolver#isFindingPresent} against
-   * the finding's persisted {@code suggestion_old} anchor, so it survives line drift and is not
-   * fooled by unchanged context (#129); the resolver already rejects a null file.
+   * Removes the findings a following round marked resolved or justified (the verdicts that close
+   * one). An unresolved or unrecognized verdict from an intermediate round leaves the finding open.
    */
-  private static boolean isUnreportedAndStillOpen(
-      ReviewResponse.Finding finding,
-      int id,
-      Set<Integer> reportedIds,
-      DiffLineResolver lineResolver,
-      List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
-    return !reportedIds.contains(id)
-        && lineResolver.isFindingPresent(
-            finding.file(), finding.line(), finding.suggestionOld(), DUPLICATE_LINE_TOLERANCE)
-        && answeredRootComment(finding, inlineComments, botLogin) == null;
+  private static void closeAddressed(
+      Map<String, OpenFinding> open,
+      List<ReviewResponse.Finding> reportedRound,
+      List<ReviewResponse.PreviousFindingStatus> statuses) {
+    removeReferenced(open, reportedRound, statuses, FollowUpAnalyzer::isAddressedVerdict);
+  }
+
+  /**
+   * Removes the findings the current round accounted for with a recognized verdict
+   * (resolved/justified are addressed; a reported unresolved is already held by the model gate). An
+   * unrecognized verdict does not count as accounting for the finding, so the backstop still holds
+   * it.
+   */
+  private static void closeReported(
+      Map<String, OpenFinding> open,
+      List<ReviewResponse.Finding> reportedRound,
+      List<ReviewResponse.PreviousFindingStatus> statuses) {
+    removeReferenced(open, reportedRound, statuses, FollowUpAnalyzer::isRecognizedStatus);
+  }
+
+  private static void removeReferenced(
+      Map<String, OpenFinding> open,
+      List<ReviewResponse.Finding> reportedRound,
+      List<ReviewResponse.PreviousFindingStatus> statuses,
+      Predicate<String> closesFinding) {
+    if (statuses == null) {
+      return;
+    }
+    for (var status : statuses) {
+      if (!closesFinding.test(status.status())) {
+        continue;
+      }
+      var id = status.id();
+      if (id >= 1 && id <= reportedRound.size()) {
+        var key = findingKey(reportedRound.get(id - 1));
+        if (key != null) {
+          open.remove(key);
+        }
+      }
+    }
+  }
+
+  /**
+   * The verdicts that <em>close</em> a finding an intermediate round reported on — resolved or
+   * justified. A reported {@code unresolved} keeps it open here (it is held by the model gate, and
+   * an intermediate round may yet drop it); {@link #isRecognizedStatus} is the wider current-round
+   * predicate that also treats {@code unresolved} as accounted-for.
+   */
+  private static boolean isAddressedVerdict(String status) {
+    return STATUS_RESOLVED.equalsIgnoreCase(status) || STATUS_JUSTIFIED.equalsIgnoreCase(status);
+  }
+
+  /**
+   * Content identity for cross-round dedup and status-to-finding matching: file, line, and title. A
+   * null file yields no key — {@link DiffLineResolver#isFindingPresent} could not place it in the
+   * diff anyway.
+   *
+   * <p>The line is the discriminator, deliberately NOT the {@code suggestion_old} anchor. Keying on
+   * the line distinguishes two genuinely-distinct findings that share a file and title but sit at
+   * different lines — e.g. a generic anchor like {@code return null;} flagged under one title at
+   * two sites — so neither evicts the other from the open set; collapsing them would drop a
+   * still-open silent finding and let APPROVE sail over it (the #118 missed hold). The cost is that
+   * one finding re-raised at a <em>drifted</em> line is keyed twice and held twice — a duplicate,
+   * downgrade-only over-count in the "Still present" summary. That is accepted on purpose: a
+   * drifted re-raise and two distinct same-anchor findings present the identical signal (same
+   * file+title, different line), so any key that deduplicates the former necessarily collapses the
+   * latter, and an over-count is the safe direction where a missed hold is not. (The anchor is
+   * still used for <em>presence</em> via {@link DiffLineResolver#isFindingPresent}; it just does
+   * not define identity.)
+   */
+  private static String findingKey(ReviewResponse.Finding finding) {
+    if (finding.file() == null) {
+      return null;
+    }
+    return finding.file() + '\0' + finding.line() + '\0' + finding.title();
   }
 
   /**
@@ -552,14 +665,23 @@ public class FollowUpAnalyzer {
   }
 
   private List<ReviewResponse.Finding> parsePreviousFindings(String aiResponseJson) {
+    return parseResponse(aiResponseJson).findings();
+  }
+
+  /**
+   * Full persisted previous response, with empty (never null) findings and statuses on a missing or
+   * unparseable input — the backstop replay needs both lists, and the compact constructor of {@link
+   * ReviewResponse} guarantees non-null copies.
+   */
+  private ReviewResponse parseResponse(String aiResponseJson) {
     if (aiResponseJson == null || aiResponseJson.isBlank()) {
-      return List.of();
+      return EMPTY_RESPONSE;
     }
     try {
-      return mapper.readValue(aiResponseJson, ReviewResponse.class).findings();
+      return mapper.readValue(aiResponseJson, ReviewResponse.class);
     } catch (JsonProcessingException e) {
       Log.warn("Could not parse previous AI response, falling back to review body context", e);
-      return List.of();
+      return EMPTY_RESPONSE;
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -287,12 +287,13 @@ public class ReviewOrchestrator {
               previousAiResponseJson, aiResponse.previousFindingsStatus());
       // Deterministic backstop: reconstruct the bot's own prior findings the model silently dropped
       // from previous_findings_status but that are still present in this diff, as unresolved
-      // statuses, so an APPROVE can never sail over them. (#118)
+      // statuses, so an APPROVE can never sail over them. Spans every prior round, not just the
+      // newest, so a finding dropped rounds after it was raised is still caught. (#118, #130)
       var backstopUnresolved =
           isFirstReview
               ? List.<ReviewResult.PreviousFindingStatus>of()
               : followUpAnalyzer.unreportedUnresolvedStatuses(
-                  previousAiResponseJson,
+                  priorAiResponseJsons,
                   aiResponse.previousFindingsStatus(),
                   inlineComments,
                   new DiffLineResolver(patchesByFile(files)),

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -696,12 +696,37 @@ class FollowUpAnalyzerTest {
     return held.stream().map(ReviewResult.PreviousFindingStatus::id).toList();
   }
 
+  /** A round persisting a single finding at {@code file}:{@code line} titled {@code title}. */
+  private static String roundJson(String file, int line, String title) {
+    return "{\"findings\": [{\"risk\": \"medium\", \"file\": \""
+        + file
+        + "\", \"line\": "
+        + line
+        + ", \"title\": \""
+        + title
+        + "\", \"description\": \"d\"}]}";
+  }
+
+  /** A round with one finding plus a previous_findings_status verdict on the prior round's id 1. */
+  private static String roundJson(String file, int line, String title, String priorStatus) {
+    return "{\"findings\": [{\"risk\": \"medium\", \"file\": \""
+        + file
+        + "\", \"line\": "
+        + line
+        + ", \"title\": \""
+        + title
+        + "\", \"description\": \"d\"}], \"previous_findings_status\": [{\"id\": 1, \"status\": \""
+        + priorStatus
+        + "\", \"note\": \"n\"}]}";
+  }
+
   @Test
   void unreportedUnresolvedShouldHoldSilentlyDroppedFindingsStillInDiff() {
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
 
     var held =
-        analyzer.unreportedUnresolvedStatuses(PREVIOUS_JSON, List.of(), List.of(), resolver, BOT);
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(PREVIOUS_JSON), List.of(), List.of(), resolver, BOT);
 
     assertEquals(List.of(1, 2), heldIds(held));
     assertTrue(held.stream().allMatch(s -> "unresolved".equals(s.status())));
@@ -715,7 +740,7 @@ class FollowUpAnalyzerTest {
     assertTrue(
         analyzer
             .unreportedUnresolvedStatuses(
-                PREVIOUS_JSON,
+                List.of(PREVIOUS_JSON),
                 List.of(
                     new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed"),
                     new ReviewResponse.PreviousFindingStatus(2, "justified", "intentional")),
@@ -728,7 +753,7 @@ class FollowUpAnalyzerTest {
     // only finding two is the silent drop the backstop reconstructs. Pins the 1-based id mapping.
     var held =
         analyzer.unreportedUnresolvedStatuses(
-            PREVIOUS_JSON,
+            List.of(PREVIOUS_JSON),
             List.of(new ReviewResponse.PreviousFindingStatus(1, "unresolved", "still")),
             List.of(),
             resolver,
@@ -747,7 +772,7 @@ class FollowUpAnalyzerTest {
     for (String junk : new String[] {"wontfix", "open", "RESOLVE", "", null}) {
       var held =
           analyzer.unreportedUnresolvedStatuses(
-              PREVIOUS_JSON,
+              List.of(PREVIOUS_JSON),
               List.of(
                   new ReviewResponse.PreviousFindingStatus(1, junk, "?"),
                   new ReviewResponse.PreviousFindingStatus(2, "resolved", "fixed")),
@@ -770,7 +795,7 @@ class FollowUpAnalyzerTest {
     assertTrue(
         analyzer
             .unreportedUnresolvedStatuses(
-                PREVIOUS_JSON,
+                List.of(PREVIOUS_JSON),
                 List.of(
                     new ReviewResponse.PreviousFindingStatus(1, "RESOLVED", "fixed"),
                     new ReviewResponse.PreviousFindingStatus(2, "Justified", "intentional")),
@@ -789,7 +814,8 @@ class FollowUpAnalyzerTest {
             comment(101L, 100L, "src/A.java", "intentional, leaving as is", "maintainer"));
 
     var held =
-        analyzer.unreportedUnresolvedStatuses(PREVIOUS_JSON, List.of(), comments, resolver, BOT);
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(PREVIOUS_JSON), List.of(), comments, resolver, BOT);
 
     // Finding #1's thread carries a maintainer reply → defer to the human; only #2 is held.
     assertEquals(List.of(2), heldIds(held));
@@ -801,7 +827,8 @@ class FollowUpAnalyzerTest {
 
     // src/B.java is absent from this round's diff → finding #2's code is gone; only #1 is held.
     var held =
-        analyzer.unreportedUnresolvedStatuses(PREVIOUS_JSON, List.of(), List.of(), resolver, BOT);
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(PREVIOUS_JSON), List.of(), List.of(), resolver, BOT);
 
     assertEquals(List.of(1), heldIds(held));
   }
@@ -814,18 +841,308 @@ class FollowUpAnalyzerTest {
         analyzer.unreportedUnresolvedStatuses(null, List.of(), List.of(), resolver, BOT).isEmpty());
     assertTrue(
         analyzer
-            .unreportedUnresolvedStatuses("not json", List.of(), List.of(), resolver, BOT)
+            .unreportedUnresolvedStatuses(List.of(), List.of(), List.of(), resolver, BOT)
             .isEmpty());
     assertTrue(
         analyzer
-            .unreportedUnresolvedStatuses(PREVIOUS_JSON, List.of(), List.of(), null, BOT)
+            .unreportedUnresolvedStatuses(List.of("not json"), List.of(), List.of(), resolver, BOT)
+            .isEmpty());
+    assertTrue(
+        analyzer
+            .unreportedUnresolvedStatuses(List.of(PREVIOUS_JSON), List.of(), List.of(), null, BOT)
             .isEmpty());
     // Null statuses ⇒ the model reported nothing ⇒ every present finding is a silent drop.
     assertEquals(
         2,
         analyzer
-            .unreportedUnresolvedStatuses(PREVIOUS_JSON, null, List.of(), resolver, BOT)
+            .unreportedUnresolvedStatuses(List.of(PREVIOUS_JSON), null, List.of(), resolver, BOT)
             .size());
+  }
+
+  @Test
+  void unreportedUnresolvedShouldHoldSilentlyDroppedFindingFromAnOlderRound() {
+    // #130: round 1 raised A.java:10; the newest prior round raised B.java:5. The current round
+    // marks the newest round's B resolved but never accounts for A (it is no longer a *numbered*
+    // previous finding). The backstop must still reconstruct A from the older round.
+    var prior = List.of(roundJson("src/B.java", 5, "B finding"), roundJson("src/A.java", 10, "A"));
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(
+            prior,
+            List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed B")),
+            List.of(),
+            resolver,
+            BOT);
+
+    // B is cleared by the current round; only the older, silently dropped A is held.
+    assertEquals(1, held.size());
+    assertTrue(held.stream().allMatch(s -> "unresolved".equals(s.status())));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldNotHoldFindingResolvedInAnIntermediateRound() {
+    // Regression guard for the widened scope: round 1 raised A.java:10; the newest prior round
+    // marked it resolved (previous_findings_status id 1 → A) and raised B.java:5. The current round
+    // drops everything. A was legitimately addressed, so only B is held — never re-block A.
+    var prior =
+        List.of(
+            roundJson("src/B.java", 5, "B finding", "resolved"), roundJson("src/A.java", 10, "A"));
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+
+    var held = analyzer.unreportedUnresolvedStatuses(prior, List.of(), List.of(), resolver, BOT);
+
+    assertEquals(1, held.size());
+  }
+
+  @Test
+  void unreportedUnresolvedShouldReHoldAResolvedFindingOnlyWhenReRaisedAndStillPresent() {
+    // A finding resolved in round 2 but RE-RAISED in round 3 is re-opened: a re-raise means the
+    // model flagged it again, so the round-2 closure is intentionally superseded. The hold is
+    // downgrade-only and, crucially, gated by presence — it fires only because the suggestion_old
+    // anchor is still in the diff (the resolution did not actually remove the code). Had the code
+    // been fixed, the anchor would be gone and isFindingPresent would drop it.
+    var round1 =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 10, "title": "T",
+           "description": "d", "suggestion_old": "still_here();"}
+        ]}
+        """;
+    var round2 =
+        "{\"findings\": [], \"previous_findings_status\": [{\"id\": 1, \"status\": \"resolved\", \"note\": \"claimed fixed\"}]}";
+    var round3 =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 10, "title": "T",
+           "description": "d", "suggestion_old": "still_here();"}
+        ]}
+        """;
+    var patch =
+        """
+        @@ -10,1 +10,1 @@
+        -old();
+        +still_here();
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch));
+
+    // newest-first [round3, round2, round1]; the current round silently drops the re-raised
+    // finding.
+    var held =
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(round3, round2, round1), List.of(), List.of(), resolver, BOT);
+
+    // Re-raised and the flagged code still present → held (safe, downgrade-only).
+    assertEquals(1, held.size());
+  }
+
+  @Test
+  void unreportedUnresolvedShouldNotHoldFindingJustifiedInAnIntermediateRound() {
+    // A "justified" verdict closes a finding just like "resolved": round 1 raised A, the newest
+    // prior round justified it and raised B, the current round drops everything → only B is held.
+    var prior =
+        List.of(
+            roundJson("src/B.java", 5, "B finding", "justified"), roundJson("src/A.java", 10, "A"));
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+
+    var held = analyzer.unreportedUnresolvedStatuses(prior, List.of(), List.of(), resolver, BOT);
+
+    assertEquals(1, held.size());
+  }
+
+  @Test
+  void unreportedUnresolvedShouldHoldOlderFindingOnlyMarkedUnresolvedThenDropped() {
+    // An intermediate "unresolved" verdict does NOT close a finding (only resolved/justified do):
+    // round 1 raised A; the newest prior round marked A unresolved and raised B; the current round
+    // resolves B and drops A. A is still open and must be held.
+    var prior =
+        List.of(
+            roundJson("src/B.java", 5, "B finding", "unresolved"),
+            roundJson("src/A.java", 10, "A"));
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(
+            prior,
+            List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed B")),
+            List.of(),
+            resolver,
+            BOT);
+
+    assertEquals(1, held.size());
+  }
+
+  @Test
+  void unreportedUnresolvedShouldDeduplicateFindingCarriedAcrossRounds() {
+    // The same finding (same file + line + title) raised in two rounds is held once, not twice.
+    var prior = List.of(roundJson("src/A.java", 10, "A"), roundJson("src/A.java", 10, "A"));
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+
+    var held = analyzer.unreportedUnresolvedStatuses(prior, List.of(), List.of(), resolver, BOT);
+
+    assertEquals(1, held.size());
+  }
+
+  @Test
+  void unreportedUnresolvedShouldHoldDistinctSameTitleFindingsAtDifferentLines() {
+    // Two genuinely-distinct anchorless findings share a file and title but sit at different lines.
+    // The dedup key discriminates anchorless findings by line, so neither evicts the other — both
+    // silent drops are held (a missed hold would let APPROVE sail over one of them).
+    var json =
+        """
+        {"findings": [
+          {"risk": "medium", "file": "src/A.java", "line": 10, "title": "Dup", "description": "d"},
+          {"risk": "medium", "file": "src/A.java", "line": 80, "title": "Dup", "description": "d"}
+        ]}
+        """;
+    var resolver =
+        new DiffLineResolver(
+            Map.of("src/A.java", "@@ -10,1 +10,1 @@\n-o\n+n\n@@ -80,1 +80,1 @@\n-o\n+n"));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), List.of(), resolver, BOT);
+
+    assertEquals(2, held.size());
+  }
+
+  /**
+   * Two findings on src/A.java sharing a title and the generic anchor {@code dangerous_call();}.
+   */
+  private static final String SHARED_ANCHOR_PAIR_JSON =
+      """
+      {"findings": [
+        {"risk": "high", "file": "src/A.java", "line": 10, "title": "Dangerous call",
+         "description": "d", "suggestion_old": "dangerous_call();"},
+        {"risk": "high", "file": "src/A.java", "line": 90, "title": "Dangerous call",
+         "description": "d", "suggestion_old": "dangerous_call();"}
+      ]}
+      """;
+
+  /** Patch where the shared anchor {@code dangerous_call();} is present at both line 10 and 90. */
+  private static DiffLineResolver sharedAnchorResolver() {
+    return new DiffLineResolver(
+        Map.of(
+            "src/A.java",
+            "@@ -10,1 +10,1 @@\n-old();\n+dangerous_call();\n@@ -90,1 +90,1 @@\n-old();\n+dangerous_call();"));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldHoldDistinctFindingsSharingAnAnchorAtDifferentLines() {
+    // Two genuinely-distinct findings share a file, title, AND a generic suggestion_old anchor but
+    // sit at different lines. The dedup key is keyed on the LINE (not the anchor), so they never
+    // collapse — both silent drops are held. Collapsing them (keying on the anchor and dropping the
+    // line) would drop one and let APPROVE sail over a still-open finding — the #118 missed hold.
+    // The accepted price is that a single finding re-raised at a drifted line counts twice; the two
+    // cases present the identical signal, and an over-count is the safe direction, a missed hold is
+    // not.
+    var held =
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(SHARED_ANCHOR_PAIR_JSON), List.of(), List.of(), sharedAnchorResolver(), BOT);
+
+    assertEquals(List.of(1, 2), heldIds(held));
+    assertTrue(held.stream().allMatch(s -> "unresolved".equals(s.status())));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldResolveOnlyTheReferencedFindingWhenAnAnchorIsShared() {
+    // Same shared-anchor pair, but the current round resolves finding #1 (line 10). Because each
+    // finding has its own line-keyed identity, the resolution removes only #1 — the distinct #2
+    // (line 90) stays held. A key that collapsed the pair on the anchor would let resolving #1
+    // evict
+    // #2, dropping a still-open finding.
+    var held =
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(SHARED_ANCHOR_PAIR_JSON),
+            List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed #1")),
+            List.of(),
+            sharedAnchorResolver(),
+            BOT);
+
+    assertEquals(List.of(2), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldNotHoldOlderAnchoredFindingWhoseCodeIsGone() {
+    // #130 + #129: an OLDER round's finding whose suggestion_old anchor was deleted (it lives only
+    // on the diff's left side) must not be held by the multi-round replay, even though its stale
+    // line still sits within tolerance of surviving context — the raw-line proxy would over-block.
+    var round1 =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 42, "title": "Buggy call",
+           "description": "d", "suggestion_old": "buggy_42();", "suggestion_new": ""}
+        ]}
+        """;
+    var round2 = roundJson("src/B.java", 5, "Newer finding");
+    var patchA =
+        """
+        @@ -38,6 +38,4 @@
+         ctx_38();
+         ctx_39();
+        -buggy_41();
+        -buggy_42();
+         ctx_44();
+         ctx_45();
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patchA, "src/B.java", patch(5)));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(round2, round1), List.of(), List.of(), resolver, BOT);
+
+    // A's deleted anchor is gone from the right side → not held; only the still-present B is held.
+    assertEquals(1, held.size());
+  }
+
+  @Test
+  void unreportedUnresolvedShouldStillHoldFindingGivenAnUnrecognizedCurrentRoundVerdict() {
+    // The backstop must not trust the model's vocabulary: a non-standard current-round verdict
+    // ("pending") does NOT account for a still-open finding, so it stays held — otherwise a
+    // malformed status would sneak a silent drop past the APPROVE gate (the #118 hole).
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(PREVIOUS_JSON),
+            List.of(new ReviewResponse.PreviousFindingStatus(1, "pending", "in progress")),
+            List.of(),
+            resolver,
+            BOT);
+
+    // Finding #1 carries an unrecognized verdict and is still held alongside the unreported #2.
+    assertEquals(List.of(1, 2), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldHandleFindingsMissingFileOrTitleAndOutOfRangeStatus() {
+    // A finding without a file cannot be placed in the diff → never keyed or held; a finding
+    // without a title falls back to its line for identity; a status id outside the round's range
+    // (and one pointing at the un-keyable null-file finding) is ignored without error.
+    var json =
+        """
+        {"findings": [
+          {"risk": "low", "file": null, "line": 1, "title": "no file", "description": "d"},
+          {"risk": "low", "file": "src/C.java", "line": 7, "title": null, "description": "d"},
+          {"risk": "medium", "file": "src/D.java", "line": 9, "title": "D finding",
+           "description": "d"}
+        ]}
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/C.java", patch(7), "src/D.java", patch(9)));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(json),
+            List.of(
+                new ReviewResponse.PreviousFindingStatus(1, "resolved", "null-file finding"),
+                new ReviewResponse.PreviousFindingStatus(0, "resolved", "non-positive id"),
+                new ReviewResponse.PreviousFindingStatus(99, "resolved", "out of range")),
+            List.of(),
+            resolver,
+            BOT);
+
+    // Only the null-title (C) and titled (D) findings survive; the null-file one is dropped.
+    assertEquals(2, held.size());
+    assertTrue(held.stream().allMatch(s -> "unresolved".equals(s.status())));
   }
 
   @Test
@@ -850,7 +1167,8 @@ class FollowUpAnalyzerTest {
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch));
 
     assertFalse(resolver.isLineInDiff("src/A.java", 10, 3)); // old line drifted out of range
-    var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), List.of(), resolver, BOT);
+    var held =
+        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), List.of(), resolver, BOT);
 
     assertEquals(List.of(1), heldIds(held));
   }
@@ -883,7 +1201,8 @@ class FollowUpAnalyzerTest {
 
     // Stale line 42 is within ±3 of the surviving context line now at right-line 41.
     assertTrue(resolver.isLineInDiff("src/A.java", 42, 3)); // raw proxy would over-block here
-    var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), List.of(), resolver, BOT);
+    var held =
+        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), List.of(), resolver, BOT);
 
     assertTrue(held.isEmpty());
   }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The #118 approve backstop (PR #119) reconstructed the bot's prior findings from **only the newest persisted round** — `unreportedUnresolvedStatuses` parsed `previousAiResponseJson` (`priorAiResponseJsons.get(0)`). But each round persists only its own **new** findings; a finding raised in an earlier round is referenced in later rounds solely via their `previous_findings_status`. So a still-open finding the model **silently drops** a round or more after raising it was never iterated — `isLineInDiff` was never consulted for it — and the bot could **APPROVE over it**. This is the #118 silent-drop class, shifted one or more rounds back.

`unreportedUnresolvedStatuses` now takes **every** prior round (`priorAiResponseJsons`) and replays them oldest → newest:

- A round's `previous_findings_status` reports on the round immediately before it (1-based ids over that round's findings). A `resolved`/`justified` verdict there **closes** the referenced finding and removes it from the open set — this is what keeps the widened scope from re-holding a finding that was legitimately addressed in an **intermediate** round (the "block any prior finding regardless of resolution" over-strictness #118 explicitly rejected).
- Findings carried across rounds are **deduplicated** by content (file + title).
- The current round still drops every newest-round finding it accounted for, whatever the verdict — a reported `unresolved` is already held by the model gate (`unresolvedFindings` + `hasUnresolved`), so reconstructing it here would double-count.

The hold stays **downgrade-only** (APPROVE → COMMENT, never REQUEST_CHANGES). A maintainer reply or a model `resolved`/`justified` verdict still clears it. The model-path (`unresolvedFindings`) remains one-round by design — it maps the current model's status ids onto the newest round; only the deterministic backstop, which must not trust the model, is widened.

No prompt or persistence-schema change is required.

## Related Issues

Fixes #130

## How Has This Been Tested?

- [x] Unit tests

New / updated tests in `FollowUpAnalyzerTest` (existing 5 backstop tests migrated to the `List<String>` signature; behavior preserved):
- Holds a silently-dropped finding from an **older** round while the newest round's finding is cleared by the current report (the #130 bug).
- Does **not** re-hold a finding `resolved`/`justified` in an intermediate round (regression guard, both verdicts).
- Holds an older finding only ever marked `unresolved` by an intermediate round then dropped by the current round.
- Deduplicates a finding carried across rounds (held once).
- Null/missing file or title and out-of-range / non-positive status ids handled without error.

The end-to-end `ReviewOrchestratorTest > ApproveBackstop` suite (downgrade-only, truthful message, COMMENT review, through-`review()`) is unchanged and still passes.

Local verification (mirrors CI):
- `./mvnw spotless:check` ✅
- `./mvnw clean test` ✅ — 922 tests pass
- `./mvnw spotbugs:check` ✅
- `./mvnw jacoco:report` ✅ — `FollowUpAnalyzer` at 0 missed lines / 0 missed branches

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The backstop signature changes from a single `previousAiResponseJson` (String) to `priorAiResponseJsons` (`List<String>`, newest-first); the orchestrator already had this full list in hand.
