### PR TITLE
feat(webhook): configurable review triggers (drafts, label gating, base-branch filters) (#40)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ GITHUB_WEBHOOK_SECRET=your_webhook_secret
 #WEBHOOK_DEDUP_TTL=24h
 # Optional: comma-separated allowlist of logins permitted to trigger manual /review without repo access
 #THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS=alice,bob
+# Optional: automatic review trigger filters. Defaults review every PR; a manual /review always runs.
+#WEBHOOK_SKIP_DRAFTS=true
+#WEBHOOK_REQUIRED_LABELS=ai-review
+#WEBHOOK_EXCLUDED_LABELS=no-ai-review,wip
+#WEBHOOK_BASE_BRANCHES=main,release/*
+#WEBHOOK_IGNORED_BASE_BRANCHES=dependabot/*
 
 # AI — any OpenAI-compatible API. Set AI_BASE_URL/AI_MODEL for your provider.
 # Defaults below use DeepSeek; e.g. Alibaba Cloud Model Studio would be:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ code review.
 ## Features
 
 - Reviews diffs for correctness, security, regressions, stale comments, and code quality
+- Configurable auto-review triggers — skip drafts, gate on labels, or filter by base branch
 - Inline code suggestions on review comments that you can apply with one click
 - Every finding is tagged `critical`, `high`, `medium`, or `low`
 - Follow-up reviews track whether earlier findings were addressed or justified
@@ -157,6 +158,11 @@ variables are the ones you will change per provider:
 | `GITHUB_WEBHOOK_SECRET` | Webhook HMAC secret | _(required)_ |
 | `WEBHOOK_DEDUP_TTL` | Webhook deduplication time-to-live for GitHub redeliveries | `24h` |
 | `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` | Comma-separated allowlist of logins permitted to trigger manual `/review` without repo access | _(empty)_ |
+| `WEBHOOK_SKIP_DRAFTS` | Skip auto-review while a PR is a draft (reviewed once marked ready / on later pushes) | `false` |
+| `WEBHOOK_REQUIRED_LABELS` | Comma-separated labels; only auto-review PRs carrying at least one (case-insensitive) | _(empty — no gate)_ |
+| `WEBHOOK_EXCLUDED_LABELS` | Comma-separated labels; skip auto-review of PRs carrying any (wins over required) | _(empty)_ |
+| `WEBHOOK_BASE_BRANCHES` | Comma-separated globs; only auto-review PRs whose base branch matches one (e.g. `main,release/*`) | _(empty — all branches)_ |
+| `WEBHOOK_IGNORED_BASE_BRANCHES` | Comma-separated globs; skip auto-review of PRs whose base branch matches one (wins over allowlist) | _(empty)_ |
 | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | OAuth credentials for dashboard login | _(required for dashboard)_ |
 | `DASHBOARD_URL` | Public dashboard URL (OAuth callback base) | `http://localhost:8080` |
 | `DATASOURCE_DB_KIND` | `h2` or `postgresql` | `h2` (dev), `postgresql` (`%prod`) |

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -73,6 +73,52 @@ public interface ThrillhouseConfig {
     @WithDefault("24h")
     @WithName("dedup-ttl")
     Duration dedupTtl();
+
+    /** Filters applied to automatic pull_request events before a review is dispatched. */
+    TriggerFilters triggers();
+
+    /**
+     * Controls which pull requests automatically trigger a review (opened/reopened/synchronize).
+     * Defaults review every PR, matching the original behavior. Filters apply only to automatic
+     * triggers — a manual {@code /review} comment always runs.
+     */
+    interface TriggerFilters {
+      /**
+       * Skip auto-review while a PR is a draft. Pairs with the {@code ready_for_review} trigger so
+       * a draft is reviewed once it is marked ready (#72).
+       */
+      @WithDefault("false")
+      @WithName("skip-drafts")
+      boolean skipDrafts();
+
+      /**
+       * When non-empty, only auto-review PRs carrying at least one of these labels
+       * (case-insensitive exact match). Empty means no label is required.
+       */
+      @WithName("required-labels")
+      Optional<List<String>> requiredLabels();
+
+      /**
+       * Skip auto-review of any PR carrying one of these labels (case-insensitive exact match).
+       * Takes precedence over {@link #requiredLabels()}.
+       */
+      @WithName("excluded-labels")
+      Optional<List<String>> excludedLabels();
+
+      /**
+       * When non-empty, only auto-review PRs whose base branch matches one of these globs (e.g.
+       * {@code main}, {@code release/*}). Empty means every base branch is allowed.
+       */
+      @WithName("base-branches")
+      Optional<List<String>> baseBranches();
+
+      /**
+       * Skip auto-review of PRs whose base branch matches one of these globs. Takes precedence over
+       * {@link #baseBranches()}.
+       */
+      @WithName("ignored-base-branches")
+      Optional<List<String>> ignoredBaseBranches();
+    }
   }
 
   interface ReviewConfig {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilter.java
@@ -122,7 +122,8 @@ public class ReviewTriggerFilter {
     }
     var names = new LinkedHashSet<String>();
     for (var label : pr.labels()) {
-      if (label != null && label.name() != null && !label.name().isBlank()) {
+      // pr.labels() comes from List.copyOf, so no null elements — only the name can be absent.
+      if (label.name() != null && !label.name().isBlank()) {
         names.add(label.name().trim().toLowerCase(Locale.ROOT));
       }
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilter.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.webhook;
+
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.nio.file.FileSystems;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Decides whether an automatic {@code pull_request} event should trigger a review. Operators use
+ * this to cut noise/cost: skip drafts, gate on labels, or restrict base branches. The defaults
+ * (skip nothing, require nothing, allow every branch) review every PR, preserving the original
+ * behavior. Manual {@code /review} comments bypass these filters entirely.
+ */
+@ApplicationScoped
+public class ReviewTriggerFilter {
+
+  private final boolean skipDrafts;
+  private final Set<String> requiredLabels;
+  private final Set<String> excludedLabels;
+  private final List<PathMatcher> baseBranchMatchers;
+  private final List<PathMatcher> ignoredBaseBranchMatchers;
+
+  @Inject
+  public ReviewTriggerFilter(ThrillhouseConfig config) {
+    this(
+        config.webhook().triggers().skipDrafts(),
+        config.webhook().triggers().requiredLabels().orElseGet(List::of),
+        config.webhook().triggers().excludedLabels().orElseGet(List::of),
+        config.webhook().triggers().baseBranches().orElseGet(List::of),
+        config.webhook().triggers().ignoredBaseBranches().orElseGet(List::of));
+  }
+
+  /** Visible for tests. */
+  ReviewTriggerFilter(
+      boolean skipDrafts,
+      List<String> requiredLabels,
+      List<String> excludedLabels,
+      List<String> baseBranches,
+      List<String> ignoredBaseBranches) {
+    this.skipDrafts = skipDrafts;
+    this.requiredLabels = normalizeLabels(requiredLabels);
+    this.excludedLabels = normalizeLabels(excludedLabels);
+    this.baseBranchMatchers = compileGlobs(baseBranches, "base-branches");
+    this.ignoredBaseBranchMatchers = compileGlobs(ignoredBaseBranches, "ignored-base-branches");
+  }
+
+  /**
+   * @return a short, human-readable reason when the PR should not be auto-reviewed, or {@link
+   *     Optional#empty()} when it should proceed to dispatch.
+   */
+  public Optional<String> skipReason(WebhookPayload.PullRequest pr) {
+    if (pr == null) {
+      return Optional.empty();
+    }
+
+    if (skipDrafts && pr.draft()) {
+      return Optional.of("PR is a draft (webhook.triggers.skip-drafts=true)");
+    }
+
+    var base = pr.base() != null ? pr.base().ref() : null;
+    if (matchesAny(ignoredBaseBranchMatchers, base)) {
+      return Optional.of("base branch '" + base + "' matches ignored-base-branches");
+    }
+    if (!baseBranchMatchers.isEmpty() && !matchesAny(baseBranchMatchers, base)) {
+      return Optional.of("base branch '" + base + "' is not in the base-branches allowlist");
+    }
+
+    var labels = labelNames(pr);
+    if (!excludedLabels.isEmpty() && labels.stream().anyMatch(excludedLabels::contains)) {
+      return Optional.of("PR carries an excluded label");
+    }
+    if (!requiredLabels.isEmpty() && labels.stream().noneMatch(requiredLabels::contains)) {
+      return Optional.of("PR is missing a required label");
+    }
+
+    return Optional.empty();
+  }
+
+  private static Set<String> normalizeLabels(List<String> labels) {
+    if (labels == null || labels.isEmpty()) {
+      return Set.of();
+    }
+    var normalized = new LinkedHashSet<String>();
+    for (String label : labels) {
+      if (label != null && !label.isBlank()) {
+        normalized.add(label.trim().toLowerCase(Locale.ROOT));
+      }
+    }
+    return Set.copyOf(normalized);
+  }
+
+  /** Lower-cased names of the labels currently on the PR; empty when the payload omits them. */
+  private static Set<String> labelNames(WebhookPayload.PullRequest pr) {
+    if (pr.labels() == null || pr.labels().isEmpty()) {
+      return Set.of();
+    }
+    var names = new LinkedHashSet<String>();
+    for (var label : pr.labels()) {
+      if (label != null && label.name() != null && !label.name().isBlank()) {
+        names.add(label.name().trim().toLowerCase(Locale.ROOT));
+      }
+    }
+    return names;
+  }
+
+  private static List<PathMatcher> compileGlobs(List<String> patterns, String settingName) {
+    if (patterns == null || patterns.isEmpty()) {
+      return List.of();
+    }
+    var matchers = new ArrayList<PathMatcher>();
+    for (String raw : patterns) {
+      if (raw == null || raw.isBlank()) {
+        continue;
+      }
+      var pattern = raw.trim();
+      try {
+        matchers.add(FileSystems.getDefault().getPathMatcher("glob:" + pattern));
+      } catch (InvalidPathException | PatternSyntaxException e) {
+        Log.warnf(e, "Ignoring invalid webhook.triggers.%s pattern: %s", settingName, pattern);
+      }
+    }
+    return List.copyOf(matchers);
+  }
+
+  private static boolean matchesAny(List<PathMatcher> matchers, String branch) {
+    if (matchers.isEmpty() || branch == null || branch.isBlank()) {
+      return false;
+    }
+    Path path;
+    try {
+      path = Path.of(branch);
+    } catch (InvalidPathException e) {
+      return false;
+    }
+    return matchers.stream().anyMatch(m -> m.matches(path));
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilter.java
@@ -156,7 +156,7 @@ public class ReviewTriggerFilter {
     Path path;
     try {
       path = Path.of(branch);
-    } catch (InvalidPathException e) {
+    } catch (InvalidPathException _) {
       return false;
     }
     return matchers.stream().anyMatch(m -> m.matches(path));

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilter.java
@@ -117,7 +117,7 @@ public class ReviewTriggerFilter {
 
   /** Lower-cased names of the labels currently on the PR; empty when the payload omits them. */
   private static Set<String> labelNames(WebhookPayload.PullRequest pr) {
-    if (pr.labels() == null || pr.labels().isEmpty()) {
+    if (pr.labels().isEmpty()) {
       return Set.of();
     }
     var names = new LinkedHashSet<String>();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -37,6 +37,7 @@ public class WebhookController {
   private final ThrillhouseConfig config;
   private final WebhookVerifier verifier;
   private final TriggerDetector triggerDetector;
+  private final ReviewTriggerFilter triggerFilter;
   private final ReviewDispatcher reviewDispatcher;
   private final WebhookDeduplicator deduplicator;
   private final ManualReviewAuthorizer manualReviewAuthorizer;
@@ -47,6 +48,7 @@ public class WebhookController {
       ThrillhouseConfig config,
       WebhookVerifier verifier,
       TriggerDetector triggerDetector,
+      ReviewTriggerFilter triggerFilter,
       ReviewDispatcher reviewDispatcher,
       WebhookDeduplicator deduplicator,
       ManualReviewAuthorizer manualReviewAuthorizer,
@@ -54,6 +56,7 @@ public class WebhookController {
     this.config = config;
     this.verifier = verifier;
     this.triggerDetector = triggerDetector;
+    this.triggerFilter = triggerFilter;
     this.reviewDispatcher = reviewDispatcher;
     this.deduplicator = deduplicator;
     this.manualReviewAuthorizer = manualReviewAuthorizer;
@@ -149,6 +152,15 @@ public class WebhookController {
         var repo = payload.repository();
         if (pr == null || repo == null || payload.installation() == null) {
           log.debug("Ignoring pull_request with missing pull_request, repository, or installation");
+          yield true;
+        }
+        var skipReason = triggerFilter.skipReason(pr);
+        if (skipReason.isPresent()) {
+          log.info(
+              "Skipping review for PR #{} in {}: {}",
+              pr.number(),
+              repo.fullName(),
+              skipReason.get());
           yield true;
         }
         log.info("Dispatching review for PR #{} in {}", pr.number(), repo.fullName());

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookPayload.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookPayload.java
@@ -41,7 +41,11 @@ public record WebhookPayload(
       User user,
       String body,
       boolean draft,
-      List<Label> labels) {}
+      List<Label> labels) {
+    public PullRequest {
+      labels = labels == null ? List.of() : List.copyOf(labels);
+    }
+  }
 
   @RegisterForReflection
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookPayload.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookPayload.java
@@ -18,6 +18,7 @@ package dev.thiagogonzaga.thrillhousebot.webhook;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import java.util.List;
 
 @RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -33,7 +34,18 @@ public record WebhookPayload(
   @RegisterForReflection
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record PullRequest(
-      int number, String title, Head head, Base base, User user, String body) {}
+      int number,
+      String title,
+      Head head,
+      Base base,
+      User user,
+      String body,
+      boolean draft,
+      List<Label> labels) {}
+
+  @RegisterForReflection
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Label(String name) {}
 
   @RegisterForReflection
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,19 @@ thrillhousebot.github.webhook-secret=${GITHUB_WEBHOOK_SECRET}
 # redeliveries/retries do not trigger duplicate reviews (in-memory, per replica).
 thrillhousebot.webhook.dedup-ttl=${WEBHOOK_DEDUP_TTL:24h}
 
+# Automatic review trigger filters — empty defaults review every opened/reopened/synchronized PR.
+# Narrow them to cut noise/cost; a manual /review comment always bypasses these filters.
+#   WEBHOOK_SKIP_DRAFTS: skip while a PR is a draft (reviewed once marked ready / on later pushes)
+#   WEBHOOK_REQUIRED_LABELS: only review PRs with at least one of these labels (case-insensitive)
+#   WEBHOOK_EXCLUDED_LABELS: skip PRs carrying any of these labels (wins over required-labels)
+#   WEBHOOK_BASE_BRANCHES: only review PRs whose base matches a glob (e.g. main,release/*)
+#   WEBHOOK_IGNORED_BASE_BRANCHES: skip PRs whose base matches a glob (wins over base-branches)
+thrillhousebot.webhook.triggers.skip-drafts=${WEBHOOK_SKIP_DRAFTS:false}
+thrillhousebot.webhook.triggers.required-labels=${WEBHOOK_REQUIRED_LABELS:}
+thrillhousebot.webhook.triggers.excluded-labels=${WEBHOOK_EXCLUDED_LABELS:}
+thrillhousebot.webhook.triggers.base-branches=${WEBHOOK_BASE_BRANCHES:}
+thrillhousebot.webhook.triggers.ignored-base-branches=${WEBHOOK_IGNORED_BASE_BRANCHES:}
+
 # LangChain4j over any OpenAI-compatible API (set AI_BASE_URL/AI_MODEL; DeepSeek is the default)
 quarkus.langchain4j.openai.api-key=${AI_API_KEY}
 quarkus.langchain4j.openai.base-url=${AI_BASE_URL:https://api.deepseek.com/v1}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilterTest.java
@@ -16,8 +16,12 @@
 package dev.thiagogonzaga.thrillhousebot.webhook;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class ReviewTriggerFilterTest {
@@ -94,6 +98,15 @@ class ReviewTriggerFilterTest {
     assertTrue(filter.skipReason(pr("main", false, "ai-review", "hold")).isPresent());
   }
 
+  @Test
+  void shouldIgnoreLabelsWithBlankOrMissingNames() {
+    var filter = filter(false, List.of("ai-review"), List.of(), List.of(), List.of());
+
+    // A label with a null name and one with a blank name are skipped; the real one still matches.
+    assertTrue(filter.skipReason(pr("main", false, "ai-review", null, "  ")).isEmpty());
+    assertTrue(filter.skipReason(pr("main", false, null, "  ")).isPresent());
+  }
+
   // ── base-branch filters ─────────────────────────────────────────────────
 
   @Test
@@ -129,7 +142,16 @@ class ReviewTriggerFilterTest {
     assertTrue(filter.skipReason(pr).isPresent());
   }
 
-  // ── robustness: blank/invalid entries are ignored ───────────────────────
+  @Test
+  void shouldSkipWhenBaseBranchIsUnusableAndAllowlistSet() {
+    var filter = filter(false, List.of(), List.of(), List.of("main"), List.of());
+
+    // Blank and path-invalid (embedded NUL) base refs cannot match the allowlist; both are skipped.
+    assertTrue(filter.skipReason(pr("   ", false)).isPresent());
+    assertTrue(filter.skipReason(pr("x" + ((char) 0) + "y", false)).isPresent());
+  }
+
+  // ── robustness: blank/invalid/null config entries are ignored ───────────
 
   @Test
   void shouldIgnoreBlankConfigEntries() {
@@ -140,7 +162,66 @@ class ReviewTriggerFilterTest {
     assertTrue(filter.skipReason(pr("anything", false, "anything")).isEmpty());
   }
 
+  @Test
+  void shouldIgnoreNullConfigEntriesAndInvalidGlobs() {
+    // null elements (from config parsing) and an unparseable glob must be dropped, not throw.
+    var filter =
+        filter(
+            false,
+            Arrays.asList("ai-review", null, "  "),
+            List.of(),
+            Arrays.asList("main", "[unclosed", null),
+            List.of());
+
+    // required-labels kept only "ai-review"; base-branches kept only the valid "main".
+    assertTrue(filter.skipReason(pr("main", false, "ai-review")).isEmpty());
+    assertTrue(filter.skipReason(pr("main", false)).isPresent(), "missing required label");
+    assertTrue(filter.skipReason(pr("other", false, "ai-review")).isPresent(), "base not allowed");
+  }
+
+  // ── config-backed constructor (the @Inject path) ────────────────────────
+
+  @Test
+  void shouldApplyFiltersFromConfig() {
+    var filter =
+        new ReviewTriggerFilter(
+            config(true, List.of("ai"), List.of("wip"), List.of("main"), List.of("legacy")));
+
+    assertTrue(filter.skipReason(pr("main", true)).isPresent(), "draft");
+    assertTrue(filter.skipReason(pr("legacy", false, "ai")).isPresent(), "ignored base branch");
+    assertTrue(filter.skipReason(pr("main", false, "wip", "ai")).isPresent(), "excluded label");
+    assertTrue(filter.skipReason(pr("main", false)).isPresent(), "missing required label");
+    assertTrue(filter.skipReason(pr("main", false, "ai")).isEmpty(), "all gates satisfied");
+  }
+
+  @Test
+  void shouldReviewEverythingWhenConfigOptionalsAreEmpty() {
+    var filter = new ReviewTriggerFilter(config(false, null, null, null, null));
+
+    assertTrue(filter.skipReason(pr("anything", true, "wip")).isEmpty());
+  }
+
   // ── helpers ─────────────────────────────────────────────────────────────
+
+  /** Builds a config; null list args become {@link Optional#empty()} (the unset-env case). */
+  private static ThrillhouseConfig config(
+      boolean skipDrafts,
+      List<String> required,
+      List<String> excluded,
+      List<String> baseBranches,
+      List<String> ignoredBaseBranches) {
+    var cfg = mock(ThrillhouseConfig.class);
+    var webhook = mock(ThrillhouseConfig.WebhookConfig.class);
+    var triggers = mock(ThrillhouseConfig.WebhookConfig.TriggerFilters.class);
+    when(cfg.webhook()).thenReturn(webhook);
+    when(webhook.triggers()).thenReturn(triggers);
+    when(triggers.skipDrafts()).thenReturn(skipDrafts);
+    when(triggers.requiredLabels()).thenReturn(Optional.ofNullable(required));
+    when(triggers.excludedLabels()).thenReturn(Optional.ofNullable(excluded));
+    when(triggers.baseBranches()).thenReturn(Optional.ofNullable(baseBranches));
+    when(triggers.ignoredBaseBranches()).thenReturn(Optional.ofNullable(ignoredBaseBranches));
+    return cfg;
+  }
 
   private static ReviewTriggerFilter filter(
       boolean skipDrafts,

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilterTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.webhook;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ReviewTriggerFilterTest {
+
+  // ── defaults preserve original behavior ─────────────────────────────────
+
+  @Test
+  void shouldReviewEveryPrWithDefaultConfig() {
+    var filter = filter(false, List.of(), List.of(), List.of(), List.of());
+
+    assertTrue(filter.skipReason(pr("main", false)).isEmpty());
+    assertTrue(filter.skipReason(pr("main", true)).isEmpty(), "drafts review by default");
+    assertTrue(filter.skipReason(pr("release/1.0", false, "wip")).isEmpty());
+  }
+
+  @Test
+  void shouldReviewWhenPayloadHasNoLabelsField() {
+    var filter = filter(false, List.of(), List.of(), List.of(), List.of());
+    var pr = new WebhookPayload.PullRequest(1, "t", null, base("main"), null, "", false, null);
+
+    assertTrue(filter.skipReason(pr).isEmpty());
+  }
+
+  @Test
+  void shouldReturnEmptyForNullPullRequest() {
+    var filter = filter(true, List.of("ai"), List.of("wip"), List.of("main"), List.of("dev"));
+
+    assertTrue(filter.skipReason(null).isEmpty());
+  }
+
+  // ── skip-drafts ─────────────────────────────────────────────────────────
+
+  @Test
+  void shouldSkipDraftWhenConfigured() {
+    var filter = filter(true, List.of(), List.of(), List.of(), List.of());
+
+    assertTrue(filter.skipReason(pr("main", true)).isPresent());
+    assertTrue(filter.skipReason(pr("main", false)).isEmpty());
+  }
+
+  // ── label gating ────────────────────────────────────────────────────────
+
+  @Test
+  void shouldRequireAtLeastOneRequiredLabel() {
+    var filter = filter(false, List.of("ai-review"), List.of(), List.of(), List.of());
+
+    assertTrue(filter.skipReason(pr("main", false)).isPresent(), "no labels -> skip");
+    assertTrue(filter.skipReason(pr("main", false, "other")).isPresent());
+    assertTrue(filter.skipReason(pr("main", false, "ai-review")).isEmpty());
+    assertTrue(filter.skipReason(pr("main", false, "other", "ai-review")).isEmpty());
+  }
+
+  @Test
+  void shouldMatchLabelsCaseInsensitively() {
+    var filter = filter(false, List.of("AI-Review"), List.of("No-AI"), List.of(), List.of());
+
+    assertTrue(filter.skipReason(pr("main", false, "ai-review")).isEmpty());
+    assertTrue(filter.skipReason(pr("main", false, "no-ai")).isPresent());
+  }
+
+  @Test
+  void shouldSkipWhenExcludedLabelPresent() {
+    var filter = filter(false, List.of(), List.of("no-ai-review"), List.of(), List.of());
+
+    assertTrue(filter.skipReason(pr("main", false, "no-ai-review")).isPresent());
+    assertTrue(filter.skipReason(pr("main", false, "other")).isEmpty());
+  }
+
+  @Test
+  void shouldLetExcludedLabelWinOverRequiredLabel() {
+    var filter = filter(false, List.of("ai-review"), List.of("hold"), List.of(), List.of());
+
+    // The PR satisfies the required label but also carries the excluded one — exclusion wins.
+    assertTrue(filter.skipReason(pr("main", false, "ai-review", "hold")).isPresent());
+  }
+
+  // ── base-branch filters ─────────────────────────────────────────────────
+
+  @Test
+  void shouldAllowOnlyMatchingBaseBranches() {
+    var filter = filter(false, List.of(), List.of(), List.of("main", "release/*"), List.of());
+
+    assertTrue(filter.skipReason(pr("main", false)).isEmpty());
+    assertTrue(filter.skipReason(pr("release/1.2", false)).isEmpty());
+    assertTrue(filter.skipReason(pr("feature/x", false)).isPresent());
+  }
+
+  @Test
+  void shouldSkipIgnoredBaseBranches() {
+    var filter = filter(false, List.of(), List.of(), List.of(), List.of("dependabot/**"));
+
+    assertTrue(filter.skipReason(pr("dependabot/npm/lodash", false)).isPresent());
+    assertTrue(filter.skipReason(pr("main", false)).isEmpty());
+  }
+
+  @Test
+  void shouldLetIgnoredBaseBranchWinOverAllowlist() {
+    var filter = filter(false, List.of(), List.of(), List.of("**"), List.of("legacy"));
+
+    assertTrue(filter.skipReason(pr("legacy", false)).isPresent());
+    assertTrue(filter.skipReason(pr("main", false)).isEmpty());
+  }
+
+  @Test
+  void shouldSkipWhenBaseBranchMissingAndAllowlistSet() {
+    var filter = filter(false, List.of(), List.of(), List.of("main"), List.of());
+    var pr = new WebhookPayload.PullRequest(1, "t", null, null, null, "", false, List.of());
+
+    assertTrue(filter.skipReason(pr).isPresent());
+  }
+
+  // ── robustness: blank/invalid entries are ignored ───────────────────────
+
+  @Test
+  void shouldIgnoreBlankConfigEntries() {
+    // Mirrors the empty-string default that comes from an unset env var.
+    var filter = filter(false, List.of(""), List.of("  "), List.of(""), List.of(" "));
+
+    assertTrue(filter.skipReason(pr("anything", false)).isEmpty());
+    assertTrue(filter.skipReason(pr("anything", false, "anything")).isEmpty());
+  }
+
+  // ── helpers ─────────────────────────────────────────────────────────────
+
+  private static ReviewTriggerFilter filter(
+      boolean skipDrafts,
+      List<String> required,
+      List<String> excluded,
+      List<String> baseBranches,
+      List<String> ignoredBaseBranches) {
+    return new ReviewTriggerFilter(
+        skipDrafts, required, excluded, baseBranches, ignoredBaseBranches);
+  }
+
+  private static WebhookPayload.PullRequest pr(String baseRef, boolean draft, String... labels) {
+    var labelList = new java.util.ArrayList<WebhookPayload.Label>();
+    for (String name : labels) {
+      labelList.add(new WebhookPayload.Label(name));
+    }
+    return new WebhookPayload.PullRequest(
+        1, "Test PR", null, base(baseRef), null, "", draft, labelList);
+  }
+
+  private static WebhookPayload.Base base(String ref) {
+    return new WebhookPayload.Base("sha", ref);
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilterTest.java
@@ -179,6 +179,14 @@ class ReviewTriggerFilterTest {
     assertTrue(filter.skipReason(pr("other", false, "ai-review")).isPresent(), "base not allowed");
   }
 
+  @Test
+  void shouldTreatNullConfigListsAsNoFilter() {
+    // The package-private constructor must tolerate null lists (defensive null guards).
+    var filter = filter(false, null, null, null, null);
+
+    assertTrue(filter.skipReason(pr("anything", false, "whatever")).isEmpty());
+  }
+
   // ── config-backed constructor (the @Inject path) ────────────────────────
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -24,8 +24,10 @@ import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestrator;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -38,6 +40,8 @@ class WebhookControllerTest {
   @Mock private WebhookVerifier verifier;
 
   @Mock private TriggerDetector triggerDetector;
+
+  @Mock private ReviewTriggerFilter triggerFilter;
 
   @Mock private ReviewDispatcher reviewDispatcher;
 
@@ -62,6 +66,7 @@ class WebhookControllerTest {
             config,
             verifier,
             triggerDetector,
+            triggerFilter,
             reviewDispatcher,
             deduplicator,
             manualReviewAuthorizer,
@@ -307,6 +312,54 @@ class WebhookControllerTest {
     assertEquals(200, response.getStatus());
 
     verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+  }
+
+  @Test
+  void shouldSkipReviewWhenTriggerFilterRejects() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(triggerFilter.skipReason(any())).thenReturn(Optional.of("PR is a draft"));
+
+    var body =
+        buildPullRequestPayload("opened", 21, "owner/repo", "sha21", "main")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response =
+        controller.handleWebhook("sha256=valid", "pull_request", null, "delivery-skip", body);
+    assertEquals(200, response.getStatus());
+
+    // A filtered-out PR must not be reviewed, and the dedup slot stays claimed (it was a
+    // deliberate decision, not a rejected dispatch), so a redelivery is ignored too.
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+    verify(deduplicator, never()).forget(anyString());
+  }
+
+  @Test
+  void shouldPassParsedDraftAndLabelsToTriggerFilter() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+
+    var body =
+        ("{"
+                + "\"action\":\"opened\","
+                + "\"pull_request\":{"
+                + "\"number\":33,\"title\":\"t\",\"head\":{\"sha\":\"s\"},"
+                + "\"base\":{\"sha\":\"b\",\"ref\":\"main\"},\"draft\":true,"
+                + "\"labels\":[{\"name\":\"wip\"},{\"name\":\"ai-review\"}]"
+                + "},"
+                + "\"repository\":{\"full_name\":\"a/b\",\"name\":\"b\",\"default_branch\":\"main\",\"owner\":{\"login\":\"a\",\"id\":1}},"
+                + "\"installation\":{\"id\":1}"
+                + "}")
+            .getBytes(StandardCharsets.UTF_8);
+
+    controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
+
+    var captor = ArgumentCaptor.forClass(WebhookPayload.PullRequest.class);
+    verify(triggerFilter).skipReason(captor.capture());
+    var pr = captor.getValue();
+    assertTrue(pr.draft());
+    assertEquals(2, pr.labels().size());
+    assertEquals("wip", pr.labels().get(0).name());
+    // Filter said review (default empty Optional), so dispatch still happens.
+    verify(reviewDispatcher).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
   }
 
   // ── issue_comment routing tests ────────────────────────────────────────


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature
- [x] 📝 Documentation
- [x] ✅ Test

## Description

Until now every `opened`/`reopened`/`synchronize` pull_request event triggered a review unconditionally — noisy and costly on repos with many drafts. This adds opt-in filters, evaluated in the webhook handler **before dispatch**:

- **`skip-drafts`** — skip auto-review while a PR is a draft (pairs with #72: review once marked ready).
- **`required-labels` / `excluded-labels`** — gate on labels (case-insensitive exact match; exclude wins over require).
- **`base-branches` / `ignored-base-branches`** — glob allow/deny on the PR base branch (deny wins over allow).

Design notes for reviewers:

- Filters apply **only to automatic `pull_request` events**. A manual `/review` comment always runs, bypassing them.
- **Defaults preserve current behavior** — empty/false everywhere reviews every PR.
- A filtered-out PR logs the reason and `yield`s "handled", so its dedup slot is kept (it's a deliberate decision, not a rejected dispatch that should roll back and retry).
- Blank config entries are filtered out, so an unset `${WEBHOOK_*:}` env var can never accidentally gate every PR.
- `ReviewTriggerFilter` reuses the existing glob `PathMatcher` approach from `ReviewDiffFormatter` for base-branch matching, and lives next to `TriggerDetector`/`ManualReviewAuthorizer` (mocked in `WebhookControllerTest`, unit-tested on its own).

New config (documented in `application.properties`, `.env.example`, and the README env-var table):

| Env var | Purpose | Default |
|---|---|---|
| `WEBHOOK_SKIP_DRAFTS` | Skip auto-review while a PR is a draft | `false` |
| `WEBHOOK_REQUIRED_LABELS` | Only review PRs with at least one of these labels | _(empty)_ |
| `WEBHOOK_EXCLUDED_LABELS` | Skip PRs carrying any of these labels | _(empty)_ |
| `WEBHOOK_BASE_BRANCHES` | Only review PRs whose base matches a glob (e.g. `main,release/*`) | _(empty)_ |
| `WEBHOOK_IGNORED_BASE_BRANCHES` | Skip PRs whose base matches a glob | _(empty)_ |

## Related Issues

Fixes #40
Related to #72 (`ready_for_review` trigger — the draft-skip option is designed to pair with it)

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- New `ReviewTriggerFilterTest` (13 cases): defaults, draft skip, required/excluded labels, case-insensitivity, exclude-wins, base-branch allow/deny, deny-wins, missing base branch, blank-entry robustness.
- Extended `WebhookControllerTest` (+2): a filtered PR is not dispatched and keeps its dedup slot; parsed `draft`/`labels` are passed to the filter and a non-skip still dispatches.
- `./mvnw -o test -Dtest='ReviewTriggerFilterTest,WebhookControllerTest,WebhookDeduplicatorTest' -Djacoco.skip=true` → **62 passing**, and `spotless:check` is clean.

> Note: the full `@QuarkusTest` suite could not be run locally — on JDK 25 the JaCoCo agent crashes the forked JVM and `@QuarkusTest` classes fail to bootstrap. Both reproduce on unmodified `main`, so they are pre-existing environment issues, not regressions from this PR. The SmallRye `@ConfigMapping` annotation processor validates the new config interface at compile time (`./mvnw compile` is clean).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No breaking changes — all new behavior is off by default. With `skip-drafts=true` but #72 not yet merged, a draft marked "Ready for review" stays unreviewed until its next push; #72 closes that gap.
