### PR TITLE
chore(release): prep v0.1.1 and clear SonarCloud code smells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,36 @@
 
 All notable changes to ThrillhouseBot.
 
-## [0.1.1] — unreleased
+## [0.1.1] — 2026-06-16
+
+### Added
+
+- **Webhook de-duplication**: redelivered webhook events are ignored within a configurable TTL (`WEBHOOK_DEDUP_TTL`), so GitHub redeliveries no longer trigger a second review of the same event (#20)
+- **CI-aware approval gating**: the bot no longer posts a green approval while a PR's required checks are red or still pending — it waits for CI before approving. Requires the new `actions: read` GitHub App permission (#95)
 
 ### Changed
 
-- **CI**: consolidated the seven duplicated Trivy scan + SARIF-upload steps across `ci.yml`, `release.yml`, and `security-scan.yml` into a single `.github/actions/trivy-scan` composite action, centralizing the pinned action SHA, Trivy version, `format: sarif`, and the `limit-severities-for-sarif` flag. The CI filesystem scan now applies `limit-severities-for-sarif` like every other scan (closes the gap tracked in #76).
-- **GitHub App Permissions**: Added `actions: read` permission to `manifest.json` (and documented in `README.md`). This is required to read GitHub Actions workflow runs and check suite statuses to evaluate CI status for PR approval gating (introduced in PR #95).
+- **CI**: consolidated the seven duplicated Trivy scan + SARIF-upload steps across `ci.yml`, `release.yml`, and `security-scan.yml` into a single `.github/actions/trivy-scan` composite action, centralizing the pinned action SHA, Trivy version, `format: sarif`, and the `limit-severities-for-sarif` flag. The filesystem and image scans now apply `limit-severities-for-sarif` like every other scan (#12, #76, #82)
+- **GitHub App permissions**: added `actions: read` to `manifest.json` (and documented in `README.md`), required to read workflow runs and check-suite status for CI-aware approval gating (#95)
+- **Observability**: traces and metrics report the actually-configured AI provider instead of a hardcoded `deepseek` (#19)
+
+### Fixed
+
+- **Follow-up review tracking**: previous-findings tracking now survives a force-push or rebase. Findings are matched by their persisted code anchor rather than a raw line number, so still-open findings are no longer silently dropped or re-raised under a drifted severity, and the approve backstop replays every prior round (not just the newest), judges presence by content, handles unrecognized statuses, resolves path variants, and clears holds on a maintainer reply even for thread-less or null-title findings (#118, #129, #130, #131, #132, #133, #140, #143)
+- **First-review summary**: a PR that was persisted but never reviewed still receives its first-run summary comment; first-review UX no longer keys off persistence state (#134)
+- **Finding quote validation**: fabricated code quoted in a finding's _description_ is now caught (not just `suggestion_old`); the chained-call citation matcher spans nested parentheses; and the matcher tolerates wrapped lines, Unicode whitespace, and intra-literal spacing — so fewer real findings are demoted and fewer phantom citations slip through (#98, #106, #120, #121, #122)
+- **Diff truncation**: oversized diffs are no longer cut mid-hunk in a way that dropped the closing code fence (#21)
+- **Webhook delivery**: a dispatch failure no longer burns the dedup slot, so a manual redelivery is processed instead of being silently dropped (#89)
+
+### Security
+
+- **Manual triggers**: manual `/review` triggers are restricted to authorized logins (`manual-trigger-allowed-logins`) (#70)
+- **Dashboard access control**: the dashboard fails closed when the GitHub App owner cannot be resolved; installation and repository access checks now paginate, so access is no longer mis-decided past the first page; and the repo-snapshot cache is no longer reused across a changed account owner (#17, #18, #91)
+
+### Documentation
+
+- Documented the new v0.1.1 configuration keys (`WEBHOOK_DEDUP_TTL`, `manual-trigger-allowed-logins`) (#94)
+- Corrected the dashboard access section of the `README.md`, which still described the removed fail-open behavior (#90)
 
 ## [0.1.0] — 2026-06-12
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>dev.thiagogonzaga.thrillhousebot</groupId>
     <artifactId>thrillhousebot</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.1.1</version>
 
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -191,34 +191,34 @@ public final class DiffLineResolver {
   }
 
   /**
-   * Resolves the {@code file} key to its non-empty exact value or, failing that, to the unique
-   * non-empty {@link FilePaths#same} variant value.
+   * Resolves {@code file} to its non-empty exact right-side line set or, failing that, to the
+   * unique non-empty {@link FilePaths#same} variant set.
    *
    * <p>A non-empty exact entry is authoritative and is returned immediately. The variant fallback
-   * runs when the exact entry is absent or empty. If multiple different variant keys match, it
-   * returns {@code null} to avoid making a comment placement on the wrong file on genuine
-   * ambiguity.
+   * runs when the exact entry is absent or empty. If multiple different variant keys match, an
+   * empty set is returned to avoid placing a comment on the wrong file on genuine ambiguity — the
+   * caller treats empty exactly as "no resolvable line", the safe direction. The result is never
+   * {@code null}.
    */
-  private static <V extends Collection<?>> V resolveForFileOrVariant(
-      Map<String, V> byFile, String file) {
-    V exact = byFile.get(file);
+  private TreeSet<Integer> resolveRightSideLinesForFileOrVariant(String file) {
+    TreeSet<Integer> exact = rightSideLinesByFile.get(file);
     if (exact != null && !exact.isEmpty()) {
       return exact;
     }
-    V resolved = null;
-    for (var entry : byFile.entrySet()) {
-      V value = entry.getValue();
+    TreeSet<Integer> resolved = null;
+    for (var entry : rightSideLinesByFile.entrySet()) {
+      TreeSet<Integer> value = entry.getValue();
       if (!entry.getKey().equals(file)
           && !value.isEmpty()
           && FilePaths.same(file, entry.getKey())) {
         if (resolved != null) {
-          // Genuine ambiguity (two suffix-colliding diff keys) - return null rather than guess
-          return null;
+          // Genuine ambiguity (two suffix-colliding diff keys) - empty rather than guess.
+          return new TreeSet<>();
         }
         resolved = value;
       }
     }
-    return resolved;
+    return resolved != null ? resolved : new TreeSet<>();
   }
 
   /** Trimmed, non-blank lines of an anchor (a finding's {@code suggestion_old}). */
@@ -241,8 +241,8 @@ public final class DiffLineResolver {
     if (file == null || requestedLine <= 0) {
       return OptionalInt.empty();
     }
-    TreeSet<Integer> lines = resolveForFileOrVariant(rightSideLinesByFile, file);
-    if (lines == null || lines.isEmpty()) {
+    TreeSet<Integer> lines = resolveRightSideLinesForFileOrVariant(file);
+    if (lines.isEmpty()) {
       return OptionalInt.empty();
     }
     if (lines.contains(requestedLine)) {
@@ -295,27 +295,53 @@ public final class DiffLineResolver {
     var newLine = 0;
     var inHunk = false;
     for (String rawLine : PromptTemplateEscaper.neutralizeMarkers(patch).split("\n", -1)) {
-      if (rawLine.startsWith("@@")) {
-        var matcher = HUNK_HEADER.matcher(rawLine);
-        if (matcher.find()) {
-          newLine = Integer.parseInt(matcher.group(1));
-          inHunk = true;
-        }
+      OptionalInt hunkStart = hunkStart(rawLine);
+      if (hunkStart.isPresent()) {
+        newLine = hunkStart.getAsInt();
+        inHunk = true;
         continue;
       }
-      if (inHunk && !rawLine.isEmpty()) {
-        var marker = rawLine.charAt(0);
-        if (marker == '+' || marker == ' ') {
-          lines.add(newLine);
-          String stripped = rawLine.substring(1).strip();
-          if (!stripped.isEmpty()) {
-            text.add(stripped);
-          }
-          lineText.put(newLine, rawLine.substring(1));
-          newLine++;
-        }
+      if (inHunk && isRightSideLine(rawLine)) {
+        appendRightSide(lines, text, lineText, newLine, rawLine);
+        newLine++;
       }
     }
     return new RightSide(lines, text, lineText);
+  }
+
+  /** The 1-based right-side start line of a hunk header, or empty if the line is not one. */
+  private static OptionalInt hunkStart(String rawLine) {
+    if (!rawLine.startsWith("@@")) {
+      return OptionalInt.empty();
+    }
+    var matcher = HUNK_HEADER.matcher(rawLine);
+    return matcher.find()
+        ? OptionalInt.of(Integer.parseInt(matcher.group(1)))
+        : OptionalInt.empty();
+  }
+
+  /** Whether the line exists on the diff's right side — an addition or a surviving context line. */
+  private static boolean isRightSideLine(String rawLine) {
+    if (rawLine.isEmpty()) {
+      return false;
+    }
+    var marker = rawLine.charAt(0);
+    return marker == '+' || marker == ' ';
+  }
+
+  /** Records one right-side line under {@code newLine}: its number, trimmed text, and raw text. */
+  private static void appendRightSide(
+      TreeSet<Integer> lines,
+      List<String> text,
+      Map<Integer, String> lineText,
+      int newLine,
+      String rawLine) {
+    lines.add(newLine);
+    String content = rawLine.substring(1);
+    String stripped = content.strip();
+    if (!stripped.isEmpty()) {
+      text.add(stripped);
+    }
+    lineText.put(newLine, content);
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -609,14 +609,33 @@ public class FollowUpAnalyzer {
     if (priorAiResponseJsons == null || priorAiResponseJsons.isEmpty() || lineResolver == null) {
       return List.of();
     }
-    // Persisted newest-first; replay oldest → newest so each round's previous_findings_status
-    // (which reports on the round immediately before it) can close the findings it addressed.
+    var chrono = toChronological(priorAiResponseJsons);
+    var open = openFindingsAcrossRounds(chrono, currentStatuses);
+    var clusters = clusterByIdentity(open);
+    return heldFromClusters(clusters, inlineComments, lineResolver, botLogin);
+  }
+
+  /**
+   * Parses the persisted (newest-first) responses into oldest → newest order, so each round's
+   * {@code previous_findings_status} (which reports on the round immediately before it) can close
+   * the findings it addressed.
+   */
+  private List<ReviewResponse> toChronological(List<String> priorAiResponseJsons) {
     var chrono = new ArrayList<ReviewResponse>();
     for (var i = priorAiResponseJsons.size() - 1; i >= 0; i--) {
       chrono.add(parseResponse(priorAiResponseJsons.get(i)));
     }
-    // Still-open prior findings keyed by content, so a finding carried across rounds is held at
-    // most once; insertion order is preserved for stable, deterministic output.
+    return chrono;
+  }
+
+  /**
+   * The still-open prior findings keyed by content (a finding carried across rounds is held at most
+   * once; insertion order is preserved for stable, deterministic output). Each round closes what
+   * the next round's status addressed, and {@code currentStatuses} — which reports on the newest
+   * prior round — drops everything the current round accounted for.
+   */
+  private Map<String, OpenFinding> openFindingsAcrossRounds(
+      List<ReviewResponse> chrono, List<ReviewResponse.PreviousFindingStatus> currentStatuses) {
     var open = new LinkedHashMap<String, OpenFinding>();
     for (var i = 0; i < chrono.size(); i++) {
       if (i > 0) {
@@ -624,10 +643,12 @@ public class FollowUpAnalyzer {
       }
       addOpenFindings(open, chrono.get(i).findings());
     }
-    // The current round reports on the newest prior round — drop everything it accounted for.
     closeReported(open, chrono.get(chrono.size() - 1).findings(), currentStatuses);
+    return open;
+  }
 
-    // Cluster the remaining open findings by tolerant identity.
+  /** Groups the open findings into clusters of tolerant ({@link #isSameFinding}) identity. */
+  private static List<List<OpenFinding>> clusterByIdentity(Map<String, OpenFinding> open) {
     var clusters = new ArrayList<List<OpenFinding>>();
     for (var openFinding : open.values()) {
       List<OpenFinding> home = null;
@@ -644,28 +665,19 @@ public class FollowUpAnalyzer {
       }
       home.add(openFinding);
     }
+    return clusters;
+  }
 
+  /** Holds one unresolved status per cluster whose code is still present and unanswered. */
+  private List<ReviewResult.PreviousFindingStatus> heldFromClusters(
+      List<List<OpenFinding>> clusters,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      DiffLineResolver lineResolver,
+      String botLogin) {
     var held = new ArrayList<ReviewResult.PreviousFindingStatus>();
     for (var cluster : clusters) {
-      boolean anyReplied = false;
-      OpenFinding target = null;
-
-      for (var member : cluster) {
-        var finding = member.finding();
-        boolean present = lineResolver.isFindingPresent(finding.file(), finding.suggestionOld());
-        if (present && target == null) {
-          target = member;
-        }
-        // The maintainer reply is located by the round-relative marker (member.id()) plus the
-        // finding's own content rather than by title, so a null-title finding's thread is still
-        // seen and a thread-less finding cannot bind to a different finding that reused the same
-        // marker index in another round (#133).
-        if (answeredRootComment(finding, member.id(), inlineComments, botLogin) != null) {
-          anyReplied = true;
-        }
-      }
-
-      if (target != null && !anyReplied) {
+      OpenFinding target = holdableTarget(cluster, inlineComments, lineResolver, botLogin);
+      if (target != null) {
         held.add(
             new ReviewResult.PreviousFindingStatus(
                 target.id(),
@@ -674,6 +686,33 @@ public class FollowUpAnalyzer {
       }
     }
     return held;
+  }
+
+  /**
+   * The first still-present member of the cluster to hold, or {@code null} when its code is gone or
+   * a maintainer has replied on it. The reply is located by the round-relative marker ({@link
+   * OpenFinding#id()}) plus the finding's own content rather than by title, so a null-title
+   * finding's thread is still seen and a thread-less finding cannot bind to a different finding
+   * that reused the same marker index in another round (#133).
+   */
+  private OpenFinding holdableTarget(
+      List<OpenFinding> cluster,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      DiffLineResolver lineResolver,
+      String botLogin) {
+    OpenFinding target = null;
+    boolean anyReplied = false;
+    for (var member : cluster) {
+      var finding = member.finding();
+      if (target == null
+          && lineResolver.isFindingPresent(finding.file(), finding.suggestionOld())) {
+        target = member;
+      }
+      if (answeredRootComment(finding, member.id(), inlineComments, botLogin) != null) {
+        anyReplied = true;
+      }
+    }
+    return anyReplied ? null : target;
   }
 
   /** A still-open prior finding and the 1-based id it carried within the round that raised it. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
@@ -16,10 +16,15 @@
 package dev.thiagogonzaga.thrillhousebot.review;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class DiffLineResolverTest {
 
@@ -290,53 +295,56 @@ class DiffLineResolverTest {
     assertFalse(resolver.isFindingPresent("A.java", "validate(x);\npersist(x);"));
   }
 
-  @Test
-  void isFindingPresentShouldLeanTowardHoldingForARecurringSingleLineAnchor() {
-    // Accepted residual: a generic single-line anchor that recurs verbatim reads as present even
-    // when the flagged occurrence changed away. The stale prior-revision line cannot disambiguate
-    // it, so the downgrade-only backstop errs toward holding rather than risking the #118 drop.
-    var patch =
-        """
-        @@ -1,6 +1,6 @@
-         if (a) {
-        -  return null;
-        +  return value;
-         }
-         if (b) {
-           return null;
-         }
-        """;
-    var resolver = new DiffLineResolver(Map.of("A.java", patch));
-
-    assertTrue(resolver.isFindingPresent("A.java", "return null;"));
+  static Stream<Arguments> findingPresentByContentCases() {
+    return Stream.of(
+        // Accepted residual: a generic single-line anchor that recurs verbatim reads as present
+        // even when the flagged occurrence changed away. The stale prior-revision line cannot
+        // disambiguate it, so the downgrade-only backstop errs toward holding (the #118 drop is
+        // worse than a needless hold).
+        arguments(
+            "recurring single-line anchor leans toward holding",
+            """
+            @@ -1,6 +1,6 @@
+             if (a) {
+            -  return null;
+            +  return value;
+             }
+             if (b) {
+               return null;
+             }
+            """,
+            "return null;"),
+        // suggestion_old is quoted from the neutralized diff (<<DIFF_START>>), but the raw GitHub
+        // patch still carries the triple-bracket sentinel; the patch side must be neutralized too.
+        arguments(
+            "diff markers are neutralized before matching",
+            """
+            @@ -1,0 +1,1 @@
+            +String s = "<<<DIFF_START>>>";
+            """,
+            "String s = \"<<DIFF_START>>\";"),
+        // Blank lines in the anchor must not be required against the right-side text.
+        arguments(
+            "blank anchor lines are ignored",
+            """
+            @@ -1,2 +1,2 @@
+             alpha()
+            +beta()
+            """,
+            "alpha()\n\n   \nbeta()"));
   }
 
-  @Test
-  void isFindingPresentShouldNeutralizeDiffMarkersBeforeMatching() {
-    // suggestion_old is quoted from the neutralized diff (<<DIFF_START>>), but the raw GitHub patch
-    // still carries the triple-bracket sentinel; the patch side must be neutralized to match.
-    var patch =
-        """
-        @@ -1,0 +1,1 @@
-        +String s = "<<<DIFF_START>>>";
-        """;
+  /**
+   * A finding's anchor that survives on the diff's right side reads as present — whether the anchor
+   * is a recurring single line, carries neutralized diff markers, or contains blank lines — so the
+   * #118 approve backstop holds it.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("findingPresentByContentCases")
+  void isFindingPresentShouldMatchSurvivingAnchorContent(String name, String patch, String anchor) {
     var resolver = new DiffLineResolver(Map.of("A.java", patch));
 
-    assertTrue(resolver.isFindingPresent("A.java", "String s = \"<<DIFF_START>>\";"));
-  }
-
-  @Test
-  void isFindingPresentShouldIgnoreBlankAnchorLines() {
-    var patch =
-        """
-        @@ -1,2 +1,2 @@
-         alpha()
-        +beta()
-        """;
-    var resolver = new DiffLineResolver(Map.of("A.java", patch));
-
-    // Blank lines in the anchor must not be required against the right-side text.
-    assertTrue(resolver.isFindingPresent("A.java", "alpha()\n\n   \nbeta()"));
+    assertTrue(resolver.isFindingPresent("A.java", anchor));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -16,13 +16,18 @@
 package dev.thiagogonzaga.thrillhousebot.review;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class FollowUpAnalyzerTest {
 
@@ -854,63 +859,133 @@ class FollowUpAnalyzerTest {
         "a maintainer reply on a null-title finding's marked thread must clear the hold");
   }
 
-  @Test
-  void unreportedUnresolvedShouldStillHoldNullTitleFindingWhenThreadHasNoReply() {
-    // #133(b): the marker plus the finding's description locate the null-title finding's thread,
-    // but
-    // with no human reply on it the hold stands. Pins that the marker path clears the hold only on
-    // an actual reply, not on the mere existence of the thread.
-    var json =
-        """
-        {"findings": [
-          {"risk": "high", "file": "src/A.java", "line": 10, "title": null,
-           "description": "frees then dereferences"}
-        ]}
-        """;
-    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
-    var comments =
-        List.of(
-            comment(
-                100L,
-                null,
-                "src/A.java",
-                "**HIGH — null**\n\nfrees then dereferences\n<!-- thrillhousebot:finding=1 -->",
-                BOT));
-
-    var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
-
-    assertEquals(List.of(1), heldIds(held));
+  static Stream<Arguments> stillPresentFindingHeldCases() {
+    return Stream.of(
+        // #133(b): a null-title finding's own thread exists (marker + description locate it) but
+        // has
+        // no human reply, so the hold stands — the marker path clears only on an actual reply, not
+        // on the mere existence of the thread.
+        arguments(
+            "null-title finding, own thread but no reply",
+            """
+            {"findings": [
+              {"risk": "high", "file": "src/A.java", "line": 10, "title": null,
+               "description": "frees then dereferences"}
+            ]}
+            """,
+            List.of(
+                comment(
+                    100L,
+                    null,
+                    "src/A.java",
+                    "**HIGH — null**\n\nfrees then dereferences\n<!-- thrillhousebot:finding=1 -->",
+                    BOT))),
+        // #133 over-clear guard: the still-present null-title finding gives no title key; an
+        // EARLIER
+        // round reused marker index 1 for a DIFFERENT, answered finding. Matching the finding's own
+        // description (not the recurring marker) keeps the hold — the #118 silent
+        // approve-over-open.
+        arguments(
+            "null-title finding, earlier round reused its marker index",
+            """
+            {"findings": [
+              {"risk": "high", "file": "src/A.java", "line": 10, "title": null,
+               "description": "frees then dereferences"}
+            ]}
+            """,
+            List.of(
+                comment(
+                    100L,
+                    null,
+                    "src/A.java",
+                    "**LOW — Naming nit**\n\nrename the local for clarity\n<!-- thrillhousebot:finding=1 -->",
+                    BOT),
+                comment(101L, 100L, "src/A.java", "fine as-is", "maintainer"))),
+        // #133 over-clear guard: a thread-less finding (summary-only that round) is still present;
+        // an earlier round reused marker index 1 for a different answered finding. Requiring the
+        // marked comment to carry this finding's own title keeps the hold.
+        arguments(
+            "thread-less finding, earlier round reused its marker index",
+            """
+            {"findings": [
+              {"risk": "high", "file": "src/A.java", "line": 10, "title": "Use-after-free",
+               "description": "frees then dereferences"}
+            ]}
+            """,
+            List.of(
+                comment(
+                    100L,
+                    null,
+                    "src/A.java",
+                    "**LOW — Naming nit**\n<!-- thrillhousebot:finding=1 -->",
+                    BOT),
+                comment(101L, 100L, "src/A.java", "fine as-is", "maintainer"))),
+        // #133 dogfood: a short title ("NPE") is a substring of an earlier answered finding's title
+        // ("NPE in handler"). Header-framing anchoring (" — NPE**" != " — NPE in handler**") plus
+        // the still-present marker=1 comment block the title-only fallback, so the hold stands.
+        arguments(
+            "short title is a substring of another finding's title",
+            """
+            {"findings": [
+              {"risk": "high", "file": "src/A.java", "line": 10, "title": "NPE",
+               "description": "dereferences a value that may be null"}
+            ]}
+            """,
+            List.of(
+                comment(
+                    100L,
+                    null,
+                    "src/A.java",
+                    "**HIGH — NPE in handler**\n\nguard the handler\n<!-- thrillhousebot:finding=1 -->",
+                    BOT),
+                comment(101L, 100L, "src/A.java", "intentional", "maintainer"))),
+        // #133 no-content-key path: a blank title and no description yield no content key, so the
+        // marker alone cannot safely identify the thread; the backstop holds the still-present
+        // finding (the safe direction) rather than risk binding to a marker-index collision.
+        arguments(
+            "blank title and no description",
+            """
+            {"findings": [
+              {"risk": "high", "file": "src/A.java", "line": 10, "title": "", "description": null}
+            ]}
+            """,
+            List.of(
+                comment(
+                    100L,
+                    null,
+                    "src/A.java",
+                    "**HIGH — flagged here**\n<!-- thrillhousebot:finding=1 -->",
+                    BOT))),
+        // #133 no-content-key path: both title and description blank → no content key, so the
+        // backstop holds the still-present finding (the safe direction).
+        arguments(
+            "blank title and blank description",
+            """
+            {"findings": [
+              {"risk": "high", "file": "src/A.java", "line": 10, "title": "", "description": ""}
+            ]}
+            """,
+            List.of(
+                comment(
+                    100L,
+                    null,
+                    "src/A.java",
+                    "**HIGH — flagged here**\n<!-- thrillhousebot:finding=1 -->",
+                    BOT))));
   }
 
-  @Test
-  void unreportedUnresolvedShouldHoldNullTitleFindingWhenEarlierRoundReusedItsMarkerIndex() {
-    // #133 over-clear guard for null-title findings: the newest round's finding #1 has title ==
-    // null
-    // and was summary-only that round (no thread of its own); its code is still present. An
-    // EARLIER,
-    // unrelated round posted a DIFFERENT finding at the same marker index 1 on the same file that a
-    // maintainer answered. The marker index recurs every round and a null title gives no title key,
-    // so without content correspondence the marker would bind to that earlier answered thread and
-    // clear a still-open finding — the #118 silent approve-over-open. Matching the finding's own
-    // description keeps the hold.
-    var json =
-        """
-        {"findings": [
-          {"risk": "high", "file": "src/A.java", "line": 10, "title": null,
-           "description": "frees then dereferences"}
-        ]}
-        """;
+  /**
+   * A prior finding whose code is still present in the current diff is held as unresolved across a
+   * variety of thread shapes — an own thread without a reply, marker-index reuse by an earlier
+   * answered finding, a short title that is a substring of another, and degenerate blank-title or
+   * no-description findings that yield no content key. Every case is the safe (downgrade-only)
+   * direction: hold rather than risk the #118 silent approve-over-open. (#133)
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("stillPresentFindingHeldCases")
+  void unreportedUnresolvedShouldHoldStillPresentFinding(
+      String name, String json, List<GitHubReviewClient.PullRequestComment> comments) {
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
-    var comments =
-        List.of(
-            comment(
-                100L,
-                null,
-                "src/A.java",
-                "**LOW — Naming nit**\n\nrename the local for clarity\n<!-- thrillhousebot:finding=1 -->",
-                BOT),
-            comment(101L, 100L, "src/A.java", "fine as-is", "maintainer"));
 
     var held =
         analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
@@ -948,73 +1023,6 @@ class FollowUpAnalyzerTest {
                 "**MEDIUM — Missing null check**\n<!-- thrillhousebot:finding=2 -->",
                 BOT),
             comment(201L, 200L, "src/A.java", "intentional", "maintainer"));
-
-    var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
-
-    assertEquals(List.of(1), heldIds(held));
-  }
-
-  @Test
-  void unreportedUnresolvedShouldHoldThreadlessFindingDespiteEarlierRoundReusingItsMarkerIndex() {
-    // #133 over-clear guard: the newest prior round's finding #1 ("Use-after-free") was
-    // summary-only
-    // that round (its flagged line was outside the diff), so it has no thread of its own; its code
-    // is still present now. An EARLIER, unrelated round posted a DIFFERENT finding at the same
-    // marker index 1 on the same file ("Naming nit") that a maintainer answered. The marker index
-    // recurs every round, so a marker-only lookup would bind to that earlier answered thread and
-    // clear a still-open finding — re-introducing the #118 silent approve-over-open. Requiring the
-    // marked comment to carry this finding's own title keeps the hold.
-    var json =
-        """
-        {"findings": [
-          {"risk": "high", "file": "src/A.java", "line": 10, "title": "Use-after-free",
-           "description": "frees then dereferences"}
-        ]}
-        """;
-    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
-    var comments =
-        List.of(
-            comment(
-                100L,
-                null,
-                "src/A.java",
-                "**LOW — Naming nit**\n<!-- thrillhousebot:finding=1 -->",
-                BOT),
-            comment(101L, 100L, "src/A.java", "fine as-is", "maintainer"));
-
-    var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
-
-    assertEquals(List.of(1), heldIds(held));
-  }
-
-  @Test
-  void unreportedUnresolvedShouldNotClearWhenAShortTitleIsASubstringOfAnotherFinding() {
-    // #133 dogfood: finding #1's title is short ("NPE") and it is thread-less this round. An
-    // earlier
-    // round raised a DIFFERENT finding at the same marker index 1 on the same file whose title
-    // CONTAINS "NPE" ("NPE in handler") and was answered. A bare title-substring match would treat
-    // that unrelated answered thread as this finding's and over-clear; anchoring on the header
-    // framing " — NPE**" does not match " — NPE in handler**", and the marker=1 comment still
-    // present on the file blocks the title-only fallback, so the hold stands.
-    var json =
-        """
-        {"findings": [
-          {"risk": "high", "file": "src/A.java", "line": 10, "title": "NPE",
-           "description": "dereferences a value that may be null"}
-        ]}
-        """;
-    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
-    var comments =
-        List.of(
-            comment(
-                100L,
-                null,
-                "src/A.java",
-                "**HIGH — NPE in handler**\n\nguard the handler\n<!-- thrillhousebot:finding=1 -->",
-                BOT),
-            comment(101L, 100L, "src/A.java", "intentional", "maintainer"));
 
     var held =
         analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
@@ -1071,60 +1079,6 @@ class FollowUpAnalyzerTest {
 
     var held =
         analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), List.of(), resolver, BOT);
-
-    assertEquals(List.of(1), heldIds(held));
-  }
-
-  @Test
-  void unreportedUnresolvedShouldHoldFindingWithBlankTitleAndNoDescription() {
-    // #133 no-content-key path: a degenerate finding with a blank title and no description yields
-    // no content key, so the marker alone cannot safely identify its thread; the backstop holds it
-    // (the safe direction) rather than risk binding to a different finding that reused the same
-    // marker index. A marked bot comment is present so the content-correspondence check runs.
-    var json =
-        """
-        {"findings": [
-          {"risk": "high", "file": "src/A.java", "line": 10, "title": "", "description": null}
-        ]}
-        """;
-    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
-    var comments =
-        List.of(
-            comment(
-                100L,
-                null,
-                "src/A.java",
-                "**HIGH — flagged here**\n<!-- thrillhousebot:finding=1 -->",
-                BOT));
-
-    var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
-
-    assertEquals(List.of(1), heldIds(held));
-  }
-
-  @Test
-  void unreportedUnresolvedShouldHoldFindingWithBlankTitleAndBlankDescription() {
-    // #133 no-content-key path: both title and description are blank, so ownContentKey yields no
-    // key and the backstop holds the still-present finding (the safe direction).
-    var json =
-        """
-        {"findings": [
-          {"risk": "high", "file": "src/A.java", "line": 10, "title": "", "description": ""}
-        ]}
-        """;
-    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
-    var comments =
-        List.of(
-            comment(
-                100L,
-                null,
-                "src/A.java",
-                "**HIGH — flagged here**\n<!-- thrillhousebot:finding=1 -->",
-                BOT));
-
-    var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
 
     assertEquals(List.of(1), heldIds(held));
   }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor
- [x] ✅ Test
- [x] 📝 Documentation
- [x] 🏗️ CI/CD

## Description

Two things, bundled as release prep for **v0.1.1**:

**1. Clear the six open SonarCloud code smells** (the quality gate was already green; these were the remaining open issues):

| Rule | Location | Fix |
|------|----------|-----|
| `java:S3776` (CRITICAL) | `FollowUpAnalyzer.unreportedUnresolvedStatuses` | Cognitive complexity **27 → ~2**; extracted `toChronological`, `openFindingsAcrossRounds`, `clusterByIdentity`, `heldFromClusters`, `holdableTarget` |
| `java:S3776` (CRITICAL) | `DiffLineResolver.parseRightSide` | Cognitive complexity **19 → ~8**; extracted `hunkStart`, `isRightSideLine`, `appendRightSide` |
| `java:S1168` (MAJOR) | `DiffLineResolver` right-side line resolver | Return an empty `TreeSet` instead of `null` on ambiguity; the sole caller already treated `null` and empty identically |
| `java:S5976` (MAJOR) ×2 | `FollowUpAnalyzerTest` | Folded six near-identical "still-present finding is held" tests into one `@ParameterizedTest` |
| `java:S5976` (MAJOR) | `DiffLineResolverTest` | Folded three `isFindingPresent` tests into one `@ParameterizedTest` |

All production refactors are **behaviour-preserving** — pure extraction / control-flow flattening, no logic change. Every merged test keeps its scenario name (via `@ParameterizedTest(name = "{0}")`) and its original `#118`/`#129`/`#133` documentation as per-case comments, so regression coverage is unchanged.

**2. Release prep**

- Rewrote the `CHANGELOG.md` `[0.1.1]` section from the **v0.1.1 milestone** (28 closed issues + the Trivy-consolidation PR), grouped into Added / Changed / Fixed / Security / Documentation with issue references.
- Bumped `pom.xml` from `0.1.1-SNAPSHOT` to `0.1.1`.

## Related Issues

N/A — these are SonarCloud findings (no tracking issues) plus release housekeeping. The CHANGELOG documents the milestone issues being released.

## How Has This Been Tested?

- [x] Unit tests

Verified locally:

- `./mvnw test` → **984 tests, 0 failures, 0 errors** (BUILD SUCCESS)
- `./mvnw spotbugs:check` → **BugInstance size is 0**
- `./mvnw spotless:check` → clean
- `./mvnw help:evaluate -Dexpression=project.version` → `0.1.1`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The two `S3776` complexity numbers are from manual scoring of the decomposed methods (all helpers comfortably under the 15 threshold); SonarCloud will reconfirm on the next CI scan once this lands. No behavioural change to the review pipeline.