### PR TITLE
fix(review): filter null elements from AI-supplied summary lists

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponse.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponse.java
@@ -18,6 +18,7 @@ package dev.thiagogonzaga.thrillhousebot.review.ai;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.List;
+import java.util.Objects;
 
 @RegisterForReflection
 public record ReviewResponse(
@@ -72,8 +73,14 @@ public record ReviewResponse(
       @JsonProperty("description_gaps") List<String> descriptionGaps,
       @JsonProperty("suggested_labels") List<String> suggestedLabels) {
     public Summary {
-      descriptionGaps = List.copyOf(descriptionGaps != null ? descriptionGaps : List.of());
-      suggestedLabels = List.copyOf(suggestedLabels != null ? suggestedLabels : List.of());
+      // The AI may emit null elements inside these arrays (e.g. ["bug", null]); List.copyOf would
+      // throw an NPE that fails the whole review, even though both lists are best-effort metadata.
+      descriptionGaps = nonNullElements(descriptionGaps);
+      suggestedLabels = nonNullElements(suggestedLabels);
+    }
+
+    private static List<String> nonNullElements(List<String> values) {
+      return values == null ? List.of() : values.stream().filter(Objects::nonNull).toList();
     }
 
     /** Convenience constructor for callers (and responses) that predate label suggestions. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponse.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponse.java
@@ -73,13 +73,15 @@ public record ReviewResponse(
       @JsonProperty("description_gaps") List<String> descriptionGaps,
       @JsonProperty("suggested_labels") List<String> suggestedLabels) {
     public Summary {
-      // The AI may emit null elements inside these arrays (e.g. ["bug", null]); List.copyOf would
-      // throw an NPE that fails the whole review, even though both lists are best-effort metadata.
-      descriptionGaps = nonNullElements(descriptionGaps);
-      suggestedLabels = nonNullElements(suggestedLabels);
+      // The AI may emit null elements inside these arrays (e.g. ["bug", null]); a bare List.copyOf
+      // would throw an NPE that fails the whole review, even though both lists are best-effort
+      // metadata. Drop the nulls first, then copy. List.copyOf is kept inline rather than folded
+      // into the helper so SpotBugs still sees the defensive copy and does not flag EI_EXPOSE_REP.
+      descriptionGaps = List.copyOf(withoutNulls(descriptionGaps));
+      suggestedLabels = List.copyOf(withoutNulls(suggestedLabels));
     }
 
-    private static List<String> nonNullElements(List<String> values) {
+    private static List<String> withoutNulls(List<String> values) {
       return values == null ? List.of() : values.stream().filter(Objects::nonNull).toList();
     }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParserTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParserTest.java
@@ -85,6 +85,20 @@ class ReviewResponseParserTest {
   }
 
   @Test
+  void shouldFilterNullElementsFromSummaryLabelArrays() {
+    // A null element inside a best-effort label/gap array must not crash the review.
+    var response =
+        parser.parse(
+            "{\"findings\":[],\"summary\":{\"total_findings\":0,"
+                + "\"suggested_labels\":[\"bug\",null,\"area/api\"],"
+                + "\"description_gaps\":[null,\"missing tests\"]}}");
+
+    assertNotNull(response.summary());
+    assertEquals(java.util.List.of("bug", "area/api"), response.summary().suggestedLabels());
+    assertEquals(java.util.List.of("missing tests"), response.summary().descriptionGaps());
+  }
+
+  @Test
   void shouldParseFindingConfidence() {
     var response =
         parser.parse(


### PR DESCRIPTION
## Summary

Addresses the MEDIUM finding ThrillhouseBot raised on [#172](https://github.com/devops-thiago/ThrillhouseBot/pull/172) (now merged):

> Null element in `suggestedLabels` can crash the review via `List.copyOf`

The `Summary` compact constructor in `ReviewResponse` ran both AI-supplied lists through `List.copyOf(...)`. `List.copyOf` rejects null elements with an `NullPointerException`, so an AI response whose `suggested_labels` (or `description_gaps`) array contains a null — e.g. `["bug", null]` — throws. `ReviewResponseParser.parse()` only catches `IOException`, so that NPE escapes through `AiReviewService` / `ReviewOrchestrator.review()` and fails the entire review session, even though label/gap suggestions are best-effort metadata that should never block a review.

## Change

- Filter nulls out of `suggestedLabels` **and** `descriptionGaps` (both come from the model, both had the identical bug — the bot's suggestion only covered the labels) before storing them. A malformed array now degrades to fewer entries instead of crashing.
- Added a parser test (`shouldFilterNullElementsFromSummaryLabelArrays`) covering null elements in both arrays.

## Testing

- `./mvnw -Dtest=ReviewResponseParserTest test` → 20/20 pass
- `./mvnw spotless:check` → clean
