### PR TITLE
fix(review): deduplicate drifted re-raised findings in backstop (#143)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -540,15 +540,53 @@ public class FollowUpAnalyzer {
     // The current round reports on the newest prior round — drop everything it accounted for.
     closeReported(open, chrono.get(chrono.size() - 1).findings(), currentStatuses);
 
+    // Cluster the remaining open findings by tolerant identity.
+    var clusters = new ArrayList<List<OpenFinding>>();
+    for (var openFinding : open.values()) {
+      List<OpenFinding> home = null;
+      for (var cluster : clusters) {
+        if (cluster.stream()
+            .anyMatch(member -> isSameFinding(member.finding(), openFinding.finding()))) {
+          home = cluster;
+          break;
+        }
+      }
+      if (home == null) {
+        home = new ArrayList<>();
+        clusters.add(home);
+      }
+      home.add(openFinding);
+    }
+
     var held = new ArrayList<ReviewResult.PreviousFindingStatus>();
-    for (var entry : open.values()) {
-      var finding = entry.finding();
-      if (lineResolver.isFindingPresent(
-              finding.file(), finding.line(), finding.suggestionOld(), DUPLICATE_LINE_TOLERANCE)
-          && answeredRootComment(finding, inlineComments, botLogin) == null) {
+    for (var cluster : clusters) {
+      boolean anyPresent = false;
+      boolean anyReplied = false;
+      OpenFinding target = null;
+
+      for (var member : cluster) {
+        var finding = member.finding();
+        boolean present =
+            lineResolver.isFindingPresent(
+                finding.file(), finding.line(), finding.suggestionOld(), DUPLICATE_LINE_TOLERANCE);
+        if (present) {
+          anyPresent = true;
+          if (target == null) {
+            target = member;
+          }
+        }
+        if (answeredRootComment(finding, inlineComments, botLogin) != null) {
+          anyReplied = true;
+        }
+      }
+
+      if (anyPresent && !anyReplied) {
+        if (target == null) {
+          target = cluster.get(0);
+        }
         held.add(
             new ReviewResult.PreviousFindingStatus(
-                entry.id(),
+                target.id(),
                 STATUS_UNRESOLVED,
                 "Flagged in an earlier round and still present; not addressed in this revision."));
       }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -560,7 +560,6 @@ public class FollowUpAnalyzer {
 
     var held = new ArrayList<ReviewResult.PreviousFindingStatus>();
     for (var cluster : clusters) {
-      boolean anyPresent = false;
       boolean anyReplied = false;
       OpenFinding target = null;
 
@@ -569,21 +568,15 @@ public class FollowUpAnalyzer {
         boolean present =
             lineResolver.isFindingPresent(
                 finding.file(), finding.line(), finding.suggestionOld(), DUPLICATE_LINE_TOLERANCE);
-        if (present) {
-          anyPresent = true;
-          if (target == null) {
-            target = member;
-          }
+        if (present && target == null) {
+          target = member;
         }
         if (answeredRootComment(finding, inlineComments, botLogin) != null) {
           anyReplied = true;
         }
       }
 
-      if (anyPresent && !anyReplied) {
-        if (target == null) {
-          target = cluster.get(0);
-        }
+      if (target != null && !anyReplied) {
         held.add(
             new ReviewResult.PreviousFindingStatus(
                 target.id(),

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -1419,4 +1419,80 @@ class FollowUpAnalyzerTest {
   void hasUnresolvedShouldReturnFalseForEmptyList() {
     assertFalse(analyzer.hasUnresolved(List.of()));
   }
+
+  @Test
+  void unreportedUnresolvedShouldDeduplicateDriftedReRaisedFindingAcrossRounds() {
+    // A finding raised in round 1 and re-raised in round 2 (with line/path drift)
+    // is held once, not twice, if both are dropped (unreported) in the current round.
+    var round1 =
+        """
+        {"findings": [
+          {"risk": "medium", "file": "src/A.java", "line": 10, "title": "SQL injection in query",
+           "description": "The query concatenates user input directly without sanitization",
+           "suggestion_old": "query = \\"SELECT * FROM users WHERE id = \\" + id;"}
+        ]}
+        """;
+    var round2 =
+        """
+        {"findings": [
+          {"risk": "medium", "file": "src/A.java", "line": 32, "title": "SQL injection in database query",
+           "description": "The database query concatenates user input directly without sanitization",
+           "suggestion_old": "query = \\"SELECT * FROM users WHERE id = \\" + id;"}
+        ]}
+        """;
+    // Both anchors are present in the current diff.
+    var resolver =
+        new DiffLineResolver(
+            Map.of(
+                "src/A.java",
+                "@@ -10,1 +10,1 @@\n-old1\n+query = \"SELECT * FROM users WHERE id = \" + id;\n@@ -32,1 +32,1 @@\n-old2\n+query = \"SELECT * FROM users WHERE id = \" + id;\n"));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(round2, round1), List.of(), List.of(), resolver, BOT);
+
+    // Only one status is held (deduplicated).
+    assertEquals(1, held.size());
+    assertEquals("unresolved", held.get(0).status());
+  }
+
+  @Test
+  void unreportedUnresolvedShouldExcludeDriftedReRaisedFindingIfAnyMemberHasReply() {
+    // If a finding was re-raised with drift, but one of the copies has a maintainer reply,
+    // the entire cluster is considered replied to and is not held.
+    var round1 =
+        """
+        {"findings": [
+          {"risk": "medium", "file": "src/A.java", "line": 10, "title": "SQL injection in query",
+           "description": "The query concatenates user input directly without sanitization",
+           "suggestion_old": "query = \\"SELECT * FROM users WHERE id = \\" + id;"}
+        ]}
+        """;
+    var round2 =
+        """
+        {"findings": [
+          {"risk": "medium", "file": "src/A.java", "line": 32, "title": "SQL injection in database query",
+           "description": "The database query concatenates user input directly without sanitization",
+           "suggestion_old": "query = \\"SELECT * FROM users WHERE id = \\" + id;"}
+        ]}
+        """;
+    var comments =
+        List.of(
+            comment(100L, null, "src/A.java", "SQL injection in query", BOT),
+            comment(101L, 100L, "src/A.java", "intentional", "maintainer"));
+
+    var resolver =
+        new DiffLineResolver(
+            Map.of(
+                "src/A.java",
+                "@@ -10,1 +10,1 @@\n-old1\n+query = \"SELECT * FROM users WHERE id = \" + id;\n@@ -32,1 +32,1 @@\n-old2\n+query = \"SELECT * FROM users WHERE id = \" + id;\n"));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(round2, round1), List.of(), comments, resolver, BOT);
+
+    // One of the cluster members has a reply → entire cluster is considered replied → empty held
+    // list.
+    assertTrue(held.isEmpty());
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] ✅ Test

## Description

The approve backstop in `FollowUpAnalyzer.unreportedUnresolvedStatuses` previously deduplicated findings across rounds with an exact content key: `file + NUL + line + NUL + title`. While this line-sensitive key is required to avoid collapsing genuinely distinct findings (avoiding a missed hold), it caused the backstop to over-count a single defect if it drifted in path, line, or title and was re-raised across rounds.

This PR implements tolerant cross-round identity clustering in the backstop logic:
- The exact map keying in `open` is preserved so we still replay rounds correctly.
- Before checking presence/reply status for the final `held` list, the surviving `open` findings are grouped into clusters using the existing `isSameFinding` tolerant comparator.
- For each cluster, we determine if it should be held:
  - It is held if **at least one** member is present in the current diff.
  - It is bypassed if **any** member has a maintainer reply.
  - If held, a single `PreviousFindingStatus` is emitted referencing the first present member's ID.

## Related Issues

Fixes #143

## How Has This Been Tested?

- [x] Unit tests

Added two unit tests to `FollowUpAnalyzerTest.java`:
- `unreportedUnresolvedShouldDeduplicateDriftedReRaisedFindingAcrossRounds`: Verifies that a finding re-raised with line/path drift is held only once in the PR summary backstop check.
- `unreportedUnresolvedShouldExcludeDriftedReRaisedFindingIfAnyMemberHasReply`: Verifies that if any member of the clustered finding has a maintainer reply, the entire cluster is bypassed.

Ran the full maven gate locally:
- `./mvnw spotless:check` ✅
- `./mvnw clean test` ✅ (all 952 tests pass)
- `./mvnw compile spotbugs:check` ✅ (0 bugs found)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors