### PR TITLE
fix(review): resolve required status checks from rulesets, not just classic branch protection

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.github;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.ws.rs.*;
@@ -57,6 +58,22 @@ public interface GitHubCheckRunClient {
       @PathParam("repo") String repo,
       @PathParam("branch") String branch);
 
+  /**
+   * Effective rules for a branch, aggregating both repository and organization rulesets. Unlike
+   * {@link #getRequiredStatusChecks}, this surfaces required checks configured via the modern
+   * rulesets feature and needs only read access (not admin). Returns an empty list when no ruleset
+   * governs the branch.
+   */
+  @GET
+  @Path("/repos/{owner}/{repo}/rules/branches/{branch}")
+  @Produces(MediaType.APPLICATION_JSON)
+  List<BranchRule> getBranchRules(
+      @HeaderParam("Authorization") String auth,
+      @HeaderParam("Accept") String accept,
+      @PathParam("owner") String owner,
+      @PathParam("repo") String repo,
+      @PathParam("branch") String branch);
+
   @GET
   @Path("/repos/{owner}/{repo}/commits/{ref}/check-runs")
   @Produces(MediaType.APPLICATION_JSON)
@@ -93,6 +110,32 @@ public interface GitHubCheckRunClient {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record Check(String context, @JsonProperty("app_id") Long appId) {}
+  }
+
+  /**
+   * One rule returned by {@link #getBranchRules}. Each ruleset rule type carries a different {@code
+   * parameters} shape; we model only the {@code required_status_checks} variant and let unknown
+   * fields (and other rule types' parameters) be ignored.
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record BranchRule(String type, Parameters parameters) {
+    private static final String REQUIRED_STATUS_CHECKS = "required_status_checks";
+
+    public boolean isRequiredStatusChecks() {
+      return REQUIRED_STATUS_CHECKS.equals(type);
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Parameters(
+        @JsonProperty("required_status_checks") List<RequiredCheck> requiredStatusChecks) {
+      public List<RequiredCheck> requiredStatusChecks() {
+        return requiredStatusChecks == null ? List.of() : List.copyOf(requiredStatusChecks);
+      }
+
+      @JsonIgnoreProperties(ignoreUnknown = true)
+      public record RequiredCheck(
+          String context, @JsonProperty("integration_id") Long integrationId) {}
+    }
   }
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -1177,7 +1177,8 @@ public class ReviewOrchestrator {
    * {@link Optional} — which the caller maps to {@code null}, gating on every check — only when
    * neither mechanism governs the branch or both lookups fail.
    */
