### PR TITLE
feat(review): add a file-by-file walkthrough table to the PR summary

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -18,6 +18,9 @@ package dev.thiagogonzaga.thrillhousebot.review;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /** Generates the PR summary comment posted on the first review. */
 @ApplicationScoped
@@ -27,10 +30,20 @@ public class PrSummaryGenerator {
   public static final String ZERO_ISSUES_MESSAGE =
       "Everything's coming up Thrillhouse! 🎉\n\nNo issues found in this PR.";
 
+  /**
+   * Upper bound on rows in the changed-files walkthrough. Keeps the comment within GitHub's size
+   * budget on large PRs; any files beyond this are rolled up into a trailing "… and N more" note.
+   */
+  static final int MAX_FILE_ROWS = 20;
+
+  /** One changed file in the walkthrough: its path and the diff's authoritative change type. */
+  public record ChangedFile(String path, String changeType) {}
+
   public String generate(
       int filesChanged,
       int additions,
       int deletions,
+      List<ChangedFile> changedFiles,
       ReviewResponse.Summary aiSummary,
       ReviewResult result) {
     var sb = new StringBuilder();
@@ -43,6 +56,8 @@ public class PrSummaryGenerator {
     sb.append("- **Files changed:** ").append(filesChanged).append("\n");
     sb.append("- **Lines added:** ").append(signed('+', additions)).append("\n");
     sb.append("- **Lines removed:** ").append(signed('-', deletions)).append("\n\n");
+
+    appendChangedFiles(sb, changedFiles, aiSummary);
 
     sb.append("### Risk Assessment\n");
     sb.append("| Risk | Count |\n");
@@ -171,6 +186,69 @@ public class PrSummaryGenerator {
       sb.append("- ").append(gap.strip()).append("\n");
     }
     sb.append("\n");
+  }
+
+  /**
+   * Renders the file-by-file walkthrough as a table of (file, change type, one-line summary). The
+   * change type comes from the diff (authoritative); the summary is the model's per-file note,
+   * matched by path. Files without a model summary still appear, so the table always mirrors the
+   * actual change set. Bounded to {@link #MAX_FILE_ROWS} rows to respect the comment-size budget.
+   */
+  private static void appendChangedFiles(
+      StringBuilder sb, List<ChangedFile> changedFiles, ReviewResponse.Summary aiSummary) {
+    if (changedFiles == null || changedFiles.isEmpty()) {
+      return;
+    }
+    Map<String, String> summaryByPath = summariesByPath(aiSummary);
+
+    sb.append("### Changed Files\n");
+    sb.append("| File | Change | Summary |\n");
+    sb.append("|------|--------|---------|\n");
+    for (ChangedFile file : changedFiles.stream().limit(MAX_FILE_ROWS).toList()) {
+      String summary = summaryByPath.getOrDefault(file.path(), "");
+      sb.append("| `")
+          .append(escapeTableCell(file.path()))
+          .append("` | ")
+          .append(changeTypeLabel(file.changeType()))
+          .append(" | ")
+          .append(summary.isBlank() ? "-" : escapeTableCell(summary.strip()))
+          .append(" |\n");
+    }
+    int overflow = changedFiles.size() - MAX_FILE_ROWS;
+    if (overflow > 0) {
+      sb.append("\n_…and ").append(overflow).append(" more file(s)._\n");
+    }
+    sb.append("\n");
+  }
+
+  /** Indexes the model's per-file notes by path; a duplicate path keeps the first note. */
+  private static Map<String, String> summariesByPath(ReviewResponse.Summary aiSummary) {
+    if (aiSummary == null) {
+      return Map.of();
+    }
+    // List.copyOf in the Summary constructor guarantees no null elements.
+    return aiSummary.fileSummaries().stream()
+        .filter(fs -> fs.path() != null && !fs.path().isBlank() && fs.summary() != null)
+        .collect(
+            Collectors.toMap(
+                fs -> fs.path().strip(),
+                ReviewResponse.FileSummary::summary,
+                (first, dup) -> first));
+  }
+
+  /** Maps a GitHub file status to a display label, falling back to the raw value when unknown. */
+  private static String changeTypeLabel(String status) {
+    if (status == null || status.isBlank()) {
+      return "Changed";
+    }
+    return switch (status.toLowerCase(Locale.ROOT)) {
+      case "added" -> "Added";
+      case "removed", "deleted" -> "Removed";
+      case "renamed" -> "Renamed";
+      case "copied" -> "Copied";
+      case "changed", "modified" -> "Modified";
+      default -> escapeTableCell(status);
+    };
   }
 
   /** Renders a signed line count, avoiding the awkward "+0"/"-0". */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -304,7 +304,9 @@ public class ReviewOrchestrator {
       List<ReviewResult.CiCheck> offendingCiChecks =
           evaluateCiChecks(auth, req.owner(), req.repo(), req.commitSha(), requiredContexts);
 
-      DiffStats diffStats = DiffStats.fromFiles(diffFormatter.reviewableFiles(files));
+      var reviewableFiles = diffFormatter.reviewableFiles(files);
+      DiffStats diffStats = DiffStats.fromFiles(reviewableFiles);
+      List<PrSummaryGenerator.ChangedFile> changedFiles = toChangedFiles(reviewableFiles);
       var unresolvedPrevious =
           followUpAnalyzer.unresolvedFindings(
               previousAiResponseJson, aiResponse.previousFindingsStatus());
@@ -326,6 +328,7 @@ public class ReviewOrchestrator {
               aiResponse,
               isFirstVisibleReview,
               diffStats,
+              changedFiles,
               unresolvedPrevious,
               offendingCiChecks,
               backstopUnresolved);
@@ -829,10 +832,21 @@ public class ReviewOrchestrator {
     }
   }
 
+  /**
+   * Projects the reviewed diff onto the (path, change type) rows the summary walkthrough renders.
+   */
+  static List<PrSummaryGenerator.ChangedFile> toChangedFiles(
+      List<GitHubPullRequestClient.FileDiff> files) {
+    return files.stream()
+        .map(f -> new PrSummaryGenerator.ChangedFile(f.filename(), f.status()))
+        .toList();
+  }
+
   ReviewResult buildResult(
       ReviewResponse aiResponse,
       boolean isFirstReview,
       DiffStats diffStats,
+      List<PrSummaryGenerator.ChangedFile> changedFiles,
       List<Finding> unresolvedPrevious,
       List<ReviewResult.CiCheck> offendingCiChecks,
       List<ReviewResult.PreviousFindingStatus> backstopUnresolved) {
@@ -891,6 +905,7 @@ public class ReviewOrchestrator {
             diffStats.filesChanged(),
             diffStats.additions(),
             diffStats.deletions(),
+            changedFiles,
             aiResponse.summary(),
             new ReviewResult(
                 findings,
@@ -926,7 +941,13 @@ public class ReviewOrchestrator {
       List<Finding> unresolvedPrevious,
       List<ReviewResult.CiCheck> offendingCiChecks) {
     return buildResult(
-        aiResponse, isFirstReview, diffStats, unresolvedPrevious, offendingCiChecks, List.of());
+        aiResponse,
+        isFirstReview,
+        diffStats,
+        List.of(),
+        unresolvedPrevious,
+        offendingCiChecks,
+        List.of());
   }
 
   ReviewResult buildResult(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -282,7 +282,8 @@ public class FindingVerificationService {
         original.overallAssessment(),
         original.prPurpose(),
         original.descriptionGaps(),
-        original.suggestedLabels());
+        original.suggestedLabels(),
+        original.fileSummaries());
   }
 
   private static int countRisk(List<ReviewResponse.Finding> findings, RiskLevel risk) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -147,6 +147,13 @@ public final class PrReviewPrompts {
               mismatches between what the author claims and what the code does (claimed changes
               that are missing, significant changes the description never mentions). Empty array
               when there is no description or no mismatch.
+            - file_summaries: an array of {path, summary} objects, one per changed file, that gives
+              reviewers a file-by-file walkthrough. "path" must match the file path exactly as it
+              appears in the diff; "summary" is a single line (max ~100 chars) describing what
+              changed in that file and why, derived from the diff — not the file name. Cover the
+              most significant files first and cap the array at 15 entries; for a larger PR,
+              summarize the 15 most impactful files and omit purely mechanical ones (generated
+              code, lockfiles, bulk renames). Empty array when nothing is worth calling out.
             - suggested_labels: ONLY when an "Available Repository Labels" section is provided,
               a JSON array of label names that best categorize this PR — area, change type, risk.
               Follow that section's guidance on which labels you may use, pick the few most

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponse.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponse.java
@@ -61,6 +61,10 @@ public record ReviewResponse(
       String status, // resolved, unresolved, justified
       String note) {}
 
+  /** One changed file the model summarized: its path and a one-line description of the change. */
+  @RegisterForReflection
+  public record FileSummary(String path, String summary) {}
+
   @RegisterForReflection
   public record Summary(
       @JsonProperty("total_findings") int totalFindings,
@@ -71,7 +75,8 @@ public record ReviewResponse(
       @JsonProperty("overall_assessment") String overallAssessment,
       @JsonProperty("pr_purpose") String prPurpose,
       @JsonProperty("description_gaps") List<String> descriptionGaps,
-      @JsonProperty("suggested_labels") List<String> suggestedLabels) {
+      @JsonProperty("suggested_labels") List<String> suggestedLabels,
+      @JsonProperty("file_summaries") List<FileSummary> fileSummaries) {
     public Summary {
       // The AI may emit null elements inside these arrays (e.g. ["bug", null]); a bare List.copyOf
       // would throw an NPE that fails the whole review, even though both lists are best-effort
@@ -79,9 +84,10 @@ public record ReviewResponse(
       // into the helper so SpotBugs still sees the defensive copy and does not flag EI_EXPOSE_REP.
       descriptionGaps = List.copyOf(withoutNulls(descriptionGaps));
       suggestedLabels = List.copyOf(withoutNulls(suggestedLabels));
+      fileSummaries = List.copyOf(withoutNulls(fileSummaries));
     }
 
-    private static List<String> withoutNulls(List<String> values) {
+    private static <T> List<T> withoutNulls(List<T> values) {
       return values == null ? List.of() : values.stream().filter(Objects::nonNull).toList();
     }
 
@@ -104,6 +110,30 @@ public record ReviewResponse(
           overallAssessment,
           prPurpose,
           descriptionGaps,
+          List.of());
+    }
+
+    /** Convenience constructor for callers (and responses) that predate per-file summaries. */
+    public Summary(
+        int totalFindings,
+        int critical,
+        int high,
+        int medium,
+        int low,
+        String overallAssessment,
+        String prPurpose,
+        List<String> descriptionGaps,
+        List<String> suggestedLabels) {
+      this(
+          totalFindings,
+          critical,
+          high,
+          medium,
+          low,
+          overallAssessment,
+          prPurpose,
+          descriptionGaps,
+          suggestedLabels,
           List.of());
     }
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -397,11 +397,15 @@ class PrSummaryGeneratorTest {
             new PrSummaryGenerator.ChangedFile("c", "renamed"),
             new PrSummaryGenerator.ChangedFile("d", "modified"),
             new PrSummaryGenerator.ChangedFile("e", null),
-            new PrSummaryGenerator.ChangedFile("f", "unmerged"));
+            new PrSummaryGenerator.ChangedFile("f", "unmerged"),
+            new PrSummaryGenerator.ChangedFile("g", ""),
+            new PrSummaryGenerator.ChangedFile("h", "deleted"),
+            new PrSummaryGenerator.ChangedFile("i", "copied"),
+            new PrSummaryGenerator.ChangedFile("j", "CHANGED"));
     var result =
         new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
 
-    var summary = generator.generate(6, 0, 0, changedFiles, null, result);
+    var summary = generator.generate(10, 0, 0, changedFiles, null, result);
 
     assertTrue(summary.contains("| `a` | Added |"));
     assertTrue(summary.contains("| `b` | Removed |"));
@@ -409,6 +413,46 @@ class PrSummaryGeneratorTest {
     assertTrue(summary.contains("| `d` | Modified |"));
     assertTrue(summary.contains("| `e` | Changed |")); // null status falls back to "Changed"
     assertTrue(summary.contains("| `f` | unmerged |")); // unknown status passes through verbatim
+    assertTrue(summary.contains("| `g` | Changed |")); // blank status falls back to "Changed"
+    assertTrue(summary.contains("| `h` | Removed |")); // "deleted" aliases to "Removed"
+    assertTrue(summary.contains("| `i` | Copied |"));
+    assertTrue(summary.contains("| `j` | Modified |")); // matching is case-insensitive
+  }
+
+  @Test
+  void shouldOmitChangedFilesSectionWhenChangedFilesNull() {
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    var summary = generator.generate(0, 0, 0, null, null, result);
+
+    assertFalse(summary.contains("Changed Files"));
+  }
+
+  @Test
+  void shouldDropMalformedFileSummariesAndKeepFirstOnDuplicatePath() {
+    var changedFiles =
+        List.of(
+            new PrSummaryGenerator.ChangedFile("src/A.java", "modified"),
+            new PrSummaryGenerator.ChangedFile("src/B.java", "added"));
+    // Malformed entries (null/blank path, null summary) are dropped; a duplicate path keeps the
+    // first usable note rather than throwing from Collectors.toMap.
+    var aiSummary =
+        summaryWithFiles(
+            new ReviewResponse.FileSummary(null, "no path"),
+            new ReviewResponse.FileSummary("  ", "blank path"),
+            new ReviewResponse.FileSummary("src/A.java", null),
+            new ReviewResponse.FileSummary("src/A.java", "first wins"),
+            new ReviewResponse.FileSummary("src/A.java", "second ignored"),
+            new ReviewResponse.FileSummary("src/B.java", "b note"));
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    var summary = generator.generate(2, 1, 0, changedFiles, aiSummary, result);
+
+    assertTrue(summary.contains("| `src/A.java` | Modified | first wins |"));
+    assertFalse(summary.contains("second ignored"));
+    assertTrue(summary.contains("| `src/B.java` | Added | b note |"));
   }
 
   private static ReviewResponse.Summary summaryWithFiles(ReviewResponse.FileSummary... files) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -36,7 +36,7 @@ class PrSummaryGeneratorTest {
         new ReviewResult(
             findings, 0, 1, 1, 0, RiskLevel.HIGH, ReviewState.REQUEST_CHANGES, true, "", List.of());
 
-    var summary = generator.generate(3, 120, 45, null, result);
+    var summary = generator.generate(3, 120, 45, List.of(), null, result);
 
     assertTrue(summary.contains("🤖 ThrillhouseBot PR Summary"));
     assertFalse(summary.contains("Repository:"));
@@ -62,7 +62,7 @@ class PrSummaryGeneratorTest {
     var result =
         new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
 
-    var summary = generator.generate(1, 5, 0, aiSummary, result);
+    var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
 
     assertTrue(summary.contains("### What this PR does"));
     assertTrue(summary.contains("Adds a user update endpoint with validation."));
@@ -84,10 +84,10 @@ class PrSummaryGeneratorTest {
 
     for (var summary :
         List.of(
-            generator.generate(1, 0, 0, null, result),
-            generator.generate(1, 0, 0, blankSummary, result),
-            generator.generate(1, 0, 0, nullPurposeSummary, result),
-            generator.generate(1, 0, 0, blankGapsSummary, result))) {
+            generator.generate(1, 0, 0, List.of(), null, result),
+            generator.generate(1, 0, 0, List.of(), blankSummary, result),
+            generator.generate(1, 0, 0, List.of(), nullPurposeSummary, result),
+            generator.generate(1, 0, 0, List.of(), blankGapsSummary, result))) {
       assertFalse(summary.contains("What this PR does"));
       assertFalse(summary.contains("Description vs. Implementation"));
     }
@@ -98,12 +98,12 @@ class PrSummaryGeneratorTest {
     var result =
         new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
 
-    var summary = generator.generate(3, 169, 0, null, result);
+    var summary = generator.generate(3, 169, 0, List.of(), null, result);
 
     assertTrue(summary.contains("**Lines added:** +169"));
     assertTrue(summary.contains("**Lines removed:** 0"));
     assertFalse(summary.contains("-0"));
-    assertTrue(generator.generate(3, 0, 7, null, result).contains("**Lines added:** 0"));
+    assertTrue(generator.generate(3, 0, 7, List.of(), null, result).contains("**Lines added:** 0"));
   }
 
   @Test
@@ -112,7 +112,7 @@ class PrSummaryGeneratorTest {
     var result =
         new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
 
-    assertFalse(generator.generate(1, 0, 0, null, result).contains("View in dashboard"));
+    assertFalse(generator.generate(1, 0, 0, List.of(), null, result).contains("View in dashboard"));
   }
 
   @Test
@@ -120,7 +120,7 @@ class PrSummaryGeneratorTest {
     var result =
         new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
 
-    var summary = generator.generate(1, 10, 2, null, result);
+    var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
     assertTrue(summary.contains("Critical | 0"));
     assertTrue(summary.contains("High | 0"));
@@ -131,7 +131,7 @@ class PrSummaryGeneratorTest {
     var result =
         new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
 
-    var summary = generator.generate(1, 10, 2, null, result);
+    var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
     assertTrue(summary.contains("Everything's coming up Thrillhouse"));
     assertTrue(summary.contains("No issues found in this PR."));
@@ -143,7 +143,8 @@ class PrSummaryGeneratorTest {
     var result =
         new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses);
 
-    assertFalse(generator.generate(1, 10, 2, null, result).contains("coming up Thrillhouse"));
+    assertFalse(
+        generator.generate(1, 10, 2, List.of(), null, result).contains("coming up Thrillhouse"));
   }
 
   @Test
@@ -152,7 +153,7 @@ class PrSummaryGeneratorTest {
     var result =
         new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses);
 
-    var summary = generator.generate(1, 10, 2, null, result);
+    var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
     assertFalse(summary.contains("Everything's coming up Thrillhouse"));
   }
@@ -164,7 +165,7 @@ class PrSummaryGeneratorTest {
         new ReviewResult(
             findings, 0, 0, 0, 1, RiskLevel.LOW, ReviewState.COMMENT, true, "", List.of());
 
-    var summary = generator.generate(1, 10, 2, null, result);
+    var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
     assertFalse(summary.contains("Everything's coming up Thrillhouse"));
     assertTrue(summary.contains("Key Findings"));
@@ -180,7 +181,7 @@ class PrSummaryGeneratorTest {
     var result =
         new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses);
 
-    var summary = generator.generate(1, 0, 0, null, result);
+    var summary = generator.generate(1, 0, 0, List.of(), null, result);
 
     assertTrue(summary.contains("Previous Findings Status"));
     assertTrue(summary.contains("✅ Resolved"));
@@ -200,7 +201,7 @@ class PrSummaryGeneratorTest {
     var result =
         new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses);
 
-    var summary = generator.generate(1, 0, 0, null, result);
+    var summary = generator.generate(1, 0, 0, List.of(), null, result);
 
     assertTrue(summary.contains("✅ Resolved | 1"), summary);
     assertTrue(summary.contains("⚠️ Still present | 1"), summary);
@@ -231,7 +232,7 @@ class PrSummaryGeneratorTest {
             "",
             List.of());
 
-    var summary = generator.generate(6, 0, 0, null, result);
+    var summary = generator.generate(6, 0, 0, List.of(), null, result);
 
     // Should only show 5 findings
     assertTrue(summary.contains("C1"));
@@ -252,7 +253,7 @@ class PrSummaryGeneratorTest {
         new ReviewResult(
             List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), checks);
 
-    var summary = generator.generate(1, 10, 2, null, result);
+    var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
     assertFalse(summary.contains("Everything's coming up Thrillhouse"));
     assertTrue(
@@ -272,7 +273,7 @@ class PrSummaryGeneratorTest {
         new ReviewResult(
             findings, 0, 0, 0, 1, RiskLevel.LOW, ReviewState.COMMENT, true, "", List.of(), checks);
 
-    var summary = generator.generate(1, 10, 2, null, result);
+    var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
     assertFalse(summary.contains("Everything's coming up Thrillhouse"));
     assertTrue(summary.contains("Key Findings"));
@@ -290,7 +291,7 @@ class PrSummaryGeneratorTest {
         new ReviewResult(
             List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), checks);
 
-    var summary = generator.generate(1, 10, 2, null, result);
+    var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
     assertTrue(summary.contains("build \\| strict"));
     assertFalse(summary.contains("build | strict"));
@@ -303,10 +304,115 @@ class PrSummaryGeneratorTest {
         new ReviewResult(
             List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), checks);
 
-    var summary = generator.generate(1, 10, 2, null, result);
+    var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
     // A null name/conclusion renders as "-" rather than throwing.
     assertTrue(summary.contains("Required CI Checks Status"));
     assertTrue(summary.contains("⏳ Pending"));
+  }
+
+  @Test
+  void shouldRenderChangedFilesTableWithPerFileSummaries() {
+    var changedFiles =
+        List.of(
+            new PrSummaryGenerator.ChangedFile("src/A.java", "modified"),
+            new PrSummaryGenerator.ChangedFile("src/B.java", "added"));
+    var aiSummary =
+        summaryWithFiles(
+            new ReviewResponse.FileSummary("src/A.java", "Adds null guard to parse()"),
+            new ReviewResponse.FileSummary("src/B.java", "New cache wrapper"));
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    var summary = generator.generate(2, 10, 1, changedFiles, aiSummary, result);
+
+    assertTrue(summary.contains("### Changed Files"));
+    assertTrue(summary.contains("| File | Change | Summary |"));
+    assertTrue(summary.contains("| `src/A.java` | Modified | Adds null guard to parse() |"));
+    assertTrue(summary.contains("| `src/B.java` | Added | New cache wrapper |"));
+  }
+
+  @Test
+  void shouldRenderDashWhenFileHasNoMatchingSummary() {
+    var changedFiles = List.of(new PrSummaryGenerator.ChangedFile("src/A.java", "modified"));
+    // AI summarized a different file; the changed file still appears, with "-" for its summary.
+    var aiSummary = summaryWithFiles(new ReviewResponse.FileSummary("src/Other.java", "unrelated"));
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    var summary = generator.generate(1, 1, 0, changedFiles, aiSummary, result);
+
+    assertTrue(summary.contains("| `src/A.java` | Modified | - |"));
+  }
+
+  @Test
+  void shouldOmitChangedFilesSectionWhenNoFiles() {
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    var summary = generator.generate(0, 0, 0, List.of(), summaryWithFiles(), result);
+
+    assertFalse(summary.contains("Changed Files"));
+  }
+
+  @Test
+  void shouldBoundChangedFilesTableAndReportOverflow() {
+    var changedFiles = new java.util.ArrayList<PrSummaryGenerator.ChangedFile>();
+    int total = PrSummaryGenerator.MAX_FILE_ROWS + 3;
+    for (int i = 0; i < total; i++) {
+      changedFiles.add(new PrSummaryGenerator.ChangedFile("src/F" + i + ".java", "modified"));
+    }
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    var summary = generator.generate(total, 0, 0, changedFiles, null, result);
+
+    // Only MAX_FILE_ROWS rows render; the first is present, the (MAX+1)th is rolled into the note.
+    assertTrue(summary.contains("`src/F0.java`"));
+    assertTrue(summary.contains("`src/F" + (PrSummaryGenerator.MAX_FILE_ROWS - 1) + ".java`"));
+    assertFalse(summary.contains("`src/F" + PrSummaryGenerator.MAX_FILE_ROWS + ".java`"));
+    assertTrue(summary.contains("…and 3 more file(s)."));
+  }
+
+  @Test
+  void shouldEscapePipesInChangedFilesTable() {
+    var changedFiles = List.of(new PrSummaryGenerator.ChangedFile("src/a|b.java", "modified"));
+    var aiSummary =
+        summaryWithFiles(new ReviewResponse.FileSummary("src/a|b.java", "handles a | b case"));
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    var summary = generator.generate(1, 1, 0, changedFiles, aiSummary, result);
+
+    assertTrue(summary.contains("src/a\\|b.java"));
+    assertTrue(summary.contains("handles a \\| b case"));
+  }
+
+  @Test
+  void shouldLabelKnownChangeTypesAndFallBackForUnknown() {
+    var changedFiles =
+        List.of(
+            new PrSummaryGenerator.ChangedFile("a", "added"),
+            new PrSummaryGenerator.ChangedFile("b", "removed"),
+            new PrSummaryGenerator.ChangedFile("c", "renamed"),
+            new PrSummaryGenerator.ChangedFile("d", "modified"),
+            new PrSummaryGenerator.ChangedFile("e", null),
+            new PrSummaryGenerator.ChangedFile("f", "unmerged"));
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    var summary = generator.generate(6, 0, 0, changedFiles, null, result);
+
+    assertTrue(summary.contains("| `a` | Added |"));
+    assertTrue(summary.contains("| `b` | Removed |"));
+    assertTrue(summary.contains("| `c` | Renamed |"));
+    assertTrue(summary.contains("| `d` | Modified |"));
+    assertTrue(summary.contains("| `e` | Changed |")); // null status falls back to "Changed"
+    assertTrue(summary.contains("| `f` | unmerged |")); // unknown status passes through verbatim
+  }
+
+  private static ReviewResponse.Summary summaryWithFiles(ReviewResponse.FileSummary... files) {
+    return new ReviewResponse.Summary(
+        0, 0, 0, 0, 0, "ok", null, List.of(), List.of(), List.of(files));
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -120,7 +120,8 @@ class ReviewOrchestratorTest {
     when(dashboardConfig.url()).thenReturn("https://bot.example");
     doNothing().when(sessionPersistence).update(anyLong(), any());
     when(projectStackResolver.resolve(any(), any(), any(), anyLong())).thenReturn("");
-    when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any())).thenReturn("");
+    when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any(), any()))
+        .thenReturn("");
     // The verifier and dedup pass findings through untouched unless a test overrides them
     when(findingVerificationService.verify(any(), any(), any(), any()))
         .thenAnswer(invocation -> invocation.getArgument(0));
@@ -677,7 +678,7 @@ class ReviewOrchestratorTest {
 
     @Test
     void shouldGenerateSummaryForFirstReviewWithFindings() {
-      when(summaryGenerator.generate(eq(4), eq(120), eq(45), any(), any()))
+      when(summaryGenerator.generate(eq(4), eq(120), eq(45), any(), any(), any()))
           .thenReturn("## Summary\n\nTest summary content");
 
       var aiResponse =
@@ -693,13 +694,13 @@ class ReviewOrchestratorTest {
               aiResponse, true, new ReviewOrchestrator.DiffStats(4, 120, 45), List.of());
 
       assertTrue(result.summaryMarkdown().contains("Test summary content"));
-      verify(summaryGenerator).generate(eq(4), eq(120), eq(45), any(), any());
+      verify(summaryGenerator).generate(eq(4), eq(120), eq(45), any(), any(), any());
     }
 
     @Test
     void shouldGenerateSummaryEvenWhenNoFindings() {
       var aiResponse = new ReviewResponse(List.of(), List.of(), null);
-      when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any()))
+      when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any(), any()))
           .thenReturn("Clean summary with celebration");
 
       var result =
@@ -707,7 +708,7 @@ class ReviewOrchestratorTest {
               aiResponse, true, new ReviewOrchestrator.DiffStats(0, 0, 0), List.of());
 
       assertEquals("Clean summary with celebration", result.summaryMarkdown());
-      verify(summaryGenerator).generate(eq(0), eq(0), eq(0), any(), any());
+      verify(summaryGenerator).generate(eq(0), eq(0), eq(0), any(), any(), any());
     }
 
     @Test
@@ -1147,7 +1148,7 @@ class ReviewOrchestratorTest {
             .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
-        when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any()))
+        when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any(), any()))
             .thenReturn("## Summary\nEverything's coming up Thrillhouse! 🎉");
 
         orchestrator.review(
@@ -1409,7 +1410,7 @@ class ReviewOrchestratorTest {
             .thenReturn(List.of());
         when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
             .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
-        when(summaryGenerator.generate(eq(1), eq(1), eq(1), any(), any()))
+        when(summaryGenerator.generate(eq(1), eq(1), eq(1), any(), any(), any()))
             .thenReturn("## 🤖 ThrillhouseBot PR Summary");
         when(suggestionFormatter.formatReviewComment(any())).thenReturn("**Medium** — fix this");
         when(aiReviewService.review(any(ReviewSession.class), any()))
@@ -2425,6 +2426,22 @@ class ReviewOrchestratorTest {
       assertEquals(4, stats.additions());
       assertEquals(6, stats.deletions());
     }
+
+    @Test
+    void toChangedFilesShouldProjectPathAndStatusInOrder() {
+      var files =
+          List.of(
+              new GitHubPullRequestClient.FileDiff("a.java", "added", 3, 0, 3, "patch"),
+              new GitHubPullRequestClient.FileDiff("b.java", "renamed", 0, 0, 0, null));
+
+      var changed = ReviewOrchestrator.toChangedFiles(files);
+
+      assertEquals(2, changed.size());
+      assertEquals("a.java", changed.get(0).path());
+      assertEquals("added", changed.get(0).changeType());
+      assertEquals("b.java", changed.get(1).path());
+      assertEquals("renamed", changed.get(1).changeType());
+    }
   }
 
   @Nested
@@ -3032,6 +3049,7 @@ class ReviewOrchestratorTest {
           new ReviewResponse(List.of(), List.of(), null),
           false,
           new ReviewOrchestrator.DiffStats(0, 0, 0),
+          List.of(), // changedFiles
           List.of(),
           List.of(),
           backstop);
@@ -3201,7 +3219,7 @@ class ReviewOrchestratorTest {
             .thenReturn("previous context");
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
-        when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any()))
+        when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any(), any()))
             .thenReturn("ThrillhouseBot PR Summary\n\nAll clear!");
 
         orchestrator.review(followUpRequest());
