### PR TITLE
fix(v0.2.0): resolve Sonar smells and review findings from release audit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Keep the Docker build context small and stable. The image builds only need
+# target/ (runtime/jvm Dockerfiles) and mvnw/.mvn/pom.xml/src (multistage), so
+# everything below is excluded — it bloats the context upload and busts the
+# build cache without being copied into any image.
+
+# Version control and CI metadata
+.git
+.gitignore
+.gitattributes
+.github
+.actions-ref
+
+# Frontend dependencies and build output. The dashboard is built separately and
+# baked into src/main/resources before the image build; the Next.js project
+# itself is never part of an image build context.
+**/node_modules
+frontend/.next
+frontend/out
+frontend/coverage
+frontend/.turbo
+
+# Docs (not copied into any image)
+docs
+
+# Secrets and local env — never ship these in a build context
+.env
+.env.*
+!.env.example
+
+# IDE / editor / OS junk
+.idea
+.vscode
+*.iml
+*.swp
+.DS_Store
+Thumbs.db
+
+# Worktree / agent scratch
+.claude

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,12 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: SonarCloud Scan
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        # SonarCloud's free/community plan analyzes only the main branch and pull requests.
+        # Run it on pushes to main and on same-repo PRs; skip pushes to develop/release/**,
+        # where branch analysis is unavailable and the scan would fail.
+        if: >-
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ code review.
 
 ## Features
 
+- Reviews diffs for correctness, security, regressions, stale comments, and code quality
 - Configurable auto-review triggers — skip drafts, gate on labels, or filter by base branch
 - Inline code suggestions on review comments that you can apply with one click
 - Every finding is tagged `critical`, `high`, `medium`, or `low`
@@ -180,8 +181,10 @@ variables are the ones you will change per provider:
 | `GITHUB_APP_ID` | GitHub App ID | _(required)_ |
 | `GITHUB_PRIVATE_KEY` | GitHub App private key (PEM) | _(required)_ |
 | `GITHUB_WEBHOOK_SECRET` | Webhook HMAC secret | _(required)_ |
+| `GITHUB_BOT_LOGINS` | Comma-separated bot account login(s) the bot skips to avoid replying to itself; override when deployed under a different App slug (`<app-slug>[bot]`) | `thrillhousebot[bot],thrillhouse-bot[bot]` |
 | `WEBHOOK_DEDUP_TTL` | Webhook deduplication time-to-live for GitHub redeliveries | `24h` |
 | `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` | Comma-separated allowlist of logins permitted to trigger manual `/review` without repo access | _(empty)_ |
+| `MANUAL_TRIGGER_AUTH_TIMEOUT` | Upper bound on the manual-trigger write-access check on the webhook ACK thread; fails closed (denies) if GitHub is slower | `5s` |
 | `WEBHOOK_SKIP_DRAFTS` | Skip auto-review while a PR is a draft (reviewed once marked ready / on later pushes) | `false` |
 | `WEBHOOK_REQUIRED_LABELS` | Comma-separated labels; only auto-review PRs carrying at least one (case-insensitive) | _(empty — no gate)_ |
 | `WEBHOOK_EXCLUDED_LABELS` | Comma-separated labels; skip auto-review of PRs carrying any (wins over required) | _(empty)_ |
@@ -307,7 +310,7 @@ To report a vulnerability, see [SECURITY.md](SECURITY.md).
 
 ## Known limitations
 
