### PR TITLE
fix(review): don't post a duplicate COMMENT review when only CI is pending

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -987,6 +987,17 @@ public class ReviewOrchestrator {
       createReviewWithFallback(auth, owner, repo, prNumber, req);
       return;
     }
+    // A COMMENT held back only by pending/failed CI (no findings, nothing unresolved) merely
+    // restates the summary comment the first review already posts, so emitting it too would
+    // duplicate that message. Skip it on the first review and let the summary stand alone.
+    // Unresolved previous findings are excluded — their COMMENT carries distinct "reply on the
+    // thread" guidance the summary lacks, so it still posts. Follow-ups post no summary, so the
+    // COMMENT is their only signal; REQUEST_CHANGES always posts; the merge gate is the check run.
+    if (result.reviewState() == ReviewState.COMMENT
+        && result.isFirstReview()
+        && unresolvedPreviousCount(result) == 0) {
+      return;
+    }
     // No new findings, but previous ones are still unresolved or CI checks are pending/failed —
     // never claim a clean review.
     var req =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2962,6 +2962,57 @@ class ReviewOrchestratorTest {
           .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
       assertEquals("REQUEST_CHANGES", captor.getValue().event());
     }
+
+    @Test
+    void postReviewShouldSkipDuplicateCommentReviewOnFirstReviewWhenOnlyCiPending() {
+      // First review, no findings, but a required check is still pending: the summary comment
+      // already conveys this, so postReview must not add a COMMENT review that duplicates it
+      // (#173).
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.COMMENT,
+              true,
+              "",
+              List.of(),
+              List.of(new ReviewResult.CiCheck("build", "check-run", "pending", null)));
+
+      orchestrator.postReview("auth", "owner", "repo", 5, "sha", result, List.of());
+
+      verify(reviewClient, never())
+          .createReview(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+    }
+
+    @Test
+    void postReviewShouldStillPostCommentReviewOnFollowUpWhenCiPending() {
+      // A follow-up review posts no summary comment, so the COMMENT review remains its only signal.
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.COMMENT,
+              false,
+              "",
+              List.of(),
+              List.of(new ReviewResult.CiCheck("build", "check-run", "pending", null)));
+
+      orchestrator.postReview("auth", "owner", "repo", 5, "sha", result, List.of());
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      assertEquals("COMMENT", captor.getValue().event());
+      assertTrue(captor.getValue().body().contains("**build**"));
+    }
   }
 
   @Nested
@@ -3777,7 +3828,7 @@ class ReviewOrchestratorTest {
     }
 
     @Test
-    void reviewShouldDowngradeToCommentWhenRequiredCheckFails() {
+    void reviewShouldDowngradeToNeutralAndPostOnlySummaryWhenRequiredCheckFails() {
       try (var mockedStatic = mockStatic(ReviewSession.class)) {
         var session = mock(ReviewSession.class);
         session.id = 1L;
@@ -3788,24 +3839,37 @@ class ReviewOrchestratorTest {
             .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
             .thenReturn(session);
 
-        // The required check ("build") is failing — a would-be APPROVE must become COMMENT.
+        // The required check ("build") is failing — a would-be APPROVE must downgrade so the check
+        // run is neutral rather than green.
         stubCommonReviewMocks(
             new GitHubCheckRunClient.CheckRunsResponse(
                 1,
                 List.of(
                     new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
                         1L, "build", "completed", "failure", null))));
+        when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any()))
+            .thenReturn("## Summary\nNo new issues, but required check **build** failed.");
 
         orchestrator.review(request());
 
-        var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
-        verify(reviewClient)
-            .createReview(
-                anyString(), anyString(), anyString(), anyString(), anyInt(), captor.capture());
-        var req = captor.getValue();
-        assertEquals("COMMENT", req.event());
-        assertTrue(req.body().contains("**build**"));
-        assertTrue(req.body().contains("failed"));
+        // No new findings: the summary comment already lists the pending/failed checks, so the bot
+        // must NOT also post a COMMENT review that merely restates it (regression guard for #173).
+        verify(reviewClient, never())
+            .createReview(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+        verify(commentClient)
+            .createComment(
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyInt(),
+                argThat(req -> req.body().contains("**build**")));
+        // The downgrade is still enforced where it matters — on the bot's own check run.
+        var captor = ArgumentCaptor.forClass(GitHubCheckRunClient.UpdateCheckRunRequest.class);
+        verify(checkRunClient)
+            .updateCheckRun(
+                anyString(), anyString(), anyString(), anyString(), anyLong(), captor.capture());
+        assertEquals("neutral", captor.getValue().conclusion());
       }
     }
 


### PR DESCRIPTION
## Summary

On a no-issues first review where a required CI check is still pending/failing, ThrillhouseBot posted the same "no issues found, but checks pending/failed" message **twice**:

1. The **PR summary** issue comment — already lists the offending checks in its *Required CI Checks Status* table.
2. A separate **COMMENT review** (`postNoIssuesReview` → `noIssuesBody`) restating "ThrillhouseBot found no issues in this PR, but some checks are still pending or failed: …".

The second is redundant. Observed when the bot reviewed its own [#173](https://github.com/devops-thiago/ThrillhouseBot/pull/173):

> ThrillhouseBot found no issues in this PR, but some checks are still pending or failed:
> - Check **format** is pending …

## Change

`postNoIssuesReview` now skips the COMMENT review on the **first** review when it is held back **solely by CI** (no new findings, nothing unresolved) — the summary already conveys it. The skip is deliberately narrow:

- **Unresolved previous findings** → still posts. That COMMENT carries distinct "reply on the thread (where one exists)" guidance the summary doesn't.
- **Follow-up reviews** (`isFirstReview == false`) → still post. They emit no summary, so the COMMENT is their only signal.
- **`REQUEST_CHANGES`** → always posts. It carries a blocking verdict.
- The merge gate is the **check run** conclusion (set independently before the review), so suppressing a non-blocking `COMMENT` review changes nothing about gating.

This mirrors the existing `APPROVE` branch, which already suppresses its body on the first review because the summary carries the message.

## Testing

- Updated `reviewShouldDowngradeToNeutralAndPostOnlySummaryWhenRequiredCheckFails`: a failing required check now downgrades the **check run to `neutral`** and posts **only the summary** — no COMMENT review.
- Added `postReviewShouldSkipDuplicateCommentReviewOnFirstReviewWhenOnlyCiPending` and `postReviewShouldStillPostCommentReviewOnFollowUpWhenCiPending`.
- `./mvnw -Dtest=ReviewOrchestratorTest test` → 148/148 pass; `spotbugs:check` + `spotless:check` clean.
