### PR TITLE
feat(review): support multi-line suggestion ranges (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This release makes the bot interactive and controllable from the PR — conversa
 
 ### Changed
 
+- **Multi-line suggestions**: when a finding's fix replaces several consecutive lines, the bot now posts a multi-line review comment (`start_line`..`line`) so the GitHub suggestion replaces the whole range in one click, instead of anchoring to a single line and mis-applying the rest. The range is derived from the flagged code's position in the diff and falls back to a single-line comment when it can't be resolved (#71)
 - **Manual-trigger authorization is time-bounded**: the write-access check for a manual `/review` (installation-token mint + collaborator-permission call) now runs under a configurable timeout (`MANUAL_TRIGGER_AUTH_TIMEOUT`, default `5s`) on the webhook ack thread and fails closed if GitHub is too slow, so a degraded GitHub can no longer tie up a webhook worker past the delivery SLA (#92)
 - **CI — actionlint guardrail**: workflows and the consolidated Trivy composite action are linted (including inline shell via shellcheck), with the release-gate scan path mirrored so it is validated on PR CI (#93)
 - **CI — faster pipeline**: SpotBugs moved off the test job's critical path into the parallel lint job, the test job collapsed into a single Maven reactor, and the native build + image publish skipped for docs-only pushes to `main` (#170)

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.github;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -125,12 +126,20 @@ public interface GitHubReviewClient {
       String side,
       String body) {}
 
+  /**
+   * A pull request review comment. When {@code startLine} is set, the comment spans the inclusive
+   * range {@code start_line}..{@code line} so a GitHub suggestion replaces every line in it (#71);
+   * a single-line comment leaves both range fields null and they are omitted from the payload.
+   */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   record CreatePullRequestCommentRequest(
       @JsonProperty("commit_id") String commitId,
       String body,
       String path,
       int line,
-      String side) {}
+      String side,
+      @JsonProperty("start_line") Integer startLine,
+      @JsonProperty("start_side") String startSide) {}
 
   /** Reply posted into an existing review thread, keyed by the thread's root comment id in path. */
   record ReplyToReviewCommentRequest(String body) {}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.TreeSet;
 import java.util.function.Predicate;
@@ -37,17 +38,20 @@ public final class DiffLineResolver {
 
   private final Map<String, TreeSet<Integer>> rightSideLinesByFile;
   private final Map<String, List<String>> rightSideTextByFile;
+  private final Map<String, List<Integer>> rightSideTextLineNumbersByFile;
   private final Map<String, Map<Integer, String>> rightSideLineTextByFile;
 
   public DiffLineResolver(Map<String, String> patchesByFile) {
     this.rightSideLinesByFile = new HashMap<>();
     this.rightSideTextByFile = new HashMap<>();
+    this.rightSideTextLineNumbersByFile = new HashMap<>();
     this.rightSideLineTextByFile = new HashMap<>();
     patchesByFile.forEach(
         (file, patch) -> {
           RightSide rightSide = parseRightSide(patch);
           rightSideLinesByFile.put(file, rightSide.lines());
           rightSideTextByFile.put(file, rightSide.text());
+          rightSideTextLineNumbersByFile.put(file, rightSide.textLineNumbers());
           rightSideLineTextByFile.put(file, rightSide.lineText());
         });
   }
@@ -261,6 +265,77 @@ public final class DiffLineResolver {
     return OptionalInt.of(floorDistance <= ceilingDistance ? floor : ceiling);
   }
 
+  /** An inclusive right-side line range whose endpoints are both lines that exist in the diff. */
+  public record LineRange(int startLine, int endLine) {}
+
+  /**
+   * Resolves the right-side line range a finding's {@code suggestion_old} (the verbatim code it
+   * replaces) occupies in the diff, so a multi-line replacement can be posted as a multi-line
+   * GitHub suggestion that overwrites the whole range rather than a single anchor line (#71).
+   *
+   * <p>The anchor's trimmed, non-blank lines must appear as a contiguous, in-order run of
+   * right-side lines (the same matching {@link #isFindingPresent} uses); the range spans the first
+   * to the last matched line. Returns empty — so the caller falls back to a single-line comment —
+   * when the anchor is blank or single-line, the file is not in the diff, the run cannot be
+   * located, or the same run appears more than once (ambiguous, so guessing a range is unsafe).
+   */
+  public Optional<LineRange> resolveSuggestionRange(String file, String suggestionOld) {
+    if (file == null) {
+      return Optional.empty();
+    }
+    List<String> anchorLines = normalizedAnchorLines(suggestionOld);
+    if (anchorLines.size() < 2) {
+      return Optional.empty();
+    }
+    String key = resolveTextKeyForFileOrVariant(file);
+    if (key == null) {
+      return Optional.empty();
+    }
+    List<String> text = rightSideTextByFile.get(key);
+    List<Integer> lineNumbers = rightSideTextLineNumbersByFile.get(key);
+    int matchOffset = -1;
+    for (int i = 0; i + anchorLines.size() <= text.size(); i++) {
+      if (matchesAt(text, i, anchorLines)) {
+        if (matchOffset != -1) {
+          // The same block appears twice — no single range is correct, so fall back.
+          return Optional.empty();
+        }
+        matchOffset = i;
+      }
+    }
+    if (matchOffset == -1) {
+      return Optional.empty();
+    }
+    int startLine = lineNumbers.get(matchOffset);
+    int endLine = lineNumbers.get(matchOffset + anchorLines.size() - 1);
+    return endLine > startLine ? Optional.of(new LineRange(startLine, endLine)) : Optional.empty();
+  }
+
+  /**
+   * Resolves {@code file} to the diff key holding its right-side text — the exact key when its text
+   * is non-empty, else the unique {@link FilePaths#same} variant. Returns {@code null} on absence
+   * or genuine ambiguity (two suffix-colliding keys), mirroring {@link
+   * #resolveRightSideLinesForFileOrVariant} so a multi-line range is never bound to the wrong file.
+   */
+  private String resolveTextKeyForFileOrVariant(String file) {
+    List<String> exact = rightSideTextByFile.get(file);
+    if (exact != null && !exact.isEmpty()) {
+      return file;
+    }
+    String resolved = null;
+    for (var entry : rightSideTextByFile.entrySet()) {
+      if (!entry.getKey().equals(file)
+          && !entry.getValue().isEmpty()
+          && FilePaths.same(file, entry.getKey())) {
+        if (resolved != null) {
+          return null;
+        }
+        resolved = entry.getKey();
+      }
+    }
+    return resolved;
+  }
+
   static TreeSet<Integer> parseRightSideLines(String patch) {
     return parseRightSide(patch).lines();
   }
@@ -269,10 +344,15 @@ public final class DiffLineResolver {
    * The right-side line numbers and the right-side code text parsed from one file's patch. The text
    * is the trimmed, non-blank right-side lines in diff order, so {@link #containsContiguous} can
    * test the anchor as a contiguous run; blank lines are dropped from both sides so a blank line
-   * inside a block never breaks an otherwise-adjacent match.
+   * inside a block never breaks an otherwise-adjacent match. {@code textLineNumbers} runs parallel
+   * to {@code text}, carrying the right-side line number of each retained line so a matched anchor
+   * run can be mapped back to a concrete line range (#71).
    */
   private record RightSide(
-      TreeSet<Integer> lines, List<String> text, Map<Integer, String> lineText) {}
+      TreeSet<Integer> lines,
+      List<String> text,
+      List<Integer> textLineNumbers,
+      Map<Integer, String> lineText) {}
 
   /**
    * Walks a unified-diff patch once, collecting the right-side line numbers and the trimmed text of
@@ -287,9 +367,10 @@ public final class DiffLineResolver {
   private static RightSide parseRightSide(String patch) {
     var lines = new TreeSet<Integer>();
     var text = new ArrayList<String>();
+    var textLineNumbers = new ArrayList<Integer>();
     var lineText = new HashMap<Integer, String>();
     if (patch == null || patch.isBlank()) {
-      return new RightSide(lines, text, lineText);
+      return new RightSide(lines, text, textLineNumbers, lineText);
     }
 
     var newLine = 0;
@@ -302,11 +383,11 @@ public final class DiffLineResolver {
         continue;
       }
       if (inHunk && isRightSideLine(rawLine)) {
-        appendRightSide(lines, text, lineText, newLine, rawLine);
+        appendRightSide(lines, text, textLineNumbers, lineText, newLine, rawLine);
         newLine++;
       }
     }
-    return new RightSide(lines, text, lineText);
+    return new RightSide(lines, text, textLineNumbers, lineText);
   }
 
   /** The 1-based right-side start line of a hunk header, or empty if the line is not one. */
@@ -333,6 +414,7 @@ public final class DiffLineResolver {
   private static void appendRightSide(
       TreeSet<Integer> lines,
       List<String> text,
+      List<Integer> textLineNumbers,
       Map<Integer, String> lineText,
       int newLine,
       String rawLine) {
@@ -341,6 +423,7 @@ public final class DiffLineResolver {
     String stripped = content.strip();
     if (!stripped.isEmpty()) {
       text.add(stripped);
+      textLineNumbers.add(newLine);
     }
     lineText.put(newLine, content);
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -306,9 +306,11 @@ public final class DiffLineResolver {
     if (matchOffset == -1) {
       return Optional.empty();
     }
+    // Right-side line numbers are walked in ascending diff order, so a run of two or more matched
+    // lines always yields endLine > startLine — no degenerate single-line range to guard against.
     int startLine = lineNumbers.get(matchOffset);
     int endLine = lineNumbers.get(matchOffset + anchorLines.size() - 1);
-    return endLine > startLine ? Optional.of(new LineRange(startLine, endLine)) : Optional.empty();
+    return Optional.of(new LineRange(startLine, endLine));
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -1107,17 +1107,41 @@ public class ReviewOrchestrator {
           finding.file(), finding.line(), resolvedLine);
     }
 
-    if (tryPostInlineComment(target, finding, findingId, resolvedLine, true)
+    // A suggestion whose old code spans several lines is posted as a multi-line comment so the
+    // GitHub suggestion overwrites the whole range, not just the anchor line (#71). The range is
+    // resolved from the verbatim old code's position in the diff; a blank/single-line/unresolvable
+    // anchor leaves it empty and the comment stays single-line.
+    var range =
+        finding.hasSuggestion()
+            ? lineResolver.resolveSuggestionRange(finding.file(), finding.suggestionOld())
+            : Optional.<DiffLineResolver.LineRange>empty();
+
+    if (tryPostInlineComment(target, finding, findingId, resolvedLine, range, true)
         || (finding.hasSuggestion()
-            && tryPostInlineComment(target, finding, findingId, resolvedLine, false))) {
+            && tryPostInlineComment(
+                target, finding, findingId, resolvedLine, Optional.empty(), false))) {
       return true;
     }
     Log.warnf("GitHub rejected inline comment for %s:%d", finding.file(), finding.line());
     return false;
   }
 
+  /**
+   * Posts one inline comment. When {@code range} is present the comment spans {@code
+   * start_line}..{@code line} (both RIGHT side); otherwise it anchors to the single {@code line}.
+   * The retry without a suggestion block always passes an empty range — a multi-line span is only
+   * meaningful with a suggestion to apply across it.
+   */
   private boolean tryPostInlineComment(
-      CommentTarget target, Finding finding, int findingId, int line, boolean includeSuggestion) {
+      CommentTarget target,
+      Finding finding,
+      int findingId,
+      int line,
+      Optional<DiffLineResolver.LineRange> range,
+      boolean includeSuggestion) {
+    int endLine = range.map(DiffLineResolver.LineRange::endLine).orElse(line);
+    Integer startLine = range.map(DiffLineResolver.LineRange::startLine).orElse(null);
+    String startSide = startLine != null ? "RIGHT" : null;
     try {
       reviewClient.createPullRequestComment(
           target.auth(),
@@ -1129,15 +1153,17 @@ public class ReviewOrchestrator {
               target.commitSha(),
               suggestionFormatter.formatReviewComment(finding, includeSuggestion, findingId),
               finding.file(),
-              line,
-              "RIGHT"));
+              endLine,
+              "RIGHT",
+              startLine,
+              startSide));
       return true;
     } catch (RuntimeException e) {
       Log.debugf(
           e,
           "Inline comment rejected for %s:%d (suggestion=%s)",
           finding.file(),
-          line,
+          endLine,
           includeSuggestion);
       return false;
     }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
@@ -804,4 +804,50 @@ class DiffLineResolverTest {
 
     assertTrue(resolver.resolveSuggestionRange("dir/Main.java", "alpha()\nbeta()").isEmpty());
   }
+
+  @Test
+  void resolveSuggestionRangeShouldReturnEmptyWhenFileNotInDiff() {
+    var patch =
+        """
+        @@ -1,2 +1,2 @@
+        +alpha()
+        +beta()
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    // A multi-line anchor whose file is absent from the diff (no exact key, no path variant)
+    // resolves to no key and so to no range.
+    assertTrue(resolver.resolveSuggestionRange("other/Z.java", "alpha()\nbeta()").isEmpty());
+  }
+
+  @Test
+  void resolveSuggestionRangeFallsBackToVariantWhenExactEntryIsEmpty() {
+    // The exact path is present but deletion-only (empty right side), and an unrelated file is also
+    // deletion-only. Neither the empty exact entry nor the empty unrelated entry may short-circuit
+    // the fallback to the path variant that actually carries the lines (#132a).
+    var deletionOnly =
+        """
+        @@ -1,2 +1,0 @@
+        -alpha()
+        -beta()
+        """;
+    var withContent =
+        """
+        @@ -10,2 +10,2 @@
+        +alpha()
+        +beta()
+        """;
+    var resolver =
+        new DiffLineResolver(
+            Map.of(
+                "dir/Main.java", deletionOnly,
+                "unrelated/Other.java", deletionOnly,
+                "src/dir/Main.java", withContent));
+
+    var range = resolver.resolveSuggestionRange("dir/Main.java", "alpha()\nbeta()");
+
+    assertTrue(range.isPresent());
+    assertEquals(10, range.get().startLine());
+    assertEquals(11, range.get().endLine());
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
@@ -689,4 +689,119 @@ class DiffLineResolverTest {
     assertNull(emptyResolver.getLineText("dir/Main.java", 11));
     assertNull(emptyResolver.getLineText("Main.java", 11));
   }
+
+  @Test
+  void resolveSuggestionRangeShouldSpanContiguousOldLines() {
+    var patch =
+        """
+        @@ -10,4 +10,4 @@
+         keep()
+        +first_new()
+        +second_new()
+        +third_new()
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    var range = resolver.resolveSuggestionRange("A.java", "first_new()\nsecond_new()\nthird_new()");
+
+    assertTrue(range.isPresent());
+    assertEquals(11, range.get().startLine());
+    assertEquals(13, range.get().endLine());
+  }
+
+  @Test
+  void resolveSuggestionRangeShouldSpanAcrossADroppedBlankLine() {
+    // A blank line between the two flagged lines advances the line counter but is excluded from the
+    // text, so the contiguous match still holds and the range covers the blank line in between.
+    var patch =
+        """
+        @@ -1,0 +1,3 @@
+        +first();
+        +
+        +third();
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    var range = resolver.resolveSuggestionRange("A.java", "first();\nthird();");
+
+    assertTrue(range.isPresent());
+    assertEquals(1, range.get().startLine());
+    assertEquals(3, range.get().endLine());
+  }
+
+  @Test
+  void resolveSuggestionRangeShouldReturnEmptyForSingleLineOrBlankAnchor() {
+    var resolver = new DiffLineResolver(Map.of("main.py", PATCH));
+
+    assertTrue(resolver.resolveSuggestionRange("main.py", "    new_line()").isEmpty());
+    assertTrue(resolver.resolveSuggestionRange("main.py", null).isEmpty());
+    assertTrue(resolver.resolveSuggestionRange("main.py", "   ").isEmpty());
+    assertTrue(resolver.resolveSuggestionRange(null, "a()\nb()").isEmpty());
+  }
+
+  @Test
+  void resolveSuggestionRangeShouldReturnEmptyWhenAnchorNotContiguous() {
+    var patch =
+        """
+        @@ -1,3 +1,3 @@
+         alpha()
+         beta()
+         gamma()
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    // Out of order / non-adjacent runs do not resolve to a range.
+    assertTrue(resolver.resolveSuggestionRange("A.java", "alpha()\ngamma()").isEmpty());
+    assertTrue(resolver.resolveSuggestionRange("A.java", "gamma()\nbeta()").isEmpty());
+    // A line changed away breaks the block.
+    assertTrue(resolver.resolveSuggestionRange("A.java", "alpha()\ndelta()").isEmpty());
+  }
+
+  @Test
+  void resolveSuggestionRangeShouldReturnEmptyWhenBlockAppearsTwice() {
+    // The same two-line block occurs twice — no single range is correct, so fall back to single
+    // line rather than guess.
+    var patch =
+        """
+        @@ -1,4 +1,4 @@
+        +open()
+        +close()
+        +open()
+        +close()
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    assertTrue(resolver.resolveSuggestionRange("A.java", "open()\nclose()").isEmpty());
+  }
+
+  @Test
+  void resolveSuggestionRangeShouldMatchAcrossPathVariants() {
+    var patch =
+        """
+        @@ -10,3 +10,3 @@
+        +alpha()
+        +beta()
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/dir/Main.java", patch));
+
+    var range = resolver.resolveSuggestionRange("dir/Main.java", "alpha()\nbeta()");
+
+    assertTrue(range.isPresent());
+    assertEquals(10, range.get().startLine());
+    assertEquals(11, range.get().endLine());
+  }
+
+  @Test
+  void resolveSuggestionRangeShouldReturnEmptyOnAmbiguousPathVariants() {
+    var patch =
+        """
+        @@ -1,2 +1,2 @@
+        +alpha()
+        +beta()
+        """;
+    // Two suffix-colliding keys both carry the block — ambiguous, so no range is bound.
+    var resolver = new DiffLineResolver(Map.of("a/dir/Main.java", patch, "b/dir/Main.java", patch));
+
+    assertTrue(resolver.resolveSuggestionRange("dir/Main.java", "alpha()\nbeta()").isEmpty());
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2293,6 +2293,97 @@ class ReviewOrchestratorTest {
               anyString(), anyString(), anyString(), anyString(), anyInt(), any());
       verify(suggestionFormatter, never()).formatReviewComment(finding, false);
     }
+
+    @Test
+    void shouldPostMultiLineCommentWhenSuggestionSpansSeveralLines() {
+      var patch =
+          """
+          @@ -10,1 +10,4 @@
+           keep()
+          +first_new()
+          +second_new()
+          +third_new()
+          """;
+      var finding =
+          new Finding(
+              RiskLevel.HIGH,
+              "src/Main.java",
+              13,
+              "Bug",
+              "desc",
+              "first_new()\nsecond_new()\nthird_new()",
+              "fixed()");
+      var result = resultWithFinding(finding, ReviewState.REQUEST_CHANGES);
+      var resolver = new DiffLineResolver(Map.of("src/Main.java", patch));
+
+      var posted =
+          orchestrator.postInlineComments(
+              "Bearer tok", "owner", "repo", 7, "sha", result, resolver);
+
+      assertEquals(1, posted);
+      // The suggestion's old code spans lines 11-13, so the comment is posted as that range.
+      verify(reviewClient, times(1))
+          .createPullRequestComment(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(
+                  req ->
+                      req.line() == 13
+                          && req.startLine() != null
+                          && req.startLine() == 11
+                          && "RIGHT".equals(req.side())
+                          && "RIGHT".equals(req.startSide())));
+    }
+
+    @Test
+    void shouldFallBackToSingleLineWhenMultiLineCommentRejected() {
+      var patch =
+          """
+          @@ -10,1 +10,3 @@
+           keep()
+          +alpha()
+          +beta()
+          """;
+      var finding =
+          new Finding(
+              RiskLevel.HIGH, "src/Main.java", 12, "Bug", "desc", "alpha()\nbeta()", "fixed()");
+      var result = resultWithFinding(finding, ReviewState.REQUEST_CHANGES);
+      var resolver = new DiffLineResolver(Map.of("src/Main.java", patch));
+
+      doThrow(new RuntimeException("422"))
+          .doReturn(
+              new GitHubReviewClient.PullRequestCommentResponse(1L, "ok", "src/Main.java", 12))
+          .when(reviewClient)
+          .createPullRequestComment(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+
+      var posted =
+          orchestrator.postInlineComments(
+              "Bearer tok", "owner", "repo", 7, "sha", result, resolver);
+
+      assertEquals(1, posted);
+      // First attempt is the multi-line range [11, 12] ...
+      verify(reviewClient)
+          .createPullRequestComment(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(req -> req.startLine() != null && req.startLine() == 11 && req.line() == 12));
+      // ... the retry without a suggestion drops the range back to a single line.
+      verify(reviewClient)
+          .createPullRequestComment(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(req -> req.startLine() == null && req.line() == 12));
+    }
   }
 
   @Nested


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature
- [x] ✅ Test

## Description

Inline suggestion comments were always posted **single-line**: `ReviewOrchestrator` anchored every finding to one diff line (`line` + `side: RIGHT`), so a suggestion whose replacement spanned several original lines applied to only that line and silently left the rest — an incorrect fix. Multi-line refactors couldn't be expressed as click-to-apply suggestions.

This change posts a **multi-line review comment** (`start_line`/`start_side` + `line`/`side`) when a finding's suggestion replaces a multi-line range, so the GitHub suggestion replaces the full range in one click.

- **`GitHubReviewClient`** — `CreatePullRequestCommentRequest` gains `start_line`/`start_side`, annotated `@JsonInclude(NON_NULL)` so single-line requests omit them from the payload (same pattern already used in `GitHubCheckRunClient`).
- **`DiffLineResolver`** — new `resolveSuggestionRange(file, suggestionOld)` locates the verbatim old code as a contiguous, in-order run of right-side diff lines and returns its `[startLine, endLine]`, reusing the existing content-matching and path-variant resolution; a parallel `textLineNumbers` list maps a matched run back to real diff line numbers.
- **`ReviewOrchestrator`** — `postFindingComment` resolves the range for findings with a suggestion and posts the multi-line comment; the no-suggestion 422 retry deliberately stays single-line.

The range resolves to empty — and the comment stays single-line — when the anchor is blank/single-line, the file isn't in the diff, the old code can't be located as a contiguous run, or the run is ambiguous (same block twice, or two suffix-colliding path variants). A multi-line comment GitHub still rejects (e.g. a range crossing hunks) is caught by the existing 422 retry.

## Related Issues

Fixes #71.

> Note: this PR targets `release/v0.3.0` (milestone v0.3.0), not the default branch, so GitHub will not auto-close #71 on merge — it should be closed via the eventual `release/v0.3.0 → main` PR or manually.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- `DiffLineResolverTest` — 9 new cases: contiguous span, span across a dropped blank line, single-line/blank/null empties, non-contiguous run, duplicate-block ambiguity, path-variant match, ambiguous-variant fallback, file-not-in-diff, and empty-exact → variant fallback.
- `ReviewOrchestratorTest$PostInlineComments` — 2 new cases: a multi-line suggestion posts a `start_line`..`line` range; a rejected multi-line comment falls back to a single-line retry.
- Full local suite green (`./mvnw test` for the touched classes, 204 tests). Codecov patch coverage 100%, SonarCloud quality gate passed (100% coverage on new code).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

No prompt/schema change: the model still reports a single `line` per finding; the range is derived from the diff, so existing findings get correct multi-line application for free. `CHANGELOG.md` updated under `[Unreleased] → Changed`.