### PR TITLE
feat(webhook): review pull requests when marked ready_for_review (#72)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -144,7 +144,9 @@ public class WebhookController {
     if (action == null) return true;
 
     return switch (action) {
-      case "opened", "reopened", "synchronize" -> {
+      // ready_for_review fires when a draft PR is marked ready; it is not followed by a
+      // synchronize, so without this the PR stays unreviewed until the next push. (#72)
+      case "opened", "reopened", "synchronize", "ready_for_review" -> {
         var pr = payload.pullRequest();
         var repo = payload.repository();
         if (pr == null || repo == null || payload.installation() == null) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -239,6 +239,34 @@ class WebhookControllerTest {
   }
 
   @Test
+  void shouldRouteReadyForReviewPullRequestToOrchestrator() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+
+    // A draft marked "Ready for review" fires ready_for_review, not synchronize, so it must
+    // dispatch on its own or the PR stays unreviewed until the next push. (#72)
+    var body =
+        buildPullRequestPayload("ready_for_review", 21, "org/svc", "sha21", "main")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response = controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
+    assertEquals(200, response.getStatus());
+
+    verify(reviewDispatcher)
+        .dispatch(
+            new ReviewOrchestrator.ReviewRequest(
+                "org",
+                "svc",
+                21,
+                "sha21",
+                "Test PR title",
+                "PR body",
+                "basesha456",
+                "main",
+                12345L,
+                false));
+  }
+
+  @Test
   void shouldDefaultMissingPrBodyToEmptyDescription() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
 


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature

## Description

Only the `pull_request` actions `opened`/`reopened`/`synchronize` triggered a review. A PR opened as a **draft** and later marked **"Ready for review"** fires `pull_request.ready_for_review`, *not* `synchronize` — so it stayed unreviewed until the next push.

This adds `ready_for_review` to the actions handled by `WebhookController.handlePullRequest`. The `ready_for_review` payload carries the full PR object (head/base SHAs, title, body), so it slots into the existing dispatch path with no other changes. This is additive and won't conflict with the future skip-while-draft option in #40 — that gates *whether* to review while drafting; this triggers a review *when* the draft becomes ready.

## Related Issues

Fixes #72
Pairs with #40 (configurable triggers / skip drafts).

## How Has This Been Tested?

- [x] Unit tests

Added `shouldRouteReadyForReviewPullRequestToOrchestrator` in `WebhookControllerTest`, mirroring the existing reopened/synchronize routing tests — it asserts a `ready_for_review` payload dispatches a `ReviewRequest` with the expected fields. Full `WebhookControllerTest` suite passes: 33/33 (`-Djacoco.skip=true -Dquarkus.jacoco.enabled=false` on JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No GitHub App manifest change needed — the App subscribes to the whole "Pull requests" event, so `ready_for_review` deliveries already arrive. `docs/ARCHITECTURE.md` references "PR opened" only as an illustrative example flow (not a comprehensive trigger list), so it was left unchanged.
