### PR TITLE
ci(trivy): bump scanner to v0.71.2 and fix Maven Central 429 on the fs scan

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -54,7 +54,7 @@ runs:
         severity: ${{ inputs.severity }}
         exit-code: ${{ inputs.exit-code }}
         trivyignores: ${{ inputs.trivyignores }}
-        version: v0.70.0
+        version: v0.71.2
         format: sarif
         limit-severities-for-sarif: true
         output: ${{ inputs.category }}.sarif

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,22 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        with:
+          java-version: "25"
+          distribution: "temurin"
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      # Trivy's Maven analyzer resolves transitive POMs from Maven Central whenever they are absent
+      # from ~/.m2. A cold cache made it fan out enough requests to trip a 429 IP block (Maven
+      # Central then refuses every request from the runner for 30 min). Populate the local
+      # repository first so Trivy reads every POM locally and makes no remote calls; the ~/.m2 cache
+      # keeps warm runs from re-downloading at all.
+      - name: Populate local Maven repository
+        run: ./mvnw -q -B dependency:go-offline
       - uses: ./.github/actions/trivy-scan
         with:
           scan-type: fs


### PR DESCRIPTION
## Summary

Two related Trivy/CI changes:

### 1. Bump Trivy scanner to v0.71.2
Updates the pinned Trivy binary from **v0.70.0** to **v0.71.2** (latest) in the `trivy-scan` composite action ([`.github/actions/trivy-scan/action.yml`](.github/actions/trivy-scan/action.yml)), the single source of the Trivy version for both CI and the release pipeline. This bumps the **Trivy binary** version (`version:` input), not the `aquasecurity/trivy-action` SHA pin (stays at `ed142fd`, v0.36.0).

### 2. Fix Maven Central 429 on the `trivy` fs scan
The `trivy` filesystem scan was failing with:

> FATAL Error: remote Maven repository returned 429 Too Many Requests for …/quarkus-hibernate-orm-panache-3.36.3.pom. Retry-After: 1800. The repository blocks all subsequent requests from this IP until the block clears.

Trivy's Maven analyzer resolves transitive POMs from Maven Central whenever they're missing from `~/.m2`. The `trivy` job had a **cold** local repository, so the scan fanned out enough requests to trip a 429 IP block — after which Maven Central refuses every request from the runner for 30 minutes and the job dies.

**Fix:** before the scan, set up the JDK, restore/save a `~/.m2` cache (matching the `test` and `format` jobs), and run `./mvnw dependency:go-offline`. Trivy then reads every POM locally and makes **no** remote calls; warm runs skip the download entirely via the cache. This follows the remediation Trivy itself prints in the error.

The `trivy-image` job is unaffected — it scans the built image's embedded artifact metadata, not `pom.xml`, so it never resolves POMs from Central.

## Testing

- `actionlint` clean on the updated workflow.
- `./mvnw -B dependency:go-offline` resolves successfully against this project.
- The bumped scanner version and the 429 fix both take effect when CI runs the `trivy` job on this PR.
