### PR TITLE
fix(review): DiffLineResolver path-variant lookup masks an empty exact match and can bind the wrong file (#132)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -16,12 +16,14 @@
 package dev.thiagogonzaga.thrillhousebot.review;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.OptionalInt;
 import java.util.TreeSet;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 /**
@@ -83,11 +85,8 @@ public final class DiffLineResolver {
     if (anchorLines.isEmpty()) {
       return isLineInDiff(file, line, tolerance);
     }
-    List<String> text = rightSideTextByFile.get(file);
-    if (text == null) {
-      text = byPathVariant(rightSideTextByFile, file);
-    }
-    return text != null && containsContiguous(text, anchorLines);
+    return presentInFileOrVariant(
+        rightSideTextByFile, file, text -> containsContiguous(text, anchorLines));
   }
 
   /** Whether {@code needle} appears as a contiguous, in-order run within {@code haystack}. */
@@ -121,27 +120,52 @@ public final class DiffLineResolver {
     if (file == null || line <= 0) {
       return false;
     }
-    NavigableSet<Integer> lines = rightSideLinesByFile.get(file);
-    if (lines == null) {
-      lines = byPathVariant(rightSideLinesByFile, file);
-    }
-    if (lines == null || lines.isEmpty()) {
-      return false;
-    }
+    return presentInFileOrVariant(
+        rightSideLinesByFile, file, lines -> lineWithinTolerance(lines, line, tolerance));
+  }
+
+  /** Whether {@code line} — or a member within {@code tolerance} of it — is in {@code lines}. */
+  private static boolean lineWithinTolerance(NavigableSet<Integer> lines, int line, int tolerance) {
     Integer floor = lines.floor(line);
     Integer ceiling = lines.ceiling(line);
     return (floor != null && line - floor <= tolerance)
         || (ceiling != null && ceiling - line <= tolerance);
   }
 
-  /** The value for the diff filename matching {@code file} as a path variant, or {@code null}. */
-  private static <V> V byPathVariant(Map<String, V> byFile, String file) {
+  /**
+   * Whether {@code predicate} holds for {@code file}'s own diff entry or, failing that, for any
+   * other diff file whose path is a {@link FilePaths#same} variant of it.
+   *
+   * <p>A <em>non-empty</em> exact entry is authoritative: the file is in the diff under exactly
+   * that name, so the result is decided from it alone and no variant is consulted — a same-suffix
+   * file that merely shares the path must never resurrect a finding whose code changed away in its
+   * own file. The variant fallback runs only when the exact entry is absent <em>or empty</em>: a
+   * deletion-only patch stores an empty right side under its exact key, which previously
+   * short-circuited the fallback and masked a variant that held the real data (#132a).
+   *
+   * <p>The fallback inspects <em>every</em> matching variant rather than the first the backing
+   * {@link HashMap} happens to iterate, so an ambiguous shortened path — two changed files sharing
+   * a suffix — yields the same answer regardless of map order (#132b, no more flaky wrong-file
+   * binding) and leans toward "present in any candidate". That lean is the safe direction for the
+   * downgrade-only #118 approve backstop, which prefers a needless APPROVE→COMMENT over silently
+   * approving over a still-open finding.
+   */
+  private static <V extends Collection<?>> boolean presentInFileOrVariant(
+      Map<String, V> byFile, String file, Predicate<V> predicate) {
+    V exact = byFile.get(file);
+    if (exact != null && !exact.isEmpty()) {
+      return predicate.test(exact);
+    }
     for (var entry : byFile.entrySet()) {
-      if (FilePaths.same(file, entry.getKey())) {
-        return entry.getValue();
+      V value = entry.getValue();
+      if (!entry.getKey().equals(file)
+          && !value.isEmpty()
+          && FilePaths.same(file, entry.getKey())
+          && predicate.test(value)) {
+        return true;
       }
     }
-    return null;
+    return false;
   }
 
   /** Trimmed, non-blank lines of an anchor (a finding's {@code suggestion_old}). */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
@@ -555,4 +555,30 @@ class DiffLineResolverTest {
     assertFalse(resolver.isFindingPresent("B.java", 1, "new_line()", 3));
     assertFalse(resolver.isLineInDiff("B.java", 11, 3));
   }
+
+  @Test
+  void isLineInDiffTreatsNonEmptyExactMatchAsAuthoritativeOverVariant() {
+    // The line-membership counterpart to the isFindingPresent authoritative-exact test: when the
+    // file's own diff entry is non-empty, the decision is made from it alone — a same-suffix
+    // variant
+    // carrying the requested line must not be consulted.
+    var exactAtLine20 =
+        """
+        @@ -1,1 +20,1 @@
+        +twenty
+        """;
+    var variantAtLine50 =
+        """
+        @@ -1,1 +50,1 @@
+        +fifty
+        """;
+    var resolver =
+        new DiffLineResolver(
+            Map.of("dir/F.java", exactAtLine20, "src/dir/F.java", variantAtLine50));
+
+    // 50 is far from the exact entry's only line (20); the variant's line 50 is never consulted.
+    assertFalse(resolver.isLineInDiff("dir/F.java", 50, 3));
+    // Sanity: the exact entry's own line still resolves.
+    assertTrue(resolver.isLineInDiff("dir/F.java", 20, 3));
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
@@ -401,4 +401,158 @@ class DiffLineResolverTest {
     assertTrue(resolver.isFindingPresent("A.java", 1, "first();\nthird();", 3));
     assertFalse(resolver.isFindingPresent("A.java", 1, "second();", 3));
   }
+
+  @Test
+  void isLineInDiffFallsBackToVariantWhenExactEntryIsEmpty() {
+    // #132(a): a deletion-only file stores its exact-path key with an empty right side, while a
+    // longer path variant holds the real right-side lines. The empty exact entry must not
+    // short-circuit the variant fallback and drop a still-open finding.
+    var deletionOnly =
+        """
+        @@ -10,2 +10,0 @@
+        -removed_one
+        -removed_two
+        """;
+    var resolver =
+        new DiffLineResolver(Map.of("dir/Main.java", deletionOnly, "src/dir/Main.java", PATCH));
+
+    assertTrue(resolver.isLineInDiff("dir/Main.java", 11, 3));
+  }
+
+  @Test
+  void isFindingPresentFallsBackToVariantWhenExactEntryIsEmpty() {
+    // #132(a), content path: the deletion-only exact entry is empty, so the anchor must be matched
+    // against the variant that actually carries the flagged code.
+    var deletionOnly =
+        """
+        @@ -10,2 +10,0 @@
+        -removed_one
+        -removed_two
+        """;
+    var resolver =
+        new DiffLineResolver(Map.of("dir/Main.java", deletionOnly, "src/dir/Main.java", PATCH));
+
+    assertTrue(resolver.isFindingPresent("dir/Main.java", 999, "new_line()", 3));
+  }
+
+  @Test
+  void isFindingPresentTreatsNonEmptyExactMatchAsAuthoritativeOverVariant() {
+    // When the finding's own file is in the diff (non-empty right side), presence is decided from
+    // it alone: a same-suffix variant that still contains the anchor must not resurrect a finding
+    // whose code was changed away in its own file.
+    var exactChangedAway =
+        """
+        @@ -1,1 +1,1 @@
+        -dangerous_call()
+        +safe_call()
+        """;
+    var variantStillHasIt =
+        """
+        @@ -1,0 +1,1 @@
+        +dangerous_call()
+        """;
+    var resolver =
+        new DiffLineResolver(
+            Map.of("dir/Helper.java", exactChangedAway, "src/dir/Helper.java", variantStillHasIt));
+
+    assertFalse(resolver.isFindingPresent("dir/Helper.java", 1, "dangerous_call()", 3));
+  }
+
+  @Test
+  void isFindingPresentHoldsWhicheverSuffixVariantCarriesTheSurvivingCode() {
+    // #132(b): two changed files share the suffix "util/Helper.java", so the ambiguous shortened
+    // model path FilePaths.same-matches both. The flagged code survives in only one of them. The
+    // old first-match-wins lookup would test presence against whichever variant the map yielded
+    // first and silently drop the finding when that was the wrong one; the scan now checks EVERY
+    // matching variant, so a decoy variant lacking the anchor cannot shadow the one that has it.
+    // Asserting the hold for both placements documents that the decision does not depend on which
+    // suffix-colliding variant happens to carry the code (the placement where the anchor lands in a
+    // non-first-iterated variant is the one that actually pins the all-variants scan).
+    var withAnchor =
+        """
+        @@ -1,0 +1,1 @@
+        +dangerous_call()
+        """;
+    var withoutAnchor =
+        """
+        @@ -1,0 +1,1 @@
+        +safe_call()
+        """;
+    var anchorInA =
+        new DiffLineResolver(
+            Map.of("a/util/Helper.java", withAnchor, "b/util/Helper.java", withoutAnchor));
+    var anchorInB =
+        new DiffLineResolver(
+            Map.of("a/util/Helper.java", withoutAnchor, "b/util/Helper.java", withAnchor));
+
+    assertTrue(anchorInA.isFindingPresent("util/Helper.java", 1, "dangerous_call()", 3));
+    assertTrue(anchorInB.isFindingPresent("util/Helper.java", 1, "dangerous_call()", 3));
+  }
+
+  @Test
+  void isFindingPresentDoesNotHoldWhenAnchorSurvivesInNoVariant() {
+    // #132(b): genuinely ambiguous path, but the flagged code survives in neither candidate — the
+    // finding is not held.
+    var withoutAnchor =
+        """
+        @@ -1,0 +1,1 @@
+        +safe_call()
+        """;
+    var resolver =
+        new DiffLineResolver(
+            Map.of("a/util/Helper.java", withoutAnchor, "b/util/Helper.java", withoutAnchor));
+
+    assertFalse(resolver.isFindingPresent("util/Helper.java", 1, "dangerous_call()", 3));
+  }
+
+  @Test
+  void isLineInDiffChecksEveryMatchingVariantNotJustTheFirstCandidate() {
+    // #132(b): suffix-colliding files both FilePaths.same-match the shortened path, but only one
+    // carries the target line. The scan checks every matching variant, so a decoy variant whose
+    // lines are elsewhere cannot shadow the one that holds the line — the old first-match lookup
+    // could have tested the decoy and dropped the match.
+    var atLine20 =
+        """
+        @@ -1,1 +20,1 @@
+        +twenty
+        """;
+    var farAway =
+        """
+        @@ -1,1 +99,1 @@
+        +far
+        """;
+    var resolver =
+        new DiffLineResolver(Map.of("a/util/Helper.java", atLine20, "b/util/Helper.java", farAway));
+
+    assertTrue(resolver.isLineInDiff("util/Helper.java", 20, 3));
+    assertFalse(resolver.isLineInDiff("util/Helper.java", 50, 3));
+  }
+
+  @Test
+  void isFindingPresentSkipsEmptyVariantSoDeletionOnlyFileDoesNotHold() {
+    // A path variant whose only patch is deletion-only carries no right-side text. It is skipped
+    // (not matched as an empty entry), so a finding whose shortened path resolves solely to that
+    // deleted file counts as no longer present.
+    var deletionOnly =
+        """
+        @@ -1,2 +1,0 @@
+        -dangerous_call()
+        -also_removed()
+        """;
+    var resolver = new DiffLineResolver(Map.of("a/util/Helper.java", deletionOnly));
+
+    assertFalse(resolver.isFindingPresent("util/Helper.java", 1, "dangerous_call()", 3));
+  }
+
+  @Test
+  void shouldNotBindBareFilenameToDirectoryVariantThroughTheFallback() {
+    // The variant scan delegates path matching to FilePaths.same, whose guard requires the shorter
+    // path to contain a directory segment. A bare "B.java" must never bind to a directory-bearing
+    // key like "src/B.java" — a bare name matches every file of that name in the repo, and a wrong
+    // bind here would falsely hold or clear approval.
+    var resolver = new DiffLineResolver(Map.of("src/B.java", PATCH));
+
+    assertFalse(resolver.isFindingPresent("B.java", 1, "new_line()", 3));
+    assertFalse(resolver.isLineInDiff("B.java", 11, 3));
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -1208,6 +1208,40 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void unreportedUnresolvedShouldHoldFindingWhoseExactDiffKeyIsEmptyButVariantCarriesIt() {
+    // #132(a) end-to-end: the finding's own file is in the diff as a deletion-only patch, so its
+    // exact key has an empty right side; the flagged code actually survives under a longer path
+    // variant. The empty exact entry must not mask the variant, or the backstop would silently
+    // approve over a still-open finding.
+    var json =
+        """
+        {"findings": [
+          {"risk": "high", "file": "dir/Main.java", "line": 1, "title": "Dangerous call",
+           "description": "unsafe", "suggestion_old": "dangerous_call()",
+           "suggestion_new": "safe_call()"}
+        ]}
+        """;
+    var deletionOnly =
+        """
+        @@ -1,2 +1,0 @@
+        -removed_one
+        -removed_two
+        """;
+    var variantWithAnchor =
+        """
+        @@ -1,0 +1,1 @@
+        +dangerous_call()
+        """;
+    var resolver =
+        new DiffLineResolver(
+            Map.of("dir/Main.java", deletionOnly, "src/dir/Main.java", variantWithAnchor));
+
+    var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), List.of(), resolver, BOT);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
   void buildPreviousFindingsContextShouldReturnEmptyForNull() {
     assertEquals("", analyzer.buildPreviousFindingsContext(null, "thrillhousebot"));
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -1236,7 +1236,8 @@ class FollowUpAnalyzerTest {
         new DiffLineResolver(
             Map.of("dir/Main.java", deletionOnly, "src/dir/Main.java", variantWithAnchor));
 
-    var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), List.of(), resolver, BOT);
+    var held =
+        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), List.of(), resolver, BOT);
 
     assertEquals(List.of(1), heldIds(held));
   }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`DiffLineResolver`'s path-variant lookup — the bridge that lets a model-reported path resolve to GitHub's diff filename for the issue-#118 approve backstop (`isFindingPresent` / `isLineInDiff`) — had two silent defects. Both are narrow (they need a deletion-only file or suffix-colliding paths) but both bias toward dropping or mis-binding a still-open finding.

**(a) Empty exact match masked a real variant.** The fallback ran only when the exact map entry was *absent* (`null`), not when it was *present but empty*. A deletion-only patch is non-blank, so it is stored with an **empty** right-side set under its exact key. If a model finding exact-matched that empty entry while a `FilePaths.same` variant key held the real right-side data, the empty exact match won, the variant was never consulted, and a still-open finding was dropped from the backstop.

**(b) Wrong-file binding.** The lookup returned the **first** `FilePaths.same` match while iterating a `HashMap` (non-deterministic order). With two changed files sharing a suffix and an ambiguous shortened model path, the backstop could resolve to the wrong file's data, flakily holding or clearing approval.

### Fix

Both call sites now route through one helper, `presentInFileOrVariant(map, file, predicate)`:

- **A non-empty exact entry is authoritative** — the file is in the diff under exactly that name, so the result is decided from it alone; a same-suffix sibling can never resurrect a finding whose code changed away in its own file.
- **The variant fallback runs when the exact entry is absent _or empty_** — fixes (a): a deletion-only empty entry no longer short-circuits the fallback.
- **It scans _every_ matching variant, not the first the map iterates** — fixes (b): the result is independent of `HashMap` order, and it leans toward "present in any candidate". That lean is the safe, downgrade-only direction for the #118 backstop, which prefers a needless APPROVE→COMMENT over silently approving over a still-open finding (consistent with the lean-to-hold philosophy from #129/#139).

> Note: the issue's literal `B.java` / `src/B.java` example only triggers for paths *with* a directory segment — `FilePaths.same` deliberately refuses to match a bare filename (it would match every same-named file in the repo). The fix and tests use directory-bearing variants accordingly.

## Related Issues

Fixes #132

## How Has This Been Tested?

- [x] Unit tests

New `DiffLineResolverTest` cases:
- (a) `isLineInDiff` / `isFindingPresent` fall back to a non-empty variant when the exact entry is empty.
- (b) presence is held whichever suffix-colliding variant carries the surviving code; `isLineInDiff` checks every matching variant, not just the first candidate; genuine ambiguity with the code in no variant is not held.
- a non-empty exact match is authoritative over a variant (no cross-file resurrection); an empty variant is skipped; a bare filename never binds to a directory-bearing variant through the fallback.

New `FollowUpAnalyzerTest` case:
- end-to-end (a): the backstop holds a still-open finding whose own diff key is empty (deletion-only) while a longer path variant carries the flagged code, through `unreportedUnresolvedStatuses`.

Local verification (mirrors CI):
- `./mvnw spotless:check` ✅
- `./mvnw verify` ✅ — 947 tests pass, JaCoCo gate met, SpotBugs clean
- Patch coverage: 0 missed lines and 0 missed branches on the changed lines (`presentInFileOrVariant`, `lineWithinTolerance`, and the reworked `isFindingPresent` / `isLineInDiff`); the only branches `DiffLineResolver` still misses are two pre-existing ternaries in the untouched `resolveRightSideLine`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No prompt or behavior change for the common case (a single exact diff filename) — the fix only affects the empty-exact and ambiguous-variant edges. The pre-fix and post-fix results are identical for every existing test; the change is additive plus a refactor of the variant lookup into a shared, order-independent helper.
