### PR TITLE
fix(review): decouple first-review UX from persistence context (#134)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -215,14 +215,19 @@ public class ReviewOrchestrator {
           buildBaseComparison(auth, req.owner(), req.repo(), req.baseSha(), req.commitSha());
 
       var priorReviews = fetchPriorReviews(auth, req.owner(), req.repo(), req.prNumber());
-      // First-review detection consults the persisted prior responses, not just formal GitHub
-      // reviews: every completed round persists its AI response keyed by repo+PR (surviving a
-      // force-push/rebase), so the previous-findings context is reconstructed for every follow-up
-      // round even on the rare path where no formal review was emitted. (#118)
+      // Two independent flags decouple UX presentation from context loading (#134):
+      //  • isFirstVisibleReview — true when no bot-authored review exists on the PR.
+      //    Gates the first-review summary issue-comment and the APPROVE celebration body.
+      //  • hasContext — true when persistence holds prior AI responses (surviving force-push/
+      //    rebase). Gates previous-findings context loading, inline comment fetching, and the
+      //    deterministic backstop. A persisted-but-unreviewed prior round (e.g. createReview
+      //    failed after persistAiResponse) must still reconstruct context without suppressing
+      //    the first user-visible summary. (#118, #134)
       List<String> priorAiResponseJsons =
           sessionPersistence.findAllPriorAiResponseJsons(repository, req.prNumber(), session.id);
-      var hasBotReview = priorReviews.stream().anyMatch(r -> BOT_LOGIN.equals(r.user().login()));
-      var isFirstReview = !hasBotReview && priorAiResponseJsons.isEmpty();
+      var isFirstVisibleReview =
+          priorReviews.stream().noneMatch(r -> BOT_LOGIN.equals(r.user().login()));
+      var hasContext = !priorAiResponseJsons.isEmpty();
       String previousAiResponseJson =
           priorAiResponseJsons.isEmpty() ? null : priorAiResponseJsons.get(0);
       List<String> olderAiResponseJsons =
@@ -230,18 +235,18 @@ public class ReviewOrchestrator {
               ? priorAiResponseJsons.subList(1, priorAiResponseJsons.size())
               : List.of();
       List<GitHubReviewClient.PullRequestComment> inlineComments =
-          isFirstReview
-              ? List.of()
-              : fetchPullRequestComments(auth, req.owner(), req.repo(), req.prNumber());
+          hasContext
+              ? fetchPullRequestComments(auth, req.owner(), req.repo(), req.prNumber())
+              : List.of();
       String previousFindings =
-          isFirstReview
-              ? ""
-              : followUpAnalyzer.buildPreviousFindingsContext(
+          hasContext
+              ? followUpAnalyzer.buildPreviousFindingsContext(
                   previousAiResponseJson,
                   priorReviews,
                   inlineComments,
                   olderAiResponseJsons,
-                  BOT_LOGIN);
+                  BOT_LOGIN)
+              : "";
 
       var instructions =
           instructionsResolver.resolve(
@@ -290,18 +295,18 @@ public class ReviewOrchestrator {
       // statuses, so an APPROVE can never sail over them. Spans every prior round, not just the
       // newest, so a finding dropped rounds after it was raised is still caught. (#118, #130)
       var backstopUnresolved =
-          isFirstReview
-              ? List.<ReviewResult.PreviousFindingStatus>of()
-              : followUpAnalyzer.unreportedUnresolvedStatuses(
+          hasContext
+              ? followUpAnalyzer.unreportedUnresolvedStatuses(
                   priorAiResponseJsons,
                   aiResponse.previousFindingsStatus(),
                   inlineComments,
                   new DiffLineResolver(patchesByFile(files)),
-                  BOT_LOGIN);
+                  BOT_LOGIN)
+              : List.<ReviewResult.PreviousFindingStatus>of();
       var result =
           buildResult(
               aiResponse,
-              isFirstReview,
+              isFirstVisibleReview,
               diffStats,
               unresolvedPrevious,
               offendingCiChecks,
@@ -325,7 +330,7 @@ public class ReviewOrchestrator {
 
       // Summary goes first so it tops the PR conversation, before the inline finding comments.
       // Posted on clean first reviews too: the celebration line lives inside the summary
-      if (isFirstReview && !result.summaryMarkdown().isBlank()) {
+      if (isFirstVisibleReview && !result.summaryMarkdown().isBlank()) {
         commentClient.createComment(
             auth,
             ACCEPT,

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2912,14 +2912,14 @@ class ReviewOrchestratorTest {
     }
 
     @Test
-    void shouldTreatAsFollowUpWhenPersistenceHasPriorResponsesDespiteNoBotReview() {
+    void shouldLoadContextFromPersistenceEvenWithoutBotReview() {
       try (var mockedStatic = mockStatic(ReviewSession.class)) {
         var session = followUpSession();
         mockedStatic
             .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
             .thenReturn(session);
         // No formal bot review exists (listReviews defaults to empty), but a prior round persisted
-        // its findings — the review must still be treated as a follow-up. (#118 fix #1)
+        // its findings — context must still be reconstructed for follow-up analysis. (#118)
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
         when(followUpAnalyzer.buildPreviousFindingsContext(
@@ -2930,12 +2930,45 @@ class ReviewOrchestratorTest {
 
         orchestrator.review(followUpRequest());
 
-        // Previous-findings context IS reconstructed without any formal bot review...
+        // Previous-findings context IS reconstructed without any formal bot review
         verify(followUpAnalyzer)
             .buildPreviousFindingsContext(any(), any(), any(), any(), eq("thrillhousebot[bot]"));
-        // ...and the first-review summary issue-comment is NOT posted.
-        verify(commentClient, never())
-            .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+      }
+    }
+
+    @Test
+    void shouldPostSummaryOnPersistedButUnreviewedPr() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = followUpSession();
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+        // No formal bot review exists, but persistence holds a prior round's AI response.
+        // The summary must still be posted: isFirstVisibleReview is true. (#134)
+        when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
+            .thenReturn(List.of(PRIOR_FINDING_JSON));
+        when(followUpAnalyzer.buildPreviousFindingsContext(
+                any(), any(), any(), any(), eq("thrillhousebot[bot]")))
+            .thenReturn("previous context");
+        when(aiReviewService.review(any(ReviewSession.class), any()))
+            .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+        when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any()))
+            .thenReturn("ThrillhouseBot PR Summary\n\nAll clear!");
+
+        orchestrator.review(followUpRequest());
+
+        // Summary IS posted because no bot review exists on the PR (first visible review)
+        verify(commentClient)
+            .createComment(
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyInt(),
+                argThat(req -> req.body().contains("ThrillhouseBot PR Summary")));
+        // Context IS still loaded from persistence
+        verify(followUpAnalyzer)
+            .buildPreviousFindingsContext(any(), any(), any(), any(), eq("thrillhousebot[bot]"));
       }
     }
 


### PR DESCRIPTION
## Summary
- Separates `isFirstReview` into two independent flags:
  - `isFirstVisibleReview`: true when no bot-authored review exists on the PR. Gates the first-review summary comment and celebration body.
  - `hasContext`: true when persistence holds prior AI responses. Gates context loading, inline comment fetching, and the deterministic backstop.
- Fixes the bug where a persisted-but-unreviewed prior round (e.g. `createReview` failed after `persistAiResponse` succeeded) suppresses the first user-visible summary and celebration comment.

## Issue
Fixes #134

## Test plan
- Added/updated unit tests in `ReviewOrchestratorTest.java` to verify:
  - Context is still loaded from persistence even without a bot review on the PR.
  - Summary is correctly posted on a persisted-but-unreviewed PR.
- Ran `./mvnw spotless:apply spotless:check spotbugs:check verify` successfully.
