### PR TITLE
fix(review): #118 backstop's maintainer-reply escape hatch fails for thread-less and null-title findings (#133)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -257,10 +257,10 @@ public class FollowUpAnalyzer {
    * finding=N} comment on the file can then be an <em>earlier, unrelated</em> round's finding that
    * happens to reuse index {@code N}. {@code requireOwnContent} closes that gap for the
    * safety-critical clearing decision — when set, a match must also carry the finding's own content
-   * ({@link #ownContentKey}: its title, or its description when it has no title), so a thread-less
-   * finding cannot bind to a different finding's same-index thread. A finding with neither title
-   * nor description has no such key and matches nothing under {@code requireOwnContent}, so the
-   * caller holds rather than risks an over-clear.
+   * ({@link #bodyCarriesOwnContent}: its title in the comment header, or its description when it
+   * has no title), so a thread-less finding cannot bind to a different finding's same-index thread.
+   * A finding with neither title nor description matches nothing under {@code requireOwnContent},
+   * so the caller holds rather than risks an over-clear.
    */
   private static Long markerRootComment(
       ReviewResponse.Finding finding,
@@ -280,29 +280,25 @@ public class FollowUpAnalyzer {
   }
 
   /**
-   * Whether {@code body} carries this finding's identifying content — its title, or its description
-   * when it has no title. The bot embeds both in every comment ({@link
-   * SuggestionFormatter#formatReviewComment}), so this distinguishes the finding's own thread from
-   * a <em>different</em> finding that reused the same marker index in an earlier round. A
-   * null-title finding falls back to its description rather than matching on the recurring marker
-   * alone (#133).
+   * Whether {@code body} is this finding's own comment, judged by content the bot embeds in every
+   * comment ({@link SuggestionFormatter#formatReviewComment}). It distinguishes the finding's own
+   * thread from a <em>different</em> finding that reused the same marker index in an earlier round.
+   *
+   * <p>A titled finding is matched on the header framing {@code " — {title}**"}, not a bare title
+   * substring, so a short title does not match an unrelated comment that merely mentions the word
+   * and a title does not match a longer title that contains it as a prefix (dogfood #133). A
+   * null-title finding has no usable header title — the bot renders the literal {@code "null"},
+   * which is too generic — so it falls back to its description, which the bot prints verbatim in
+   * the body. A finding with neither matches nothing, so the caller holds rather than risk an
+   * over-clear.
    */
   private static boolean bodyCarriesOwnContent(ReviewResponse.Finding finding, String body) {
-    String key = ownContentKey(finding);
-    return key != null && body.contains(key);
-  }
-
-  /**
-   * The finding's title if it has one, otherwise its description; {@code null} when it has neither.
-   */
-  private static String ownContentKey(ReviewResponse.Finding finding) {
-    if (finding.title() != null && !finding.title().isBlank()) {
-      return finding.title();
+    String title = finding.title();
+    if (title != null && !title.isBlank()) {
+      return body.contains(" — " + title + "**");
     }
-    if (finding.description() != null && !finding.description().isBlank()) {
-      return finding.description();
-    }
-    return null;
+    String description = finding.description();
+    return description != null && !description.isBlank() && body.contains(description);
   }
 
   /**
@@ -350,19 +346,27 @@ public class FollowUpAnalyzer {
    * silent approve-over-open), the marked thread is resolved with {@code requireOwnContent}: a
    * thread-less finding (no inline comment that round) must not bind to an earlier round's
    * <em>different</em> finding that merely reuses index {@code N} on the same file and was
-   * answered. The content key is the finding's title, or its description when it has no title — so
-   * a null-title finding is matched by its own description rather than the recurring marker alone.
-   * Falls back to the title scan only when no marked thread exists at all (pre-marker comments),
-   * where the title is the only available key.
+   * answered. The content key is the finding's title in the comment header, or its description when
+   * it has no title — so a null-title finding is matched by its own description rather than the
+   * recurring marker alone.
+   *
+   * <p>When no own-content match is found but a {@code finding=N} comment <em>does</em> exist on
+   * the file, that comment belongs to a different finding (the index recurs across rounds), so the
+   * hold stands — the title-only fallback must not bind to it. Only genuinely pre-marker comments,
+   * with no marker for this index on the file at all, fall through to the title scan, where the
+   * title is the only available key.
    */
   private static Long answeredRootComment(
       ReviewResponse.Finding finding,
       int findingId,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       String botLogin) {
-    Long markerRoot = markerRootComment(finding, findingId, true, inlineComments, botLogin);
-    if (markerRoot != null) {
-      return hasHumanReply(markerRoot, inlineComments, botLogin) ? markerRoot : null;
+    Long own = markerRootComment(finding, findingId, true, inlineComments, botLogin);
+    if (own != null) {
+      return hasHumanReply(own, inlineComments, botLogin) ? own : null;
+    }
+    if (markerRootComment(finding, findingId, false, inlineComments, botLogin) != null) {
+      return null;
     }
     return answeredRootComment(finding, inlineComments, botLogin);
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -231,21 +231,48 @@ public class FollowUpAnalyzer {
       int findingId,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       String botLogin) {
-    // Markers reuse the same indices every review round, so a PR with several rounds carries
-    // several comments with this exact marker. Restricting to the finding's file and taking the
-    // newest match binds the latest round's findings to their own threads, not a previous
-    // round's thread that happens to share the index.
+    Long markerRoot = markerRootComment(finding, findingId, false, inlineComments, botLogin);
+    if (markerRoot != null) {
+      return markerRoot;
+    }
+    return rootCommentByTitle(finding, inlineComments, botLogin);
+  }
+
+  /**
+   * The newest bot root comment on the finding's file carrying its {@code findingId} marker, or
+   * {@code null} when none does. Markers reuse the same indices every review round, so a PR with
+   * several rounds carries several comments with this exact marker; restricting to the finding's
+   * file and taking the newest match binds the latest round's findings to their own threads, not a
+   * previous round's thread that happens to share the index. Title-independent, so it locates a
+   * null-title finding's thread that {@link #rootCommentsByTitle} cannot.
+   *
+   * <p>The newest-match heuristic alone is not enough when the finding had <em>no</em> thread of
+   * its own that round (its line was outside the diff, so it was summary-only): the newest {@code
+   * finding=N} comment on the file can then be an <em>earlier, unrelated</em> round's finding that
+   * happens to reuse index {@code N}. {@code requireOwnTitle} closes that gap for the
+   * safety-critical clearing decision — when set, a match must also carry the finding's title in
+   * its body, so a thread-less finding cannot bind to a different finding's same-index thread. A
+   * null-title finding has no such key and still relies on the marker plus file alone.
+   */
+  private static Long markerRootComment(
+      ReviewResponse.Finding finding,
+      int findingId,
+      boolean requireOwnTitle,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      String botLogin) {
     String marker = SuggestionFormatter.findingMarker(findingId);
     var markerMatches =
         botRootComments(inlineComments, botLogin)
             .filter(c -> c.body() != null && c.body().contains(marker))
             .filter(c -> finding.file() == null || FilePaths.same(finding.file(), c.path()))
+            .filter(
+                c ->
+                    !requireOwnTitle
+                        || finding.title() == null
+                        || c.body().contains(finding.title()))
             .map(GitHubReviewClient.PullRequestComment::id)
             .toList();
-    if (!markerMatches.isEmpty()) {
-      return markerMatches.get(markerMatches.size() - 1);
-    }
-    return rootCommentByTitle(finding, inlineComments, botLogin);
+    return markerMatches.isEmpty() ? null : markerMatches.get(markerMatches.size() - 1);
   }
 
   /**
@@ -276,6 +303,36 @@ public class FollowUpAnalyzer {
       }
     }
     return null;
+  }
+
+  /**
+   * Maintainer-reply check for a finding whose 1-based prompt {@code findingId} is known — the
+   * backstop's newest-prior-round case. The finding's own {@code thrillhousebot:finding=N} marked
+   * thread is authoritative: when one exists, only a reply on <em>it</em> clears the hold. The
+   * marker is title-independent, so a {@code null}-title finding's thread is seen — the title-only
+   * {@link #answeredRootComment(ReviewResponse.Finding, List, String)} consults {@link
+   * #rootCommentsByTitle}, which returns {@code List.of()} for a null title and can never find the
+   * reply, leaving the backstop to hold the finding every round with no human escape (#133b). It
+   * also keeps a reply on a same-title sibling's thread (a different index) from clearing this
+   * finding.
+   *
+   * <p>Because clearing the hold is the dangerous direction (over-clearing re-introduces the #118
+   * silent approve-over-open), the marked thread is resolved with {@code requireOwnTitle}: a
+   * thread-less finding (no inline comment that round) must not bind to an earlier round's
+   * <em>different</em> finding that merely reuses index {@code N} on the same file and was
+   * answered. Falls back to the title scan only when no marked thread exists at all (pre-marker
+   * comments), where the title is the only available key.
+   */
+  private static Long answeredRootComment(
+      ReviewResponse.Finding finding,
+      int findingId,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      String botLogin) {
+    Long markerRoot = markerRootComment(finding, findingId, true, inlineComments, botLogin);
+    if (markerRoot != null) {
+      return hasHumanReply(markerRoot, inlineComments, botLogin) ? markerRoot : null;
+    }
+    return answeredRootComment(finding, inlineComments, botLogin);
   }
 
   /** All bot root comments matching the finding's file and title, oldest first. */
@@ -522,7 +579,9 @@ public class FollowUpAnalyzer {
    * status entry, its flagged code is still present in the current diff, and no maintainer has
    * replied on its thread. Presence is judged by {@link DiffLineResolver#isFindingPresent} against
    * the finding's persisted {@code suggestion_old} anchor, so it survives line drift and is not
-   * fooled by unchanged context (#129); the resolver already rejects a null file.
+   * fooled by unchanged context (#129); the resolver already rejects a null file. The maintainer
+   * reply is located by the {@code id}-keyed marker rather than by title, so a null-title finding's
+   * thread is still seen (#133).
    */
   private static boolean isUnreportedAndStillOpen(
       ReviewResponse.Finding finding,
@@ -534,7 +593,7 @@ public class FollowUpAnalyzer {
     return !reportedIds.contains(id)
         && lineResolver.isFindingPresent(
             finding.file(), finding.line(), finding.suggestionOld(), DUPLICATE_LINE_TOLERANCE)
-        && answeredRootComment(finding, inlineComments, botLogin) == null;
+        && answeredRootComment(finding, id, inlineComments, botLogin) == null;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -249,15 +249,17 @@ public class FollowUpAnalyzer {
    * <p>The newest-match heuristic alone is not enough when the finding had <em>no</em> thread of
    * its own that round (its line was outside the diff, so it was summary-only): the newest {@code
    * finding=N} comment on the file can then be an <em>earlier, unrelated</em> round's finding that
-   * happens to reuse index {@code N}. {@code requireOwnTitle} closes that gap for the
-   * safety-critical clearing decision — when set, a match must also carry the finding's title in
-   * its body, so a thread-less finding cannot bind to a different finding's same-index thread. A
-   * null-title finding has no such key and still relies on the marker plus file alone.
+   * happens to reuse index {@code N}. {@code requireOwnContent} closes that gap for the
+   * safety-critical clearing decision — when set, a match must also carry the finding's own content
+   * ({@link #ownContentKey}: its title, or its description when it has no title), so a thread-less
+   * finding cannot bind to a different finding's same-index thread. A finding with neither title
+   * nor description has no such key and matches nothing under {@code requireOwnContent}, so the
+   * caller holds rather than risks an over-clear.
    */
   private static Long markerRootComment(
       ReviewResponse.Finding finding,
       int findingId,
-      boolean requireOwnTitle,
+      boolean requireOwnContent,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       String botLogin) {
     String marker = SuggestionFormatter.findingMarker(findingId);
@@ -265,14 +267,36 @@ public class FollowUpAnalyzer {
         botRootComments(inlineComments, botLogin)
             .filter(c -> c.body() != null && c.body().contains(marker))
             .filter(c -> finding.file() == null || FilePaths.same(finding.file(), c.path()))
-            .filter(
-                c ->
-                    !requireOwnTitle
-                        || finding.title() == null
-                        || c.body().contains(finding.title()))
+            .filter(c -> !requireOwnContent || bodyCarriesOwnContent(finding, c.body()))
             .map(GitHubReviewClient.PullRequestComment::id)
             .toList();
     return markerMatches.isEmpty() ? null : markerMatches.get(markerMatches.size() - 1);
+  }
+
+  /**
+   * Whether {@code body} carries this finding's identifying content — its title, or its description
+   * when it has no title. The bot embeds both in every comment ({@link
+   * SuggestionFormatter#formatReviewComment}), so this distinguishes the finding's own thread from
+   * a <em>different</em> finding that reused the same marker index in an earlier round. A
+   * null-title finding falls back to its description rather than matching on the recurring marker
+   * alone (#133).
+   */
+  private static boolean bodyCarriesOwnContent(ReviewResponse.Finding finding, String body) {
+    String key = ownContentKey(finding);
+    return key != null && body.contains(key);
+  }
+
+  /**
+   * The finding's title if it has one, otherwise its description; {@code null} when it has neither.
+   */
+  private static String ownContentKey(ReviewResponse.Finding finding) {
+    if (finding.title() != null && !finding.title().isBlank()) {
+      return finding.title();
+    }
+    if (finding.description() != null && !finding.description().isBlank()) {
+      return finding.description();
+    }
+    return null;
   }
 
   /**
@@ -317,11 +341,13 @@ public class FollowUpAnalyzer {
    * finding.
    *
    * <p>Because clearing the hold is the dangerous direction (over-clearing re-introduces the #118
-   * silent approve-over-open), the marked thread is resolved with {@code requireOwnTitle}: a
+   * silent approve-over-open), the marked thread is resolved with {@code requireOwnContent}: a
    * thread-less finding (no inline comment that round) must not bind to an earlier round's
    * <em>different</em> finding that merely reuses index {@code N} on the same file and was
-   * answered. Falls back to the title scan only when no marked thread exists at all (pre-marker
-   * comments), where the title is the only available key.
+   * answered. The content key is the finding's title, or its description when it has no title — so
+   * a null-title finding is matched by its own description rather than the recurring marker alone.
+   * Falls back to the title scan only when no marked thread exists at all (pre-marker comments),
+   * where the title is the only available key.
    */
   private static Long answeredRootComment(
       ReviewResponse.Finding finding,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -725,10 +725,16 @@ public class ReviewOrchestrator {
         .count();
   }
 
+  // A backstop-held finding can be summary-only — its flagged line was outside the diff when first
+  // raised, so it was never posted as an inline comment and has no thread to reply on (#133a).
+  // The guidance therefore qualifies the reply path ("where one exists") instead of promising a
+  // thread that may not be there; fixing the code, or a model resolved/justified verdict, still
+  // clears such a finding.
   static String unresolvedPreviousMessage(long unresolved) {
     return String.format(
         "No new issues in this revision, but %d previous finding(s) remain unresolved — "
-            + "fix them or reply on their threads with why they are deferred.",
+            + "fix them, or reply on their review thread (where one exists) with why they are"
+            + " deferred.",
         unresolved);
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -796,6 +796,182 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void unreportedUnresolvedShouldSeeMaintainerReplyOnNullTitleFindingViaMarker() {
+    // #133(b): a prior finding persisted with title == null. Its inline thread carries the hidden
+    // finding marker, so the maintainer reply must be seen even though the title-only
+    // rootCommentsByTitle returns nothing for a null title. Without the marker-keyed lookup the
+    // backstop would hold this finding every round with no way for the human to clear it.
+    var json =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 10, "title": null,
+           "description": "anchorless finding"}
+        ]}
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+    var comments =
+        List.of(
+            comment(
+                100L,
+                null,
+                "src/A.java",
+                "**HIGH — some defect**\n<!-- thrillhousebot:finding=1 -->",
+                BOT),
+            comment(101L, 100L, "src/A.java", "intentional, won't fix", "maintainer"));
+
+    var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), comments, resolver, BOT);
+
+    assertTrue(
+        held.isEmpty(),
+        "a maintainer reply on a null-title finding's marked thread must clear the hold");
+  }
+
+  @Test
+  void unreportedUnresolvedShouldStillHoldNullTitleFindingWhenThreadHasNoReply() {
+    // #133(b): the marker locates the null-title finding's thread, but with no human reply on it
+    // the hold stands. Pins that the marker path clears the hold only on an actual reply, not on
+    // the mere existence of the thread, and that presence still resolves for a null-title finding.
+    var json =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 10, "title": null,
+           "description": "anchorless finding"}
+        ]}
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+    var comments =
+        List.of(
+            comment(
+                100L,
+                null,
+                "src/A.java",
+                "**HIGH — some defect**\n<!-- thrillhousebot:finding=1 -->",
+                BOT));
+
+    var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), comments, resolver, BOT);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldBindReplyToTheFindingsOwnMarkedThread() {
+    // #133(b): two same-title findings in the round. The maintainer replied only on finding #2's
+    // marked thread; the marker keeps the reply bound to #2, so #1 is still held and #2 is cleared
+    // — a title-only check could not tell the two threads apart.
+    var json =
+        """
+        {"findings": [
+          {"risk": "medium", "file": "src/A.java", "line": 10, "title": "Missing null check",
+           "description": "first"},
+          {"risk": "medium", "file": "src/A.java", "line": 50, "title": "Missing null check",
+           "description": "second"}
+        ]}
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10) + "\n" + patch(50)));
+    var comments =
+        List.of(
+            comment(
+                100L,
+                null,
+                "src/A.java",
+                "**MEDIUM — Missing null check**\n<!-- thrillhousebot:finding=1 -->",
+                BOT),
+            comment(
+                200L,
+                null,
+                "src/A.java",
+                "**MEDIUM — Missing null check**\n<!-- thrillhousebot:finding=2 -->",
+                BOT),
+            comment(201L, 200L, "src/A.java", "intentional", "maintainer"));
+
+    var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), comments, resolver, BOT);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldHoldThreadlessFindingDespiteEarlierRoundReusingItsMarkerIndex() {
+    // #133 over-clear guard: the newest prior round's finding #1 ("Use-after-free") was
+    // summary-only
+    // that round (its flagged line was outside the diff), so it has no thread of its own; its code
+    // is still present now. An EARLIER, unrelated round posted a DIFFERENT finding at the same
+    // marker index 1 on the same file ("Naming nit") that a maintainer answered. The marker index
+    // recurs every round, so a marker-only lookup would bind to that earlier answered thread and
+    // clear a still-open finding — re-introducing the #118 silent approve-over-open. Requiring the
+    // marked comment to carry this finding's own title keeps the hold.
+    var json =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 10, "title": "Use-after-free",
+           "description": "frees then dereferences"}
+        ]}
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+    var comments =
+        List.of(
+            comment(
+                100L,
+                null,
+                "src/A.java",
+                "**LOW — Naming nit**\n<!-- thrillhousebot:finding=1 -->",
+                BOT),
+            comment(101L, 100L, "src/A.java", "fine as-is", "maintainer"));
+
+    var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), comments, resolver, BOT);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldHoldFindingWhenItsMarkedThreadHasOnlyABotReply() {
+    // #133 over-clear guard: the finding's own marked thread exists, but its only reply is the bot
+    // itself. The marker locates the thread, yet hasHumanReply must exclude the bot, so the hold
+    // stands — pins the marker-keyed branch (not just the title path) to clear only on a human
+    // reply.
+    var json =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 10, "title": "Use-after-free",
+           "description": "frees then dereferences"}
+        ]}
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+    var comments =
+        List.of(
+            comment(
+                100L,
+                null,
+                "src/A.java",
+                "**HIGH — Use-after-free**\n<!-- thrillhousebot:finding=1 -->",
+                BOT),
+            comment(101L, 100L, "src/A.java", "tracking this", BOT));
+
+    var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), comments, resolver, BOT);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldHoldNullTitleFindingWhenNoThreadExistsAtAll() {
+    // #133(b) safe-direction lock: a null-title finding with neither a marker thread nor a
+    // title-matchable thread. markerRootComment returns null and the title-only fallback finds
+    // nothing (rootCommentsByTitle is empty for a null title), so the still-present finding is
+    // held.
+    var json =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 10, "title": null,
+           "description": "anchorless finding"}
+        ]}
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+
+    var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), List.of(), resolver, BOT);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
   void unreportedUnresolvedShouldExcludeFindingsNotInCurrentDiff() {
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -990,6 +990,39 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void unreportedUnresolvedShouldNotClearWhenAShortTitleIsASubstringOfAnotherFinding() {
+    // #133 dogfood: finding #1's title is short ("NPE") and it is thread-less this round. An
+    // earlier
+    // round raised a DIFFERENT finding at the same marker index 1 on the same file whose title
+    // CONTAINS "NPE" ("NPE in handler") and was answered. A bare title-substring match would treat
+    // that unrelated answered thread as this finding's and over-clear; anchoring on the header
+    // framing " — NPE**" does not match " — NPE in handler**", and the marker=1 comment still
+    // present on the file blocks the title-only fallback, so the hold stands.
+    var json =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 10, "title": "NPE",
+           "description": "dereferences a value that may be null"}
+        ]}
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+    var comments =
+        List.of(
+            comment(
+                100L,
+                null,
+                "src/A.java",
+                "**HIGH — NPE in handler**\n\nguard the handler\n<!-- thrillhousebot:finding=1 -->",
+                BOT),
+            comment(101L, 100L, "src/A.java", "intentional", "maintainer"));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
   void unreportedUnresolvedShouldHoldFindingWhenItsMarkedThreadHasOnlyABotReply() {
     // #133 over-clear guard: a null-title finding's own marked thread exists, but its only reply is
     // the bot itself. The null title forces resolution through the marker-keyed branch (the

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -1043,6 +1043,60 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void unreportedUnresolvedShouldHoldFindingWithBlankTitleAndNoDescription() {
+    // #133 no-content-key path: a degenerate finding with a blank title and no description yields
+    // no content key, so the marker alone cannot safely identify its thread; the backstop holds it
+    // (the safe direction) rather than risk binding to a different finding that reused the same
+    // marker index. A marked bot comment is present so the content-correspondence check runs.
+    var json =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 10, "title": "", "description": null}
+        ]}
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+    var comments =
+        List.of(
+            comment(
+                100L,
+                null,
+                "src/A.java",
+                "**HIGH — flagged here**\n<!-- thrillhousebot:finding=1 -->",
+                BOT));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldHoldFindingWithBlankTitleAndBlankDescription() {
+    // #133 no-content-key path: both title and description are blank, so ownContentKey yields no
+    // key and the backstop holds the still-present finding (the safe direction).
+    var json =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 10, "title": "", "description": ""}
+        ]}
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+    var comments =
+        List.of(
+            comment(
+                100L,
+                null,
+                "src/A.java",
+                "**HIGH — flagged here**\n<!-- thrillhousebot:finding=1 -->",
+                BOT));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
   void unreportedUnresolvedShouldExcludeFindingsNotInCurrentDiff() {
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -798,14 +798,15 @@ class FollowUpAnalyzerTest {
   @Test
   void unreportedUnresolvedShouldSeeMaintainerReplyOnNullTitleFindingViaMarker() {
     // #133(b): a prior finding persisted with title == null. Its inline thread carries the hidden
-    // finding marker, so the maintainer reply must be seen even though the title-only
-    // rootCommentsByTitle returns nothing for a null title. Without the marker-keyed lookup the
-    // backstop would hold this finding every round with no way for the human to clear it.
+    // finding marker and the finding's description (the bot embeds both in every comment), so the
+    // maintainer reply must be seen even though the title-only rootCommentsByTitle returns nothing
+    // for a null title. Without the marker-keyed lookup the backstop would hold this finding every
+    // round with no way for the human to clear it.
     var json =
         """
         {"findings": [
           {"risk": "high", "file": "src/A.java", "line": 10, "title": null,
-           "description": "anchorless finding"}
+           "description": "frees then dereferences"}
         ]}
         """;
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
@@ -815,7 +816,7 @@ class FollowUpAnalyzerTest {
                 100L,
                 null,
                 "src/A.java",
-                "**HIGH — some defect**\n<!-- thrillhousebot:finding=1 -->",
+                "**HIGH — null**\n\nfrees then dereferences\n<!-- thrillhousebot:finding=1 -->",
                 BOT),
             comment(101L, 100L, "src/A.java", "intentional, won't fix", "maintainer"));
 
@@ -828,14 +829,15 @@ class FollowUpAnalyzerTest {
 
   @Test
   void unreportedUnresolvedShouldStillHoldNullTitleFindingWhenThreadHasNoReply() {
-    // #133(b): the marker locates the null-title finding's thread, but with no human reply on it
-    // the hold stands. Pins that the marker path clears the hold only on an actual reply, not on
-    // the mere existence of the thread, and that presence still resolves for a null-title finding.
+    // #133(b): the marker plus the finding's description locate the null-title finding's thread,
+    // but
+    // with no human reply on it the hold stands. Pins that the marker path clears the hold only on
+    // an actual reply, not on the mere existence of the thread.
     var json =
         """
         {"findings": [
           {"risk": "high", "file": "src/A.java", "line": 10, "title": null,
-           "description": "anchorless finding"}
+           "description": "frees then dereferences"}
         ]}
         """;
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
@@ -845,8 +847,42 @@ class FollowUpAnalyzerTest {
                 100L,
                 null,
                 "src/A.java",
-                "**HIGH — some defect**\n<!-- thrillhousebot:finding=1 -->",
+                "**HIGH — null**\n\nfrees then dereferences\n<!-- thrillhousebot:finding=1 -->",
                 BOT));
+
+    var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), comments, resolver, BOT);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldHoldNullTitleFindingWhenEarlierRoundReusedItsMarkerIndex() {
+    // #133 over-clear guard for null-title findings: the newest round's finding #1 has title ==
+    // null
+    // and was summary-only that round (no thread of its own); its code is still present. An
+    // EARLIER,
+    // unrelated round posted a DIFFERENT finding at the same marker index 1 on the same file that a
+    // maintainer answered. The marker index recurs every round and a null title gives no title key,
+    // so without content correspondence the marker would bind to that earlier answered thread and
+    // clear a still-open finding — the #118 silent approve-over-open. Matching the finding's own
+    // description keeps the hold.
+    var json =
+        """
+        {"findings": [
+          {"risk": "high", "file": "src/A.java", "line": 10, "title": null,
+           "description": "frees then dereferences"}
+        ]}
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+    var comments =
+        List.of(
+            comment(
+                100L,
+                null,
+                "src/A.java",
+                "**LOW — Naming nit**\n\nrename the local for clarity\n<!-- thrillhousebot:finding=1 -->",
+                BOT),
+            comment(101L, 100L, "src/A.java", "fine as-is", "maintainer"));
 
     var held = analyzer.unreportedUnresolvedStatuses(json, List.of(), comments, resolver, BOT);
 
@@ -924,14 +960,16 @@ class FollowUpAnalyzerTest {
 
   @Test
   void unreportedUnresolvedShouldHoldFindingWhenItsMarkedThreadHasOnlyABotReply() {
-    // #133 over-clear guard: the finding's own marked thread exists, but its only reply is the bot
-    // itself. The marker locates the thread, yet hasHumanReply must exclude the bot, so the hold
-    // stands — pins the marker-keyed branch (not just the title path) to clear only on a human
-    // reply.
+    // #133 over-clear guard: a null-title finding's own marked thread exists, but its only reply is
+    // the bot itself. The null title forces resolution through the marker-keyed branch (the
+    // title-only path cannot see a null-title thread at all), and hasHumanReply must exclude the
+    // bot
+    // there, so the hold stands. Removing the hasHumanReply check on that branch would flip this to
+    // a clear.
     var json =
         """
         {"findings": [
-          {"risk": "high", "file": "src/A.java", "line": 10, "title": "Use-after-free",
+          {"risk": "high", "file": "src/A.java", "line": 10, "title": null,
            "description": "frees then dereferences"}
         ]}
         """;
@@ -942,7 +980,7 @@ class FollowUpAnalyzerTest {
                 100L,
                 null,
                 "src/A.java",
-                "**HIGH — Use-after-free**\n<!-- thrillhousebot:finding=1 -->",
+                "**HIGH — null**\n\nfrees then dereferences\n<!-- thrillhousebot:finding=1 -->",
                 BOT),
             comment(101L, 100L, "src/A.java", "tracking this", BOT));
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2879,6 +2879,29 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void shouldQualifyReplyGuidanceSinceABackstopFindingMayHaveNoThread() {
+      // #133(a): a backstop-held finding can be summary-only — its flagged line was outside the
+      // diff when first raised, so it was never posted inline and has no thread to reply on. The
+      // COMMENT guidance must not unconditionally tell the maintainer to "reply on their threads";
+      // it qualifies the reply path so it stays honest when no thread exists.
+      delegateStatusGate();
+      var result =
+          buildWithBackstop(
+              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still present")));
+
+      orchestrator.postReview("auth", "owner", "repo", 5, "sha", result, List.of());
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      var body = captor.getValue().body();
+      assertTrue(body.contains("where one exists"), "the reply guidance must be qualified");
+      assertFalse(
+          body.contains("reply on their threads"),
+          "must not unconditionally promise a thread that may not exist");
+    }
+
+    @Test
     void shouldHoldApproveOverSilentlyDroppedPriorFindingThroughReview() {
       try (var mockedStatic = mockStatic(ReviewSession.class)) {
         var session = followUpSession();

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2882,8 +2882,8 @@ class ReviewOrchestratorTest {
     void shouldQualifyReplyGuidanceSinceABackstopFindingMayHaveNoThread() {
       // #133(a): a backstop-held finding can be summary-only — its flagged line was outside the
       // diff when first raised, so it was never posted inline and has no thread to reply on. The
-      // COMMENT guidance must not unconditionally tell the maintainer to "reply on their threads";
-      // it qualifies the reply path so it stays honest when no thread exists.
+      // COMMENT guidance must qualify the reply path (where a thread exists) rather than directing
+      // the maintainer to a thread that may not be there.
       delegateStatusGate();
       var result =
           buildWithBackstop(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2880,10 +2880,10 @@ class ReviewOrchestratorTest {
 
     @Test
     void shouldQualifyReplyGuidanceSinceABackstopFindingMayHaveNoThread() {
-      // #133(a): a backstop-held finding can be summary-only — its flagged line was outside the
-      // diff when first raised, so it was never posted inline and has no thread to reply on. The
-      // COMMENT guidance must qualify the reply path (where a thread exists) rather than directing
-      // the maintainer to a thread that may not be there.
+      // Issue 133 case a: a backstop-held finding can be summary-only when its flagged line was
+      // outside the diff at the time it was first raised, so no inline thread was ever posted for
+      // it. The COMMENT guidance must then qualify the reply path rather than point the maintainer
+      // at a thread that is not present.
       delegateStatusGate();
       var result =
           buildWithBackstop(


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The #118 approve backstop holds `APPROVE → COMMENT` over a still-present prior finding the model silently dropped, **unless** a maintainer replied on the finding's inline thread. Two cases made that escape hatch silently unavailable, so the only way to clear the hold was the model's own `resolved`/`justified` verdict:

- **(b) Null-title findings.** `answeredRootComment` consulted `rootCommentsByTitle`, which returns `List.of()` when `finding.title() == null`. A real maintainer reply on a null-title finding's thread was therefore never seen, and the backstop kept emitting `unresolved` every round with no human escape. The reply check now locates the thread by the hidden `thrillhousebot:finding=N` marker (title-independent), the way `rootCommentId` already does.
- **(a) Thread-less findings.** A finding whose flagged line was outside the diff when first raised is posted only in the summary comment, with no inline thread. When the backstop held it, the no-issues `COMMENT` body told the maintainer to *"reply on their threads with why they are deferred"* — but there was no thread to reply on. `unresolvedPreviousMessage` now qualifies the reply path (*"reply on their review thread (where one exists)"*). The hold itself is correct per #118 and is preserved; the only bug was the misleading guidance.

### Over-clear guard (caught in self-review)

The marker index is a 1-based position that **recurs every round**. A marker-only lookup could bind a *thread-less* newest-round finding to an **earlier, unrelated** round's finding that reuses the same index `N` on the same file — and if that unrelated thread had been answered, the still-open finding would be silently cleared, re-introducing the exact #118 silent approve-over-open. The backstop now resolves the marked thread with `requireOwnTitle`, so a match must also carry the finding's **own title** before its reply is treated as authoritative. Same-title siblings within a round are still told apart by the marker index. (`rootCommentId` and the cross-round `dropRepliedDuplicates` title path are intentionally left unchanged.)

## Related Issues

Fixes #133

## How Has This Been Tested?

- [x] Unit tests

New tests in `FollowUpAnalyzerTest`:
- maintainer reply on a **null-title** finding's marked thread clears the hold (#133b);
- null-title finding with a marked thread but no reply stays held;
- a reply on a **same-title sibling**'s thread does not clear a different finding (marker disambiguation);
- **over-clear regression**: a thread-less finding stays held even when an earlier round reused its marker index on the same file with a maintainer reply;
- a marked thread whose only reply is the bot itself stays held;
- a null-title finding with no thread at all stays held (safe-direction fallback).

New test in `ReviewOrchestratorTest > ApproveBackstop`:
- the no-issues `COMMENT` guidance is qualified ("where one exists") and no longer unconditionally promises a thread (#133a).

Local verification (mirrors CI):
- `./mvnw spotless:check` ✅
- `./mvnw verify` ✅ — 750 tests pass, JaCoCo gate met, SpotBugs clean
- The two key new tests are genuine regression tests: both fail against the pre-fix code and pass after.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The model can still clear these findings via `resolved`/`justified`, so the hold was never strictly permanent; this PR restores the documented **maintainer-reply** contract for both cases and makes the "reply on their threads" guidance honest. Scoped narrowly to the backstop's clearing decision — `rootCommentId`, the #129 presence anchor, and the #131 recognized-status handling are untouched.