### PR TITLE
fix(review): judge #118 backstop finding-presence by content anchor, not raw line (#129)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -15,8 +15,9 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.OptionalInt;
@@ -33,20 +34,88 @@ public final class DiffLineResolver {
   static final Pattern HUNK_HEADER = Pattern.compile("@@ -\\d+(?:,\\d+)? \\+(\\d+)(?:,\\d+)? @@");
 
   private final Map<String, TreeSet<Integer>> rightSideLinesByFile;
+  private final Map<String, List<String>> rightSideTextByFile;
 
   public DiffLineResolver(Map<String, String> patchesByFile) {
     this.rightSideLinesByFile = new HashMap<>();
+    this.rightSideTextByFile = new HashMap<>();
     patchesByFile.forEach(
-        (file, patch) -> rightSideLinesByFile.put(file, parseRightSideLines(patch)));
+        (file, patch) -> {
+          RightSide rightSide = parseRightSide(patch);
+          rightSideLinesByFile.put(file, rightSide.lines());
+          rightSideTextByFile.put(file, rightSide.text());
+        });
+  }
+
+  /**
+   * Whether the prior finding's flagged code is still present on the right side (additions and
+   * surviving context) of the current diff — the predicate the issue #118 approve backstop relies
+   * on to tell a still-open finding from one whose code has been changed away.
+   *
+   * <p>When the finding carries an {@code anchor} (its persisted {@code suggestion_old}, the
+   * verbatim code it flagged), presence is judged by <em>content</em>: the anchor's non-blank lines
+   * must appear, in order and adjacent, as a contiguous run of right-side lines. This is immune to
+   * the two failure modes of a raw line-number test (#129): a force-push/rebase that drifts the
+   * still-open code by more than {@code tolerance} lines no longer reads as "gone" (under-block,
+   * re-opening #118), and code that was deleted or replaced no longer reads as "present" just
+   * because a surviving context line sits near the stale line number (over-block) — the replaced
+   * text exists only on the diff's left side. Requiring a contiguous run, rather than mere
+   * set-membership of each line, also stops a multi-line block whose lines happen to survive
+   * scattered in unrelated places from reading as still-present.
+   *
+   * <p>One residual the content test cannot resolve: a single generic anchor line (e.g. {@code
+   * return null;}) that was changed away at the finding's location but recurs verbatim elsewhere in
+   * the same file still reads as present. The stale prior-revision line cannot disambiguate it
+   * (that is the drift the check exists to tolerate), so this errs toward holding — a needless
+   * APPROVE→COMMENT, the safe direction for a downgrade-only backstop, never the #118 under-block.
+   *
+   * <p>When the finding has no anchor (a suggestion-less finding, or one whose suggestion was
+   * stripped), it falls back to {@link #isLineInDiff}. That fallback is a coarse line proxy that
+   * retains the raw-line fragility in <em>both</em> directions (it can under-block on drift and
+   * over-block on nearby context); it applies only to the minority of anchorless findings, for
+   * which no flagged-code content survives to match against.
+   */
+  public boolean isFindingPresent(String file, int line, String anchor, int tolerance) {
+    if (file == null) {
+      return false;
+    }
+    List<String> anchorLines = normalizedAnchorLines(anchor);
+    if (anchorLines.isEmpty()) {
+      return isLineInDiff(file, line, tolerance);
+    }
+    List<String> text = rightSideTextByFile.get(file);
+    if (text == null) {
+      text = byPathVariant(rightSideTextByFile, file);
+    }
+    return text != null && containsContiguous(text, anchorLines);
+  }
+
+  /** Whether {@code needle} appears as a contiguous, in-order run within {@code haystack}. */
+  private static boolean containsContiguous(List<String> haystack, List<String> needle) {
+    for (int i = 0; i + needle.size() <= haystack.size(); i++) {
+      if (matchesAt(haystack, i, needle)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean matchesAt(List<String> haystack, int offset, List<String> needle) {
+    for (int j = 0; j < needle.size(); j++) {
+      if (!haystack.get(offset + j).equals(needle.get(j))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**
    * Whether {@code line} — or a line within {@code tolerance} of it — is an actual right-side line
    * of the file's diff. Unlike {@link #resolveRightSideLine}, this never snaps to an arbitrarily
-   * distant line: it answers "is the flagged line genuinely still in this diff", which the approve
-   * backstop relies on to tell a still-open finding from one whose code has been changed away. The
-   * file is matched with {@link FilePaths#same}, so a model path variant still resolves to the
-   * diff's filename.
+   * distant line. It is the anchorless fallback for {@link #isFindingPresent}: a coarse
+   * line-membership proxy used only when a finding carries no flagged-code anchor to match by
+   * content. The file is matched with {@link FilePaths#same}, so a model path variant still
+   * resolves to the diff's filename.
    */
   public boolean isLineInDiff(String file, int line, int tolerance) {
     if (file == null || line <= 0) {
@@ -54,9 +123,9 @@ public final class DiffLineResolver {
     }
     NavigableSet<Integer> lines = rightSideLinesByFile.get(file);
     if (lines == null) {
-      lines = lookupByPathVariant(file);
+      lines = byPathVariant(rightSideLinesByFile, file);
     }
-    if (lines.isEmpty()) {
+    if (lines == null || lines.isEmpty()) {
       return false;
     }
     Integer floor = lines.floor(line);
@@ -65,13 +134,29 @@ public final class DiffLineResolver {
         || (ceiling != null && ceiling - line <= tolerance);
   }
 
-  private NavigableSet<Integer> lookupByPathVariant(String file) {
-    for (var entry : rightSideLinesByFile.entrySet()) {
+  /** The value for the diff filename matching {@code file} as a path variant, or {@code null}. */
+  private static <V> V byPathVariant(Map<String, V> byFile, String file) {
+    for (var entry : byFile.entrySet()) {
       if (FilePaths.same(file, entry.getKey())) {
         return entry.getValue();
       }
     }
-    return Collections.emptyNavigableSet();
+    return null;
+  }
+
+  /** Trimmed, non-blank lines of an anchor (a finding's {@code suggestion_old}). */
+  private static List<String> normalizedAnchorLines(String anchor) {
+    if (anchor == null || anchor.isBlank()) {
+      return List.of();
+    }
+    var lines = new ArrayList<String>();
+    for (String raw : anchor.split("\n", -1)) {
+      String stripped = raw.strip();
+      if (!stripped.isEmpty()) {
+        lines.add(stripped);
+      }
+    }
+    return lines;
   }
 
   /** Returns the requested line or the nearest commentable line in the same file diff. */
@@ -100,14 +185,37 @@ public final class DiffLineResolver {
   }
 
   static TreeSet<Integer> parseRightSideLines(String patch) {
+    return parseRightSide(patch).lines();
+  }
+
+  /**
+   * The right-side line numbers and the right-side code text parsed from one file's patch. The text
+   * is the trimmed, non-blank right-side lines in diff order, so {@link #containsContiguous} can
+   * test the anchor as a contiguous run; blank lines are dropped from both sides so a blank line
+   * inside a block never breaks an otherwise-adjacent match.
+   */
+  private record RightSide(TreeSet<Integer> lines, List<String> text) {}
+
+  /**
+   * Walks a unified-diff patch once, collecting the right-side line numbers and the trimmed text of
+   * every right-side line. Additions ({@code '+'}) and context ({@code ' '}) lines exist on the
+   * RIGHT side and advance its counter; deletions ({@code '-'}) exist only on the LEFT side and are
+   * skipped — which is exactly why content matched against this text distinguishes still-present
+   * code from code that was replaced (the replacement's old text survives only as a deletion). The
+   * patch is run through {@link PromptTemplateEscaper#neutralizeMarkers} first, because the model's
+   * persisted {@code suggestion_old} was quoted from the already-neutralized diff, so the raw side
+   * must be neutralized to compare equal (mirrors {@code FindingQuoteValidator}).
+   */
+  private static RightSide parseRightSide(String patch) {
     var lines = new TreeSet<Integer>();
+    var text = new ArrayList<String>();
     if (patch == null || patch.isBlank()) {
-      return lines;
+      return new RightSide(lines, text);
     }
 
     var newLine = 0;
     var inHunk = false;
-    for (String rawLine : patch.split("\n", -1)) {
+    for (String rawLine : PromptTemplateEscaper.neutralizeMarkers(patch).split("\n", -1)) {
       if (rawLine.startsWith("@@")) {
         var matcher = HUNK_HEADER.matcher(rawLine);
         if (matcher.find()) {
@@ -118,14 +226,16 @@ public final class DiffLineResolver {
       }
       if (inHunk && !rawLine.isEmpty()) {
         var marker = rawLine.charAt(0);
-        // Additions and context lines are commentable on the RIGHT side and advance its
-        // counter; deletions ('-') exist only on the LEFT side.
         if (marker == '+' || marker == ' ') {
           lines.add(newLine);
+          String stripped = rawLine.substring(1).strip();
+          if (!stripped.isEmpty()) {
+            text.add(stripped);
+          }
           newLine++;
         }
       }
     }
-    return lines;
+    return new RightSide(lines, text);
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -503,8 +503,10 @@ public class FollowUpAnalyzer {
 
   /**
    * A prior finding (1-based {@code id}) is a still-open silent drop when the model named it in no
-   * status entry, its flagged line is still in the current diff, and no maintainer has replied on
-   * its thread. {@link DiffLineResolver#isLineInDiff} already rejects a null file.
+   * status entry, its flagged code is still present in the current diff, and no maintainer has
+   * replied on its thread. Presence is judged by {@link DiffLineResolver#isFindingPresent} against
+   * the finding's persisted {@code suggestion_old} anchor, so it survives line drift and is not
+   * fooled by unchanged context (#129); the resolver already rejects a null file.
    */
   private static boolean isUnreportedAndStillOpen(
       ReviewResponse.Finding finding,
@@ -514,7 +516,8 @@ public class FollowUpAnalyzer {
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       String botLogin) {
     return !reportedIds.contains(id)
-        && lineResolver.isLineInDiff(finding.file(), finding.line(), DUPLICATE_LINE_TOLERANCE)
+        && lineResolver.isFindingPresent(
+            finding.file(), finding.line(), finding.suggestionOld(), DUPLICATE_LINE_TOLERANCE)
         && answeredRootComment(finding, inlineComments, botLogin) == null;
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
@@ -209,4 +209,196 @@ class DiffLineResolverTest {
     assertTrue(lines.contains(1));
     assertTrue(lines.contains(2));
   }
+
+  @Test
+  void isFindingPresentShouldHoldAnchorThatDriftedBeyondToleranceViaContent() {
+    // The still-open code survived verbatim but a force-push pushed it from old line 10 to line 32.
+    var patch =
+        """
+        @@ -10,2 +30,3 @@
+         keep_one()
+        +inserted_line()
+             dangerous_call()
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    // The raw line-number proxy drops it (32 is far from the old line 10); content matching holds.
+    assertFalse(resolver.isLineInDiff("A.java", 10, 3));
+    assertTrue(resolver.isFindingPresent("A.java", 10, "dangerous_call()", 3));
+  }
+
+  @Test
+  void isFindingPresentShouldNotHoldDeletedCodeWhenOnlyNearbyContextSurvives() {
+    // #129(b), literal mechanism: the flagged line 42 is deleted outright; the bug-block survives
+    // only as left-side deletions, while context lines 38-39 / 44-45 remain on the right side.
+    var patch =
+        """
+        @@ -38,8 +38,4 @@
+         ctx_38()
+         ctx_39()
+        -buggy_40()
+        -buggy_41()
+        -buggy_42()
+        -buggy_43()
+         ctx_44()
+         ctx_45()
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    // The raw line-number proxy is fooled: stale line 42 is within ±3 of the surviving context
+    // line now at right-line 41 (ctx_45), so it reads "present" though the bug was deleted.
+    assertTrue(resolver.isLineInDiff("A.java", 42, 3));
+    // Content matching is not: the anchor exists only as a deletion, never on the right side.
+    assertFalse(resolver.isFindingPresent("A.java", 42, "buggy_42()", 3));
+  }
+
+  @Test
+  void isFindingPresentShouldRequireAnchorAsContiguousInOrderRun() {
+    var patch =
+        """
+        @@ -1,3 +1,3 @@
+         alpha()
+         beta()
+         gamma()
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    assertTrue(resolver.isFindingPresent("A.java", 1, "alpha()\nbeta()", 3));
+    assertTrue(resolver.isFindingPresent("A.java", 1, "beta()\ngamma()", 3));
+    // A line changed away breaks the block.
+    assertFalse(resolver.isFindingPresent("A.java", 1, "alpha()\ndelta()", 3));
+    // Lines that survive only non-adjacently or out of order are not a contiguous run (#129(b)).
+    assertFalse(resolver.isFindingPresent("A.java", 1, "alpha()\ngamma()", 3));
+    assertFalse(resolver.isFindingPresent("A.java", 1, "gamma()\nbeta()", 3));
+  }
+
+  @Test
+  void isFindingPresentShouldNotHoldMultiLineAnchorSurvivingScattered() {
+    // The flagged two-line block was replaced, but each of its lines coincidentally survives in an
+    // unrelated place; they never appear adjacent, so the block counts as gone (#129(b)).
+    var patch =
+        """
+        @@ -1,5 +1,5 @@
+         validate(x);
+         do_one();
+         do_two();
+         do_three();
+         persist(x);
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    assertFalse(resolver.isFindingPresent("A.java", 1, "validate(x);\npersist(x);", 3));
+  }
+
+  @Test
+  void isFindingPresentShouldLeanTowardHoldingForARecurringSingleLineAnchor() {
+    // Accepted residual: a generic single-line anchor that recurs verbatim reads as present even
+    // when the flagged occurrence changed away. The stale prior-revision line cannot disambiguate
+    // it, so the downgrade-only backstop errs toward holding rather than risking the #118 drop.
+    var patch =
+        """
+        @@ -1,6 +1,6 @@
+         if (a) {
+        -  return null;
+        +  return value;
+         }
+         if (b) {
+           return null;
+         }
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    assertTrue(resolver.isFindingPresent("A.java", 2, "return null;", 3));
+  }
+
+  @Test
+  void isFindingPresentShouldNeutralizeDiffMarkersBeforeMatching() {
+    // suggestion_old is quoted from the neutralized diff (<<DIFF_START>>), but the raw GitHub patch
+    // still carries the triple-bracket sentinel; the patch side must be neutralized to match.
+    var patch =
+        """
+        @@ -1,0 +1,1 @@
+        +String s = "<<<DIFF_START>>>";
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    assertTrue(resolver.isFindingPresent("A.java", 1, "String s = \"<<DIFF_START>>\";", 3));
+  }
+
+  @Test
+  void isFindingPresentShouldIgnoreBlankAnchorLines() {
+    var patch =
+        """
+        @@ -1,2 +1,2 @@
+         alpha()
+        +beta()
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    // Blank lines in the anchor must not be required against the right-side text.
+    assertTrue(resolver.isFindingPresent("A.java", 1, "alpha()\n\n   \nbeta()", 3));
+  }
+
+  @Test
+  void isFindingPresentShouldFallBackToLineMembershipWithoutAnchor() {
+    var resolver = new DiffLineResolver(Map.of("main.py", PATCH));
+
+    // No anchor (null or blank): behaves like isLineInDiff.
+    assertTrue(resolver.isFindingPresent("main.py", 11, null, 3));
+    assertTrue(resolver.isFindingPresent("main.py", 11, "   ", 3));
+    assertFalse(resolver.isFindingPresent("main.py", 99, null, 3));
+  }
+
+  @Test
+  void isFindingPresentShouldMatchAnchorAcrossPathVariantsAndIgnoreLine() {
+    var resolver = new DiffLineResolver(Map.of("src/dir/Main.java", PATCH));
+
+    // Path variant resolves, indentation is stripped, and the stale line number is irrelevant.
+    assertTrue(resolver.isFindingPresent("dir/Main.java", 999, "new_line()", 3));
+  }
+
+  @Test
+  void isFindingPresentShouldRejectNullFileAndAnchorOutsideItsOwnFile() {
+    var resolver = new DiffLineResolver(Map.of("A.java", PATCH));
+
+    assertFalse(resolver.isFindingPresent(null, 11, "new_line()", 3));
+    // The anchor text exists in A.java's diff, but the finding points at a file not in the diff —
+    // matching is file-scoped so an unrelated file never validates the finding.
+    assertFalse(resolver.isFindingPresent("B.java", 11, "new_line()", 3));
+  }
+
+  @Test
+  void isFindingPresentShouldNotHoldWhenFileHasOnlyDeletions() {
+    var deletionOnly =
+        """
+        @@ -10,2 +10,0 @@
+        -buggy_call()
+        -also_removed()
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", deletionOnly));
+
+    // The flagged code was deleted outright: it survives only on the left side, so the file's
+    // right-side text is empty and the finding counts as no longer present.
+    assertFalse(resolver.isFindingPresent("A.java", 10, "buggy_call()", 3));
+  }
+
+  @Test
+  void shouldTrackBlankRightSideLineNumberButNotItsText() {
+    var patch =
+        """
+        @@ -1,0 +1,3 @@
+        +first();
+        +
+        +third();
+        """;
+    var lines = DiffLineResolver.parseRightSideLines(patch);
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    // A blank added line still advances the right-side counter (it is a commentable line) ...
+    assertEquals(3, lines.size());
+    // ... but is excluded from the right-side text, so "first();" and "third();" are adjacent and
+    // match contiguously. Were the blank kept, it would sit between them and break the run.
+    assertTrue(resolver.isFindingPresent("A.java", 1, "first();\nthird();", 3));
+    assertFalse(resolver.isFindingPresent("A.java", 1, "second();", 3));
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -785,6 +785,66 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void unreportedUnresolvedShouldHoldStillOpenFindingThatDriftedBeyondTolerance() {
+    // #129(a): a force-push moved the still-open code from old line 10 to line 32. The raw
+    // line-number proxy would drop it (re-opening #118); the suggestion_old anchor still matches.
+    var json =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 10, "title": "Dangerous call",
+           "description": "unsafe", "suggestion_old": "dangerous_call();",
+           "suggestion_new": "safe_call();"}
+        ]}
+        """;
+    var patch =
+        """
+        @@ -10,2 +30,3 @@
+         keep_one();
+        +inserted_line();
+         dangerous_call();
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch));
+
+    assertFalse(resolver.isLineInDiff("src/A.java", 10, 3)); // old line drifted out of range
+    var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), List.of(), resolver, BOT);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldNotHoldFixedFindingWhoseContextSurvives() {
+    // #129(b): line 42's bug was deleted, but GitHub still emits surrounding context lines, so the
+    // raw line-number proxy is fooled into holding. The deleted anchor is gone from the right side.
+    var json =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 42, "title": "Buggy call",
+           "description": "bug", "suggestion_old": "buggy_42();",
+           "suggestion_new": ""}
+        ]}
+        """;
+    var patch =
+        """
+        @@ -38,8 +38,4 @@
+         ctx_38();
+         ctx_39();
+        -buggy_40();
+        -buggy_41();
+        -buggy_42();
+        -buggy_43();
+         ctx_44();
+         ctx_45();
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch));
+
+    // Stale line 42 is within ±3 of the surviving context line now at right-line 41.
+    assertTrue(resolver.isLineInDiff("src/A.java", 42, 3)); // raw proxy would over-block here
+    var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), List.of(), resolver, BOT);
+
+    assertTrue(held.isEmpty());
+  }
+
+  @Test
   void buildPreviousFindingsContextShouldReturnEmptyForNull() {
     assertEquals("", analyzer.buildPreviousFindingsContext(null, "thrillhousebot"));
   }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The #118 approve backstop (PR #119) decides *"is this prior finding still present in the current diff?"* with `DiffLineResolver.isLineInDiff(finding.file(), finding.line(), 3)` — an exact ±3 membership test of the **prior-revision** line number against the **current** revision's right-side line set (which mixes additions *and* context lines). That proxy is fragile in **both** directions:

- **(a) Line drift — under-block (re-opens #118).** A force-push/rebase that shifts still-open code by more than 3 lines makes `isLineInDiff` return `false`; the finding is dropped and the bot APPROVEs over a genuinely-open finding — the exact #118 failure direction, and the worse one.
- **(b) Surviving context — over-block.** Because the right-side set includes unchanged **context** lines, a replaced/deleted line whose neighbours survive within ±3 of the stale line number reads as "present"; a fixed finding is needlessly held (APPROVE → COMMENT).

### Fix — content/anchor matching

Presence is now judged by the finding's persisted `suggestion_old` (the verbatim flagged code), not the raw line number:

- `DiffLineResolver` parses each patch into an **ordered list of right-side line texts** (additions + surviving context; deletions excluded), after `PromptTemplateEscaper.neutralizeMarkers` (parity with how the model quoted `suggestion_old`).
- New `isFindingPresent(file, line, anchor, tolerance)` holds the finding present iff the anchor's non-blank lines appear as a **contiguous, in-order run** on the right side. Drift no longer matters (matching is location-independent), and replaced/deleted code is correctly absent (it survives only as a left-side deletion). Requiring a contiguous run also stops a multi-line block whose lines survive *scattered* in unrelated places from reading as present.
- `FollowUpAnalyzer.isUnreportedAndStillOpen` passes `finding.suggestionOld()` as the anchor.
- **Anchorless findings** (no/stripped `suggestion_old`) fall back to the old `isLineInDiff` line proxy — the only signal available without flagged-code content.

The backstop remains **downgrade-only** (APPROVE → COMMENT, never REQUEST_CHANGES). One documented residual: a recurring single generic line (e.g. `return null;`) changed away at the finding's location but present verbatim elsewhere leans toward **holding** — over-firing only (a needless COMMENT), never the #118 under-block, since the stale prior-revision line cannot disambiguate it.

## Related Issues

Fixes #129

## How Has This Been Tested?

- [x] Unit tests

New / updated tests:
- `DiffLineResolverTest` — `isFindingPresent`: drift held via content, deleted code with surviving context **not** held (literal #129(b) via line-proximity), contiguous in-order run required, multi-line scatter not held, blank-line handling, marker neutralization, recurring-single-line lean-hold residual, anchorless fallback, path variants, null/empty inputs.
- `FollowUpAnalyzerTest` — end-to-end backstop: still-open drift held, deleted-with-surviving-context not held.

Local verification (mirrors CI):
- `./mvnw spotless:check` ✅
- `./mvnw spotbugs:check` ✅
- `./mvnw verify` ✅ — 927 tests pass, JaCoCo gate met
- Patch coverage: the new methods (`isFindingPresent`, `containsContiguous`, `matchesAt`, `byPathVariant`, `normalizedAnchorLines`, `parseRightSide`) have 0 missed lines and 0 missed branches.

The change was additionally put through a two-round adversarial multi-agent review; the first round caught an over-block from naive set-membership, which this PR fixes with contiguous-run matching.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No prompt change required — the backstop stays deterministic and independent of the model's `previous_findings_status`. The issue's noted *sibling gap* (the backstop only checks the newest prior round) is intentionally out of scope and tracked separately.
