### PR TITLE
ci: add actionlint guardrail for workflows and the Trivy composite (#93)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,32 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - run: ./mvnw spotless:check -q
 
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      # release.yml references the trivy-scan composite through a runtime
+      # side-path (./.actions-ref/.github/actions/...) populated by a sparse
+      # checkout, so that path does not exist at lint time. Mirror it with a
+      # symlink so actionlint resolves and validates the release-gate scan's
+      # inputs too — those scans are otherwise never exercised on PR CI.
+      - name: Mirror release.yml side-path for the trivy-scan composite
+        run: |
+          mkdir -p .actions-ref/.github
+          ln -s "$PWD/.github/actions" .actions-ref/.github/actions
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          curl -fsSL -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
+      # shellcheck ships on ubuntu-latest, so actionlint also lints inline run: scripts.
+      - name: Lint workflows and composite actions
+        run: ./actionlint -color
+
   test:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What type of PR is this?

- [x] 🏗️ CI/CD

## Description

Adds an `actionlint` job to `ci.yml` that lints every workflow **and** the consolidated `.github/actions/trivy-scan` composite action on each push/PR. Before this, there was no CI lint for GitHub Actions YAML, so a malformed workflow, a broken local-action reference, or a renamed composite input would only surface at runtime — worst of all on the release-gating Trivy scan, which isn't exercised on PR CI.

The job:

1. **Mirrors `release.yml`'s runtime side-path** (`.actions-ref/.github/actions`) with a symlink. `release.yml` references the composite via `./.actions-ref/.github/actions/trivy-scan`, a path populated by a sparse checkout that doesn't exist at lint time. The symlink lets actionlint resolve and validate the **release-gate** scan's inputs too (including the release-only `trivyignores` input), which no other PR-time check covers.
2. **Installs actionlint v1.7.12** from a pinned release, verified with `sha256sum -c` (hard fail on mismatch) — matching this repo's pinned-binary convention (cf. the `crane` install in `release.yml`).
3. **Lints all workflows + the composite.** `shellcheck` ships on `ubuntu-latest`, so actionlint also lints inline `run:` scripts.

### Notes for reviewers

- **No smoke job.** Issue #93 listed a smoke job as *optional*. actionlint + the symlink already validate the composite's inputs/resolution at every call site (incl. the release gate) without pulling images or running Trivy on each PR (heavier, and partly redundant with the existing `trivy` fs job). Easy to add later for runtime coverage.
- **Raw pinned binary over `reviewdog/action-actionlint`** — fewer supply-chain deps, an unambiguous hard gate (non-zero exit fails the job), consistent with the repo's pinned-download pattern.
- **CHANGELOG.md left untouched** — entries are curated at release-prep and there's no "Unreleased" section to append to.
- One inherent actionlint limit: a local-action path that doesn't exist at lint time is *silently skipped* (not errored), so a literally mistyped local-action path isn't caught — but a renamed/removed **input** on an existing action is, which is the more likely regression.

## Related Issues

Closes #93. Relates to #82 (the Trivy composite consolidation this guards).

## How Has This Been Tested?

- [x] Manual testing

Verified locally with `actionlint` 1.7.12 + `shellcheck` 0.11.0:

- Full suite passes clean (exit 0), **with and without** the symlink — no false positives on existing workflows (incl. `release.yml`'s `.actions-ref` side-path).
- Guardrail bites: a deliberately renamed composite input (`scan-typo`) is flagged at the `ci.yml`/`security-scan.yml` call sites **and**, via the symlink, at `release.yml`'s side-path calls.
- The new job's own YAML and inline shell pass actionlint+shellcheck.
- Confirmed the pinned download URL resolves, the SHA256 matches, and the linux tarball extracts a top-level `actionlint` binary.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors

## Additional Notes

CI-only change; no application code touched. Runs with the workflow's default `contents: read` permissions (the job only reads files).