### PR TITLE
fix(review): unrecognized previous_findings_status escapes the #118 backstop and unresolved gate (#131)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -580,14 +580,23 @@ public class FollowUpAnalyzer {
     return body != null ? body : "";
   }
 
-  /** Converts AI response's previous_findings_status into ReviewResult statuses. */
+  /**
+   * Converts AI response's previous_findings_status into ReviewResult statuses, keeping only the
+   * recognized values (resolved / justified / unresolved). An unrecognized status is meaningless
+   * noise that no count or gate acts on, and for a still-open finding the backstop already emits a
+   * synthetic {@code "unresolved"} for that id — passing the raw value through too would leave two
+   * entries with the same id in the result. Dropping it keeps {@code previousStatuses} one-per-id
+   * and matches the backstop's recognized-status contract (#131).
+   */
   public List<ReviewResult.PreviousFindingStatus> toStatuses(
       List<ReviewResponse.PreviousFindingStatus> aiStatuses) {
     if (aiStatuses == null) return List.of();
 
     var result = new ArrayList<ReviewResult.PreviousFindingStatus>();
     for (var s : aiStatuses) {
-      result.add(new ReviewResult.PreviousFindingStatus(s.id(), s.status(), s.note()));
+      if (isRecognizedStatus(s.status())) {
+        result.add(new ReviewResult.PreviousFindingStatus(s.id(), s.status(), s.note()));
+      }
     }
     return result;
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -37,6 +37,16 @@ import java.util.stream.Stream;
 public class FollowUpAnalyzer {
 
   private static final String STATUS_UNRESOLVED = "unresolved";
+  private static final String STATUS_RESOLVED = "resolved";
+  private static final String STATUS_JUSTIFIED = "justified";
+
+  /**
+   * The only statuses the prompt contract defines for {@code previous_findings_status} ("resolved"
+   * | "unresolved" | "justified"). A value outside this set does not count as the model accounting
+   * for a finding — see {@link #isRecognizedStatus} and #131.
+   */
+  private static final Set<String> RECOGNIZED_STATUSES =
+      Set.of(STATUS_RESOLVED, STATUS_JUSTIFIED, STATUS_UNRESOLVED);
 
   private final ObjectMapper mapper;
 
@@ -461,9 +471,10 @@ public class FollowUpAnalyzer {
    * <p>Scoped to the newest prior round only ({@code previousAiResponseJson});
    * previous_findings_status ids are 1-based positions over exactly that list, so iterating it
    * keeps the id mapping aligned with {@link #unresolvedFindings} and rules the off-by-one out by
-   * construction. Findings the model <em>did</em> account for (any status id) are skipped, so this
-   * never double-counts the model-reported {@code unresolved} items the {@link #hasUnresolved} gate
-   * already holds.
+   * construction. Findings the model <em>did</em> account for (a <em>recognized</em> status id —
+   * resolved / justified / unresolved) are skipped, so this never double-counts the model-reported
+   * {@code unresolved} items the {@link #hasUnresolved} gate already holds; an unrecognized status
+   * is not an accounting and falls through to the backstop (#131).
    *
    * <p>It is downgrade-only — these statuses reach the APPROVE gate but never {@code outstanding},
    * so they can turn APPROVE into COMMENT, never into REQUEST_CHANGES. A maintainer reply on the
@@ -483,7 +494,12 @@ public class FollowUpAnalyzer {
     var reportedIds = new HashSet<Integer>();
     if (statuses != null) {
       for (var status : statuses) {
-        reportedIds.add(status.id());
+        // Only a recognized status accounts for a finding. An unrecognized value (empty, null, a
+        // typo, "wontfix") must fall through to the backstop; otherwise the finding escapes both
+        // this skip and the unresolved gate. (#131)
+        if (isRecognizedStatus(status.status())) {
+          reportedIds.add(status.id());
+        }
       }
     }
     var held = new ArrayList<ReviewResult.PreviousFindingStatus>();
@@ -516,6 +532,20 @@ public class FollowUpAnalyzer {
     return !reportedIds.contains(id)
         && lineResolver.isLineInDiff(finding.file(), finding.line(), DUPLICATE_LINE_TOLERANCE)
         && answeredRootComment(finding, inlineComments, botLogin) == null;
+  }
+
+  /**
+   * A model-reported status counts as the model accounting for a finding only when it is one of the
+   * contract's recognized values (resolved / justified / unresolved, case-insensitively). Any other
+   * value — empty, null, a typo, or an out-of-vocabulary word like {@code "wontfix"} — must fall
+   * through to the backstop: otherwise a still-open finding with an unrecognized status escapes
+   * BOTH the backstop (its id is present in {@code reportedIds}) AND the {@link #hasUnresolved}
+   * gate (its value is not {@code "unresolved"}), re-introducing the silent approve-over-open the
+   * backstop exists to stop. {@code unresolved} stays in the set so the backstop never
+   * double-counts an item the gate already holds via the model's own status. (#131)
+   */
+  private static boolean isRecognizedStatus(String status) {
+    return status != null && RECOGNIZED_STATUSES.contains(status.toLowerCase(Locale.ROOT));
   }
 
   private List<ReviewResponse.Finding> parsePreviousFindings(String aiResponseJson) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -68,11 +68,17 @@ public class PrSummaryGenerator {
       return;
     }
     var resolved =
-        result.previousStatuses().stream().filter(s -> "resolved".equals(s.status())).count();
+        result.previousStatuses().stream()
+            .filter(s -> "resolved".equalsIgnoreCase(s.status()))
+            .count();
     var unresolved =
-        result.previousStatuses().stream().filter(s -> "unresolved".equals(s.status())).count();
+        result.previousStatuses().stream()
+            .filter(s -> "unresolved".equalsIgnoreCase(s.status()))
+            .count();
     var justified =
-        result.previousStatuses().stream().filter(s -> "justified".equals(s.status())).count();
+        result.previousStatuses().stream()
+            .filter(s -> "justified".equalsIgnoreCase(s.status()))
+            .count();
     sb.append("### Previous Findings Status\n");
     sb.append("| Status | Count |\n");
     sb.append("|--------|-------|\n");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -737,6 +737,50 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void unreportedUnresolvedShouldHoldFindingsWithUnrecognizedStatus() {
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+
+    // #131: a status outside the contract's resolved/justified/unresolved vocabulary does NOT count
+    // as the model accounting for the finding. Finding #1 is still open in the diff, so each junk
+    // value must fall through to the backstop and be held — otherwise it would escape both the
+    // backstop (id present) and the unresolved gate (value != "unresolved").
+    for (String junk : new String[] {"wontfix", "open", "RESOLVE", "", null}) {
+      var held =
+          analyzer.unreportedUnresolvedStatuses(
+              PREVIOUS_JSON,
+              List.of(
+                  new ReviewResponse.PreviousFindingStatus(1, junk, "?"),
+                  new ReviewResponse.PreviousFindingStatus(2, "resolved", "fixed")),
+              List.of(),
+              resolver,
+              BOT);
+      // #2 carries a recognized status and is accounted for; only #1 (junk status) is held.
+      assertEquals(
+          List.of(1), heldIds(held), "status \"" + junk + "\" must not suppress the backstop");
+    }
+  }
+
+  @Test
+  void unreportedUnresolvedShouldRecognizeStatusesCaseInsensitively() {
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+
+    // Recognized statuses are matched case-insensitively, so upper/mixed case still accounts for a
+    // finding and nothing is held — the model-reported "unresolved" stays held by the gate, not
+    // double-counted here.
+    assertTrue(
+        analyzer
+            .unreportedUnresolvedStatuses(
+                PREVIOUS_JSON,
+                List.of(
+                    new ReviewResponse.PreviousFindingStatus(1, "RESOLVED", "fixed"),
+                    new ReviewResponse.PreviousFindingStatus(2, "Justified", "intentional")),
+                List.of(),
+                resolver,
+                BOT)
+            .isEmpty());
+  }
+
+  @Test
   void unreportedUnresolvedShouldExcludeFindingsWithMaintainerReply() {
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
     var comments =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -997,6 +997,26 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void toStatusesShouldDropUnrecognizedStatuses() {
+    // #131: an unrecognized status is meaningless, and for a still-open finding the backstop
+    // already emits a synthetic "unresolved" for that id — passing the raw value through too would
+    // leave two entries with the same id in previousStatuses. Only recognized values survive,
+    // case-insensitively.
+    var aiStatuses =
+        List.of(
+            new ReviewResponse.PreviousFindingStatus(1, "wontfix", "nope"),
+            new ReviewResponse.PreviousFindingStatus(2, "Resolved", "fixed"),
+            new ReviewResponse.PreviousFindingStatus(3, "", "blank"),
+            new ReviewResponse.PreviousFindingStatus(4, null, "missing"));
+
+    var statuses = analyzer.toStatuses(aiStatuses);
+
+    assertEquals(1, statuses.size());
+    assertEquals(2, statuses.get(0).id());
+    assertEquals("Resolved", statuses.get(0).status());
+  }
+
+  @Test
   void hasUnresolvedShouldReturnTrueWhenUnresolvedPresent() {
     var statuses =
         List.of(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -188,6 +188,26 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
+  void shouldCountPreviousFindingsStatusCaseInsensitively() {
+    // Counting must be case-insensitive, consistent with the gate logic; a model emitting
+    // "Resolved"/"UNRESOLVED"/"Justified" would otherwise be undercounted to zero in the table.
+    var statuses =
+        List.of(
+            new ReviewResult.PreviousFindingStatus(1, "Resolved", "Fixed"),
+            new ReviewResult.PreviousFindingStatus(2, "UNRESOLVED", "Still broken"),
+            new ReviewResult.PreviousFindingStatus(3, "Justified", "Intentional"));
+
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses);
+
+    var summary = generator.generate(1, 0, 0, null, result);
+
+    assertTrue(summary.contains("✅ Resolved | 1"), summary);
+    assertTrue(summary.contains("⚠️ Still present | 1"), summary);
+    assertTrue(summary.contains("💬 Justified | 1"), summary);
+  }
+
+  @Test
   void shouldLimitKeyFindingsToFive() {
     var findings =
         List.of(


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The #118 approve backstop (`FollowUpAnalyzer.unreportedUnresolvedStatuses`, PR #119) decided which prior findings the model "accounted for" by collecting **every** id present in `previous_findings_status`, regardless of the status *value*:

```java
for (var status : statuses) {
  reportedIds.add(status.id());   // any value: resolved / unresolved / justified / garbage
}
```

`isUnreportedAndStillOpen` then skips any id in `reportedIds`, while the approval gate only holds when the status string literally equals `"unresolved"` (`hasUnresolved`). So a still-open prior finding whose model status was an **unrecognized** value (`""`, `null`, `"wontfix"`, `"open"`, a typo) was:

- **skipped by the backstop** — its id was in `reportedIds`, so no synthetic `unresolved` was produced, **and**
- **not held by the unresolved gate** — its value ≠ `"unresolved"`.

It escaped both → the bot **approved over a still-open finding** — the exact silent approve-over-open the backstop exists to stop, re-expressed as a junk status entry instead of an omission.

### Fix

A finding now counts as "accounted for" only when the model gave it a **recognized** status (`resolved` / `justified` / `unresolved`, case-insensitively):

- Added `RECOGNIZED_STATUSES = Set.of(resolved, justified, unresolved)` and an `isRecognizedStatus(String)` helper (case-insensitive via `toLowerCase(Locale.ROOT)`, matching the rest of the codebase).
- `reportedIds` only collects ids whose status `isRecognizedStatus(...)`. Any unrecognized value falls through to the backstop and holds `APPROVE → COMMENT`.
- `unresolved` stays in the recognized set, so the backstop never double-counts an item the `hasUnresolved` gate already holds via the model's own status.

### Follow-on hardening (same recognized-status invariant)

Two related gaps were caught by a multi-angle review of the diff and fixed here rather than deferred:

- **`toStatuses` now keeps only recognized statuses.** For a still-open finding the backstop emits a synthetic `"unresolved"` for that id; passing the model's raw *unrecognized* value through too left **two entries with the same id** in `previousStatuses`. The raw value was inert (counted by nothing), but dropping it keeps the list one-per-id and consistent with the backstop contract.
- **`PrSummaryGenerator.appendPreviousFindings` now counts case-insensitively.** It used case-sensitive `.equals(...)` while every gate path uses `equalsIgnoreCase`; a model emitting e.g. `"Resolved"` was undercounted to zero in the "Previous Findings Status" table.

No prompt change is required — the backstop stays deterministic.

## Related Issues

Fixes #131

## How Has This Been Tested?

- [x] Unit tests

New tests:
- `FollowUpAnalyzerTest.unreportedUnresolvedShouldHoldFindingsWithUnrecognizedStatus` — for each of `{"wontfix", "open", "RESOLVE", "", null}` on a finding still present in the diff, the backstop holds it.
- `FollowUpAnalyzerTest.unreportedUnresolvedShouldRecognizeStatusesCaseInsensitively` — uppercase/mixed-case recognized statuses suppress the backstop (no double-count).
- `FollowUpAnalyzerTest.toStatusesShouldDropUnrecognizedStatuses` — only recognized values survive conversion (case-insensitively); `wontfix`/`""`/`null` are dropped.
- `PrSummaryGeneratorTest.shouldCountPreviousFindingsStatusCaseInsensitively` — `"Resolved"`/`"UNRESOLVED"`/`"Justified"` are each counted in the table.

The existing `unreportedUnresolvedShouldSkipAnyFindingTheModelReported` and `toStatusesShouldConvertAllStatuses` still pass, pinning the no-regression contract.

Local verification (mirrors CI):
- `./mvnw spotless:check` ✅
- `./mvnw verify` ✅ — 920 tests pass, JaCoCo gate met, SpotBugs clean
- Patch coverage: 0 missed lines / 0 missed branches on both `FollowUpAnalyzer` and `PrSummaryGenerator`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
