### PR TITLE
fix(review): anchorless findings backstop fallback and content anchor population (#140)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -37,15 +37,18 @@ public final class DiffLineResolver {
 
   private final Map<String, TreeSet<Integer>> rightSideLinesByFile;
   private final Map<String, List<String>> rightSideTextByFile;
+  private final Map<String, Map<Integer, String>> rightSideLineTextByFile;
 
   public DiffLineResolver(Map<String, String> patchesByFile) {
     this.rightSideLinesByFile = new HashMap<>();
     this.rightSideTextByFile = new HashMap<>();
+    this.rightSideLineTextByFile = new HashMap<>();
     patchesByFile.forEach(
         (file, patch) -> {
           RightSide rightSide = parseRightSide(patch);
           rightSideLinesByFile.put(file, rightSide.lines());
           rightSideTextByFile.put(file, rightSide.text());
+          rightSideLineTextByFile.put(file, rightSide.lineText());
         });
   }
 
@@ -72,21 +75,42 @@ public final class DiffLineResolver {
    * APPROVE→COMMENT, the safe direction for a downgrade-only backstop, never the #118 under-block.
    *
    * <p>When the finding has no anchor (a suggestion-less finding, or one whose suggestion was
-   * stripped), it falls back to {@link #isLineInDiff}. That fallback is a coarse line proxy that
-   * retains the raw-line fragility in <em>both</em> directions (it can under-block on drift and
-   * over-block on nearby context); it applies only to the minority of anchorless findings, for
-   * which no flagged-code content survives to match against.
+   * stripped), it falls back to checking whether the file has any changes in the diff. This leans
+   * toward holding (returning true) for the downgrade-only backstop, avoiding the drift-fragile
+   * under-blocking behavior of a raw line check.
    */
-  public boolean isFindingPresent(String file, int line, String anchor, int tolerance) {
+  public boolean isFindingPresent(String file, String anchor) {
     if (file == null) {
       return false;
     }
     List<String> anchorLines = normalizedAnchorLines(anchor);
     if (anchorLines.isEmpty()) {
-      return isLineInDiff(file, line, tolerance);
+      return presentInFileOrVariant(rightSideLinesByFile, file, lines -> true);
     }
     return presentInFileOrVariant(
         rightSideTextByFile, file, text -> containsContiguous(text, anchorLines));
+  }
+
+  /**
+   * Retrieves the right-side text of a specific line number, or {@code null} if not in the diff.
+   */
+  public String getLineText(String file, int line) {
+    if (file == null || line <= 0) {
+      return null;
+    }
+    Map<Integer, String> exact = rightSideLineTextByFile.get(file);
+    if (exact != null && !exact.isEmpty()) {
+      return exact.get(line);
+    }
+    for (var entry : rightSideLineTextByFile.entrySet()) {
+      var value = entry.getValue();
+      if (!entry.getKey().equals(file)
+          && !value.isEmpty()
+          && FilePaths.same(file, entry.getKey())) {
+        return value.get(line);
+      }
+    }
+    return null;
   }
 
   /** Whether {@code needle} appears as a contiguous, in-order run within {@code haystack}. */
@@ -111,9 +135,7 @@ public final class DiffLineResolver {
   /**
    * Whether {@code line} — or a line within {@code tolerance} of it — is an actual right-side line
    * of the file's diff. Unlike {@link #resolveRightSideLine}, this never snaps to an arbitrarily
-   * distant line. It is the anchorless fallback for {@link #isFindingPresent}: a coarse
-   * line-membership proxy used only when a finding carries no flagged-code anchor to match by
-   * content. The file is matched with {@link FilePaths#same}, so a model path variant still
+   * distant line. The file is matched with {@link FilePaths#same}, so a model path variant still
    * resolves to the diff's filename.
    */
   public boolean isLineInDiff(String file, int line, int tolerance) {
@@ -249,7 +271,8 @@ public final class DiffLineResolver {
    * test the anchor as a contiguous run; blank lines are dropped from both sides so a blank line
    * inside a block never breaks an otherwise-adjacent match.
    */
-  private record RightSide(TreeSet<Integer> lines, List<String> text) {}
+  private record RightSide(
+      TreeSet<Integer> lines, List<String> text, Map<Integer, String> lineText) {}
 
   /**
    * Walks a unified-diff patch once, collecting the right-side line numbers and the trimmed text of
@@ -264,8 +287,9 @@ public final class DiffLineResolver {
   private static RightSide parseRightSide(String patch) {
     var lines = new TreeSet<Integer>();
     var text = new ArrayList<String>();
+    var lineText = new HashMap<Integer, String>();
     if (patch == null || patch.isBlank()) {
-      return new RightSide(lines, text);
+      return new RightSide(lines, text, lineText);
     }
 
     var newLine = 0;
@@ -287,10 +311,11 @@ public final class DiffLineResolver {
           if (!stripped.isEmpty()) {
             text.add(stripped);
           }
+          lineText.put(newLine, rawLine.substring(1));
           newLine++;
         }
       }
     }
-    return new RightSide(lines, text);
+    return new RightSide(lines, text, lineText);
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -565,9 +565,7 @@ public class FollowUpAnalyzer {
 
       for (var member : cluster) {
         var finding = member.finding();
-        boolean present =
-            lineResolver.isFindingPresent(
-                finding.file(), finding.line(), finding.suggestionOld(), DUPLICATE_LINE_TOLERANCE);
+        boolean present = lineResolver.isFindingPresent(finding.file(), finding.suggestionOld());
         if (present && target == null) {
           target = member;
         }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -278,6 +278,8 @@ public class ReviewOrchestrator {
       aiResponse =
           followUpAnalyzer.dropRepliedDuplicates(
               aiResponse, priorAiResponseJsons, inlineComments, BOT_LOGIN);
+      var lineResolver = new DiffLineResolver(patchesByFile(files));
+      aiResponse = populateMissingAnchors(aiResponse, lineResolver);
       persistAiResponse(session, aiResponse);
 
       // Fetch required status checks and evaluate CI checks on the head SHA. An absent result means
@@ -300,7 +302,7 @@ public class ReviewOrchestrator {
                   priorAiResponseJsons,
                   aiResponse.previousFindingsStatus(),
                   inlineComments,
-                  new DiffLineResolver(patchesByFile(files)),
+                  lineResolver,
                   BOT_LOGIN)
               : List.<ReviewResult.PreviousFindingStatus>of();
       var result =
@@ -425,6 +427,40 @@ public class ReviewOrchestrator {
     } catch (JsonProcessingException e) {
       Log.warn("Failed to serialize AI response for session persistence", e);
     }
+  }
+
+  ReviewResponse populateMissingAnchors(ReviewResponse response, DiffLineResolver lineResolver) {
+    if (response.findings().isEmpty()) {
+      return response;
+    }
+    var adjusted = new ArrayList<ReviewResponse.Finding>(response.findings().size());
+    var changed = false;
+    for (ReviewResponse.Finding finding : response.findings()) {
+      if (finding.suggestionOld() == null || finding.suggestionOld().isBlank()) {
+        String fallback = lineResolver.getLineText(finding.file(), finding.line());
+        if (fallback != null && !fallback.isBlank()) {
+          Log.infof(
+              "Populating missing content anchor for finding '%s' (%s:%d) with: '%s'",
+              finding.title(), finding.file(), finding.line(), fallback.strip());
+          adjusted.add(
+              new ReviewResponse.Finding(
+                  finding.risk(),
+                  finding.confidence(),
+                  finding.file(),
+                  finding.line(),
+                  finding.title(),
+                  finding.description(),
+                  fallback,
+                  finding.suggestionNew()));
+          changed = true;
+          continue;
+        }
+      }
+      adjusted.add(finding);
+    }
+    return changed
+        ? new ReviewResponse(adjusted, response.previousFindingsStatus(), response.summary())
+        : response;
   }
 
   long createCheckRun(String auth, String owner, String repo, String headSha, String detailsUrl) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
@@ -224,7 +224,7 @@ class DiffLineResolverTest {
 
     // The raw line-number proxy drops it (32 is far from the old line 10); content matching holds.
     assertFalse(resolver.isLineInDiff("A.java", 10, 3));
-    assertTrue(resolver.isFindingPresent("A.java", 10, "dangerous_call()", 3));
+    assertTrue(resolver.isFindingPresent("A.java", "dangerous_call()"));
   }
 
   @Test
@@ -249,7 +249,7 @@ class DiffLineResolverTest {
     // line now at right-line 41 (ctx_45), so it reads "present" though the bug was deleted.
     assertTrue(resolver.isLineInDiff("A.java", 42, 3));
     // Content matching is not: the anchor exists only as a deletion, never on the right side.
-    assertFalse(resolver.isFindingPresent("A.java", 42, "buggy_42()", 3));
+    assertFalse(resolver.isFindingPresent("A.java", "buggy_42()"));
   }
 
   @Test
@@ -263,13 +263,13 @@ class DiffLineResolverTest {
         """;
     var resolver = new DiffLineResolver(Map.of("A.java", patch));
 
-    assertTrue(resolver.isFindingPresent("A.java", 1, "alpha()\nbeta()", 3));
-    assertTrue(resolver.isFindingPresent("A.java", 1, "beta()\ngamma()", 3));
+    assertTrue(resolver.isFindingPresent("A.java", "alpha()\nbeta()"));
+    assertTrue(resolver.isFindingPresent("A.java", "beta()\ngamma()"));
     // A line changed away breaks the block.
-    assertFalse(resolver.isFindingPresent("A.java", 1, "alpha()\ndelta()", 3));
+    assertFalse(resolver.isFindingPresent("A.java", "alpha()\ndelta()"));
     // Lines that survive only non-adjacently or out of order are not a contiguous run (#129(b)).
-    assertFalse(resolver.isFindingPresent("A.java", 1, "alpha()\ngamma()", 3));
-    assertFalse(resolver.isFindingPresent("A.java", 1, "gamma()\nbeta()", 3));
+    assertFalse(resolver.isFindingPresent("A.java", "alpha()\ngamma()"));
+    assertFalse(resolver.isFindingPresent("A.java", "gamma()\nbeta()"));
   }
 
   @Test
@@ -287,7 +287,7 @@ class DiffLineResolverTest {
         """;
     var resolver = new DiffLineResolver(Map.of("A.java", patch));
 
-    assertFalse(resolver.isFindingPresent("A.java", 1, "validate(x);\npersist(x);", 3));
+    assertFalse(resolver.isFindingPresent("A.java", "validate(x);\npersist(x);"));
   }
 
   @Test
@@ -308,7 +308,7 @@ class DiffLineResolverTest {
         """;
     var resolver = new DiffLineResolver(Map.of("A.java", patch));
 
-    assertTrue(resolver.isFindingPresent("A.java", 2, "return null;", 3));
+    assertTrue(resolver.isFindingPresent("A.java", "return null;"));
   }
 
   @Test
@@ -322,7 +322,7 @@ class DiffLineResolverTest {
         """;
     var resolver = new DiffLineResolver(Map.of("A.java", patch));
 
-    assertTrue(resolver.isFindingPresent("A.java", 1, "String s = \"<<DIFF_START>>\";", 3));
+    assertTrue(resolver.isFindingPresent("A.java", "String s = \"<<DIFF_START>>\";"));
   }
 
   @Test
@@ -336,17 +336,18 @@ class DiffLineResolverTest {
     var resolver = new DiffLineResolver(Map.of("A.java", patch));
 
     // Blank lines in the anchor must not be required against the right-side text.
-    assertTrue(resolver.isFindingPresent("A.java", 1, "alpha()\n\n   \nbeta()", 3));
+    assertTrue(resolver.isFindingPresent("A.java", "alpha()\n\n   \nbeta()"));
   }
 
   @Test
-  void isFindingPresentShouldFallBackToLineMembershipWithoutAnchor() {
+  void isFindingPresentShouldFallBackToHoldingWithoutAnchorIfFileHasChanges() {
     var resolver = new DiffLineResolver(Map.of("main.py", PATCH));
 
-    // No anchor (null or blank): behaves like isLineInDiff.
-    assertTrue(resolver.isFindingPresent("main.py", 11, null, 3));
-    assertTrue(resolver.isFindingPresent("main.py", 11, "   ", 3));
-    assertFalse(resolver.isFindingPresent("main.py", 99, null, 3));
+    // No anchor (null or blank): leans toward holding (returns true) if the file has changes.
+    assertTrue(resolver.isFindingPresent("main.py", null));
+    assertTrue(resolver.isFindingPresent("main.py", "   "));
+    assertTrue(resolver.isFindingPresent("main.py", null));
+    assertFalse(resolver.isFindingPresent("other.py", null));
   }
 
   @Test
@@ -354,17 +355,17 @@ class DiffLineResolverTest {
     var resolver = new DiffLineResolver(Map.of("src/dir/Main.java", PATCH));
 
     // Path variant resolves, indentation is stripped, and the stale line number is irrelevant.
-    assertTrue(resolver.isFindingPresent("dir/Main.java", 999, "new_line()", 3));
+    assertTrue(resolver.isFindingPresent("dir/Main.java", "new_line()"));
   }
 
   @Test
   void isFindingPresentShouldRejectNullFileAndAnchorOutsideItsOwnFile() {
     var resolver = new DiffLineResolver(Map.of("A.java", PATCH));
 
-    assertFalse(resolver.isFindingPresent(null, 11, "new_line()", 3));
+    assertFalse(resolver.isFindingPresent(null, "new_line()"));
     // The anchor text exists in A.java's diff, but the finding points at a file not in the diff —
     // matching is file-scoped so an unrelated file never validates the finding.
-    assertFalse(resolver.isFindingPresent("B.java", 11, "new_line()", 3));
+    assertFalse(resolver.isFindingPresent("B.java", "new_line()"));
   }
 
   @Test
@@ -379,7 +380,7 @@ class DiffLineResolverTest {
 
     // The flagged code was deleted outright: it survives only on the left side, so the file's
     // right-side text is empty and the finding counts as no longer present.
-    assertFalse(resolver.isFindingPresent("A.java", 10, "buggy_call()", 3));
+    assertFalse(resolver.isFindingPresent("A.java", "buggy_call()"));
   }
 
   @Test
@@ -398,8 +399,8 @@ class DiffLineResolverTest {
     assertEquals(3, lines.size());
     // ... but is excluded from the right-side text, so "first();" and "third();" are adjacent and
     // match contiguously. Were the blank kept, it would sit between them and break the run.
-    assertTrue(resolver.isFindingPresent("A.java", 1, "first();\nthird();", 3));
-    assertFalse(resolver.isFindingPresent("A.java", 1, "second();", 3));
+    assertTrue(resolver.isFindingPresent("A.java", "first();\nthird();"));
+    assertFalse(resolver.isFindingPresent("A.java", "second();"));
   }
 
   @Test
@@ -432,7 +433,7 @@ class DiffLineResolverTest {
     var resolver =
         new DiffLineResolver(Map.of("dir/Main.java", deletionOnly, "src/dir/Main.java", PATCH));
 
-    assertTrue(resolver.isFindingPresent("dir/Main.java", 999, "new_line()", 3));
+    assertTrue(resolver.isFindingPresent("dir/Main.java", "new_line()"));
   }
 
   @Test
@@ -455,7 +456,7 @@ class DiffLineResolverTest {
         new DiffLineResolver(
             Map.of("dir/Helper.java", exactChangedAway, "src/dir/Helper.java", variantStillHasIt));
 
-    assertFalse(resolver.isFindingPresent("dir/Helper.java", 1, "dangerous_call()", 3));
+    assertFalse(resolver.isFindingPresent("dir/Helper.java", "dangerous_call()"));
   }
 
   @Test
@@ -485,8 +486,8 @@ class DiffLineResolverTest {
         new DiffLineResolver(
             Map.of("a/util/Helper.java", withoutAnchor, "b/util/Helper.java", withAnchor));
 
-    assertTrue(anchorInA.isFindingPresent("util/Helper.java", 1, "dangerous_call()", 3));
-    assertTrue(anchorInB.isFindingPresent("util/Helper.java", 1, "dangerous_call()", 3));
+    assertTrue(anchorInA.isFindingPresent("util/Helper.java", "dangerous_call()"));
+    assertTrue(anchorInB.isFindingPresent("util/Helper.java", "dangerous_call()"));
   }
 
   @Test
@@ -502,7 +503,7 @@ class DiffLineResolverTest {
         new DiffLineResolver(
             Map.of("a/util/Helper.java", withoutAnchor, "b/util/Helper.java", withoutAnchor));
 
-    assertFalse(resolver.isFindingPresent("util/Helper.java", 1, "dangerous_call()", 3));
+    assertFalse(resolver.isFindingPresent("util/Helper.java", "dangerous_call()"));
   }
 
   @Test
@@ -541,7 +542,7 @@ class DiffLineResolverTest {
         """;
     var resolver = new DiffLineResolver(Map.of("a/util/Helper.java", deletionOnly));
 
-    assertFalse(resolver.isFindingPresent("util/Helper.java", 1, "dangerous_call()", 3));
+    assertFalse(resolver.isFindingPresent("util/Helper.java", "dangerous_call()"));
   }
 
   @Test
@@ -552,7 +553,7 @@ class DiffLineResolverTest {
     // bind here would falsely hold or clear approval.
     var resolver = new DiffLineResolver(Map.of("src/B.java", PATCH));
 
-    assertFalse(resolver.isFindingPresent("B.java", 1, "new_line()", 3));
+    assertFalse(resolver.isFindingPresent("B.java", "new_line()"));
     assertFalse(resolver.isLineInDiff("B.java", 11, 3));
   }
 
@@ -636,5 +637,48 @@ class DiffLineResolverTest {
         new DiffLineResolver(Map.of("dir/F.java", deletionOnly, "src/dir/F.java", PATCH));
 
     assertEquals(OptionalInt.of(11), resolver.resolveRightSideLine("dir/F.java", 11));
+  }
+
+  @Test
+  void shouldReturnLineTextFromPatch() {
+    var resolver = new DiffLineResolver(Map.of("main.py", PATCH));
+
+    assertEquals("def unchanged():", resolver.getLineText("main.py", 10));
+    assertEquals("    new_line()", resolver.getLineText("main.py", 11));
+    assertEquals("    added_line()", resolver.getLineText("main.py", 12));
+    assertNull(resolver.getLineText("main.py", 9));
+    assertNull(resolver.getLineText("main.py", 0));
+    assertNull(resolver.getLineText("main.py", -5));
+    assertNull(resolver.getLineText("other.py", 11));
+    assertNull(resolver.getLineText(null, 11));
+  }
+
+  @Test
+  void shouldReturnLineTextAcrossPathVariants() {
+    var deletionOnly =
+        """
+        @@ -1,2 +1,0 @@
+        -dangerous_call()
+        -also_removed()
+        """;
+    var resolver =
+        new DiffLineResolver(Map.of("dir/Main.java", deletionOnly, "src/dir/Main.java", PATCH));
+
+    // 1. Exact match exists but is empty (deletion-only) -> falls back to variant and resolves line
+    assertEquals("    new_line()", resolver.getLineText("dir/Main.java", 11));
+
+    // 2. Bare filename does not bind to directory variant (requires directory segment)
+    assertNull(resolver.getLineText("Main.java", 11));
+
+    // 3. Suffix variant with directory segment matches and resolves line
+    var resolverSuffix =
+        new DiffLineResolver(Map.of("a/dir/Main.java", deletionOnly, "b/dir/Main.java", PATCH));
+    assertEquals("    new_line()", resolverSuffix.getLineText("dir/Main.java", 11));
+
+    // 4. Both exact match and variants are empty (or no matching variant has the line) -> returns
+    // null
+    var emptyResolver = new DiffLineResolver(Map.of("dir/Main.java", deletionOnly));
+    assertNull(emptyResolver.getLineText("dir/Main.java", 11));
+    assertNull(emptyResolver.getLineText("Main.java", 11));
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2450,6 +2450,106 @@ class ReviewOrchestratorTest {
     }
   }
 
+  @Nested
+  class PopulateMissingAnchors {
+
+    @Test
+    void shouldPopulateMissingAnchorsFromDiff() {
+      var patch =
+          """
+          @@ -10,3 +10,4 @@
+           def unchanged():
+          -    old_line()
+          +    new_line()
+          +    added_line()
+          """;
+      var lineResolver = new DiffLineResolver(Map.of("main.py", patch));
+      var findingWithAnchor =
+          new ReviewResponse.Finding(
+              "high", "high", "main.py", 11, "Title", "Desc", "existing_anchor", "new_line()");
+      var findingWithoutAnchor =
+          new ReviewResponse.Finding(
+              "high", "high", "main.py", 11, "Title", "Desc", null, "new_line()");
+      var findingOnContextLine =
+          new ReviewResponse.Finding(
+              "high", "high", "main.py", 10, "Title", "Desc", "   ", "new_line()");
+      var findingOutsideDiff =
+          new ReviewResponse.Finding(
+              "high", "high", "main.py", 99, "Title", "Desc", null, "new_line()");
+
+      var response =
+          new ReviewResponse(
+              List.of(
+                  findingWithAnchor,
+                  findingWithoutAnchor,
+                  findingOnContextLine,
+                  findingOutsideDiff),
+              List.of(),
+              null);
+
+      var updated = orchestrator.populateMissingAnchors(response, lineResolver);
+
+      assertEquals(4, updated.findings().size());
+
+      // 1. Finding with existing anchor is left unchanged
+      assertEquals("existing_anchor", updated.findings().get(0).suggestionOld());
+
+      // 2. Finding without anchor is populated from diff
+      assertEquals("    new_line()", updated.findings().get(1).suggestionOld());
+
+      // 3. Finding on context line is populated from diff
+      assertEquals("def unchanged():", updated.findings().get(2).suggestionOld());
+
+      // 4. Finding outside diff has no anchor and is left null
+      assertNull(updated.findings().get(3).suggestionOld());
+    }
+
+    @Test
+    void shouldReturnOriginalResponseWhenFindingsIsEmpty() {
+      var lineResolver = new DiffLineResolver(Map.of());
+      var response = new ReviewResponse(List.of(), List.of(), null);
+      var updated = orchestrator.populateMissingAnchors(response, lineResolver);
+      assertSame(response, updated);
+    }
+
+    @Test
+    void shouldNotPopulateWhenSuggestionOldIsNotBlank() {
+      var patch =
+          """
+          @@ -10,3 +10,4 @@
+           def unchanged():
+          -    old_line()
+          +    new_line()
+          +    added_line()
+          """;
+      var lineResolver = new DiffLineResolver(Map.of("main.py", patch));
+      var finding =
+          new ReviewResponse.Finding(
+              "high", "high", "main.py", 11, "Title", "Desc", "  anchor  ", "new_line()");
+      var response = new ReviewResponse(List.of(finding), List.of(), null);
+      var updated = orchestrator.populateMissingAnchors(response, lineResolver);
+      assertSame(response, updated);
+    }
+
+    @Test
+    void shouldNotPopulateWhenFallbackIsBlank() {
+      var patch =
+          """
+          @@ -1,3 +1,3 @@
+          +first()
+          +
+          +third()
+          """;
+      var lineResolver = new DiffLineResolver(Map.of("main.py", patch));
+      var finding =
+          new ReviewResponse.Finding(
+              "high", "high", "main.py", 2, "Title", "Desc", null, "new_line()");
+      var response = new ReviewResponse(List.of(finding), List.of(), null);
+      var updated = orchestrator.populateMissingAnchors(response, lineResolver);
+      assertSame(response, updated);
+    }
+  }
+
   // ─────────────────────────────────────────────────────────────
   // resolveMissingPrDetails
   // ─────────────────────────────────────────────────────────────
@@ -2886,6 +2986,16 @@ class ReviewOrchestratorTest {
             .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
             .thenReturn(session);
         delegateStatusGate();
+        when(reviewClient.listPullRequestComments(
+                anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(
+                List.of(
+                    new GitHubReviewClient.PullRequestComment(
+                        1L,
+                        null,
+                        "src/Main.java",
+                        "body",
+                        new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]"))));
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
         when(followUpAnalyzer.buildPreviousFindingsContext(


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

<!-- A clear and concise description of what this PR does and why. -->

PR #139 replaced the #118 approve backstop's raw `±tolerance` line-presence proxy with **content-anchor** matching: `DiffLineResolver.isFindingPresent` matches a prior finding's persisted `suggestion_old` as a contiguous run on the diff's right side, which is immune to line drift. But that only applies when the finding **has** an anchor. When `suggestion_old` is null/blank — a suggestion-less finding, or one whose suggestion `FindingQuoteValidator` stripped on demotion — `isFindingPresent` fell back to `DiffLineResolver.isLineInDiff`, the same raw line-membership proxy #129 set out to retire.

This PR resolves the anchorless backstop holes:
1. **Content Anchor Population**: We construct `DiffLineResolver` earlier and extract a fallback content anchor (the right-side line text from the diff) for any finding that does not have a `suggestion_old` before persisting the AI response.
2. **Conservative Fallback**: We update the anchorless fallback in `DiffLineResolver.isFindingPresent` to lean toward holding (returning `true` if the file has any changes in the diff) instead of using the drift-fragile `isLineInDiff` check.
3. Updated Javadoc comments in `DiffLineResolver` to match the new behavior.

## Related Issues

<!--
Link any related issues. Use "Fixes #<number>" to auto-close on merge.
If there is no associated issue, write "N/A".
-->

Fixes #140

## How Has This Been Tested?

<!--
Describe the tests you ran to verify your changes.
Provide instructions so reviewers can reproduce.
-->

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Added unit tests in `ReviewOrchestratorTest` verifying that `suggestionOld` is populated from the diff for findings that lack it.
Added unit tests in `DiffLineResolverTest` verifying the new fallback behavior and the retrieval of line text.
Full test suite passes locally: `./mvnw test`
Quality checks pass locally: `spotless:check` and `spotbugs:check`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

<!-- If applicable, add screenshots or log output to help explain your changes. -->

N/A

## Additional Notes

<!-- Any additional context, deployment notes, or breaking changes. -->

No breaking changes.
