### PR TITLE
ci: trim PR-gate time — move spotbugs to format, collapse test reactor, skip docs-only native builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,36 @@ permissions:
   actions: read
 
 jobs:
+  # Did this push change anything other than docs (*.md, docs/**)? The native build and image
+  # publish (main only) are skipped for docs-only commits. Fails open — anything uncertain
+  # (first push, missing parent, a multi-file change) counts as code, so a real change is never
+  # skipped. Note: a docs-only main commit then has no per-SHA image, so do not cut a release
+  # from one (the release workflow verifies the image exists).
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - id: filter
+        env:
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] \
+            || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only "$BEFORE" "$SHA")
+          if [ -z "$changed" ] || printf '%s\n' "$changed" | grep -qvE '(\.md$|^docs/)'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   format:
     runs-on: ubuntu-latest
     steps:
@@ -28,7 +58,9 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - run: ./mvnw spotless:check -q
+      # spotbugs runs here, off the test job's critical path. It analyzes main classes, so
+      # compile first; spotless needs no compile.
+      - run: ./mvnw clean compile spotbugs:check spotless:check -q
 
   actionlint:
     runs-on: ubuntu-latest
@@ -74,9 +106,9 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - run: ./mvnw clean test
-      - run: ./mvnw spotbugs:check
-      - run: ./mvnw jacoco:report
+      # One reactor: build + test + coverage report in a single Maven run (spotbugs moved to the
+      # format job). Avoids re-starting Maven and recompiling across separate invocations.
+      - run: ./mvnw clean test jacoco:report
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -123,8 +155,8 @@ jobs:
           path: frontend/out/
 
   native-build:
-    needs: [frontend]
-    if: github.ref == 'refs/heads/main'
+    needs: [frontend, changes]
+    if: github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Implements three of the CI speedups from the pipeline-timing analysis. Targets `release/v0.2.0` (builds on the CI changes already merged there in #165).

### Changes

1. **Move `spotbugs:check` from `test` → `format`.** The `format` job runs in parallel, so this takes spotbugs (~18s) off the `test` job's critical path — which is the PR gate. The format job now compiles main classes first (`./mvnw clean compile spotbugs:check spotless:check`), since spotbugs analyzes bytecode; verified locally.
2. **Collapse the `test` job into one reactor** — `./mvnw clean test jacoco:report` replaces three separate `./mvnw` invocations, avoiding two extra Maven startups and a recompile (~15–30s). (spotbugs moved out per #1, so it's not in this reactor.)
3. **Skip the native build on docs-only pushes.** A new `changes` job detects whether a push touched anything beyond `*.md` / `docs/**`; `native-build` (and therefore `docker` / `trivy-image`, which depend on it) is gated on it. A README-only commit to `main` no longer triggers the full ~7-minute native build + image publish. **Fails open** — first push, missing parent, or any non-docs file counts as code, so a real change is never skipped.

### Net effect
- **PR gate:** ~20–30s shaved off the `test` job (the PR critical path).
- **`main`:** a full native build skipped on docs-only commits.

### Notes / caveats
- The `native-build` / `docker` jobs are **main-only**, so change #3's skip behavior activates once this reaches `main`; on release-branch CI it's inert. This PR's CI still validates the `format` and `test` reactors and the `changes` job wiring (and `actionlint` passes, including shellcheck on the inline script).
- **SHA-image caveat (accepted):** a docs-only `main` commit then has no per-`SHA` image, so don't cut a release from one — the release workflow verifies the image exists.
