### PR TITLE
feat(webhook): expand slash commands (/help, /summary, /resolve, /pause, /resume) (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ code review.
 - Follow-up reviews track whether earlier findings were addressed or justified
 - Conversational replies: reply to a finding or `@thrillhousebot` it in a PR thread and the bot answers in context
 - A summary comment on the first run, with a risk breakdown
+- Operable from the PR with comment commands — `/help`, `/review`, `/summary`, `/resolve`, `/pause`, `/resume`
 - Live dashboard (Next.js) with a WebSocket activity feed, cost charts, and token tracking
 - OpenTelemetry traces, token histograms, cost counters, and latency metrics
 - Reads per-repo instructions from `.github/thrillhousebot.md`, falling back to Copilot/Claude/Agents files
@@ -58,6 +59,29 @@ API. Point `AI_BASE_URL` and `AI_MODEL` at your provider of choice:
 
 The default is DeepSeek, used only because it is inexpensive; nothing in the bot
 is tied to it.
+
+## Commands
+
+Drive the bot directly from a PR by commenting one of these. Each also accepts the
+mention form, e.g. `@Thrillhousebot review`.
+
+| Command | What it does | Access |
+|---|---|---|
+| `/help` | List the available commands | anyone |
+| `/review` | Run (or re-run) a full review of the PR | write |
+| `/summary` | Post the PR summary, but only if one has not been generated yet (otherwise no-op) | write |
+| `/resolve` | Resolve ThrillhouseBot's outstanding finding threads on the PR | write |
+| `/pause` | Silence the bot on the PR | write |
+| `/resume` | Re-enable the bot on a paused PR | write |
+
+**Access** — every command except `/help` requires the commenter to hold write access to
+the repository (or to be named in
+`THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS`), since reviews spend the operator's
+AI budget.
+
+**Pause** — while a PR is paused, ThrillhouseBot skips automatic reviews on new commits and
+ignores `/review` and `/summary` (it replies once to say it is paused). `/resume` lifts the
+pause. `/help` and `/resolve` keep working while paused.
 
 ## Quick start
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionPersistence.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionPersistence.java
@@ -78,6 +78,21 @@ public class ReviewSessionPersistence {
         .toList();
   }
 
+  /**
+   * Whether any completed review exists for the PR. The first completed review posts the PR summary
+   * comment, so this doubles as "has a summary already been generated" for the {@code /summary}
+   * command gate.
+   */
+  @Transactional
+  public boolean hasCompletedReview(String repository, int prNumber) {
+    return this.repository.count(
+            "repository = ?1 and prNumber = ?2 and status = ?3",
+            repository,
+            prNumber,
+            ReviewSession.STATUS_COMPLETED)
+        > 0;
+  }
+
   /** Loads a managed session by ID and applies updates — safe after the entity becomes detached. */
   @Transactional
   public void update(long sessionId, Consumer<ReviewSession> mutator) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -55,6 +55,23 @@ public interface GitHubReviewClient {
       @PathParam("repo") String repo,
       @PathParam("pullNumber") int pullNumber);
 
+  /**
+   * Paged variant of {@link #listPullRequestComments}. GitHub serves 30 comments per page by
+   * default; callers that need every comment (e.g. {@code /resolve}) must request a larger {@code
+   * per_page} and walk the pages until a short one.
+   */
+  @GET
+  @Path("/repos/{owner}/{repo}/pulls/{pullNumber}/comments")
+  @Produces(MediaType.APPLICATION_JSON)
+  List<PullRequestComment> listPullRequestComments(
+      @HeaderParam("Authorization") String auth,
+      @HeaderParam("Accept") String accept,
+      @PathParam("owner") String owner,
+      @PathParam("repo") String repo,
+      @PathParam("pullNumber") int pullNumber,
+      @QueryParam("per_page") int perPage,
+      @QueryParam("page") int page);
+
   @POST
   @Path("/repos/{owner}/{repo}/pulls/{pullNumber}/comments")
   @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommand.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommand.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.webhook;
+
+/**
+ * A command parsed from a PR comment. {@link #NONE} means the comment carried no recognized
+ * command. Detected by {@link TriggerDetector#detectCommand(String)} and routed by {@link
+ * WebhookController}.
+ */
+public enum CommentCommand {
+  /** No recognized command in the comment. */
+  NONE,
+  /** Run (or re-run) a full review. */
+  REVIEW,
+  /** List the available commands. */
+  HELP,
+  /** Regenerate the PR summary (only when none has been posted yet). */
+  SUMMARY,
+  /** Resolve the bot's outstanding finding threads on the PR. */
+  RESOLVE,
+  /** Silence the bot on the PR until {@link #RESUME}. */
+  PAUSE,
+  /** Re-enable the bot on a paused PR. */
+  RESUME
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
@@ -25,6 +25,7 @@ import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestrator;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -43,6 +44,11 @@ public class CommentCommandService {
 
   private static final String ACCEPT = "application/vnd.github+json";
   private static final String BOT_LOGIN = "thrillhousebot[bot]";
+
+  // GitHub serves 30 review comments per page by default; request the 100 max and walk a bounded
+  // number of pages so /resolve covers every bot finding thread, not just the first page.
+  private static final int COMMENTS_PER_PAGE = 100;
+  private static final int MAX_COMMENT_PAGES = 10;
 
   /** Posted when a review-generating command lands on a paused PR. */
   static final String PAUSED_NOTICE =
@@ -213,7 +219,7 @@ public class CommentCommandService {
       log.info("Ignoring unauthorized /pause from @{} on PR #{}", ctx.login(), num(ctx));
       return;
     }
-    prPauseService.pause(ctx.owner(), ctx.repo(), ctx.prNumber(), ctx.login());
+    prPauseService.pause(ctx.owner(), ctx.repo(), ctx.prNumber());
     postComment(
         auth,
         ctx,
@@ -235,18 +241,31 @@ public class CommentCommandService {
             : "ThrillhouseBot was not paused on this PR.");
   }
 
-  /** Root-comment ids of the bot's own inline finding comments (thread roots carry no reply id). */
+  /**
+   * Root-comment ids of the bot's own inline finding comments (thread roots carry no reply id).
+   * Walks every page so a PR with many comments does not leave later-page bot threads unresolved.
+   */
   private List<Long> botRootCommentIds(String auth, CommandContext ctx) {
-    var comments =
-        reviewClient.listPullRequestComments(auth, ACCEPT, ctx.owner(), ctx.repo(), ctx.prNumber());
-    if (comments == null) {
-      return List.of();
+    var ids = new ArrayList<Long>();
+    for (int page = 1; page <= MAX_COMMENT_PAGES; page++) {
+      var comments =
+          reviewClient.listPullRequestComments(
+              auth, ACCEPT, ctx.owner(), ctx.repo(), ctx.prNumber(), COMMENTS_PER_PAGE, page);
+      if (comments == null || comments.isEmpty()) {
+        break;
+      }
+      for (var c : comments) {
+        if (c.inReplyToId() == null
+            && c.user() != null
+            && BOT_LOGIN.equalsIgnoreCase(c.user().login())) {
+          ids.add(c.id());
+        }
+      }
+      if (comments.size() < COMMENTS_PER_PAGE) {
+        break; // a short page is GitHub's last-page marker
+      }
     }
-    return comments.stream()
-        .filter(c -> c.inReplyToId() == null)
-        .filter(c -> c.user() != null && BOT_LOGIN.equalsIgnoreCase(c.user().login()))
-        .map(GitHubReviewClient.PullRequestComment::id)
-        .toList();
+    return ids;
   }
 
   private boolean authorized(CommandContext ctx) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
@@ -202,8 +202,21 @@ public class CommentCommandService {
     var resolved = 0;
     for (long rootCommentId : botRootCommentIds) {
       var thread = threads.get(rootCommentId);
-      if (thread != null && !thread.resolved() && reviewThreadService.resolve(auth, thread.id())) {
-        resolved++;
+      if (thread == null || thread.resolved()) {
+        continue;
+      }
+      // A failure on one thread (e.g. a transient GraphQL error) must not abort the rest.
+      try {
+        if (reviewThreadService.resolve(auth, thread.id())) {
+          resolved++;
+        }
+      } catch (RuntimeException e) {
+        log.warn(
+            "Failed to resolve thread {} on {} #{} (continuing)",
+            thread.id(),
+            repository(ctx),
+            num(ctx),
+            e);
       }
     }
     postComment(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.webhook;
+
+import dev.thiagogonzaga.thrillhousebot.config.ReviewExecutor;
+import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSessionPersistence;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
+import dev.thiagogonzaga.thrillhousebot.github.ReviewThreadService;
+import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
+import dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestrator;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Executes the comment commands beyond {@code /review} — {@code /help}, {@code /summary}, {@code
+ * /resolve}, {@code /pause}, {@code /resume}. Work runs on the shared review executor so the
+ * webhook 200-ack thread is never blocked by GitHub API calls.
+ */
+@ApplicationScoped
+public class CommentCommandService {
+
+  private static final Logger log = LoggerFactory.getLogger(CommentCommandService.class);
+
+  private static final String ACCEPT = "application/vnd.github+json";
+  private static final String BOT_LOGIN = "thrillhousebot[bot]";
+
+  /** Posted when a review-generating command lands on a paused PR. */
+  static final String PAUSED_NOTICE =
+      "⏸️ ThrillhouseBot is paused on this PR. Comment `/resume` to re-enable reviews.";
+
+  static final String HELP_TEXT =
+      """
+      ## 🤖 ThrillhouseBot commands
+
+      | Command | What it does |
+      |---------|--------------|
+      | `/review` | Run a fresh review of this PR |
+      | `/summary` | Post the PR summary if one has not been generated yet |
+      | `/resolve` | Resolve ThrillhouseBot's open finding threads on this PR |
+      | `/pause` | Silence the bot on this PR (no automatic or manual reviews) |
+      | `/resume` | Re-enable the bot on a paused PR |
+      | `/help` | Show this list |
+
+      You can also use the mention form, e.g. `@Thrillhousebot review`. \
+      Every command except `/help` requires write access to the repository.""";
+
+  private final ExecutorService executor;
+  private final GitHubAuthClient authClient;
+  private final GitHubCommentClient commentClient;
+  private final GitHubReviewClient reviewClient;
+  private final ReviewThreadService reviewThreadService;
+  private final ReviewDispatcher reviewDispatcher;
+  private final ReviewSessionPersistence sessionPersistence;
+  private final PrPauseService prPauseService;
+  private final ManualReviewAuthorizer authorizer;
+
+  @Inject
+  public CommentCommandService(
+      @ReviewExecutor ExecutorService executor,
+      GitHubAuthClient authClient,
+      @RestClient GitHubCommentClient commentClient,
+      @RestClient GitHubReviewClient reviewClient,
+      ReviewThreadService reviewThreadService,
+      ReviewDispatcher reviewDispatcher,
+      ReviewSessionPersistence sessionPersistence,
+      PrPauseService prPauseService,
+      ManualReviewAuthorizer authorizer) {
+    this.executor = executor;
+    this.authClient = authClient;
+    this.commentClient = commentClient;
+    this.reviewClient = reviewClient;
+    this.reviewThreadService = reviewThreadService;
+    this.reviewDispatcher = reviewDispatcher;
+    this.sessionPersistence = sessionPersistence;
+    this.prPauseService = prPauseService;
+    this.authorizer = authorizer;
+  }
+
+  /** PR coordinates and commenter identity for one command. */
+  public record CommandContext(
+      CommentCommand command,
+      String owner,
+      String repo,
+      int prNumber,
+      String defaultBranch,
+      long installationId,
+      String login,
+      String authorAssociation) {}
+
+  /** Runs the command's effect asynchronously. */
+  public void handle(CommandContext ctx) {
+    executor.execute(() -> execute(ctx));
+  }
+
+  /** Posts the paused notice asynchronously — used when a {@code /review} lands on a paused PR. */
+  public void notifyPaused(CommandContext ctx) {
+    executor.execute(
+        () -> {
+          try {
+            postComment(authClient.getAuthHeader(ctx.installationId()), ctx, PAUSED_NOTICE);
+          } catch (RuntimeException e) {
+            log.warn(
+                "Failed to post paused notice on {}/{} #{}", ctx.owner(), ctx.repo(), num(ctx));
+          }
+        });
+  }
+
+  /** Visible for tests: performs the command effect on the calling thread. */
+  void execute(CommandContext ctx) {
+    try {
+      var auth = authClient.getAuthHeader(ctx.installationId());
+      switch (ctx.command()) {
+        case HELP -> postComment(auth, ctx, HELP_TEXT);
+        case SUMMARY -> handleSummary(ctx, auth);
+        case RESOLVE -> handleResolve(ctx, auth);
+        case PAUSE -> handlePause(ctx, auth);
+        case RESUME -> handleResume(ctx, auth);
+        default -> log.debug("CommentCommandService ignoring command {}", ctx.command());
+      }
+    } catch (RuntimeException e) {
+      log.error(
+          "Failed to handle {} command on {}/{} #{}",
+          ctx.command(),
+          ctx.owner(),
+          ctx.repo(),
+          num(ctx),
+          e);
+    }
+  }
+
+  private void handleSummary(CommandContext ctx, String auth) {
+    if (!authorized(ctx)) {
+      log.info("Ignoring unauthorized /summary from @{} on PR #{}", ctx.login(), num(ctx));
+      return;
+    }
+    if (prPauseService.isPaused(ctx.owner(), ctx.repo(), ctx.prNumber())) {
+      postComment(auth, ctx, PAUSED_NOTICE);
+      return;
+    }
+    if (sessionPersistence.hasCompletedReview(repository(ctx), ctx.prNumber())) {
+      // A summary was already generated on the first review; the command is a no-op by design.
+      log.info("Ignoring /summary — a summary already exists on {} #{}", repository(ctx), num(ctx));
+      return;
+    }
+    log.info(
+        "Generating summary via review for {} #{} (triggered by @{})",
+        repository(ctx),
+        num(ctx),
+        ctx.login());
+    reviewDispatcher.dispatch(
+        new ReviewOrchestrator.ReviewRequest(
+            ctx.owner(),
+            ctx.repo(),
+            ctx.prNumber(),
+            "",
+            "(manual summary)",
+            "",
+            "",
+            ctx.defaultBranch(),
+            ctx.installationId(),
+            true));
+  }
+
+  private void handleResolve(CommandContext ctx, String auth) {
+    if (!authorized(ctx)) {
+      log.info("Ignoring unauthorized /resolve from @{} on PR #{}", ctx.login(), num(ctx));
+      return;
+    }
+    var botRootCommentIds = botRootCommentIds(auth, ctx);
+    if (botRootCommentIds.isEmpty()) {
+      postComment(auth, ctx, "No open ThrillhouseBot finding threads to resolve.");
+      return;
+    }
+    var threads =
+        reviewThreadService.threadsByRootComment(auth, ctx.owner(), ctx.repo(), ctx.prNumber());
+    var resolved = 0;
+    for (long rootCommentId : botRootCommentIds) {
+      var thread = threads.get(rootCommentId);
+      if (thread != null && !thread.resolved() && reviewThreadService.resolve(auth, thread.id())) {
+        resolved++;
+      }
+    }
+    postComment(
+        auth,
+        ctx,
+        resolved > 0
+            ? "✅ Resolved " + resolved + " ThrillhouseBot finding thread(s)."
+            : "No open ThrillhouseBot finding threads to resolve.");
+  }
+
+  private void handlePause(CommandContext ctx, String auth) {
+    if (!authorized(ctx)) {
+      log.info("Ignoring unauthorized /pause from @{} on PR #{}", ctx.login(), num(ctx));
+      return;
+    }
+    prPauseService.pause(ctx.owner(), ctx.repo(), ctx.prNumber(), ctx.login());
+    postComment(
+        auth,
+        ctx,
+        "⏸️ ThrillhouseBot is now paused on this PR — automatic and manual reviews are silenced. "
+            + "Comment `/resume` to re-enable.");
+  }
+
+  private void handleResume(CommandContext ctx, String auth) {
+    if (!authorized(ctx)) {
+      log.info("Ignoring unauthorized /resume from @{} on PR #{}", ctx.login(), num(ctx));
+      return;
+    }
+    var wasPaused = prPauseService.resume(ctx.owner(), ctx.repo(), ctx.prNumber());
+    postComment(
+        auth,
+        ctx,
+        wasPaused
+            ? "▶️ ThrillhouseBot resumed on this PR. Comment `/review` to run a review now."
+            : "ThrillhouseBot was not paused on this PR.");
+  }
+
+  /** Root-comment ids of the bot's own inline finding comments (thread roots carry no reply id). */
+  private List<Long> botRootCommentIds(String auth, CommandContext ctx) {
+    var comments =
+        reviewClient.listPullRequestComments(auth, ACCEPT, ctx.owner(), ctx.repo(), ctx.prNumber());
+    if (comments == null) {
+      return List.of();
+    }
+    return comments.stream()
+        .filter(c -> c.inReplyToId() == null)
+        .filter(c -> c.user() != null && BOT_LOGIN.equalsIgnoreCase(c.user().login()))
+        .map(GitHubReviewClient.PullRequestComment::id)
+        .toList();
+  }
+
+  private boolean authorized(CommandContext ctx) {
+    return authorizer.isAuthorized(
+        ctx.owner(), ctx.repo(), ctx.installationId(), ctx.login(), ctx.authorAssociation());
+  }
+
+  private void postComment(String auth, CommandContext ctx, String body) {
+    commentClient.createComment(
+        auth,
+        ACCEPT,
+        ctx.owner(),
+        ctx.repo(),
+        ctx.prNumber(),
+        new GitHubCommentClient.CreateCommentRequest(body));
+  }
+
+  private static String repository(CommandContext ctx) {
+    return ctx.owner() + "/" + ctx.repo();
+  }
+
+  private static int num(CommandContext ctx) {
+    return ctx.prNumber();
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/PausedPr.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/PausedPr.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.webhook;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+
+/**
+ * Marks a pull request the bot has been silenced on via {@code /pause}. A single row per PR (the
+ * unique constraint enforces it) means the bot skips automatic reviews and manual {@code /review} /
+ * {@code /summary} on that PR until {@code /resume} removes the row.
+ */
+@Entity
+@Table(
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_pausedpr_repository_pr",
+            columnNames = {"repository", "prNumber"}))
+@RegisterForReflection
+public class PausedPr extends PanacheEntity {
+
+  /** Repository in "owner/repo" form. */
+  @Column(nullable = false)
+  public String repository;
+
+  /** Pull request number, unique together with {@link #repository}. */
+  @Column(nullable = false)
+  public int prNumber;
+
+  /** Login of the user who paused the PR (audit only). */
+  public String pausedBy;
+
+  /** When the PR was paused. */
+  public Instant pausedAt;
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/PausedPr.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/PausedPr.java
@@ -21,12 +21,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.time.Instant;
 
 /**
  * Marks a pull request the bot has been silenced on via {@code /pause}. A single row per PR (the
  * unique constraint enforces it) means the bot skips automatic reviews and manual {@code /review} /
- * {@code /summary} on that PR until {@code /resume} removes the row.
+ * {@code /summary} on that PR until {@code /resume} removes the row. Presence of the row is the
+ * whole state — the bot is paused iff a row exists.
  */
 @Entity
 @Table(
@@ -44,10 +44,4 @@ public class PausedPr extends PanacheEntity {
   /** Pull request number, unique together with {@link #repository}. */
   @Column(nullable = false)
   public int prNumber;
-
-  /** Login of the user who paused the PR (audit only). */
-  public String pausedBy;
-
-  /** When the PR was paused. */
-  public Instant pausedAt;
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/PausedPrRepository.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/PausedPrRepository.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.webhook;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PausedPrRepository implements PanacheRepository<PausedPr> {}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/PrPauseService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/PrPauseService.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.webhook;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.time.Instant;
+
+/**
+ * Tracks which pull requests the bot has been paused on. Short DB transactions only — never spans
+ * an external API call.
+ */
+@ApplicationScoped
+public class PrPauseService {
+
+  private static final String BY_PR = "repository = ?1 and prNumber = ?2";
+
+  private final PausedPrRepository repository;
+
+  @Inject
+  public PrPauseService(PausedPrRepository repository) {
+    this.repository = repository;
+  }
+
+  /** Whether the bot is currently paused on {@code owner/repo} PR {@code prNumber}. */
+  @Transactional
+  public boolean isPaused(String owner, String repo, int prNumber) {
+    return repository.count(BY_PR, repoKey(owner, repo), prNumber) > 0;
+  }
+
+  /** Pauses the bot on the PR. Idempotent: a second pause leaves the single row untouched. */
+  @Transactional
+  public void pause(String owner, String repo, int prNumber, String pausedBy) {
+    var key = repoKey(owner, repo);
+    if (repository.count(BY_PR, key, prNumber) > 0) {
+      return;
+    }
+    var paused = new PausedPr();
+    paused.repository = key;
+    paused.prNumber = prNumber;
+    paused.pausedBy = pausedBy;
+    paused.pausedAt = Instant.now();
+    repository.persist(paused);
+  }
+
+  /** Resumes the bot on the PR. Returns whether a paused row was actually removed. */
+  @Transactional
+  public boolean resume(String owner, String repo, int prNumber) {
+    return repository.delete(BY_PR, repoKey(owner, repo), prNumber) > 0;
+  }
+
+  private static String repoKey(String owner, String repo) {
+    return owner + "/" + repo;
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/PrPauseService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/PrPauseService.java
@@ -18,7 +18,6 @@ package dev.thiagogonzaga.thrillhousebot.webhook;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import java.time.Instant;
 
 /**
  * Tracks which pull requests the bot has been paused on. Short DB transactions only — never spans
@@ -44,7 +43,7 @@ public class PrPauseService {
 
   /** Pauses the bot on the PR. Idempotent: a second pause leaves the single row untouched. */
   @Transactional
-  public void pause(String owner, String repo, int prNumber, String pausedBy) {
+  public void pause(String owner, String repo, int prNumber) {
     var key = repoKey(owner, repo);
     if (repository.count(BY_PR, key, prNumber) > 0) {
       return;
@@ -52,8 +51,6 @@ public class PrPauseService {
     var paused = new PausedPr();
     paused.repository = key;
     paused.prNumber = prNumber;
-    paused.pausedBy = pausedBy;
-    paused.pausedAt = Instant.now();
     repository.persist(paused);
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
@@ -16,18 +16,57 @@
 package dev.thiagogonzaga.thrillhousebot.webhook;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import java.util.Set;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
 public class TriggerDetector {
 
-  private static final Set<Pattern> TRIGGER_PATTERNS =
-      Set.of(
-          Pattern.compile(
-              ".*(?:^|\\s)/review(?:\\s|$).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL),
-          Pattern.compile(
-              ".*@thrillhousebot\\s+review\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+  /**
+   * Command word → its matching patterns, in detection precedence order. A comment carrying more
+   * than one command resolves to the first entry that matches, so {@code review} stays first to
+   * preserve the original trigger behavior. Each command accepts both the {@code /word} slash form
+   * and the {@code @Thrillhousebot word} mention form.
+   */
+  private static final Map<CommentCommand, List<Pattern>> COMMAND_PATTERNS = buildPatterns();
+
+  private static Map<CommentCommand, List<Pattern>> buildPatterns() {
+    var patterns = new LinkedHashMap<CommentCommand, List<Pattern>>();
+    patterns.put(CommentCommand.REVIEW, patternsFor("review"));
+    patterns.put(CommentCommand.HELP, patternsFor("help"));
+    patterns.put(CommentCommand.SUMMARY, patternsFor("summary"));
+    patterns.put(CommentCommand.RESOLVE, patternsFor("resolve"));
+    patterns.put(CommentCommand.PAUSE, patternsFor("pause"));
+    patterns.put(CommentCommand.RESUME, patternsFor("resume"));
+    return patterns;
+  }
+
+  private static List<Pattern> patternsFor(String word) {
+    return List.of(
+        Pattern.compile(
+            ".*(?:^|\\s)/" + word + "(?:\\s|$).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL),
+        Pattern.compile(
+            ".*@thrillhousebot\\s+" + word + "\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+  }
+
+  /**
+   * Parses the first recognized command from a comment body. Each command matches either its slash
+   * form ("/review") or its mention form ("@Thrillhousebot review"). Returns {@link
+   * CommentCommand#NONE} when the comment carries no command.
+   */
+  public CommentCommand detectCommand(String commentBody) {
+    if (commentBody == null || commentBody.isBlank()) {
+      return CommentCommand.NONE;
+    }
+    for (var entry : COMMAND_PATTERNS.entrySet()) {
+      if (entry.getValue().stream().anyMatch(p -> p.matcher(commentBody).matches())) {
+        return entry.getKey();
+      }
+    }
+    return CommentCommand.NONE;
+  }
 
   /** Matches an {@code @thrillhousebot} mention with a word boundary, anywhere in the comment. */
   private static final Pattern MENTION_PATTERN =
@@ -38,10 +77,7 @@ public class TriggerDetector {
    * "@Thrillhousebot review"
    */
   public boolean isReviewTrigger(String commentBody) {
-    if (commentBody == null || commentBody.isBlank()) {
-      return false;
-    }
-    return TRIGGER_PATTERNS.stream().anyMatch(p -> p.matcher(commentBody).matches());
+    return detectCommand(commentBody) == CommentCommand.REVIEW;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -17,7 +17,6 @@ package dev.thiagogonzaga.thrillhousebot.webhook;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
-import dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyService;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestrator;
@@ -41,9 +40,11 @@ public class WebhookController {
   private final TriggerDetector triggerDetector;
   private final ReviewTriggerFilter triggerFilter;
   private final ReviewDispatcher reviewDispatcher;
-  private final MaintainerReplyDispatcher replyDispatcher;
+  private final MaintainerReplyService.ReplyDispatcher replyDispatcher;
   private final WebhookDeduplicator deduplicator;
   private final ManualReviewAuthorizer manualReviewAuthorizer;
+  private final CommentCommandService commentCommandService;
+  private final PrPauseService prPauseService;
   private final ObjectMapper mapper;
 
   @Inject
@@ -53,9 +54,11 @@ public class WebhookController {
       TriggerDetector triggerDetector,
       ReviewTriggerFilter triggerFilter,
       ReviewDispatcher reviewDispatcher,
-      MaintainerReplyDispatcher replyDispatcher,
+      MaintainerReplyService.ReplyDispatcher replyDispatcher,
       WebhookDeduplicator deduplicator,
       ManualReviewAuthorizer manualReviewAuthorizer,
+      CommentCommandService commentCommandService,
+      PrPauseService prPauseService,
       ObjectMapper mapper) {
     this.config = config;
     this.verifier = verifier;
@@ -65,6 +68,8 @@ public class WebhookController {
     this.replyDispatcher = replyDispatcher;
     this.deduplicator = deduplicator;
     this.manualReviewAuthorizer = manualReviewAuthorizer;
+    this.commentCommandService = commentCommandService;
+    this.prPauseService = prPauseService;
     this.mapper = mapper;
   }
 
@@ -162,6 +167,14 @@ public class WebhookController {
           log.debug("Ignoring pull_request with missing pull_request, repository, or installation");
           yield true;
         }
+
+        // A /pause on this PR silences automatic reviews until /resume — stay silent here, no
+        // comment, since the event was not user-initiated.
+        if (prPauseService.isPaused(repo.owner().login(), repo.name(), pr.number())) {
+          log.info("Skipping review for paused PR #{} in {}", pr.number(), repo.fullName());
+          yield true;
+        }
+
         var skipReason = triggerFilter.skipReason(pr);
         if (skipReason.isPresent()) {
           log.info(
@@ -171,6 +184,7 @@ public class WebhookController {
               skipReason.get());
           yield true;
         }
+
         log.info("Dispatching review for PR #{} in {}", pr.number(), repo.fullName());
         yield reviewDispatcher.dispatch(
             new ReviewOrchestrator.ReviewRequest(
@@ -222,42 +236,37 @@ public class WebhookController {
       return true;
     }
 
-    if (triggerDetector.isReviewTrigger(payload.comment().body())) {
+    var command = triggerDetector.detectCommand(payload.comment().body());
+
+    if (command != CommentCommand.NONE) {
       var repo = payload.repository();
       if (repo == null || payload.installation() == null) {
-        log.debug("Ignoring review trigger with missing repository or installation");
+        log.debug("Ignoring {} command with missing repository or installation", command);
         return true;
       }
-      var owner = repo.owner().login();
-      var login = payload.comment().user().login();
-      var installationId = payload.installation().id();
-      // Manual triggers spend the operator's API budget, so restrict them to users who actually
-      // hold write access to the repository (or are explicitly allowlisted).
-      if (!manualReviewAuthorizer.isAuthorized(
-          owner, repo.name(), installationId, login, payload.comment().authorAssociation())) {
-        log.info(
-            "Ignoring unauthorized manual review trigger from @{} on PR #{}",
-            login,
-            payload.issue().number());
-        return true;
-      }
-      log.info("Manual review triggered by @{} on PR #{}", login, payload.issue().number());
-      // On issue_comment the issue number equals the PR number
-      return reviewDispatcher.dispatch(
-          new ReviewOrchestrator.ReviewRequest(
-              owner,
+      // On issue_comment the issue number equals the PR number.
+      var ctx =
+          new CommentCommandService.CommandContext(
+              command,
+              repo.owner().login(),
               repo.name(),
               payload.issue().number(),
-              "",
-              "(manual review)",
-              "",
-              "",
               repo.defaultBranch(),
-              installationId,
-              true));
+              payload.installation().id(),
+              payload.comment().user().login(),
+              payload.comment().authorAssociation());
+
+      // /review keeps its synchronous authorize-then-dispatch path so the dispatch outcome can roll
+      // back the webhook dedup slot (#89). Every other command runs asynchronously off the ack
+      // thread.
+      if (command == CommentCommand.REVIEW) {
+        return handleReviewCommand(ctx);
+      }
+      commentCommandService.handle(ctx);
+      return true;
     }
 
-    // Not a review command: a bare @thrillhousebot mention on a PR is a conversational question.
+    // Not a command: a bare @thrillhousebot mention on a PR is a conversational question.
     if (config.review().conversationalRepliesEnabled()
         && triggerDetector.containsBotMention(payload.comment().body())) {
       var repo = payload.repository();
@@ -286,6 +295,7 @@ public class WebhookController {
               true,
               null));
     }
+
     return true;
   }
 
@@ -356,5 +366,44 @@ public class WebhookController {
             comment.id(),
             mentioned,
             comment.diffHunk()));
+  }
+
+  /**
+   * Handles a manual {@code /review}: honors a pause, restricts the paid review to write-access
+   * holders, then dispatches it.
+   *
+   * @return the dispatch outcome (so a rejected dispatch rolls back the dedup slot), or {@code
+   *     true} when the command was handled without dispatching (paused or unauthorized).
+   */
+  private boolean handleReviewCommand(CommentCommandService.CommandContext ctx) {
+    if (prPauseService.isPaused(ctx.owner(), ctx.repo(), ctx.prNumber())) {
+      log.info(
+          "Ignoring /review on paused PR #{} in {}/{}", ctx.prNumber(), ctx.owner(), ctx.repo());
+      commentCommandService.notifyPaused(ctx);
+      return true;
+    }
+    // Manual triggers spend the operator's API budget, so restrict them to users who actually
+    // hold write access to the repository (or are explicitly allowlisted).
+    if (!manualReviewAuthorizer.isAuthorized(
+        ctx.owner(), ctx.repo(), ctx.installationId(), ctx.login(), ctx.authorAssociation())) {
+      log.info(
+          "Ignoring unauthorized manual review trigger from @{} on PR #{}",
+          ctx.login(),
+          ctx.prNumber());
+      return true;
+    }
+    log.info("Manual review triggered by @{} on PR #{}", ctx.login(), ctx.prNumber());
+    return reviewDispatcher.dispatch(
+        new ReviewOrchestrator.ReviewRequest(
+            ctx.owner(),
+            ctx.repo(),
+            ctx.prNumber(),
+            "",
+            "(manual review)",
+            "",
+            "",
+            ctx.defaultBranch(),
+            ctx.installationId(),
+            true));
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -17,6 +17,7 @@ package dev.thiagogonzaga.thrillhousebot.webhook;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyService;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestrator;
@@ -40,7 +41,7 @@ public class WebhookController {
   private final TriggerDetector triggerDetector;
   private final ReviewTriggerFilter triggerFilter;
   private final ReviewDispatcher reviewDispatcher;
-  private final MaintainerReplyService.ReplyDispatcher replyDispatcher;
+  private final MaintainerReplyDispatcher replyDispatcher;
   private final WebhookDeduplicator deduplicator;
   private final ManualReviewAuthorizer manualReviewAuthorizer;
   private final CommentCommandService commentCommandService;
@@ -54,7 +55,7 @@ public class WebhookController {
       TriggerDetector triggerDetector,
       ReviewTriggerFilter triggerFilter,
       ReviewDispatcher reviewDispatcher,
-      MaintainerReplyService.ReplyDispatcher replyDispatcher,
+      MaintainerReplyDispatcher replyDispatcher,
       WebhookDeduplicator deduplicator,
       ManualReviewAuthorizer manualReviewAuthorizer,
       CommentCommandService commentCommandService,

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionPersistenceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionPersistenceTest.java
@@ -124,6 +124,24 @@ class ReviewSessionPersistenceTest extends ReviewSessionTestSupport {
     assertTrue(persistence.findAllPriorAiResponseJsons("owner/repo", 3, current.id).isEmpty());
   }
 
+  @Test
+  void shouldReportCompletedReviewExists() throws Exception {
+    persistSessionWith("owner/repo", 3, ReviewSession.STATUS_COMPLETED, "{\"v\":1}");
+
+    assertTrue(persistence.hasCompletedReview("owner/repo", 3));
+  }
+
+  @Test
+  void shouldNotReportCompletedReviewForOtherStatusesOrPrs() throws Exception {
+    persistSessionWith("owner/repo", 3, ReviewSession.STATUS_IN_PROGRESS, null);
+    persistSessionWith("owner/repo", 3, ReviewSession.STATUS_FAILED, null);
+    persistSessionWith("owner/repo", 4, ReviewSession.STATUS_COMPLETED, "{\"v\":1}");
+
+    // No completed review for PR #3, and the completed one on PR #4 must not leak across.
+    assertFalse(persistence.hasCompletedReview("owner/repo", 3));
+    assertFalse(persistence.hasCompletedReview("other/repo", 4));
+  }
+
   private ReviewSession persistSession() throws Exception {
     tx.begin();
     ReviewSession session = ReviewSession.create("owner/repo", 3, "PR", "abc");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
@@ -28,6 +28,7 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.ReviewResponse
 import dev.thiagogonzaga.thrillhousebot.github.ReviewThreadService;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestrator;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -157,7 +158,8 @@ class CommentCommandServiceTest {
     var botRoot = comment(100L, null, "thrillhousebot[bot]");
     var botReply = comment(101L, 100L, "thrillhousebot[bot]");
     var humanRoot = comment(200L, null, "octocat");
-    when(reviewClient.listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(7)))
+    when(reviewClient.listPullRequestComments(
+            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(1)))
         .thenReturn(List.of(botRoot, botReply, humanRoot));
     when(reviewThreadService.threadsByRootComment(any(), eq("owner"), eq("repo"), eq(7)))
         .thenReturn(
@@ -177,7 +179,8 @@ class CommentCommandServiceTest {
   @Test
   void resolveReportsNothingToDoWhenNoBotThreads() {
     authorize(true);
-    when(reviewClient.listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(7)))
+    when(reviewClient.listPullRequestComments(
+            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(1)))
         .thenReturn(List.of(comment(200L, null, "octocat")));
 
     service.handle(ctx(CommentCommand.RESOLVE));
@@ -187,12 +190,35 @@ class CommentCommandServiceTest {
   }
 
   @Test
+  void resolveWalksAllCommentPages() {
+    authorize(true);
+    var page1 = new ArrayList<PullRequestComment>();
+    for (int i = 1; i <= 100; i++) {
+      page1.add(comment(i, null, "thrillhousebot[bot]"));
+    }
+    when(reviewClient.listPullRequestComments(
+            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(1)))
+        .thenReturn(page1);
+    when(reviewClient.listPullRequestComments(
+            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(2)))
+        .thenReturn(List.of());
+    when(reviewThreadService.threadsByRootComment(any(), eq("owner"), eq("repo"), eq(7)))
+        .thenReturn(Map.of());
+
+    service.handle(ctx(CommentCommand.RESOLVE));
+
+    // A full first page must force a second-page fetch so later-page bot threads are not missed.
+    verify(reviewClient)
+        .listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(2));
+  }
+
+  @Test
   void pausePersistsAndConfirms() {
     authorize(true);
 
     service.handle(ctx(CommentCommand.PAUSE));
 
-    verify(prPauseService).pause("owner", "repo", 7, "octocat");
+    verify(prPauseService).pause("owner", "repo", 7);
     assertTrue(postedBody().contains("paused"));
   }
 
@@ -202,7 +228,7 @@ class CommentCommandServiceTest {
 
     service.handle(ctx(CommentCommand.PAUSE));
 
-    verify(prPauseService, never()).pause(any(), any(), anyInt(), any());
+    verify(prPauseService, never()).pause(any(), any(), anyInt());
     verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
@@ -267,6 +267,30 @@ class CommentCommandServiceTest {
   }
 
   @Test
+  void resolveContinuesWhenOneThreadResolutionThrows() {
+    authorize(true);
+    when(reviewClient.listPullRequestComments(
+            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(1)))
+        .thenReturn(
+            List.of(
+                comment(100L, null, "thrillhousebot[bot]"),
+                comment(102L, null, "thrillhousebot[bot]")));
+    when(reviewThreadService.threadsByRootComment(any(), eq("owner"), eq("repo"), eq(7)))
+        .thenReturn(
+            Map.of(
+                100L, new ReviewThreadService.ThreadRef("T100", false),
+                102L, new ReviewThreadService.ThreadRef("T102", false)));
+    when(reviewThreadService.resolve(any(), eq("T100"))).thenThrow(new RuntimeException("network"));
+    when(reviewThreadService.resolve(any(), eq("T102"))).thenReturn(true);
+
+    service.handle(ctx(CommentCommand.RESOLVE));
+
+    // The failure on T100 must not stop T102 from being resolved.
+    verify(reviewThreadService).resolve(any(), eq("T102"));
+    assertTrue(postedBody().contains("Resolved 1"));
+  }
+
+  @Test
   void resolveSkipsAlreadyResolvedThreads() {
     authorize(true);
     when(reviewClient.listPullRequestComments(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
@@ -156,22 +156,28 @@ class CommentCommandServiceTest {
   void resolveResolvesOnlyUnresolvedBotThreads() {
     authorize(true);
     var botRoot = comment(100L, null, "thrillhousebot[bot]");
+    var botRoot2 = comment(102L, null, "thrillhousebot[bot]");
     var botReply = comment(101L, 100L, "thrillhousebot[bot]");
     var humanRoot = comment(200L, null, "octocat");
+    var authorless = new PullRequestComment(300L, null, "src/Foo.java", "body", null);
     when(reviewClient.listPullRequestComments(
             any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(1)))
-        .thenReturn(List.of(botRoot, botReply, humanRoot));
+        .thenReturn(List.of(botRoot, botRoot2, botReply, humanRoot, authorless));
     when(reviewThreadService.threadsByRootComment(any(), eq("owner"), eq("repo"), eq(7)))
         .thenReturn(
             Map.of(
                 100L, new ReviewThreadService.ThreadRef("T100", false),
+                102L, new ReviewThreadService.ThreadRef("T102", false),
                 200L, new ReviewThreadService.ThreadRef("T200", false)));
     when(reviewThreadService.resolve(any(), eq("T100"))).thenReturn(true);
+    when(reviewThreadService.resolve(any(), eq("T102"))).thenReturn(false); // GitHub didn't confirm
 
     service.handle(ctx(CommentCommand.RESOLVE));
 
-    // Only the bot's own root-comment thread is resolved; the human thread is left alone.
+    // Both bot threads are attempted; only the confirmed one is counted. The human thread is left
+    // alone, and the bot's reply (not a thread root) is ignored.
     verify(reviewThreadService).resolve(any(), eq("T100"));
+    verify(reviewThreadService).resolve(any(), eq("T102"));
     verify(reviewThreadService, never()).resolve(any(), eq("T200"));
     assertTrue(postedBody().contains("Resolved 1"));
   }
@@ -258,6 +264,101 @@ class CommentCommandServiceTest {
     service.notifyPaused(ctx(CommentCommand.REVIEW));
 
     assertEquals(CommentCommandService.PAUSED_NOTICE, postedBody());
+  }
+
+  @Test
+  void resolveSkipsAlreadyResolvedThreads() {
+    authorize(true);
+    when(reviewClient.listPullRequestComments(
+            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(1)))
+        .thenReturn(List.of(comment(100L, null, "thrillhousebot[bot]")));
+    when(reviewThreadService.threadsByRootComment(any(), eq("owner"), eq("repo"), eq(7)))
+        .thenReturn(Map.of(100L, new ReviewThreadService.ThreadRef("T100", true)));
+
+    service.handle(ctx(CommentCommand.RESOLVE));
+
+    // An already-resolved thread is not resolved again, and the message reflects nothing to do.
+    verify(reviewThreadService, never()).resolve(any(), any());
+    assertTrue(postedBody().contains("No open"));
+  }
+
+  @Test
+  void resolveStopsAtMaxCommentPages() {
+    authorize(true);
+    var fullPage = new ArrayList<PullRequestComment>();
+    for (int i = 1; i <= 100; i++) {
+      fullPage.add(comment(i, null, "octocat"));
+    }
+    // Every page is full, so the walk is bounded by the page cap rather than a short page.
+    when(reviewClient.listPullRequestComments(
+            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), anyInt()))
+        .thenReturn(fullPage);
+
+    service.handle(ctx(CommentCommand.RESOLVE));
+
+    verify(reviewClient, times(10))
+        .listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), anyInt());
+    assertTrue(postedBody().contains("No open"));
+  }
+
+  @Test
+  void resolveHandlesNullCommentsPage() {
+    authorize(true);
+    when(reviewClient.listPullRequestComments(
+            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(1)))
+        .thenReturn(null);
+
+    service.handle(ctx(CommentCommand.RESOLVE));
+
+    verify(reviewThreadService, never()).threadsByRootComment(any(), any(), any(), anyInt());
+    assertTrue(postedBody().contains("No open"));
+  }
+
+  @Test
+  void resolveIgnoredWhenUnauthorized() {
+    authorize(false);
+
+    service.handle(ctx(CommentCommand.RESOLVE));
+
+    verify(reviewClient, never())
+        .listPullRequestComments(any(), any(), any(), any(), anyInt(), anyInt(), anyInt());
+    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+  }
+
+  @Test
+  void resumeIgnoredWhenUnauthorized() {
+    authorize(false);
+
+    service.handle(ctx(CommentCommand.RESUME));
+
+    verify(prPauseService, never()).resume(any(), any(), anyInt());
+    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+  }
+
+  @Test
+  void executeSwallowsRuntimeExceptions() {
+    when(authClient.getAuthHeader(anyLong())).thenThrow(new RuntimeException("boom"));
+
+    // A failure inside the async task must be logged, not propagated to the executor thread.
+    assertDoesNotThrow(() -> service.handle(ctx(CommentCommand.HELP)));
+    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+  }
+
+  @Test
+  void executeIgnoresReviewCommand() {
+    // /review is handled synchronously by the controller; the service's switch default is a no-op.
+    service.execute(ctx(CommentCommand.REVIEW));
+
+    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+    verify(reviewDispatcher, never()).dispatch(any());
+  }
+
+  @Test
+  void notifyPausedSwallowsRuntimeExceptions() {
+    when(authClient.getAuthHeader(anyLong())).thenThrow(new RuntimeException("boom"));
+
+    assertDoesNotThrow(() -> service.notifyPaused(ctx(CommentCommand.REVIEW)));
+    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
   }
 
   private static PullRequestComment comment(long id, Long inReplyToId, String login) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.webhook;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSessionPersistence;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.PullRequestComment;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.ReviewResponse;
+import dev.thiagogonzaga.thrillhousebot.github.ReviewThreadService;
+import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
+import dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestrator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class CommentCommandServiceTest {
+
+  @Mock private ExecutorService executor;
+  @Mock private GitHubAuthClient authClient;
+  @Mock private GitHubCommentClient commentClient;
+  @Mock private GitHubReviewClient reviewClient;
+  @Mock private ReviewThreadService reviewThreadService;
+  @Mock private ReviewDispatcher reviewDispatcher;
+  @Mock private ReviewSessionPersistence sessionPersistence;
+  @Mock private PrPauseService prPauseService;
+  @Mock private ManualReviewAuthorizer authorizer;
+
+  private CommentCommandService service;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    when(authClient.getAuthHeader(anyLong())).thenReturn("token");
+    // Run submitted work inline so the async handoff is exercised synchronously in tests.
+    doAnswer(
+            inv -> {
+              inv.getArgument(0, Runnable.class).run();
+              return null;
+            })
+        .when(executor)
+        .execute(any(Runnable.class));
+    service =
+        new CommentCommandService(
+            executor,
+            authClient,
+            commentClient,
+            reviewClient,
+            reviewThreadService,
+            reviewDispatcher,
+            sessionPersistence,
+            prPauseService,
+            authorizer);
+  }
+
+  private CommentCommandService.CommandContext ctx(CommentCommand command) {
+    return new CommentCommandService.CommandContext(
+        command, "owner", "repo", 7, "main", 12345L, "octocat", "OWNER");
+  }
+
+  private void authorize(boolean allowed) {
+    when(authorizer.isAuthorized("owner", "repo", 12345L, "octocat", "OWNER")).thenReturn(allowed);
+  }
+
+  private String postedBody() {
+    var body = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+    verify(commentClient)
+        .createComment(any(), any(), eq("owner"), eq("repo"), eq(7), body.capture());
+    return body.getValue().body();
+  }
+
+  @Test
+  void helpPostsCommandListWithoutAuthorization() {
+    service.handle(ctx(CommentCommand.HELP));
+
+    assertEquals(CommentCommandService.HELP_TEXT, postedBody());
+    verifyNoInteractions(authorizer);
+    verify(reviewDispatcher, never()).dispatch(any());
+  }
+
+  @Test
+  void summaryDispatchesReviewWhenNoSummaryExists() {
+    authorize(true);
+    when(prPauseService.isPaused("owner", "repo", 7)).thenReturn(false);
+    when(sessionPersistence.hasCompletedReview("owner/repo", 7)).thenReturn(false);
+
+    service.handle(ctx(CommentCommand.SUMMARY));
+
+    verify(reviewDispatcher)
+        .dispatch(
+            new ReviewOrchestrator.ReviewRequest(
+                "owner", "repo", 7, "", "(manual summary)", "", "", "main", 12345L, true));
+    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+  }
+
+  @Test
+  void summaryIsNoOpWhenSummaryAlreadyExists() {
+    authorize(true);
+    when(prPauseService.isPaused("owner", "repo", 7)).thenReturn(false);
+    when(sessionPersistence.hasCompletedReview("owner/repo", 7)).thenReturn(true);
+
+    service.handle(ctx(CommentCommand.SUMMARY));
+
+    verify(reviewDispatcher, never()).dispatch(any());
+    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+  }
+
+  @Test
+  void summaryPostsPausedNoticeWhenPaused() {
+    authorize(true);
+    when(prPauseService.isPaused("owner", "repo", 7)).thenReturn(true);
+
+    service.handle(ctx(CommentCommand.SUMMARY));
+
+    assertEquals(CommentCommandService.PAUSED_NOTICE, postedBody());
+    verify(reviewDispatcher, never()).dispatch(any());
+    verify(sessionPersistence, never()).hasCompletedReview(any(), anyInt());
+  }
+
+  @Test
+  void summaryIgnoredWhenUnauthorized() {
+    authorize(false);
+
+    service.handle(ctx(CommentCommand.SUMMARY));
+
+    verify(reviewDispatcher, never()).dispatch(any());
+    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+    verifyNoInteractions(prPauseService);
+  }
+
+  @Test
+  void resolveResolvesOnlyUnresolvedBotThreads() {
+    authorize(true);
+    var botRoot = comment(100L, null, "thrillhousebot[bot]");
+    var botReply = comment(101L, 100L, "thrillhousebot[bot]");
+    var humanRoot = comment(200L, null, "octocat");
+    when(reviewClient.listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(7)))
+        .thenReturn(List.of(botRoot, botReply, humanRoot));
+    when(reviewThreadService.threadsByRootComment(any(), eq("owner"), eq("repo"), eq(7)))
+        .thenReturn(
+            Map.of(
+                100L, new ReviewThreadService.ThreadRef("T100", false),
+                200L, new ReviewThreadService.ThreadRef("T200", false)));
+    when(reviewThreadService.resolve(any(), eq("T100"))).thenReturn(true);
+
+    service.handle(ctx(CommentCommand.RESOLVE));
+
+    // Only the bot's own root-comment thread is resolved; the human thread is left alone.
+    verify(reviewThreadService).resolve(any(), eq("T100"));
+    verify(reviewThreadService, never()).resolve(any(), eq("T200"));
+    assertTrue(postedBody().contains("Resolved 1"));
+  }
+
+  @Test
+  void resolveReportsNothingToDoWhenNoBotThreads() {
+    authorize(true);
+    when(reviewClient.listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(7)))
+        .thenReturn(List.of(comment(200L, null, "octocat")));
+
+    service.handle(ctx(CommentCommand.RESOLVE));
+
+    verify(reviewThreadService, never()).threadsByRootComment(any(), any(), any(), anyInt());
+    assertTrue(postedBody().contains("No open"));
+  }
+
+  @Test
+  void pausePersistsAndConfirms() {
+    authorize(true);
+
+    service.handle(ctx(CommentCommand.PAUSE));
+
+    verify(prPauseService).pause("owner", "repo", 7, "octocat");
+    assertTrue(postedBody().contains("paused"));
+  }
+
+  @Test
+  void pauseIgnoredWhenUnauthorized() {
+    authorize(false);
+
+    service.handle(ctx(CommentCommand.PAUSE));
+
+    verify(prPauseService, never()).pause(any(), any(), anyInt(), any());
+    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+  }
+
+  @Test
+  void resumeClearsPauseAndConfirms() {
+    authorize(true);
+    when(prPauseService.resume("owner", "repo", 7)).thenReturn(true);
+
+    service.handle(ctx(CommentCommand.RESUME));
+
+    verify(prPauseService).resume("owner", "repo", 7);
+    assertTrue(postedBody().contains("resumed"));
+  }
+
+  @Test
+  void resumeReportsWhenNotPaused() {
+    authorize(true);
+    when(prPauseService.resume("owner", "repo", 7)).thenReturn(false);
+
+    service.handle(ctx(CommentCommand.RESUME));
+
+    assertTrue(postedBody().contains("was not paused"));
+  }
+
+  @Test
+  void notifyPausedPostsTheNotice() {
+    service.notifyPaused(ctx(CommentCommand.REVIEW));
+
+    assertEquals(CommentCommandService.PAUSED_NOTICE, postedBody());
+  }
+
+  private static PullRequestComment comment(long id, Long inReplyToId, String login) {
+    return new PullRequestComment(
+        id, inReplyToId, "src/Foo.java", "body", new ReviewResponse.User(login));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/PrPauseServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/PrPauseServiceTest.java
@@ -39,13 +39,13 @@ class PrPauseServiceTest {
   @Test
   void pauseThenIsPausedReturnsTrue() {
     assertFalse(service.isPaused("owner", "repo", 7));
-    service.pause("owner", "repo", 7, "octocat");
+    service.pause("owner", "repo", 7);
     assertTrue(service.isPaused("owner", "repo", 7));
   }
 
   @Test
   void resumeClearsPause() {
-    service.pause("owner", "repo", 7, "octocat");
+    service.pause("owner", "repo", 7);
     assertTrue(service.resume("owner", "repo", 7));
     assertFalse(service.isPaused("owner", "repo", 7));
   }
@@ -57,8 +57,8 @@ class PrPauseServiceTest {
 
   @Test
   void pauseIsIdempotent() {
-    service.pause("owner", "repo", 7, "octocat");
-    service.pause("owner", "repo", 7, "someoneElse");
+    service.pause("owner", "repo", 7);
+    service.pause("owner", "repo", 7);
 
     assertTrue(service.isPaused("owner", "repo", 7));
     assertEquals(1, PausedPr.count("repository = ?1 and prNumber = ?2", "owner/repo", 7));
@@ -66,7 +66,7 @@ class PrPauseServiceTest {
 
   @Test
   void pauseIsScopedPerPr() {
-    service.pause("owner", "repo", 7, "octocat");
+    service.pause("owner", "repo", 7);
 
     assertFalse(service.isPaused("owner", "repo", 8));
     assertFalse(service.isPaused("other", "repo", 7));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/PrPauseServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/PrPauseServiceTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.webhook;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.UserTransaction;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class PrPauseServiceTest {
+
+  @Inject PrPauseService service;
+  @Inject UserTransaction tx;
+
+  @AfterEach
+  void cleanup() throws Exception {
+    tx.begin();
+    PausedPr.deleteAll();
+    tx.commit();
+  }
+
+  @Test
+  void pauseThenIsPausedReturnsTrue() {
+    assertFalse(service.isPaused("owner", "repo", 7));
+    service.pause("owner", "repo", 7, "octocat");
+    assertTrue(service.isPaused("owner", "repo", 7));
+  }
+
+  @Test
+  void resumeClearsPause() {
+    service.pause("owner", "repo", 7, "octocat");
+    assertTrue(service.resume("owner", "repo", 7));
+    assertFalse(service.isPaused("owner", "repo", 7));
+  }
+
+  @Test
+  void resumeReturnsFalseWhenNotPaused() {
+    assertFalse(service.resume("owner", "repo", 7));
+  }
+
+  @Test
+  void pauseIsIdempotent() {
+    service.pause("owner", "repo", 7, "octocat");
+    service.pause("owner", "repo", 7, "someoneElse");
+
+    assertTrue(service.isPaused("owner", "repo", 7));
+    assertEquals(1, PausedPr.count("repository = ?1 and prNumber = ?2", "owner/repo", 7));
+  }
+
+  @Test
+  void pauseIsScopedPerPr() {
+    service.pause("owner", "repo", 7, "octocat");
+
+    assertFalse(service.isPaused("owner", "repo", 8));
+    assertFalse(service.isPaused("other", "repo", 7));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
@@ -47,6 +47,49 @@ class TriggerDetectorTest {
   }
 
   @Test
+  void shouldDetectEachSlashCommand() {
+    assertEquals(CommentCommand.REVIEW, detector.detectCommand("/review"));
+    assertEquals(CommentCommand.HELP, detector.detectCommand("please /help"));
+    assertEquals(CommentCommand.SUMMARY, detector.detectCommand("/summary this PR"));
+    assertEquals(CommentCommand.RESOLVE, detector.detectCommand("/resolve"));
+    assertEquals(CommentCommand.PAUSE, detector.detectCommand("hey /pause"));
+    assertEquals(CommentCommand.RESUME, detector.detectCommand("/resume now"));
+  }
+
+  @Test
+  void shouldDetectEachMentionCommand() {
+    assertEquals(CommentCommand.REVIEW, detector.detectCommand("@Thrillhousebot review"));
+    assertEquals(CommentCommand.HELP, detector.detectCommand("@thrillhousebot help"));
+    assertEquals(CommentCommand.SUMMARY, detector.detectCommand("@thrillhousebot summary please"));
+    assertEquals(CommentCommand.RESOLVE, detector.detectCommand("@thrillhousebot resolve"));
+    assertEquals(CommentCommand.PAUSE, detector.detectCommand("@thrillhousebot pause"));
+    assertEquals(CommentCommand.RESUME, detector.detectCommand("@thrillhousebot resume"));
+  }
+
+  @Test
+  void shouldNotConfuseSimilarCommandWords() {
+    // /resume and /resolve must not match the /review pattern, and vice versa.
+    assertEquals(CommentCommand.RESUME, detector.detectCommand("/resume"));
+    assertEquals(CommentCommand.RESOLVE, detector.detectCommand("/resolve"));
+    assertEquals(CommentCommand.REVIEW, detector.detectCommand("/review"));
+  }
+
+  @Test
+  void shouldReturnNoneForNonCommandComments() {
+    assertEquals(CommentCommand.NONE, detector.detectCommand("Looks good!"));
+    assertEquals(CommentCommand.NONE, detector.detectCommand("review this"));
+    assertEquals(CommentCommand.NONE, detector.detectCommand("@thrillhousebot hello"));
+    assertEquals(CommentCommand.NONE, detector.detectCommand(""));
+    assertEquals(CommentCommand.NONE, detector.detectCommand(null));
+  }
+
+  @Test
+  void shouldPreferReviewWhenMultipleCommandsPresent() {
+    // review has detection precedence so the original trigger behavior is preserved.
+    assertEquals(CommentCommand.REVIEW, detector.detectCommand("/help and /review"));
+  }
+
+  @Test
   void shouldDetectBotMention() {
     assertTrue(detector.containsBotMention("@thrillhousebot hello"));
     assertTrue(detector.containsBotMention("hey @Thrillhousebot what about this?"));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -1159,6 +1159,30 @@ class WebhookControllerTest {
     verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
   }
 
+  @Test
+  void shouldIgnoreCommandWhenInstallationMissing() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(triggerDetector.detectCommand("/help")).thenReturn(CommentCommand.HELP);
+    when(triggerDetector.isBotComment("user")).thenReturn(false);
+
+    var body =
+        "{"
+            + "\"action\":\"created\","
+            + "\"issue\":{\"number\":1,\"pull_request\":{\"url\":\"u\"}},"
+            + "\"comment\":{\"id\":1,\"body\":\"/help\",\"user\":{\"login\":\"user\",\"id\":1}},"
+            + "\"repository\":{\"full_name\":\"a/b\",\"name\":\"b\",\"default_branch\":\"main\",\"owner\":{\"login\":\"a\",\"id\":1}},"
+            + "\"installation\":null"
+            + "}";
+
+    var response =
+        controller.handleWebhook(
+            "sha256=valid", "issue_comment", null, DELIVERY, body.getBytes(StandardCharsets.UTF_8));
+    assertEquals(200, response.getStatus());
+
+    // A command with no installation cannot be authenticated to GitHub, so nothing runs.
+    verifyNoInteractions(commentCommandService);
+  }
+
   // ── helper methods ─────────────────────────────────────────────────────
 
   private String buildPullRequestPayload(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -55,6 +55,10 @@ class WebhookControllerTest {
 
   @Mock private ManualReviewAuthorizer manualReviewAuthorizer;
 
+  @Mock private CommentCommandService commentCommandService;
+
+  @Mock private PrPauseService prPauseService;
+
   private final ObjectMapper mapper = new ObjectMapper();
 
   /** A non-null delivery id; the mocked deduplicator reports it unseen unless a test overrides. */
@@ -79,6 +83,8 @@ class WebhookControllerTest {
             replyDispatcher,
             deduplicator,
             manualReviewAuthorizer,
+            commentCommandService,
+            prPauseService,
             mapper);
   }
 
@@ -298,6 +304,22 @@ class WebhookControllerTest {
   }
 
   @Test
+  void shouldSkipAutomaticReviewWhenPrPaused() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(prPauseService.isPaused("owner", "myrepo", 99)).thenReturn(true);
+
+    var body =
+        buildPullRequestPayload("synchronize", 99, "owner/myrepo", "headsha123", "main")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response = controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
+    assertEquals(200, response.getStatus());
+
+    // A paused PR must not auto-review on new commits.
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+  }
+
+  @Test
   void shouldIgnoreClosedPullRequest() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
 
@@ -404,7 +426,7 @@ class WebhookControllerTest {
   @Test
   void shouldTriggerManualReviewOnReviewCommand() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
-    when(triggerDetector.isReviewTrigger("/review")).thenReturn(true);
+    when(triggerDetector.detectCommand("/review")).thenReturn(CommentCommand.REVIEW);
     when(triggerDetector.isBotComment("octocat")).thenReturn(false);
     when(manualReviewAuthorizer.isAuthorized("owner", "repo", 12345L, "octocat", "OWNER"))
         .thenReturn(true);
@@ -425,7 +447,7 @@ class WebhookControllerTest {
   @Test
   void shouldIgnoreUnauthorizedManualReviewTrigger() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
-    when(triggerDetector.isReviewTrigger("/review")).thenReturn(true);
+    when(triggerDetector.detectCommand("/review")).thenReturn(CommentCommand.REVIEW);
     when(triggerDetector.isBotComment("stranger")).thenReturn(false);
     when(manualReviewAuthorizer.isAuthorized(
             anyString(), anyString(), anyLong(), anyString(), any()))
@@ -439,6 +461,51 @@ class WebhookControllerTest {
     assertEquals(200, response.getStatus());
 
     // A user without write access must not be able to spend the operator's API budget.
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+  }
+
+  @Test
+  void shouldSkipManualReviewOnPausedPr() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(triggerDetector.detectCommand("/review")).thenReturn(CommentCommand.REVIEW);
+    when(triggerDetector.isBotComment("octocat")).thenReturn(false);
+    when(prPauseService.isPaused("owner", "repo", 77)).thenReturn(true);
+
+    var body =
+        buildIssueCommentPayload("created", 77, "owner/repo", "octocat", "/review")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, DELIVERY, body);
+    assertEquals(200, response.getStatus());
+
+    // A paused PR neither authorizes nor dispatches the review; it just posts the paused notice.
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+    verifyNoInteractions(manualReviewAuthorizer);
+    verify(commentCommandService).notifyPaused(any(CommentCommandService.CommandContext.class));
+  }
+
+  @Test
+  void shouldRouteNonReviewCommandsToCommandService() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(triggerDetector.detectCommand("/help")).thenReturn(CommentCommand.HELP);
+    when(triggerDetector.isBotComment("octocat")).thenReturn(false);
+
+    var body =
+        buildIssueCommentPayload("created", 77, "owner/repo", "octocat", "/help")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, DELIVERY, body);
+    assertEquals(200, response.getStatus());
+
+    var ctx = org.mockito.ArgumentCaptor.forClass(CommentCommandService.CommandContext.class);
+    verify(commentCommandService).handle(ctx.capture());
+    assertEquals(CommentCommand.HELP, ctx.getValue().command());
+    assertEquals("owner", ctx.getValue().owner());
+    assertEquals("repo", ctx.getValue().repo());
+    assertEquals(77, ctx.getValue().prNumber());
+    assertEquals(12345L, ctx.getValue().installationId());
+    // /help must not consult authorization or the review dispatcher.
+    verifyNoInteractions(manualReviewAuthorizer);
     verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
   }
 
@@ -477,7 +544,7 @@ class WebhookControllerTest {
   @Test
   void shouldIgnoreIssueCommentWithoutTrigger() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
-    when(triggerDetector.isReviewTrigger("Nice PR!")).thenReturn(false);
+    when(triggerDetector.detectCommand("Nice PR!")).thenReturn(CommentCommand.NONE);
     when(triggerDetector.isBotComment("octocat")).thenReturn(false);
 
     var body =
@@ -487,14 +554,14 @@ class WebhookControllerTest {
     var response = controller.handleWebhook("sha256=valid", "issue_comment", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
-    // Orchestrator should NOT be called when trigger not detected
+    // Neither the dispatcher nor the command service runs when no command is detected.
     verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+    verifyNoInteractions(commentCommandService);
   }
 
   @Test
   void shouldIgnoreBotComment() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
-    when(triggerDetector.isReviewTrigger("/review")).thenReturn(true);
     when(triggerDetector.isBotComment("thrillhousebot[bot]")).thenReturn(true);
 
     var body =
@@ -504,8 +571,9 @@ class WebhookControllerTest {
     var response = controller.handleWebhook("sha256=valid", "issue_comment", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
-    // Orchestrator should NOT be called for bot comments
+    // The bot's own comment is dropped before command detection, so nothing runs.
     verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+    verifyNoInteractions(commentCommandService);
   }
 
   // ── conversational reply tests ─────────────────────────────────────────
@@ -1071,7 +1139,7 @@ class WebhookControllerTest {
   @Test
   void shouldIgnoreReviewTriggerWithMissingRepository() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
-    when(triggerDetector.isReviewTrigger("/review")).thenReturn(true);
+    when(triggerDetector.detectCommand("/review")).thenReturn(CommentCommand.REVIEW);
     when(triggerDetector.isBotComment("user")).thenReturn(false);
 
     var body =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -581,7 +581,8 @@ class WebhookControllerTest {
   @Test
   void shouldDispatchReplyForBotMentionOnPrComment() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
-    when(triggerDetector.isReviewTrigger("@thrillhousebot is this thread-safe?")).thenReturn(false);
+    when(triggerDetector.detectCommand("@thrillhousebot is this thread-safe?"))
+        .thenReturn(CommentCommand.NONE);
     when(triggerDetector.isBotComment("octocat")).thenReturn(false);
     when(triggerDetector.containsBotMention("@thrillhousebot is this thread-safe?"))
         .thenReturn(true);
@@ -620,7 +621,7 @@ class WebhookControllerTest {
   void shouldNotDispatchReplyForMentionWhenRepliesDisabled() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
     when(reviewConfig.conversationalRepliesEnabled()).thenReturn(false);
-    when(triggerDetector.isReviewTrigger("@thrillhousebot hi")).thenReturn(false);
+    when(triggerDetector.detectCommand("@thrillhousebot hi")).thenReturn(CommentCommand.NONE);
     when(triggerDetector.isBotComment("octocat")).thenReturn(false);
 
     var body =
@@ -896,7 +897,7 @@ class WebhookControllerTest {
   @Test
   void shouldIgnoreMentionWithMissingInstallation() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
-    when(triggerDetector.isReviewTrigger("@thrillhousebot hi")).thenReturn(false);
+    when(triggerDetector.detectCommand("@thrillhousebot hi")).thenReturn(CommentCommand.NONE);
     when(triggerDetector.isBotComment("octocat")).thenReturn(false);
     when(triggerDetector.containsBotMention("@thrillhousebot hi")).thenReturn(true);
 
@@ -920,7 +921,7 @@ class WebhookControllerTest {
   @Test
   void shouldIgnoreMentionWithMissingRepository() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
-    when(triggerDetector.isReviewTrigger("@thrillhousebot hi")).thenReturn(false);
+    when(triggerDetector.detectCommand("@thrillhousebot hi")).thenReturn(CommentCommand.NONE);
     when(triggerDetector.isBotComment("octocat")).thenReturn(false);
     when(triggerDetector.containsBotMention("@thrillhousebot hi")).thenReturn(true);
 


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature
- [x] ✅ Test
- [x] 📝 Documentation

## Description

The only PR command surface was `/review`. This adds a richer, intentionally-designed
set of comment commands so the bot can be operated directly from the PR:

| Command | What it does | Access |
|---|---|---|
| `/help` | List the available commands | anyone |
| `/review` | Run (or re-run) a full review (unchanged) | write |
| `/summary` | Post the PR summary, **only when none has been generated yet** (otherwise a no-op) | write |
| `/resolve` | Resolve ThrillhouseBot's outstanding finding threads on the PR | write |
| `/pause` | Silence the bot on the PR | write |
| `/resume` | Re-enable the bot on a paused PR | write |

Each command also accepts the `@Thrillhousebot <word>` mention form.

**Design**
- Detection moves from a boolean trigger to a `CommentCommand` enum (`TriggerDetector.detectCommand`); `isReviewTrigger` now delegates to it, so existing behavior and callers are unchanged.
- Non-review commands run **asynchronously** on the shared `@ReviewExecutor`, so the webhook 200-ack thread is never blocked by GitHub API calls. `/review` keeps its **synchronous** authorize-then-dispatch path to preserve the #89 dedup-rollback contract.
- **`/summary`** (per the issue's "regenerate the summary" intent, as clarified): if no completed review exists for the PR it dispatches a review (which posts the summary as the first review); if a summary already exists it does nothing.
- **`/pause`** silences *everything* — automatic reviews on push/open *and* manual `/review` / `/summary` — until `/resume`. Pause state is a persisted per-PR row (`PausedPr`, Hibernate auto-DDL — no migration; the project has no Flyway/Liquibase). `/help` and `/resolve` keep working while paused. An explicit `/review` or `/summary` on a paused PR gets a one-line "paused" reply; automatic events stay silent.
- Every command except `/help` requires repository write access, reusing the existing `ManualReviewAuthorizer` (reviews spend the operator's AI budget).

README gains a **Commands** section (table, access rules, pause semantics) and a Features bullet.

## Related Issues

Closes #32 (milestone v0.2.0).

## How Has This Been Tested?

- [x] Unit tests

New / expanded tests:
- `TriggerDetectorTest` — `detectCommand` for every `/word` and mention form, `NONE` for non-commands, review-precedence, and similar-word disambiguation (`/resume` vs `/resolve` vs `/review`).
- `WebhookControllerTest` — non-review commands route to the command service; paused PR skips both the automatic review and the `/review` dispatch (posting the paused notice).
- `CommentCommandServiceTest` (new) — help posts without auth; summary dispatches only when no summary exists, no-ops when one exists, replies when paused, and is rejected for unauthorized users; resolve resolves only the bot's own unresolved threads; pause/resume persist and confirm.
- `PrPauseServiceTest` (new, `@QuarkusTest`) — pause/isPaused/resume, idempotent pause, per-PR scoping.

Local verification:
- `./mvnw test` → **1009 tests, 0 failures, 0 errors** (BUILD SUCCESS), Spotless check clean.
  - Note: run with `-Djacoco.skip=true -Dquarkus.jacoco.enabled=false` because the JaCoCo 0.8.15 agent crashes at JVM startup under JDK 25 with `-XX:+UseCompactObjectHeaders` (a pre-existing local-tooling incompatibility, unrelated to this change).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The manual GitHub smoke test (live App install + Smee) was not run; the automated tests cover the routing, authorization, pause gating, and each command's effect.