-  private Optional<List<String>> resolveRequiredContexts(String auth, ReviewRequest req) {
+  // Package-private so each resolution branch can be exercised directly in tests.
+  Optional<List<String>> resolveRequiredContexts(String auth, ReviewRequest req) {
     String branch;
     try {
       var prDetails =

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -35,6 +35,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1170,22 +1171,86 @@ public class ReviewOrchestrator {
   }
 
   /**
-   * Resolves the required status-check contexts for the PR's target branch, returning {@code null}
-   * (gate on all checks) when the branch is unprotected or the lookup fails.
+   * Resolves the required status-check contexts for the PR's target branch. The contexts come from
+   * two GitHub mechanisms, unioned: repository/organization <em>rulesets</em> (modern; needs only
+   * read access) and <em>classic branch protection</em> (legacy; needs admin). Returns an empty
+   * {@link Optional} — which the caller maps to {@code null}, gating on every check — only when
+   * neither mechanism governs the branch or both lookups fail.
    */
   private Optional<List<String>> resolveRequiredContexts(String auth, ReviewRequest req) {
+    String branch;
     try {
       var prDetails =
           prClient.getPullRequest(auth, ACCEPT, req.owner(), req.repo(), req.prNumber());
       if (prDetails == null || prDetails.base() == null || prDetails.base().ref() == null) {
         return Optional.empty();
       }
+      branch = prDetails.base().ref();
+    } catch (Exception e) {
+      Log.warnf(e, "Could not resolve target branch; gating CI on all checks");
+      return Optional.empty();
+    }
+
+    var contexts = new LinkedHashSet<String>();
+    boolean resolved = false;
+    var fromRulesets = requiredContextsFromRulesets(auth, req, branch);
+    if (fromRulesets.isPresent()) {
+      resolved = true;
+      contexts.addAll(fromRulesets.get());
+    }
+    var fromClassic = requiredContextsFromClassicProtection(auth, req, branch);
+    if (fromClassic.isPresent()) {
+      resolved = true;
+      contexts.addAll(fromClassic.get());
+    }
+
+    return resolved ? Optional.of(List.copyOf(contexts)) : Optional.empty();
+  }
+
+  /**
+   * Required contexts declared by rulesets governing {@code branch}. An empty {@link Optional}
+   * means no ruleset applies (or the lookup failed); a present-but-empty list means a ruleset
+   * applies but mandates no status checks.
+   */
+  private Optional<List<String>> requiredContextsFromRulesets(
+      String auth, ReviewRequest req, String branch) {
+    try {
+      var rules = checkRunClient.getBranchRules(auth, ACCEPT, req.owner(), req.repo(), branch);
+      if (rules == null || rules.isEmpty()) {
+        return Optional.empty();
+      }
+      var contexts = new ArrayList<String>();
+      for (var rule : rules) {
+        if (rule.isRequiredStatusChecks() && rule.parameters() != null) {
+          for (var check : rule.parameters().requiredStatusChecks()) {
+            if (check.context() != null) {
+              contexts.add(check.context());
+            }
+          }
+        }
+      }
+      return Optional.of(contexts);
+    } catch (Exception e) {
+      Log.warnf(
+          e, "Could not fetch branch rules (rulesets) for %s; trying classic protection", branch);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Required contexts declared by classic branch protection. An empty {@link Optional} means the
+   * branch is not protected this way — expected, not an error, for ruleset-only repositories — or
+   * the lookup failed.
+   */
+  private Optional<List<String>> requiredContextsFromClassicProtection(
+      String auth, ReviewRequest req, String branch) {
+    try {
       var protection =
-          checkRunClient.getRequiredStatusChecks(
-              auth, ACCEPT, req.owner(), req.repo(), prDetails.base().ref());
+          checkRunClient.getRequiredStatusChecks(auth, ACCEPT, req.owner(), req.repo(), branch);
       return protection == null ? Optional.empty() : Optional.of(protection.contexts());
     } catch (Exception e) {
-      Log.warnf(e, "Could not fetch required status checks for branch, falling back to all checks");
+      // A 404 here is normal when the repo uses rulesets instead of classic branch protection.
+      Log.debugf(e, "No classic branch protection for %s", branch);
       return Optional.empty();
     }
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -3993,6 +3993,103 @@ class ReviewOrchestratorTest {
                 argThat(req -> "APPROVE".equals(req.event())));
       }
     }
+
+    @Test
+    void reviewShouldGateOnRulesetRequiredChecksWhenClassicProtectionIs404() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        // Repo uses rulesets, not classic protection: the classic endpoint 404s. The ruleset marks
+        // only "build" as required, so the failing-but-unrequired "flaky" check must be ignored and
+        // APPROVE must stand. (Were we falling back to gating on ALL checks, "flaky" would block
+        // it.)
+        stubCommonReviewMocks(
+            new GitHubCheckRunClient.CheckRunsResponse(
+                2,
+                List.of(
+                    new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                        1L, "build", "completed", "success", null),
+                    new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                        2L, "flaky", "completed", "failure", null))));
+        when(checkRunClient.getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenThrow(new RuntimeException("Not Found, status code 404"));
+        when(checkRunClient.getBranchRules(
+                anyString(), anyString(), eq("owner"), eq("repo"), eq("main")))
+            .thenReturn(requiredStatusCheckRuleset("build"));
+
+        orchestrator.review(request());
+
+        verify(reviewClient)
+            .createReview(
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyInt(),
+                argThat(req -> "APPROVE".equals(req.event())));
+      }
+    }
+
+    @Test
+    void reviewShouldDowngradeWhenRulesetRequiresAMissingCheck() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        // The ruleset requires "integration", which never reported on the head SHA — it is
+        // therefore
+        // pending, so a would-be APPROVE must downgrade to neutral.
+        stubCommonReviewMocks(
+            new GitHubCheckRunClient.CheckRunsResponse(
+                1,
+                List.of(
+                    new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                        1L, "build", "completed", "success", null))));
+        when(checkRunClient.getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenThrow(new RuntimeException("Not Found, status code 404"));
+        when(checkRunClient.getBranchRules(
+                anyString(), anyString(), eq("owner"), eq("repo"), eq("main")))
+            .thenReturn(requiredStatusCheckRuleset("integration"));
+        when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any()))
+            .thenReturn("## Summary\nRequired check **integration** has not reported yet.");
+
+        orchestrator.review(request());
+
+        var captor = ArgumentCaptor.forClass(GitHubCheckRunClient.UpdateCheckRunRequest.class);
+        verify(checkRunClient)
+            .updateCheckRun(
+                anyString(), anyString(), anyString(), anyString(), anyLong(), captor.capture());
+        assertEquals("neutral", captor.getValue().conclusion());
+      }
+    }
+
+    private List<GitHubCheckRunClient.BranchRule> requiredStatusCheckRuleset(String... contexts) {
+      var checks =
+          new java.util.ArrayList<GitHubCheckRunClient.BranchRule.Parameters.RequiredCheck>();
+      for (String context : contexts) {
+        checks.add(new GitHubCheckRunClient.BranchRule.Parameters.RequiredCheck(context, null));
+      }
+      return List.of(
+          // A non-status-check rule (pull_request) is included to prove it is skipped.
+          new GitHubCheckRunClient.BranchRule("pull_request", null),
+          new GitHubCheckRunClient.BranchRule(
+              "required_status_checks", new GitHubCheckRunClient.BranchRule.Parameters(checks)));
+    }
   }
 
   @Nested

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -4093,6 +4093,146 @@ class ReviewOrchestratorTest {
   }
 
   @Nested
