### PR TITLE
fix(webhook): bound the manual-review authorization GitHub API call on the ACK path (#92)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -115,6 +115,17 @@ public interface ThrillhouseConfig {
      */
     @WithName("manual-trigger-allowed-logins")
     Optional<List<String>> manualTriggerAllowedLogins();
+
+    /**
+     * Upper bound on the manual-review write-access check — the installation-token mint (on a cold
+     * cache) plus the GitHub collaborator-permission call — which runs on the synchronous webhook
+     * acknowledgement thread. GitHub expects the {@code 200} ACK within ~10s, so when this elapses
+     * the check fails closed (denying the manual review) instead of letting a degraded GitHub tie
+     * up a webhook worker past the delivery SLA.
+     */
+    @WithDefault("5s")
+    @WithName("manual-trigger-auth-timeout")
+    Duration manualTriggerAuthTimeout();
   }
 
   interface DashboardConfig {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizer.java
@@ -137,6 +137,11 @@ public class ManualReviewAuthorizer {
           login,
           timeout);
     } catch (ExecutionException e) {
+      // Fail closed on an expected runtime failure, but let a fatal Error (OOM, etc.) propagate as
+      // it would have before the check ran on a separate thread, rather than masking it.
+      if (e.getCause() instanceof Error error) {
+        throw error;
+      }
       log.warn(
           "Permission check failed for {}/{} user {} — denying manual review",
           owner,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizer.java
@@ -137,13 +137,12 @@ public class ManualReviewAuthorizer {
           login,
           timeout);
     } catch (ExecutionException e) {
-      var cause = e.getCause() != null ? e.getCause() : e;
       log.warn(
-          "Permission check failed for {}/{} user {}: {} — denying manual review",
+          "Permission check failed for {}/{} user {} — denying manual review",
           owner,
           repo,
           login,
-          cause.getMessage());
+          e.getCause());
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       check.cancel(true);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizer.java
@@ -128,7 +128,7 @@ public class ManualReviewAuthorizer {
         authCheckExecutor.submit(() -> writeAccessConfirmed(owner, repo, installationId, login));
     try {
       return check.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-    } catch (TimeoutException e) {
+    } catch (TimeoutException _) {
       check.cancel(true);
       log.warn(
           "Permission check for {}/{} user {} exceeded {} on the ACK path — denying manual review",
@@ -148,7 +148,7 @@ public class ManualReviewAuthorizer {
           repo,
           login,
           e.getCause());
-    } catch (InterruptedException e) {
+    } catch (InterruptedException _) {
       Thread.currentThread().interrupt();
       check.cancel(true);
       log.warn(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizer.java
@@ -18,11 +18,18 @@ package dev.thiagogonzaga.thrillhousebot.webhook;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubInstallationClient;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +64,15 @@ public class ManualReviewAuthorizer {
   private final GitHubAuthClient authClient;
   private final GitHubInstallationClient installationClient;
 
+  /**
+   * Runs the write-access check (token mint + permission call) off the webhook acknowledgement
+   * thread so it can be abandoned once {@code manual-trigger-auth-timeout} elapses. Virtual threads
+   * keep an abandoned-but-still-blocked check cheap if GitHub is slow to respond.
+   */
+  private final ExecutorService authCheckExecutor =
+      Executors.newThreadPerTaskExecutor(
+          Thread.ofVirtual().name("manual-review-auth-", 0).factory());
+
   @Inject
   public ManualReviewAuthorizer(
       ThrillhouseConfig config,
@@ -65,6 +81,11 @@ public class ManualReviewAuthorizer {
     this.config = config;
     this.authClient = authClient;
     this.installationClient = installationClient;
+  }
+
+  @PreDestroy
+  void shutdown() {
+    authCheckExecutor.shutdownNow();
   }
 
   /**
@@ -102,20 +123,45 @@ public class ManualReviewAuthorizer {
   }
 
   private boolean hasWriteAccess(String owner, String repo, long installationId, String login) {
+    var timeout = config.review().manualTriggerAuthTimeout();
+    Future<Boolean> check =
+        authCheckExecutor.submit(() -> writeAccessConfirmed(owner, repo, installationId, login));
     try {
-      var permission =
-          installationClient.collaboratorPermission(
-              authClient.getAuthHeader(installationId), ACCEPT, owner, repo, login);
-      var level = permission == null ? null : permission.permission();
-      return level != null && WRITE_PERMISSIONS.contains(level.trim().toLowerCase(Locale.ROOT));
-    } catch (RuntimeException e) {
+      return check.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (TimeoutException e) {
+      check.cancel(true);
+      log.warn(
+          "Permission check for {}/{} user {} exceeded {} on the ACK path — denying manual review",
+          owner,
+          repo,
+          login,
+          timeout);
+    } catch (ExecutionException e) {
+      var cause = e.getCause() != null ? e.getCause() : e;
       log.warn(
           "Permission check failed for {}/{} user {}: {} — denying manual review",
           owner,
           repo,
           login,
-          e.getMessage());
-      return false;
+          cause.getMessage());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      check.cancel(true);
+      log.warn(
+          "Permission check for {}/{} user {} was interrupted — denying manual review",
+          owner,
+          repo,
+          login);
     }
+    return false;
+  }
+
+  private boolean writeAccessConfirmed(
+      String owner, String repo, long installationId, String login) {
+    var permission =
+        installationClient.collaboratorPermission(
+            authClient.getAuthHeader(installationId), ACCEPT, owner, repo, login);
+    var level = permission == null ? null : permission.permission();
+    return level != null && WRITE_PERMISSIONS.contains(level.trim().toLowerCase(Locale.ROOT));
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,6 +56,9 @@ thrillhousebot.review.instructions-file=.github/thrillhousebot.md
 # Second-pass AI audit that drops/downgrades unverifiable findings before they are posted
 thrillhousebot.review.verifier-enabled=${REVIEW_VERIFIER_ENABLED:true}
 thrillhousebot.review.ignored-files=**/pom.xml,**/package-lock.json,**/*.lock,**/*.generated.*,**/target/**
+# Upper bound on the manual-trigger write-access check (token mint + collaborator-permission call)
+# that runs on the webhook ACK thread; fails closed if GitHub is too slow to answer within the SLA.
+thrillhousebot.review.manual-trigger-auth-timeout=${MANUAL_TRIGGER_AUTH_TIMEOUT:5s}
 
 # Database (H2 for dev, PostgreSQL for prod)
 quarkus.datasource.db-kind=${DATASOURCE_DB_KIND:h2}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizerTest.java
@@ -26,6 +26,7 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubInstallationClient.Collabor
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -168,26 +169,33 @@ class ManualReviewAuthorizerTest {
     // ACK-path budget. The check must abandon it and deny rather than block the webhook worker.
     when(reviewConfig.manualTriggerAuthTimeout()).thenReturn(Duration.ofMillis(100));
     when(authClient.getAuthHeader(anyLong())).thenReturn("Bearer token");
+    // The latch keeps the call in flight (past the timeout) without a wall-clock sleep.
+    var release = new CountDownLatch(1);
     when(installationClient.collaboratorPermission(
             anyString(), anyString(), anyString(), anyString(), anyString()))
         .thenAnswer(
             inv -> {
-              Thread.sleep(2000);
+              release.await();
               return new CollaboratorPermission("admin", "admin");
             });
 
-    assertFalse(authorizer.isAuthorized("o", "r", 1L, "member", "MEMBER"));
+    try {
+      assertFalse(authorizer.isAuthorized("o", "r", 1L, "member", "MEMBER"));
+    } finally {
+      release.countDown(); // let the abandoned check finish so its thread does not leak
+    }
   }
 
   @Test
   void shouldFailClosedWhenInterruptedWhileWaitingOnPermissionCheck() {
     when(authClient.getAuthHeader(anyLong())).thenReturn("Bearer token");
-    // The check is still in flight when the waiting thread is interrupted.
+    // The latch keeps the check in flight so the waiting thread observes the interrupt.
+    var release = new CountDownLatch(1);
     when(installationClient.collaboratorPermission(
             anyString(), anyString(), anyString(), anyString(), anyString()))
         .thenAnswer(
             inv -> {
-              Thread.sleep(2000);
+              release.await();
               return new CollaboratorPermission("admin", "admin");
             });
 
@@ -198,6 +206,7 @@ class ManualReviewAuthorizerTest {
       assertTrue(Thread.currentThread().isInterrupted());
     } finally {
       Thread.interrupted(); // clear so the flag does not leak into later tests
+      release.countDown();
     }
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizerTest.java
@@ -178,4 +178,32 @@ class ManualReviewAuthorizerTest {
 
     assertFalse(authorizer.isAuthorized("o", "r", 1L, "member", "MEMBER"));
   }
+
+  @Test
+  void shouldFailClosedWhenInterruptedWhileWaitingOnPermissionCheck() {
+    when(authClient.getAuthHeader(anyLong())).thenReturn("Bearer token");
+    // The check is still in flight when the waiting thread is interrupted.
+    when(installationClient.collaboratorPermission(
+            anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenAnswer(
+            inv -> {
+              Thread.sleep(2000);
+              return new CollaboratorPermission("admin", "admin");
+            });
+
+    Thread.currentThread().interrupt(); // observed when hasWriteAccess waits on the check
+    try {
+      assertFalse(authorizer.isAuthorized("o", "r", 1L, "member", "MEMBER"));
+      // The handler restores the interrupt flag rather than swallowing it.
+      assertTrue(Thread.currentThread().isInterrupted());
+    } finally {
+      Thread.interrupted(); // clear so the flag does not leak into later tests
+    }
+  }
+
+  @Test
+  void shutdownStopsTheAuthCheckExecutor() {
+    // @PreDestroy must release the background executor without throwing.
+    assertDoesNotThrow(() -> authorizer.shutdown());
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizerTest.java
@@ -23,6 +23,7 @@ import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubInstallationClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubInstallationClient.CollaboratorPermission;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +48,7 @@ class ManualReviewAuthorizerTest {
     MockitoAnnotations.openMocks(this);
     when(config.review()).thenReturn(reviewConfig);
     when(reviewConfig.manualTriggerAllowedLogins()).thenReturn(Optional.empty());
+    when(reviewConfig.manualTriggerAuthTimeout()).thenReturn(Duration.ofSeconds(5));
     authorizer = new ManualReviewAuthorizer(config, authClient, installationClient);
   }
 
@@ -158,5 +160,22 @@ class ManualReviewAuthorizerTest {
   void shouldTreatPermissionLevelCaseInsensitively() {
     stubPermission("WRITE");
     assertTrue(authorizer.isAuthorized("o", "r", 1L, "member", "MEMBER"));
+  }
+
+  @Test
+  void shouldFailClosedWhenPermissionCheckExceedsTimeout() {
+    // GitHub is degraded: the permission call would eventually answer "admin", but not within the
+    // ACK-path budget. The check must abandon it and deny rather than block the webhook worker.
+    when(reviewConfig.manualTriggerAuthTimeout()).thenReturn(Duration.ofMillis(100));
+    when(authClient.getAuthHeader(anyLong())).thenReturn("Bearer token");
+    when(installationClient.collaboratorPermission(
+            anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenAnswer(
+            inv -> {
+              Thread.sleep(2000);
+              return new CollaboratorPermission("admin", "admin");
+            });
+
+    assertFalse(authorizer.isAuthorized("o", "r", 1L, "member", "MEMBER"));
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizerTest.java
@@ -202,6 +202,21 @@ class ManualReviewAuthorizerTest {
   }
 
   @Test
+  void shouldPropagateErrorFromPermissionCheck() {
+    // A fatal Error must not be masked as a denied review — it propagates as it would have before
+    // the check moved onto a separate thread.
+    when(authClient.getAuthHeader(anyLong())).thenReturn("Bearer token");
+    var fatal = new Error("simulated fatal");
+    when(installationClient.collaboratorPermission(
+            anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenThrow(fatal);
+
+    var thrown =
+        assertThrows(Error.class, () -> authorizer.isAuthorized("o", "r", 1L, "member", "MEMBER"));
+    assertSame(fatal, thrown);
+  }
+
+  @Test
   void shutdownStopsTheAuthCheckExecutor() {
     // @PreDestroy must release the background executor without throwing.
     assertDoesNotThrow(() -> authorizer.shutdown());


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [x] 🚀 Performance
- [x] ✅ Test
- [x] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`ManualReviewAuthorizer.hasWriteAccess` makes a **blocking** GitHub call — `collaboratorPermission`, plus a possible installation-token mint on a cold cache — on the synchronous webhook request thread before the `200` ACK is returned (`WebhookController.handleIssueComment` → `isAuthorized`). GitHub expects the webhook ACK within ~10s; under a degraded GitHub a single authorized `/review` could occupy a webhook worker thread past that SLA, risk a redelivery, and tie up the request pool.

This PR adds an explicit, short, **configurable** timeout to that authorization work so it fails fast on the ACK path.

### Why an in-code timeout rather than a REST-client `read-timeout`

Both blocking calls route through the `github-api` REST client — the **same** client that fetches large PR diffs (`getPullRequestFiles` / `compareCommits`) on the review path. Setting `quarkus.rest-client."github-api".read-timeout` to a few seconds would also clamp those large-diff fetches, risking spurious review failures. So the bound is applied **in code**, scoped to exactly the ACK-path authorization and covering **both** the token mint and the permission call.

### What changed

- **`ManualReviewAuthorizer`** runs the write-access check on a dedicated virtual-thread executor (matching the existing `ReviewExecutorProducer` idiom) and applies `Future.get(timeout)`. It still **fails closed** on missing permission / any API error — same behavior as before — and now also on timeout or interrupt. The executor is torn down via `@PreDestroy`.
- **`ThrillhouseConfig.ReviewConfig`** gains `manual-trigger-auth-timeout` (Duration, default **5s**).
- **`application.properties`** surfaces it as the `MANUAL_TRIGGER_AUTH_TIMEOUT` env override.

The negative `author_association` pre-filter (zero-API rejection of non-write associations) and the allowlist short-circuit are untouched, so the common abuse path still makes **no** API call. Automatic `pull_request` reviews are unaffected.

## Related Issues

Fixes #92
Refs #85, #70

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- New `ManualReviewAuthorizerTest.shouldFailClosedWhenPermissionCheckExceedsTimeout`: with a 100ms timeout and a permission call that would otherwise answer "admin" after 2s, the check abandons it and denies.
- `ManualReviewAuthorizerTest` + `WebhookControllerTest`: **45 tests, 0 failures** (run with `-Djacoco.skip=true -Dquarkus.jacoco.enabled=false` on JDK 25).
- `./mvnw spotless:check` passes.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The timeout is operator-tunable (`MANUAL_TRIGGER_AUTH_TIMEOUT`, default `5s`) and bounds the entire authorization round-trip on the webhook acknowledgement thread, including a cold-cache installation-token mint.
