### PR TITLE
fix(review): resolveRightSideLine honors path-variants consistently (#144)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -168,6 +168,37 @@ public final class DiffLineResolver {
     return false;
   }
 
+  /**
+   * Resolves the {@code file} key to its non-empty exact value or, failing that, to the unique
+   * non-empty {@link FilePaths#same} variant value.
+   *
+   * <p>A non-empty exact entry is authoritative and is returned immediately. The variant fallback
+   * runs when the exact entry is absent or empty. If multiple different variant keys match, it
+   * returns {@code null} to avoid making a comment placement on the wrong file on genuine
+   * ambiguity.
+   */
+  private static <V extends Collection<?>> V resolveForFileOrVariant(
+      Map<String, V> byFile, String file) {
+    V exact = byFile.get(file);
+    if (exact != null && !exact.isEmpty()) {
+      return exact;
+    }
+    V resolved = null;
+    for (var entry : byFile.entrySet()) {
+      V value = entry.getValue();
+      if (!entry.getKey().equals(file)
+          && !value.isEmpty()
+          && FilePaths.same(file, entry.getKey())) {
+        if (resolved != null) {
+          // Genuine ambiguity (two suffix-colliding diff keys) - return null rather than guess
+          return null;
+        }
+        resolved = value;
+      }
+    }
+    return resolved;
+  }
+
   /** Trimmed, non-blank lines of an anchor (a finding's {@code suggestion_old}). */
   private static List<String> normalizedAnchorLines(String anchor) {
     if (anchor == null || anchor.isBlank()) {
@@ -188,7 +219,7 @@ public final class DiffLineResolver {
     if (file == null || requestedLine <= 0) {
       return OptionalInt.empty();
     }
-    TreeSet<Integer> lines = rightSideLinesByFile.get(file);
+    TreeSet<Integer> lines = resolveForFileOrVariant(rightSideLinesByFile, file);
     if (lines == null || lines.isEmpty()) {
       return OptionalInt.empty();
     }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
@@ -581,4 +581,60 @@ class DiffLineResolverTest {
     // Sanity: the exact entry's own line still resolves.
     assertTrue(resolver.isLineInDiff("dir/F.java", 20, 3));
   }
+
+  @Test
+  void resolveRightSideLineShouldMatchAcrossPathVariants() {
+    var resolver = new DiffLineResolver(Map.of("src/dir/F.java", PATCH));
+    assertEquals(OptionalInt.of(11), resolver.resolveRightSideLine("dir/F.java", 11));
+  }
+
+  @Test
+  void resolveRightSideLineTreatsNonEmptyExactMatchAsAuthoritativeOverVariant() {
+    var exactAtLine20 =
+        """
+        @@ -1,1 +20,1 @@
+        +twenty
+        """;
+    var variantAtLine50 =
+        """
+        @@ -1,1 +50,1 @@
+        +fifty
+        """;
+    var resolver =
+        new DiffLineResolver(
+            Map.of("dir/F.java", exactAtLine20, "src/dir/F.java", variantAtLine50));
+
+    assertEquals(OptionalInt.of(20), resolver.resolveRightSideLine("dir/F.java", 50));
+  }
+
+  @Test
+  void resolveRightSideLineReturnsEmptyOnAmbiguity() {
+    var aVariant =
+        """
+        @@ -1,1 +20,1 @@
+        +twenty
+        """;
+    var bVariant =
+        """
+        @@ -1,1 +50,1 @@
+        +fifty
+        """;
+    var resolver = new DiffLineResolver(Map.of("a/dir/F.java", aVariant, "b/dir/F.java", bVariant));
+
+    assertTrue(resolver.resolveRightSideLine("dir/F.java", 20).isEmpty());
+  }
+
+  @Test
+  void resolveRightSideLineFallsBackToVariantWhenExactEntryIsEmpty() {
+    var deletionOnly =
+        """
+        @@ -10,2 +10,0 @@
+        -removed_one
+        -removed_two
+        """;
+    var resolver =
+        new DiffLineResolver(Map.of("dir/F.java", deletionOnly, "src/dir/F.java", PATCH));
+
+    assertEquals(OptionalInt.of(11), resolver.resolveRightSideLine("dir/F.java", 11));
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] ✅ Test

## Description

Updated `DiffLineResolver.resolveRightSideLine` to honor path variants when resolving AI-reported lines to commentable right-side lines. Added a helper method `resolveForFileOrVariant` that performs this lookup, falling back to a unique `FilePaths.same` variant if the exact match is absent or empty (e.g. deletion-only patch), and returns empty on genuine ambiguity (2+ matching variants) to prevent wrong-file comment placement.

## Related Issues

Fixes #144

## How Has This Been Tested?

Ran unit tests and verified code coverage locally.

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Local verification run `./mvnw spotless:apply verify` passed:
```
[INFO] Results:
[INFO] 
[INFO] Tests run: 967, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] All coverage checks have been met.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```

## Additional Notes

None.