@@ -3847,7 +3865,7 @@ class ReviewOrchestratorTest {
                 List.of(
                     new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
                         1L, "build", "completed", "failure", null))));
-        when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any()))
+        when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any(), any()))
             .thenReturn("## Summary\nNo new issues, but required check **build** failed.");
 
         orchestrator.review(request());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseTest.java
@@ -17,7 +17,9 @@ package dev.thiagogonzaga.thrillhousebot.review.ai;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -82,5 +84,51 @@ class ReviewResponseTest {
     assertEquals(1, response.previousFindingsStatus().size());
     assertEquals("resolved", response.previousFindingsStatus().get(0).status());
     assertEquals("needs fix", response.summary().overallAssessment());
+  }
+
+  @Test
+  void summaryConvenienceConstructorsDefaultFileSummariesToEmpty() {
+    // Callers (and older AI responses) that predate file summaries must still construct cleanly.
+    var noLabels = new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", "purpose", List.of());
+    var withLabels =
+        new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", "purpose", List.of(), List.of("bug"));
+
+    assertTrue(noLabels.fileSummaries().isEmpty());
+    assertTrue(withLabels.fileSummaries().isEmpty());
+  }
+
+  @Test
+  void summaryShouldDropNullFileSummaryElements() {
+    // The AI may emit a null array element; the defensive copy must drop it, not throw.
+    var summary =
+        new ReviewResponse.Summary(
+            0,
+            0,
+            0,
+            0,
+            0,
+            "ok",
+            null,
+            List.of(),
+            List.of(),
+            Arrays.asList(new ReviewResponse.FileSummary("a.java", "changed"), null));
+
+    assertEquals(1, summary.fileSummaries().size());
+    assertEquals("a.java", summary.fileSummaries().get(0).path());
+  }
+
+  @Test
+  void shouldDeserializeFileSummariesFromJson() throws Exception {
+    var json =
+        """
+        {"summary": {"total_findings": 0, "overall_assessment": "ok",
+         "file_summaries": [{"path": "src/A.java", "summary": "adds guard"}]}}
+        """;
+
+    var response = new ObjectMapper().readValue(json, ReviewResponse.class);
+
+    assertEquals(1, response.summary().fileSummaries().size());
+    assertEquals("src/A.java", response.summary().fileSummaries().get(0).path());
+    assertEquals("adds guard", response.summary().fileSummaries().get(0).summary());
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature

## Description

The first-run PR summary has a risk breakdown but no structured walkthrough, so reviewers have to orient themselves on larger PRs straight from the diff. This adds a **Changed Files** table to the summary comment — `path`, change type, and a one-line description per file — so the summary mirrors the actual change set at a glance.

How it works:
- **Change type** is taken authoritatively from the diff (`FileDiff.status`), mapped to a friendly label (Added / Removed / Renamed / Modified; unknown values pass through; a null status renders as "Changed").
- **One-line description** comes from the model via a new `file_summaries` array on the review JSON. It rides the existing review call, so there is **no extra AI cost**. The model is asked for the 15 most impactful files (skipping generated/lockfile noise).
- The renderer **joins** the model's summaries to the diff's file list **by path**, so a file the model skips still appears in the table with `-` for its summary — the table always reflects the real change set.
- The table is **bounded to 20 rows** with an "…and N more file(s)" overflow note, and all cells are pipe-escaped, to stay within GitHub's comment-size budget.

Rendered output:

```markdown
### Changed Files
| File | Change | Summary |
|------|--------|---------|
| `src/A.java` | Modified | Adds null guard to parse() |
| `src/B.java` | Added | New cache wrapper |
```

Implementation notes for reviewers:
- `ReviewResponse.Summary` gains a `file_summaries` field (+ nested `FileSummary` record) with null-element filtering and back-compat convenience constructors, so existing callers/responses are unaffected.
- `FindingVerificationService.recount` now preserves `file_summaries` when it rebuilds the summary after verification (otherwise the field would be silently dropped).
- `PrSummaryGenerator.generate` takes a new `List<ChangedFile>` argument; `ReviewOrchestrator` projects the reviewed diff into it via `toChangedFiles` and threads it through `buildResult`.

## Related Issues

Closes #39

## How Has This Been Tested?

- [x] Unit tests

New/updated unit tests cover: table rendering with per-file summaries, the `-` fallback when a file has no model summary, omitting the section when there are no files, row-bounding + overflow note, pipe escaping, change-type label mapping (including null/unknown), the `toChangedFiles` projection, plus `file_summaries` JSON deserialization, null-element filtering, and back-compat constructors.

Full suite: **381 passing**. Spotless clean, SpotBugs (Max effort) reports 0 bugs.

> Note: tests were run with the JaCoCo coverage agent disabled (`-Djacoco.skip=true -Dquarkus.jacoco.enabled=false`) because JaCoCo 0.8.15 crashes the JVM at startup on Java 25 — a pre-existing, unrelated environment issue.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No config flag — the walkthrough is part of the always-on summary content (like `pr_purpose`), and cost is bounded by the 15-file prompt cap and the 20-row render cap. Pairs with #54 (Mermaid control-flow diagram), which builds on the same `PrSummaryGenerator`.