-Early v0.1.0 release:
+This is still an early-stage project; the current constraints are:
 
 - **GitHub only** — no GitLab or Bitbucket integration.
 - **Large diffs** — the model sees at most `thrillhousebot.review.max-diff-lines` diff

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -42,6 +42,7 @@ public class StartupConfigValidator {
   private static final Logger log = LoggerFactory.getLogger(StartupConfigValidator.class);
 
   private static final String PRIVATE_KEY_PROPERTY = "thrillhousebot.github.private-key";
+  private static final String APP_ID_PROPERTY = "thrillhousebot.github.app-id";
 
   private final ThrillhouseConfig config;
   private final String aiApiKey;
@@ -72,7 +73,7 @@ public class StartupConfigValidator {
     var problems = new ArrayList<String>();
 
     var github = config.github();
-    requirePresent(problems, github.appId(), "GITHUB_APP_ID", "thrillhousebot.github.app-id");
+    validateAppId(problems, github.appId());
     validatePrivateKey(problems, github.privateKey());
     requirePresent(
         problems,
@@ -95,6 +96,22 @@ public class StartupConfigValidator {
       List<String> problems, String value, String envVar, String property) {
     if (value == null || value.isBlank()) {
       problems.add(envVar + " is required but is not set (" + property + ")");
+    }
+  }
+
+  /**
+   * The GitHub App id is the JWT issuer; a non-numeric value passes a bare presence check but
+   * yields a JWT GitHub rejects on the first call, so reject it at boot — exactly the late failure
+   * this validator exists to prevent.
+   */
+  private static void validateAppId(List<String> problems, String appId) {
+    if (appId == null || appId.isBlank()) {
+      problems.add("GITHUB_APP_ID is required but is not set (" + APP_ID_PROPERTY + ")");
+      return;
+    }
+    if (!appId.strip().chars().allMatch(Character::isDigit)) {
+      problems.add(
+          "GITHUB_APP_ID must be the numeric GitHub App id (" + APP_ID_PROPERTY + "): " + appId);
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -62,6 +62,15 @@ public interface ThrillhouseConfig {
 
     @WithName("webhook-secret")
     String webhookSecret();
+
+    /**
+     * GitHub login(s) of this App's bot account, used to skip the bot's own comments and avoid
+     * infinite reply loops. Defaults to the names this project ships under; override when the App
+     * is deployed under a different slug (its bot login is {@code <app-slug>[bot]}).
+     */
+    @WithName("bot-logins")
+    @WithDefault("thrillhousebot[bot],thrillhouse-bot[bot]")
+    List<String> botLogins();
   }
 
   interface WebhookConfig {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/ReviewThreadService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/ReviewThreadService.java
@@ -35,16 +35,21 @@ public class ReviewThreadService {
 
   private static final String THREADS_QUERY =
       """
-      query($owner: String!, $name: String!, $number: Int!) {
+      query($owner: String!, $name: String!, $number: Int!, $after: String) {
         repository(owner: $owner, name: $name) {
           pullRequest(number: $number) {
-            reviewThreads(first: 100) {
+            reviewThreads(first: 100, after: $after) {
               nodes { id isResolved comments(first: 1) { nodes { databaseId } } }
+              pageInfo { hasNextPage endCursor }
             }
           }
         }
       }
       """;
+
+  // A PR with more review threads than this (100 per page) is far beyond anything realistic; the
+  // bound just stops a malformed pageInfo from looping forever.
+  private static final int MAX_THREAD_PAGES = 20;
 
   private static final String RESOLVE_MUTATION =
       """
@@ -63,30 +68,46 @@ public class ReviewThreadService {
     this.graphQLClient = graphQLClient;
   }
 
-  /** Maps each thread's root-comment database id to the thread's node id and resolution state. */
+  /**
+   * Maps each thread's root-comment database id to the thread's node id and resolution state. Walks
+   * every page so a PR with more than 100 review threads still has all its threads resolvable —
+   * otherwise {@code /resolve} would silently skip bot findings past the first page.
+   */
   public Map<Long, ThreadRef> threadsByRootComment(
       String auth, String owner, String repo, int prNumber) {
-    var response =
-        graphQLClient.execute(
-            auth,
-            new GitHubGraphQLClient.GraphQLRequest(
-                THREADS_QUERY, Map.of("owner", owner, "name", repo, "number", prNumber)));
     var threads = new HashMap<Long, ThreadRef>();
-    var nodes =
-        response
-            .path("data")
-            .path("repository")
-            .path("pullRequest")
-            .path("reviewThreads")
-            .path("nodes");
-    for (JsonNode node : nodes) {
-      var firstComment = node.path("comments").path("nodes").path(0);
-      if (firstComment.path("databaseId").isNumber() && node.path("id").isTextual()) {
-        threads.put(
-            firstComment.path("databaseId").asLong(),
-            new ThreadRef(node.path("id").asText(), node.path("isResolved").asBoolean()));
+    String after = null;
+    int page = 0;
+    do {
+      var variables = new HashMap<String, Object>();
+      variables.put("owner", owner);
+      variables.put("name", repo);
+      variables.put("number", prNumber);
+      if (after != null) {
+        variables.put("after", after);
       }
-    }
+      var reviewThreads =
+          graphQLClient
+              .execute(auth, new GitHubGraphQLClient.GraphQLRequest(THREADS_QUERY, variables))
+              .path("data")
+              .path("repository")
+              .path("pullRequest")
+              .path("reviewThreads");
+      for (JsonNode node : reviewThreads.path("nodes")) {
+        var firstComment = node.path("comments").path("nodes").path(0);
+        if (firstComment.path("databaseId").isNumber() && node.path("id").isTextual()) {
+          threads.put(
+              firstComment.path("databaseId").asLong(),
+              new ThreadRef(node.path("id").asText(), node.path("isResolved").asBoolean()));
+        }
+      }
+      var pageInfo = reviewThreads.path("pageInfo");
+      after =
+          pageInfo.path("hasNextPage").asBoolean(false)
+              ? pageInfo.path("endCursor").asText(null)
+              : null;
+      page++;
+    } while (after != null && page < MAX_THREAD_PAGES);
     return threads;
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
@@ -26,6 +26,7 @@ import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -43,6 +44,11 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 public class MaintainerReplyService {
 
   private static final String ACCEPT = "application/vnd.github+json";
+
+  // GitHub serves 30 review comments per page by default; request the 100 max and walk a bounded
+  // number of pages so a busy thread's root comment and prior replies are not missed past page one.
+  private static final int COMMENTS_PER_PAGE = 100;
+  private static final int MAX_COMMENT_PAGES = 10;
 
   private final GitHubAuthClient authClient;
   private final ManualReviewAuthorizer authorizer;
@@ -228,14 +234,23 @@ public class MaintainerReplyService {
   }
 
   private List<GitHubReviewClient.PullRequestComment> listReviewComments(String auth, ReplyTask t) {
+    var all = new ArrayList<GitHubReviewClient.PullRequestComment>();
     try {
-      var comments =
-          reviewClient.listPullRequestComments(auth, ACCEPT, t.owner(), t.repo(), t.prNumber());
-      return comments != null ? comments : List.of();
+      List<GitHubReviewClient.PullRequestComment> batch;
+      int page = 1;
+      do {
+        batch =
+            reviewClient.listPullRequestComments(
+                auth, ACCEPT, t.owner(), t.repo(), t.prNumber(), COMMENTS_PER_PAGE, page);
+        if (batch != null) {
+          all.addAll(batch);
+        }
+        page++;
+      } while (batch != null && batch.size() == COMMENTS_PER_PAGE && page <= MAX_COMMENT_PAGES);
     } catch (RuntimeException e) {
       Log.warn("Failed to list PR review comments for reply context", e);
-      return List.of();
     }
+    return all;
   }
 
   private static GitHubReviewClient.PullRequestComment findRoot(
@@ -255,10 +270,11 @@ public class MaintainerReplyService {
       long triggeringCommentId) {
     var sb = new StringBuilder();
     for (var c : comments) {
-      if (c.inReplyToId() == null || c.inReplyToId() != rootCommentId) {
-        continue;
-      }
-      if (c.id() == triggeringCommentId) {
+      // Keep only the other replies on this thread: skip non-replies, replies to a different root,
+      // and the message that triggered this reply.
+      if (c.inReplyToId() == null
+          || c.inReplyToId() != rootCommentId
+          || c.id() == triggeringCommentId) {
         continue;
       }
       String author = c.user() != null ? c.user().login() : "unknown";

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
@@ -237,7 +237,9 @@ public class CommentCommandService {
       log.info("Ignoring unauthorized /pause from @{} on PR #{}", ctx.login(), num(ctx));
       return;
     }
-    pauseIdempotently(ctx);
+    if (!pauseIfPossible(ctx)) {
+      return; // genuine failure already logged — do not post a misleading confirmation
+    }
     postComment(
         auth,
         ctx,
@@ -248,17 +250,22 @@ public class CommentCommandService {
   /**
    * Pauses the PR, tolerating a concurrent {@code /pause} that wins the insert race. The unique
    * constraint lets only one of two simultaneous inserts succeed; the loser's transaction throws,
-   * but the PR is paused either way, so a row that already exists is success — only a genuine
-   * failure (no row afterwards) is propagated, keeping the confirmation comment intact.
+   * but the PR is paused either way — so a row that exists afterwards counts as success.
+   *
+   * @return whether the PR is paused after this call (newly, or by a concurrent {@code /pause})
    */
-  private void pauseIdempotently(CommandContext ctx) {
+  private boolean pauseIfPossible(CommandContext ctx) {
     try {
       prPauseService.pause(ctx.owner(), ctx.repo(), ctx.prNumber());
+      return true;
     } catch (RuntimeException e) {
-      if (!prPauseService.isPaused(ctx.owner(), ctx.repo(), ctx.prNumber())) {
-        throw e;
+      boolean paused = prPauseService.isPaused(ctx.owner(), ctx.repo(), ctx.prNumber());
+      if (paused) {
+        log.debug("Concurrent /pause already paused {}/{} #{}", ctx.owner(), ctx.repo(), num(ctx));
+      } else {
+        log.error("Failed to pause {}/{} #{}", ctx.owner(), ctx.repo(), num(ctx), e);
       }
-      log.debug("Concurrent /pause already paused {}/{} #{}", ctx.owner(), ctx.repo(), num(ctx));
+      return paused;
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
@@ -126,7 +126,7 @@ public class CommentCommandService {
             postComment(authClient.getAuthHeader(ctx.installationId()), ctx, PAUSED_NOTICE);
           } catch (RuntimeException e) {
             log.warn(
-                "Failed to post paused notice on {}/{} #{}", ctx.owner(), ctx.repo(), num(ctx));
+                "Failed to post paused notice on {}/{} #{}", ctx.owner(), ctx.repo(), num(ctx), e);
           }
         });
   }
@@ -165,12 +165,17 @@ public class CommentCommandService {
     }
     if (sessionPersistence.hasCompletedReview(repository(ctx), ctx.prNumber())) {
       // A summary was already generated on the first review; the command is a no-op by design.
-      log.info("Ignoring /summary — a summary already exists on {} #{}", repository(ctx), num(ctx));
+      log.info(
+          "Ignoring /summary — a summary already exists on {}/{} #{}",
+          ctx.owner(),
+          ctx.repo(),
+          num(ctx));
       return;
     }
     log.info(
-        "Generating summary via review for {} #{} (triggered by @{})",
-        repository(ctx),
+        "Generating summary via review for {}/{} #{} (triggered by @{})",
+        ctx.owner(),
+        ctx.repo(),
         num(ctx),
         ctx.login());
     reviewDispatcher.dispatch(
@@ -232,12 +237,29 @@ public class CommentCommandService {
       log.info("Ignoring unauthorized /pause from @{} on PR #{}", ctx.login(), num(ctx));
       return;
     }
-    prPauseService.pause(ctx.owner(), ctx.repo(), ctx.prNumber());
+    pauseIdempotently(ctx);
     postComment(
         auth,
         ctx,
         "⏸️ ThrillhouseBot is now paused on this PR — automatic and manual reviews are silenced. "
             + "Comment `/resume` to re-enable.");
+  }
+
+  /**
+   * Pauses the PR, tolerating a concurrent {@code /pause} that wins the insert race. The unique
+   * constraint lets only one of two simultaneous inserts succeed; the loser's transaction throws,
+   * but the PR is paused either way, so a row that already exists is success — only a genuine
+   * failure (no row afterwards) is propagated, keeping the confirmation comment intact.
+   */
+  private void pauseIdempotently(CommandContext ctx) {
+    try {
+      prPauseService.pause(ctx.owner(), ctx.repo(), ctx.prNumber());
+    } catch (RuntimeException e) {
+      if (!prPauseService.isPaused(ctx.owner(), ctx.repo(), ctx.prNumber())) {
+        throw e;
+      }
+      log.debug("Concurrent /pause already paused {}/{} #{}", ctx.owner(), ctx.repo(), num(ctx));
+    }
   }
 
   private void handleResume(CommandContext ctx, String auth) {
@@ -260,24 +282,24 @@ public class CommentCommandService {
    */
   private List<Long> botRootCommentIds(String auth, CommandContext ctx) {
     var ids = new ArrayList<Long>();
-    for (int page = 1; page <= MAX_COMMENT_PAGES; page++) {
-      var comments =
+    List<GitHubReviewClient.PullRequestComment> comments;
+    int page = 1;
+    do {
+      comments =
           reviewClient.listPullRequestComments(
               auth, ACCEPT, ctx.owner(), ctx.repo(), ctx.prNumber(), COMMENTS_PER_PAGE, page);
-      if (comments == null || comments.isEmpty()) {
-        break;
-      }
-      for (var c : comments) {
-        if (c.inReplyToId() == null
-            && c.user() != null
-            && BOT_LOGIN.equalsIgnoreCase(c.user().login())) {
-          ids.add(c.id());
+      if (comments != null) {
+        for (var c : comments) {
+          if (c.inReplyToId() == null
+              && c.user() != null
+              && BOT_LOGIN.equalsIgnoreCase(c.user().login())) {
+            ids.add(c.id());
+          }
         }
       }
-      if (comments.size() < COMMENTS_PER_PAGE) {
-        break; // a short page is GitHub's last-page marker
-      }
-    }
+      page++;
+      // A short (or absent) page is GitHub's last-page marker; a full page means walk the next one.
+    } while (comments != null && comments.size() == COMMENTS_PER_PAGE && page <= MAX_COMMENT_PAGES);
     return ids;
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
@@ -43,7 +43,6 @@ public class CommentCommandService {
   private static final Logger log = LoggerFactory.getLogger(CommentCommandService.class);
 
   private static final String ACCEPT = "application/vnd.github+json";
-  private static final String BOT_LOGIN = "thrillhousebot[bot]";
 
   // GitHub serves 30 review comments per page by default; request the 100 max and walk a bounded
   // number of pages so /resolve covers every bot finding thread, not just the first page.
@@ -79,6 +78,7 @@ public class CommentCommandService {
   private final ReviewSessionPersistence sessionPersistence;
   private final PrPauseService prPauseService;
   private final ManualReviewAuthorizer authorizer;
+  private final TriggerDetector triggerDetector;
 
   @Inject
   public CommentCommandService(
@@ -90,7 +90,8 @@ public class CommentCommandService {
       ReviewDispatcher reviewDispatcher,
       ReviewSessionPersistence sessionPersistence,
       PrPauseService prPauseService,
-      ManualReviewAuthorizer authorizer) {
+      ManualReviewAuthorizer authorizer,
+      TriggerDetector triggerDetector) {
     this.executor = executor;
     this.authClient = authClient;
     this.commentClient = commentClient;
@@ -100,6 +101,7 @@ public class CommentCommandService {
     this.sessionPersistence = sessionPersistence;
     this.prPauseService = prPauseService;
     this.authorizer = authorizer;
+    this.triggerDetector = triggerDetector;
   }
 
   /** PR coordinates and commenter identity for one command. */
@@ -299,7 +301,7 @@ public class CommentCommandService {
         for (var c : comments) {
           if (c.inReplyToId() == null
               && c.user() != null
-              && BOT_LOGIN.equalsIgnoreCase(c.user().login())) {
+              && triggerDetector.isBotComment(c.user().login())) {
             ids.add(c.id());
           }
         }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
@@ -15,14 +15,23 @@
  */
 package dev.thiagogonzaga.thrillhousebot.webhook;
 
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class TriggerDetector {
+
+  /** Default GitHub App bot logins used when none are configured. */
+  static final List<String> DEFAULT_BOT_LOGINS =
+      List.of("thrillhousebot[bot]", "thrillhouse-bot[bot]");
 
   /**
    * Command word → its matching patterns, in detection precedence order. A comment carrying more
@@ -31,6 +40,45 @@ public class TriggerDetector {
    * and the {@code @Thrillhousebot word} mention form.
    */
   private static final Map<CommentCommand, List<Pattern>> COMMAND_PATTERNS = buildPatterns();
+
+  /** Matches an {@code @thrillhousebot} mention with a word boundary, anywhere in the comment. */
+  private static final Pattern MENTION_PATTERN =
+      Pattern.compile(".*@thrillhousebot\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+  // Fenced code (``` … ``` or ~~~ … ~~~), blockquote lines (> …) and inline code (`…`) are quoted
+  // context, not instructions: a maintainer quoting or documenting a command must not execute it.
+  private static final Pattern FENCED_CODE = Pattern.compile("(?s)```.*?```|~~~.*?~~~");
+  private static final Pattern BLOCKQUOTE_LINE = Pattern.compile("(?m)^[ \\t]*>.*$");
+  private static final Pattern INLINE_CODE = Pattern.compile("`[^`\\n]*`");
+
+  private final Set<String> botLogins;
+
+  @Inject
+  public TriggerDetector(ThrillhouseConfig config) {
+    this(config.github().botLogins());
+  }
+
+  /** Default detector wired with the built-in bot logins (used in tests and as a fallback). */
+  public TriggerDetector() {
+    this(DEFAULT_BOT_LOGINS);
+  }
+
+  TriggerDetector(List<String> configuredBotLogins) {
+    var normalized =
+        (configuredBotLogins == null ? DEFAULT_BOT_LOGINS : configuredBotLogins)
+            .stream()
+                .filter(s -> s != null && !s.isBlank())
+                .map(s -> s.strip().toLowerCase(Locale.ROOT))
+                .collect(Collectors.toUnmodifiableSet());
+    // Never end up with an empty set: that would make isBotComment always false and let the bot
+    // answer its own replies (an infinite loop). Fall back to the built-in logins instead.
+    this.botLogins =
+        normalized.isEmpty()
+            ? DEFAULT_BOT_LOGINS.stream()
+                .map(s -> s.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toUnmodifiableSet())
+            : normalized;
+  }
 
   private static Map<CommentCommand, List<Pattern>> buildPatterns() {
     var patterns = new LinkedHashMap<CommentCommand, List<Pattern>>();
@@ -52,6 +100,17 @@ public class TriggerDetector {
   }
 
   /**
+   * Strips quoted context — fenced code blocks, blockquotes, and inline code — so a command that
+   * only appears inside them (e.g. when quoting another comment or documenting the command list) is
+   * not mistaken for an instruction.
+   */
+  static String stripQuotedContext(String body) {
+    var withoutFenced = FENCED_CODE.matcher(body).replaceAll(" ");
+    var withoutQuotes = BLOCKQUOTE_LINE.matcher(withoutFenced).replaceAll(" ");
+    return INLINE_CODE.matcher(withoutQuotes).replaceAll(" ");
+  }
+
+  /**
    * Parses the first recognized command from a comment body. Each command matches either its slash
    * form ("/review") or its mention form ("@Thrillhousebot review"). Returns {@link
    * CommentCommand#NONE} when the comment carries no command.
@@ -60,17 +119,14 @@ public class TriggerDetector {
     if (commentBody == null || commentBody.isBlank()) {
       return CommentCommand.NONE;
     }
+    var body = stripQuotedContext(commentBody);
     for (var entry : COMMAND_PATTERNS.entrySet()) {
-      if (entry.getValue().stream().anyMatch(p -> p.matcher(commentBody).matches())) {
+      if (entry.getValue().stream().anyMatch(p -> p.matcher(body).matches())) {
         return entry.getKey();
       }
     }
     return CommentCommand.NONE;
   }
-
-  /** Matches an {@code @thrillhousebot} mention with a word boundary, anywhere in the comment. */
-  private static final Pattern MENTION_PATTERN =
-      Pattern.compile(".*@thrillhousebot\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
   /**
    * Checks whether a comment body contains a review trigger keyword. Triggers: "/review" or
@@ -89,13 +145,14 @@ public class TriggerDetector {
     if (commentBody == null || commentBody.isBlank()) {
       return false;
     }
-    return MENTION_PATTERN.matcher(commentBody).matches();
+    return MENTION_PATTERN.matcher(stripQuotedContext(commentBody)).matches();
   }
 
   /** Checks whether the comment author is the bot itself. Prevents infinite review loops. */
   public boolean isBotComment(String authorLogin) {
-    if (authorLogin == null) return false;
-    return ("thrillhousebot[bot]".equalsIgnoreCase(authorLogin)
-        || "thrillhouse-bot[bot]".equalsIgnoreCase(authorLogin));
+    if (authorLogin == null) {
+      return false;
+    }
+    return botLogins.contains(authorLogin.toLowerCase(Locale.ROOT));
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -168,6 +168,12 @@ public class WebhookController {
           log.debug("Ignoring pull_request with missing pull_request, repository, or installation");
           yield true;
         }
+        // head/base drive the review request; a payload missing either would NPE below. The trigger
+        // filter already treats base as nullable, so guard here rather than crash the delivery.
+        if (pr.head() == null || pr.base() == null) {
+          log.debug("Ignoring pull_request #{} with missing head or base", pr.number());
+          yield true;
+        }
 
         // A /pause on this PR silences automatic reviews until /resume — stay silent here, no
         // comment, since the event was not user-initiated.
@@ -238,66 +244,74 @@ public class WebhookController {
     }
 
     var command = triggerDetector.detectCommand(payload.comment().body());
-
     if (command != CommentCommand.NONE) {
-      var repo = payload.repository();
-      if (repo == null || payload.installation() == null) {
-        log.debug("Ignoring {} command with missing repository or installation", command);
-        return true;
-      }
-      // On issue_comment the issue number equals the PR number.
-      var ctx =
-          new CommentCommandService.CommandContext(
-              command,
-              repo.owner().login(),
-              repo.name(),
-              payload.issue().number(),
-              repo.defaultBranch(),
-              payload.installation().id(),
-              payload.comment().user().login(),
-              payload.comment().authorAssociation());
+      return handleCommentCommand(payload, command);
+    }
+    // Not a command: a bare @thrillhousebot mention on a PR is a conversational question.
+    return maybeDispatchConversationalMention(payload);
+  }
 
-      // /review keeps its synchronous authorize-then-dispatch path so the dispatch outcome can roll
-      // back the webhook dedup slot (#89). Every other command runs asynchronously off the ack
-      // thread.
-      if (command == CommentCommand.REVIEW) {
-        return handleReviewCommand(ctx);
-      }
-      commentCommandService.handle(ctx);
+  /**
+   * Builds the command context and routes a recognized comment command. {@code /review} keeps its
+   * synchronous authorize-then-dispatch path so the dispatch outcome can roll back the webhook
+   * dedup slot (#89); every other command runs asynchronously off the ack thread.
+   */
+  private boolean handleCommentCommand(WebhookPayload payload, CommentCommand command) {
+    var repo = payload.repository();
+    if (repo == null || payload.installation() == null) {
+      log.debug("Ignoring {} command with missing repository or installation", command);
       return true;
     }
+    // On issue_comment the issue number equals the PR number.
+    var ctx =
+        new CommentCommandService.CommandContext(
+            command,
+            repo.owner().login(),
+            repo.name(),
+            payload.issue().number(),
+            repo.defaultBranch(),
+            payload.installation().id(),
+            payload.comment().user().login(),
+            payload.comment().authorAssociation());
 
-    // Not a command: a bare @thrillhousebot mention on a PR is a conversational question.
-    if (config.review().conversationalRepliesEnabled()
-        && triggerDetector.containsBotMention(payload.comment().body())) {
-      var repo = payload.repository();
-      if (repo == null || payload.installation() == null) {
-        log.debug("Ignoring bot mention with missing repository or installation");
-        return true;
-      }
-      log.info(
-          "Conversational mention from @{} on PR #{}",
-          payload.comment().user().login(),
-          payload.issue().number());
-      return replyDispatcher.dispatch(
-          new MaintainerReplyService.ReplyTask(
-              repo.owner().login(),
-              repo.name(),
-              payload.issue().number(),
-              payload.installation().id(),
-              payload.comment().user().login(),
-              payload.comment().authorAssociation(),
-              payload.comment().body(),
-              payload.issue().title(),
-              payload.issue().body(),
-              false,
-              null,
-              payload.comment().id(),
-              true,
-              null));
+    if (command == CommentCommand.REVIEW) {
+      return handleReviewCommand(ctx);
     }
-
+    commentCommandService.handle(ctx);
     return true;
+  }
+
+  /** Dispatches a conversational reply for a bare {@code @thrillhousebot} mention on a PR. */
+  private boolean maybeDispatchConversationalMention(WebhookPayload payload) {
+    if (!config.review().conversationalRepliesEnabled()
+        || !triggerDetector.containsBotMention(payload.comment().body())) {
+      return true;
+    }
+    var repo = payload.repository();
+    if (repo == null || payload.installation() == null) {
+      log.debug("Ignoring bot mention with missing repository or installation");
+      return true;
+    }
+    log.info(
+        "Conversational mention from @{} on PR #{}",
+        payload.comment().user().login(),
+        payload.issue().number());
+    return replyDispatcher.dispatch(
+        new MaintainerReplyService.ReplyTask(
+            repo.owner().login(),
+            repo.name(),
+            payload.issue().number(),
+            payload.installation().id(),
+            payload.comment().user().login(),
+            payload.comment().authorAssociation(),
+            payload.comment().body(),
+            payload.issue().title(),
+            payload.issue().body(),
+            false,
+            null,
+            payload.comment().id(),
+            true,
+            null));
   }
 
   /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,6 +18,9 @@ github-api/mp-rest/url=https://api.github.com
 thrillhousebot.github.app-id=${GITHUB_APP_ID:}
 thrillhousebot.github.private-key=${GITHUB_PRIVATE_KEY:}
 thrillhousebot.github.webhook-secret=${GITHUB_WEBHOOK_SECRET:}
+# Bot account login(s) used to skip the bot's own comments (loop protection). Override when the App
+# is deployed under a different slug — its bot login is <app-slug>[bot].
+thrillhousebot.github.bot-logins=${GITHUB_BOT_LOGINS:thrillhousebot[bot],thrillhouse-bot[bot]}
 
 # Webhook redelivery dedup — drop repeat X-GitHub-Delivery ids within the TTL so GitHub
 # redeliveries/retries do not trigger duplicate reviews (in-memory, per replica).

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -127,6 +127,12 @@ class StartupConfigValidatorTest {
   }
 
   @Test
+  void failsFastWhenAppIdNull() {
+    var ex = assertFailsValidation(new ConfigBuilder().appId(null).build());
+    assertTrue(ex.getMessage().contains("GITHUB_APP_ID is required"), ex.getMessage());
+  }
+
+  @Test
   void failsFastWhenAppIdIsNotNumeric() {
     // A non-numeric app id passes a bare presence check but yields a JWT GitHub rejects, so it must
     // be rejected at boot rather than on the first webhook.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -127,6 +127,21 @@ class StartupConfigValidatorTest {
   }
 
   @Test
+  void failsFastWhenAppIdIsNotNumeric() {
+    // A non-numeric app id passes a bare presence check but yields a JWT GitHub rejects, so it must
+    // be rejected at boot rather than on the first webhook.
+    var ex = assertFailsValidation(new ConfigBuilder().appId("my-app").build());
+    assertTrue(
+        ex.getMessage().contains("GITHUB_APP_ID must be the numeric GitHub App id"),
+        ex.getMessage());
+  }
+
+  @Test
+  void passesWhenAppIdIsNumericWithSurroundingWhitespace() {
+    new ConfigBuilder().appId("  12345  ").build().validate();
+  }
+
+  @Test
   void failsFastWhenPrivateKeyMissing() {
     var ex = assertFailsValidation(new ConfigBuilder().privateKey("  ").build());
     assertTrue(ex.getMessage().contains("GITHUB_PRIVATE_KEY is required"), ex.getMessage());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/ReviewThreadServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/ReviewThreadServiceTest.java
@@ -95,6 +95,22 @@ class ReviewThreadServiceTest {
   }
 
   @Test
+  void shouldStopAtThePageBoundWhenGitHubKeepsReportingMorePages() throws Exception {
+    // hasNextPage never goes false, so only the page bound can stop the walk.
+    stubResponse(
+        """
+        {"data": {"repository": {"pullRequest": {"reviewThreads": {
+          "nodes": [{"id": "T", "isResolved": false, "comments": {"nodes": [{"databaseId": 1}]}}],
+          "pageInfo": {"hasNextPage": true, "endCursor": "C"}
+        }}}}}
+        """);
+
+    service.threadsByRootComment("auth", "owner", "repo", 7);
+
+    verify(graphQLClient, times(20)).execute(anyString(), any());
+  }
+
+  @Test
   void shouldSkipThreadsWithMissingIdsOrComments() throws Exception {
     stubResponse(
         """

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/ReviewThreadServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/ReviewThreadServiceTest.java
@@ -63,6 +63,38 @@ class ReviewThreadServiceTest {
   }
 
   @Test
+  void shouldWalkAllPagesWhenThreadsSpanMoreThanOnePage() throws Exception {
+    var page1 =
+        mapper.readTree(
+            """
+            {"data": {"repository": {"pullRequest": {"reviewThreads": {
+              "nodes": [{"id": "T1", "isResolved": false, "comments": {"nodes": [{"databaseId": 100}]}}],
+              "pageInfo": {"hasNextPage": true, "endCursor": "CURSOR1"}
+            }}}}}
+            """);
+    var page2 =
+        mapper.readTree(
+            """
+            {"data": {"repository": {"pullRequest": {"reviewThreads": {
+              "nodes": [{"id": "T2", "isResolved": true, "comments": {"nodes": [{"databaseId": 200}]}}],
+              "pageInfo": {"hasNextPage": false, "endCursor": null}
+            }}}}}
+            """);
+    when(graphQLClient.execute(anyString(), any())).thenReturn(page1, page2);
+
+    var threads = service.threadsByRootComment("auth", "owner", "repo", 7);
+
+    assertEquals(2, threads.size());
+    assertEquals("T1", threads.get(100L).id());
+    assertEquals("T2", threads.get(200L).id());
+    // Page 1 carries no cursor; page 2 carries the cursor returned by page 1.
+    var captor = ArgumentCaptor.forClass(GitHubGraphQLClient.GraphQLRequest.class);
+    verify(graphQLClient, times(2)).execute(eq("auth"), captor.capture());
+    assertNull(captor.getAllValues().get(0).variables().get("after"));
+    assertEquals("CURSOR1", captor.getAllValues().get(1).variables().get("after"));
+  }
+
+  @Test
   void shouldSkipThreadsWithMissingIdsOrComments() throws Exception {
     stubResponse(
         """

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
@@ -26,6 +26,7 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReplyAssistant;
 import dev.thiagogonzaga.thrillhousebot.webhook.ManualReviewAuthorizer;
 import dev.thiagogonzaga.thrillhousebot.webhook.TriggerDetector;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -133,7 +134,7 @@ class MaintainerReplyServiceTest {
   void replyOnBotThreadPostsAnswerWithFindingAndPriorRepliesAsContext() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(
             List.of(
                 comment(99L, null, BOT, "**CRITICAL — possible NPE** on user lookup"),
@@ -176,10 +177,37 @@ class MaintainerReplyServiceTest {
   }
 
   @Test
+  void walksAllCommentPagesToFindARootBeyondTheFirstPage() {
+    authorize();
+    // Page 1 is full (100 comments) so a second page is fetched; the bot finding root is on page 2.
+    var firstPage = new ArrayList<GitHubReviewClient.PullRequestComment>();
+    for (int i = 0; i < 100; i++) {
+      firstPage.add(comment(2000L + i, 77L, "octocat", "noise " + i));
+    }
+    when(reviewClient.listPullRequestComments(
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), eq(100), eq(1)))
+        .thenReturn(firstPage);
+    when(reviewClient.listPullRequestComments(
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), eq(100), eq(2)))
+        .thenReturn(List.of(comment(99L, null, BOT, "**finding** on page two")));
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("Answer.");
+
+    service.handle(reviewThreadTask(false));
+
+    // Root comment 99 lived on page 2; without pagination the bot would have stayed silent.
+    verify(reviewClient)
+        .listPullRequestComments(
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), eq(100), eq(2));
+    verify(reviewClient)
+        .replyToReviewComment(
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), eq(99L), any());
+  }
+
+  @Test
   void replyOnHumanThreadWithoutMentionPostsNothing() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(
             List.of(
                 comment(99L, null, "someone", "I think this is wrong"),
@@ -196,7 +224,7 @@ class MaintainerReplyServiceTest {
   void replyOnHumanThreadWithMentionStillAnswers() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(List.of(comment(99L, null, "someone", "what does the bot think?")));
     when(replyAssistant.reply(any(), any(), any(), any(), any()))
         .thenReturn("My take: looks fine.");
@@ -238,7 +266,7 @@ class MaintainerReplyServiceTest {
   void blankAssistantReplyPostsNothing() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
     when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("   ");
 
@@ -252,7 +280,7 @@ class MaintainerReplyServiceTest {
   void assistantFailureIsSwallowed() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
     when(replyAssistant.reply(any(), any(), any(), any(), any()))
         .thenThrow(new RuntimeException("model down"));
@@ -295,7 +323,7 @@ class MaintainerReplyServiceTest {
   void listCommentsFailureStillAnswersAnExplicitMention() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenThrow(new RuntimeException("GitHub 503"));
     when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("Still here.");
 
@@ -345,7 +373,7 @@ class MaintainerReplyServiceTest {
   void postFailureIsSwallowedByOuterHandler() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
     when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("answer");
     doThrow(new RuntimeException("GitHub 422"))
@@ -373,7 +401,7 @@ class MaintainerReplyServiceTest {
   void botThreadReplyWithNullDiffHunkSendsEmptyCodeContext() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
     when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("ok");
     var task =
@@ -395,7 +423,7 @@ class MaintainerReplyServiceTest {
   void threadRenderingSkipsOtherThreadsAndHandlesAnonymousReplies() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(
             List.of(
                 comment(99L, null, BOT, "**finding**"),
@@ -424,7 +452,7 @@ class MaintainerReplyServiceTest {
     // The root exists but its author is unknown (e.g. deleted account): it must not count as the
     // bot's thread, so an unmentioned reply on it is left alone.
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(List.of(commentNoUser(99L, null, "author is null")));
 
     service.handle(reviewThreadTask(false));
@@ -438,7 +466,7 @@ class MaintainerReplyServiceTest {
   void nullAssistantReplyPostsNothing() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
     when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(null);
 
@@ -453,7 +481,7 @@ class MaintainerReplyServiceTest {
     authorize();
     // GitHub returning a null body (vs an empty list) must not NPE — it falls back to no context.
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(null);
     when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("ok");
 
@@ -470,7 +498,7 @@ class MaintainerReplyServiceTest {
     authorize();
     // The root is not first in the list, so the id filter must skip a non-matching comment first.
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(
             List.of(
                 comment(500L, 88L, "x", "unrelated thread"),

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
@@ -204,6 +204,39 @@ class MaintainerReplyServiceTest {
   }
 
   @Test
+  void nullCommentPageIsTreatedAsEmptyAndPostsNothing() {
+    authorize();
+    when(reviewClient.listPullRequestComments(
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+        .thenReturn(null);
+
+    service.handle(reviewThreadTask(false));
+
+    // No comments resolve a root, and the reply was not an explicit mention, so the bot stays
+    // silent.
+    verifyNoInteractions(replyAssistant);
+  }
+
+  @Test
+  void stopsAtTheCommentPageBoundOnAVeryLongThread() {
+    authorize();
+    // Every page is full, so only the page bound can stop the walk.
+    var fullPage = new ArrayList<GitHubReviewClient.PullRequestComment>();
+    for (int i = 0; i < 100; i++) {
+      fullPage.add(comment(3000L + i, 88L, "octocat", "noise " + i));
+    }
+    when(reviewClient.listPullRequestComments(
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+        .thenReturn(fullPage);
+
+    service.handle(reviewThreadTask(false));
+
+    verify(reviewClient, times(10))
+        .listPullRequestComments(
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt());
+  }
+
+  @Test
   void replyOnHumanThreadWithoutMentionPostsNothing() {
     authorize();
     when(reviewClient.listPullRequestComments(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
@@ -74,7 +74,8 @@ class CommentCommandServiceTest {
             reviewDispatcher,
             sessionPersistence,
             prPauseService,
-            authorizer);
+            authorizer,
+            new TriggerDetector());
   }
 
   private CommentCommandService.CommandContext ctx(CommentCommand command) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
@@ -239,6 +239,35 @@ class CommentCommandServiceTest {
   }
 
   @Test
+  void pauseStillConfirmsWhenConcurrentPauseWonTheInsertRace() {
+    authorize(true);
+    // The unique-constraint loser: pause() throws, but the winning concurrent /pause left the row,
+    // so the PR is paused and the confirmation must still be posted.
+    doThrow(new RuntimeException("unique constraint violation"))
+        .when(prPauseService)
+        .pause("owner", "repo", 7);
+    when(prPauseService.isPaused("owner", "repo", 7)).thenReturn(true);
+
+    service.handle(ctx(CommentCommand.PAUSE));
+
+    assertTrue(postedBody().contains("paused"));
+  }
+
+  @Test
+  void pauseDoesNotConfirmWhenInsertGenuinelyFailed() {
+    authorize(true);
+    doThrow(new RuntimeException("database unavailable"))
+        .when(prPauseService)
+        .pause("owner", "repo", 7);
+    when(prPauseService.isPaused("owner", "repo", 7)).thenReturn(false);
+
+    service.handle(ctx(CommentCommand.PAUSE));
+
+    // A real failure (no row afterwards) propagates to the top-level handler; no confirmation.
+    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+  }
+
+  @Test
   void resumeClearsPauseAndConfirms() {
     authorize(true);
     when(prPauseService.resume("owner", "repo", 7)).thenReturn(true);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
@@ -16,7 +16,11 @@
 package dev.thiagogonzaga.thrillhousebot.webhook;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class TriggerDetectorTest {
@@ -118,5 +122,49 @@ class TriggerDetectorTest {
     assertFalse(detector.isBotComment("octocat"));
     assertFalse(detector.isBotComment("thrillhousebot"));
     assertFalse(detector.isBotComment(""));
+  }
+
+  @Test
+  void shouldNotDetectCommandInsideFencedCodeBlock() {
+    assertEquals(CommentCommand.NONE, detector.detectCommand("```\n/pause\n```"));
+    assertEquals(CommentCommand.NONE, detector.detectCommand("~~~\n/resolve\n~~~"));
+  }
+
+  @Test
+  void shouldNotDetectCommandInsideBlockquote() {
+    assertEquals(CommentCommand.NONE, detector.detectCommand("> /pause"));
+    assertEquals(CommentCommand.NONE, detector.detectCommand("  > someone said /resume"));
+  }
+
+  @Test
+  void shouldNotDetectCommandOrMentionInsideInlineCode() {
+    assertEquals(CommentCommand.NONE, detector.detectCommand("use `/review` to trigger a review"));
+    assertFalse(detector.containsBotMention("ping `@thrillhousebot` here"));
+  }
+
+  @Test
+  void shouldStillDetectRealCommandAlongsideQuotedOne() {
+    // A genuine command outside the quoted block still fires.
+    assertEquals(CommentCommand.REVIEW, detector.detectCommand("> quoting a /pause\n/review"));
+  }
+
+  @Test
+  void shouldUseConfiguredBotLogins() {
+    var config = mock(ThrillhouseConfig.class);
+    var github = mock(ThrillhouseConfig.GitHubConfig.class);
+    when(config.github()).thenReturn(github);
+    when(github.botLogins()).thenReturn(List.of("my-app[bot]", " Other[Bot] "));
+    var configured = new TriggerDetector(config);
+
+    assertTrue(configured.isBotComment("my-app[bot]"));
+    assertTrue(configured.isBotComment("other[bot]")); // normalized: trimmed + case-insensitive
+    assertFalse(configured.isBotComment("thrillhousebot[bot]"));
+  }
+
+  @Test
+  void shouldFallBackToDefaultLoginsWhenConfiguredListIsEmpty() {
+    // An empty list would make isBotComment always false and let the bot loop on its own replies.
+    var withEmptyConfig = new TriggerDetector(List.of());
+    assertTrue(withEmptyConfig.isBotComment("thrillhousebot[bot]"));
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -122,6 +123,7 @@ class TriggerDetectorTest {
     assertFalse(detector.isBotComment("octocat"));
     assertFalse(detector.isBotComment("thrillhousebot"));
     assertFalse(detector.isBotComment(""));
+    assertFalse(detector.isBotComment(null));
   }
 
   @Test
@@ -166,5 +168,18 @@ class TriggerDetectorTest {
     // An empty list would make isBotComment always false and let the bot loop on its own replies.
     var withEmptyConfig = new TriggerDetector(List.of());
     assertTrue(withEmptyConfig.isBotComment("thrillhousebot[bot]"));
+  }
+
+  @Test
+  void shouldFallBackToDefaultLoginsWhenConfiguredListIsNull() {
+    var withNullConfig = new TriggerDetector((List<String>) null);
+    assertTrue(withNullConfig.isBotComment("thrillhousebot[bot]"));
+  }
+
+  @Test
+  void shouldIgnoreNullAndBlankConfiguredLogins() {
+    var detector = new TriggerDetector(Arrays.asList("keep[bot]", null, "   "));
+    assertTrue(detector.isBotComment("keep[bot]"));
+    assertFalse(detector.isBotComment("thrillhousebot[bot]")); // replaced by the configured list
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
@@ -178,8 +178,8 @@ class TriggerDetectorTest {
 
   @Test
   void shouldIgnoreNullAndBlankConfiguredLogins() {
-    var detector = new TriggerDetector(Arrays.asList("keep[bot]", null, "   "));
-    assertTrue(detector.isBotComment("keep[bot]"));
-    assertFalse(detector.isBotComment("thrillhousebot[bot]")); // replaced by the configured list
+    var configured = new TriggerDetector(Arrays.asList("keep[bot]", null, "   "));
+    assertTrue(configured.isBotComment("keep[bot]"));
+    assertFalse(configured.isBotComment("thrillhousebot[bot]")); // replaced by the configured list
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -230,6 +230,27 @@ class WebhookControllerTest {
   }
 
   @Test
+  void shouldIgnorePullRequestWithMissingBase() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+
+    // head present, base omitted — the other side of the head/base guard.
+    var body =
+        ("{"
+                + "\"action\":\"opened\","
+                + "\"pull_request\":{\"number\":42,\"title\":\"T\","
+                + "\"head\":{\"sha\":\"h\",\"ref\":\"feature\"},\"user\":{\"login\":\"octocat\",\"id\":1}},"
+                + "\"repository\":{\"full_name\":\"owner/repo\",\"name\":\"repo\","
+                + "\"default_branch\":\"main\",\"owner\":{\"login\":\"owner\",\"id\":2}},"
+                + "\"installation\":{\"id\":12345}}")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response = controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
+    assertEquals(200, response.getStatus());
+
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+  }
+
+  @Test
   void shouldRouteSynchronizePullRequestToOrchestrator() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -29,6 +29,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -204,6 +206,27 @@ class WebhookControllerTest {
                 "default",
                 12345L,
                 false));
+  }
+
+  @Test
+  void shouldIgnorePullRequestWithMissingHead() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+
+    // A pull_request event whose payload omits head (or base) must not NPE — it is ignored.
+    var body =
+        ("{"
+                + "\"action\":\"opened\","
+                + "\"pull_request\":{\"number\":42,\"title\":\"T\","
+                + "\"base\":{\"sha\":\"b\",\"ref\":\"main\"},\"user\":{\"login\":\"octocat\",\"id\":1}},"
+                + "\"repository\":{\"full_name\":\"owner/repo\",\"name\":\"repo\","
+                + "\"default_branch\":\"main\",\"owner\":{\"login\":\"owner\",\"id\":2}},"
+                + "\"installation\":{\"id\":12345}}")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response = controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
+    assertEquals(200, response.getStatus());
+
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
   }
 
   @Test
@@ -707,14 +730,21 @@ class WebhookControllerTest {
                 "@@ -1 +1 @@"));
   }
 
-  @Test
-  void shouldIgnoreReviewCommentThatNeitherRepliesNorMentions() {
+  @ParameterizedTest
+  @EnumSource(IgnoredReviewComment.class)
+  void shouldIgnoreReviewCommentWithoutDispatching(IgnoredReviewComment scenario) {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
-    when(triggerDetector.isBotComment("octocat")).thenReturn(false);
-    when(triggerDetector.containsBotMention("looks good")).thenReturn(false);
+    scenario.applySetup(triggerDetector, reviewConfig);
 
     var body =
-        buildReviewCommentPayload("created", 42, "owner/repo", "octocat", "looks good", null, 3000L)
+        buildReviewCommentPayload(
+                "created",
+                42,
+                "owner/repo",
+                scenario.author,
+                scenario.commentBody,
+                scenario.inReplyToId,
+                scenario.commentId)
             .getBytes(StandardCharsets.UTF_8);
 
     var response =
@@ -725,22 +755,45 @@ class WebhookControllerTest {
     verify(replyDispatcher, never()).dispatch(any(MaintainerReplyService.ReplyTask.class));
   }
 
-  @Test
-  void shouldIgnoreOwnReviewComment() {
-    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
-    when(triggerDetector.isBotComment("thrillhousebot[bot]")).thenReturn(true);
+  /** Review-comment scenarios that must be ignored without dispatching a conversational reply. */
+  private enum IgnoredReviewComment {
+    NEITHER_REPLIES_NOR_MENTIONS("octocat", "looks good", null, 3000L) {
+      @Override
+      void applySetup(
+          TriggerDetector triggerDetector, ThrillhouseConfig.ReviewConfig reviewConfig) {
+        when(triggerDetector.isBotComment("octocat")).thenReturn(false);
+        when(triggerDetector.containsBotMention("looks good")).thenReturn(false);
+      }
+    },
+    OWN_COMMENT("thrillhousebot[bot]", "follow-up", 99L, 4000L) {
+      @Override
+      void applySetup(
+          TriggerDetector triggerDetector, ThrillhouseConfig.ReviewConfig reviewConfig) {
+        when(triggerDetector.isBotComment("thrillhousebot[bot]")).thenReturn(true);
+      }
+    },
+    REPLIES_DISABLED("octocat", "Why?", 99L, 6000L) {
+      @Override
+      void applySetup(
+          TriggerDetector triggerDetector, ThrillhouseConfig.ReviewConfig reviewConfig) {
+        when(reviewConfig.conversationalRepliesEnabled()).thenReturn(false);
+      }
+    };
 
-    var body =
-        buildReviewCommentPayload(
-                "created", 42, "owner/repo", "thrillhousebot[bot]", "follow-up", 99L, 4000L)
-            .getBytes(StandardCharsets.UTF_8);
+    final String author;
+    final String commentBody;
+    final Long inReplyToId;
+    final long commentId;
 
-    var response =
-        controller.handleWebhook(
-            "sha256=valid", "pull_request_review_comment", null, DELIVERY, body);
-    assertEquals(200, response.getStatus());
+    IgnoredReviewComment(String author, String commentBody, Long inReplyToId, long commentId) {
+      this.author = author;
+      this.commentBody = commentBody;
+      this.inReplyToId = inReplyToId;
+      this.commentId = commentId;
+    }
 
-    verify(replyDispatcher, never()).dispatch(any(MaintainerReplyService.ReplyTask.class));
+    abstract void applySetup(
+        TriggerDetector triggerDetector, ThrillhouseConfig.ReviewConfig reviewConfig);
   }
 
   @Test
@@ -759,23 +812,6 @@ class WebhookControllerTest {
     // Editing a review comment must not re-trigger a reply.
     verify(replyDispatcher, never()).dispatch(any(MaintainerReplyService.ReplyTask.class));
     verifyNoInteractions(triggerDetector);
-  }
-
-  @Test
-  void shouldIgnoreReviewCommentWhenRepliesDisabled() {
-    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
-    when(reviewConfig.conversationalRepliesEnabled()).thenReturn(false);
-
-    var body =
-        buildReviewCommentPayload("created", 42, "owner/repo", "octocat", "Why?", 99L, 6000L)
-            .getBytes(StandardCharsets.UTF_8);
-
-    var response =
-        controller.handleWebhook(
-            "sha256=valid", "pull_request_review_comment", null, DELIVERY, body);
-    assertEquals(200, response.getStatus());
-
-    verify(replyDispatcher, never()).dispatch(any(MaintainerReplyService.ReplyTask.class));
   }
 
   @Test


### PR DESCRIPTION
Follow-ups from the `release/v0.2.0` review of the eight merged feature PRs (#157–#164). The quality gate passed on all of them, but the audit surfaced 7 open Sonar code smells and 7 behavior findings. This PR addresses every one, with tests, and targets `release/v0.2.0`.

## Sonar code smells (now resolved)
| Rule | Where | Fix |
|------|-------|-----|
| S3776 | `WebhookController.handleIssueComment` | Extracted `handleCommentCommand` + `maybeDispatchConversationalMention` to drop cognitive complexity from 17 |
| S135 | `MaintainerReplyService.renderThread`, `CommentCommandService.botRootCommentIds` | Collapsed the double `break`/`continue` (do-while paging) |
| S2629 | `CommentCommandService` `/summary` logs | Removed the eager `repository(ctx)` string concat from the log args |
| S7467 | `CommentCommandService.notifyPaused` | Log the previously-unused `catch` exception |
| S5976 | `WebhookControllerTest` | Parameterized the three "ignore review comment" tests into one `@ParameterizedTest` |

## Review findings (fixed)
1. **Reply context pagination** — `MaintainerReplyService` listed PR review comments with the non-paged client (GitHub's 30/page default), so on a busy thread the root comment and prior replies past page one were missed. It now walks pages (100/page, bounded).
2. **Commands in quoted text** — `TriggerDetector` matched `/pause`, `/resolve`, etc. inside fenced code blocks and blockquotes. It now strips fenced code, blockquotes, and inline code before detection, so quoting or documenting a command no longer executes it.
3. **`/resolve` thread cap** — `ReviewThreadService` queried `reviewThreads(first: 100)` with no cursor, so `/resolve` silently skipped bot threads beyond the first 100. It now paginates via `pageInfo`/`after` (bounded).
4. **`/pause` race** — the check-then-insert could throw on a concurrent `/pause` (unique-constraint loser), dropping the confirmation. `/pause` is now idempotent: a row that already exists counts as success and still posts the confirmation; only a genuine failure propagates.
5. **Hard-coded bot logins** — the infinite-loop guard hard-coded two logins, so a different App slug would let the bot answer its own replies. Bot logins are now configurable (`thrillhousebot.github.bot-logins`, env `GITHUB_BOT_LOGINS`), falling back to the built-in logins if empty.
6. **Null head/base NPE** — a `pull_request` event missing `head`/`base` would NPE and silently drop the delivery; `WebhookController` now guards and ignores it.
7. **Non-numeric `GITHUB_APP_ID`** — passed the fail-fast validator and only failed on the first webhook; `StartupConfigValidator` now rejects it at boot.

## Notes
- The bot's own inline findings on the original PRs were already validated by the maintainer (5 fixed, 5 declined). The `/pause` race here is the one decline ("premise doesn't hold") that was valid — the async `/pause` path runs on the unbounded virtual-thread executor, so concurrent commands can race. Fixed with bounded impact.
- The four "declined false positives" in #159 were independently re-verified as correct (GitHub review threads are flat; arrow-case yields the boolean; non-PR mentions are guarded) and are **not** changed here.

## Testing
- Full suite: **1160 tests, 0 failures**, `spotless:check` clean (run with `-Djacoco.skip=true -Dquarkus.jacoco.enabled=false` per the JDK 25 JaCoCo issue).
- New/updated tests cover: app-id numeric validation, fenced/quoted command stripping, configurable + empty-fallback bot logins, GraphQL thread pagination, reply-comment pagination, the `/pause` race (both branches), and the null head/base guard.