+  class ResolveRequiredContexts {
+
+    private ReviewOrchestrator.ReviewRequest req() {
+      return new ReviewOrchestrator.ReviewRequest(
+          "owner", "repo", 42, "sha", "Test PR", "", "base", "main", 123L, false);
+    }
+
+    private void stubBaseRef(String ref) {
+      when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(42)))
+          .thenReturn(
+              new GitHubPullRequestClient.PullRequestDetails(
+                  "Test PR",
+                  "",
+                  new GitHubPullRequestClient.Ref("head", "feature"),
+                  new GitHubPullRequestClient.Ref("base", ref)));
+    }
+
+    private GitHubCheckRunClient.BranchRule.Parameters.RequiredCheck check(String context) {
+      return new GitHubCheckRunClient.BranchRule.Parameters.RequiredCheck(context, null);
+    }
+
+    private GitHubCheckRunClient.BranchRule statusCheckRule(
+        GitHubCheckRunClient.BranchRule.Parameters.RequiredCheck... checks) {
+      return new GitHubCheckRunClient.BranchRule(
+          "required_status_checks",
+          new GitHubCheckRunClient.BranchRule.Parameters(List.of(checks)));
+    }
+
+    private void stubClassic(GitHubCheckRunClient.RequiredStatusChecks protection) {
+      when(checkRunClient.getRequiredStatusChecks(
+              anyString(), anyString(), anyString(), anyString(), anyString()))
+          .thenReturn(protection);
+    }
+
+    @Test
+    void returnsEmptyWhenPullRequestLookupThrows() {
+      when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(42)))
+          .thenThrow(new RuntimeException("boom"));
+
+      assertTrue(orchestrator.resolveRequiredContexts("auth", req()).isEmpty());
+      verifyNoInteractions(checkRunClient);
+    }
+
+    @Test
+    void returnsEmptyWhenPullRequestDetailsAreNull() {
+      when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(42))).thenReturn(null);
+
+      assertTrue(orchestrator.resolveRequiredContexts("auth", req()).isEmpty());
+    }
+
+    @Test
+    void returnsEmptyWhenBaseRefIsNull() {
+      stubBaseRef(null);
+
+      assertTrue(orchestrator.resolveRequiredContexts("auth", req()).isEmpty());
+      verify(checkRunClient, never())
+          .getBranchRules(anyString(), anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void fallsBackToClassicWhenRulesetLookupThrows() {
+      stubBaseRef("main");
+      when(checkRunClient.getBranchRules(
+              anyString(), anyString(), anyString(), anyString(), anyString()))
+          .thenThrow(new RuntimeException("rules boom"));
+      stubClassic(new GitHubCheckRunClient.RequiredStatusChecks(List.of("build"), List.of()));
+
+      assertEquals(
+          List.of("build"), orchestrator.resolveRequiredContexts("auth", req()).orElseThrow());
+    }
+
+    @Test
+    void fallsBackToClassicWhenNoRulesetGovernsBranch() {
+      stubBaseRef("main");
+      when(checkRunClient.getBranchRules(
+              anyString(), anyString(), anyString(), anyString(), anyString()))
+          .thenReturn(List.of());
+      stubClassic(new GitHubCheckRunClient.RequiredStatusChecks(List.of("build"), List.of()));
+
+      assertEquals(
+          List.of("build"), orchestrator.resolveRequiredContexts("auth", req()).orElseThrow());
+    }
+
+    @Test
+    void skipsRequiredStatusChecksRuleWithNullParameters() {
+      stubBaseRef("main");
+      when(checkRunClient.getBranchRules(
+              anyString(), anyString(), anyString(), anyString(), anyString()))
+          .thenReturn(List.of(new GitHubCheckRunClient.BranchRule("required_status_checks", null)));
+      // Classic 404s — a ruleset governs the branch but contributes no required contexts.
+      when(checkRunClient.getRequiredStatusChecks(
+              anyString(), anyString(), anyString(), anyString(), anyString()))
+          .thenThrow(new RuntimeException("Not Found, status code 404"));
+
+      var result = orchestrator.resolveRequiredContexts("auth", req());
+      assertTrue(result.isPresent());
+      assertTrue(result.orElseThrow().isEmpty());
+    }
+
+    @Test
+    void skipsRequiredCheckWithNullContext() {
+      stubBaseRef("main");
+      when(checkRunClient.getBranchRules(
+              anyString(), anyString(), anyString(), anyString(), anyString()))
+          .thenReturn(List.of(statusCheckRule(check(null), check("build"))));
+      when(checkRunClient.getRequiredStatusChecks(
+              anyString(), anyString(), anyString(), anyString(), anyString()))
+          .thenThrow(new RuntimeException("Not Found, status code 404"));
+
+      assertEquals(
+          List.of("build"), orchestrator.resolveRequiredContexts("auth", req()).orElseThrow());
+    }
+
+    @Test
+    void unionsRulesetAndClassicContextsWithoutDuplicates() {
+      stubBaseRef("main");
+      when(checkRunClient.getBranchRules(
+              anyString(), anyString(), anyString(), anyString(), anyString()))
+          .thenReturn(List.of(statusCheckRule(check("build"), check("lint"))));
+      stubClassic(
+          new GitHubCheckRunClient.RequiredStatusChecks(List.of("lint", "deploy"), List.of()));
+
+      assertEquals(
+          List.of("build", "lint", "deploy"),
+          orchestrator.resolveRequiredContexts("auth", req()).orElseThrow());
+    }
+
+    @Test
+    void returnsEmptyWhenNeitherMechanismGovernsBranch() {
+      stubBaseRef("main");
+      when(checkRunClient.getBranchRules(
+              anyString(), anyString(), anyString(), anyString(), anyString()))
+          .thenReturn(null);
+      stubClassic(null);
+
+      assertTrue(orchestrator.resolveRequiredContexts("auth", req()).isEmpty());
+    }
+  }
+
+  @Nested
   class CiChecksGating {
 
     @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The bot's required-status-check lookup only queried the **classic** branch-protection endpoint (`GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks`). That endpoint is blind to **repository/organization rulesets** — the modern GitHub mechanism for branch protection.

When a repo protects its branch via a ruleset (as this repo does for `main` via the `main-protection` ruleset), the classic endpoint returns `404 Branch not protected`. The orchestrator caught that, logged a noisy `WARN` ("Could not fetch required status checks for branch, falling back to all checks"), and silently fell back to gating approvals on **all** checks instead of the actual required set.

The 404 (not a 403) was the giveaway: admin/`Administration: read` access was already granted and working — there simply is no *classic* protection to read.

### Fix

- **`GitHubCheckRunClient`**: add `getBranchRules` for `GET /repos/{owner}/{repo}/rules/branches/{branch}` — the endpoint that returns the *effective* rules aggregated across all rulesets and needs only read access (not admin) — plus a `BranchRule` record modeling the `required_status_checks` rule type.
- **`ReviewOrchestrator.resolveRequiredContexts`**: now **unions** required contexts from both mechanisms — rulesets (modern, read-only) and classic branch protection (legacy, admin) — and only falls back to "gate on all checks" when neither governs the branch. The classic-endpoint 404 is now logged at `DEBUG`, since for ruleset-only repos it's expected, not an error.

For this repo, the gate now resolves the real required set (`format`, `test`, `frontend`, `trivy`) instead of falling back.

## Related Issues

N/A

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

- Verified `GET /rules/branches/main` against the live repo returns the four required contexts (`format`, `test`, `frontend`, `trivy`), while the classic endpoint 404s.
- Added two `ReviewOrchestratorTest` cases: one proving ruleset contexts are honored when classic protection 404s (a failing *non-required* check is correctly ignored, so APPROVE stands), one proving a missing ruleset-required check downgrades the approval to `neutral`.
- Full `ReviewOrchestratorTest` suite: **150 tests pass** (148 existing + 2 new). `spotless:check` clean.

> Note: tests were run with `-Djacoco.skip=true -Dquarkus.jacoco.enabled=false` — JaCoCo's `-javaagent` fails to attach on the local JDK 25 setup (unrelated to this change).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The `Administration: read` permission can stay — it's still used for repos that rely on classic branch protection — but it's no longer required for ruleset-only repos, since `/rules/branches/{branch}` needs only read access.
