### PR TITLE
feat(review): add an opt-in Mermaid control-flow diagram to the PR summary

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -193,6 +193,20 @@ public interface ThrillhouseConfig {
     Duration manualTriggerAuthTimeout();
 
     LabelsConfig labels();
+
+    DiagramConfig diagram();
+  }
+
+  /**
+   * Opt-in Mermaid control-flow diagram in the PR summary. When {@link #enabled()} the model is
+   * asked to emit a small Mermaid diagram of the affected control flow for non-trivial changes,
+   * which the summary comment renders as a collapsible block (GitHub renders Mermaid natively). It
+   * rides the existing review call, so it costs only a few extra output tokens.
+   */
+  interface DiagramConfig {
+    /** Master switch — no diagram is requested or rendered unless this is {@code true}. */
+    @WithDefault("false")
+    boolean enabled();
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -39,6 +39,29 @@ public class PrSummaryGenerator {
   /** One changed file in the walkthrough: its path and the diff's authoritative change type. */
   public record ChangedFile(String path, String changeType) {}
 
+  /**
+   * Upper bound on the rendered Mermaid source. A diagram larger than this is dropped rather than
+   * posted: it is likely runaway or truncated output, and GitHub silently fails to render oversized
+   * Mermaid blocks anyway. Comfortably fits the ~12-node diagrams the prompt asks for.
+   */
+  static final int MAX_DIAGRAM_CHARS = 4000;
+
+  /**
+   * Mermaid diagram-type keywords the first source line may start with. The model is asked for a
+   * flowchart or sequence diagram; the wider set is accepted so a valid diagram is never dropped on
+   * a technicality, while arbitrary prose (which would render as a broken block) still is.
+   */
+  private static final List<String> MERMAID_PREFIXES =
+      List.of(
+          "graph",
+          "flowchart",
+          "sequencediagram",
+          "classdiagram",
+          "statediagram",
+          "erdiagram",
+          "journey",
+          "gantt");
+
   public String generate(
       int filesChanged,
       int additions,
@@ -51,6 +74,7 @@ public class PrSummaryGenerator {
 
     appendPrPurpose(sb, aiSummary);
     appendDescriptionGaps(sb, aiSummary);
+    appendWalkthroughDiagram(sb, aiSummary);
 
     sb.append("### Changes Overview\n");
     sb.append("- **Files changed:** ").append(filesChanged).append("\n");
@@ -249,6 +273,55 @@ public class PrSummaryGenerator {
       case "changed", "modified" -> "Modified";
       default -> escapeTableCell(status);
     };
+  }
+
+  /**
+   * Renders the optional Mermaid control-flow diagram as a collapsible block. The model supplies
+   * raw Mermaid source (no fences); this validates it is a real diagram, neutralizes any stray code
+   * fences so it cannot break out of the block, and drops anything oversized or unrecognized.
+   */
+  private static void appendWalkthroughDiagram(StringBuilder sb, ReviewResponse.Summary aiSummary) {
+    if (aiSummary == null) {
+      return;
+    }
+    String diagram = sanitizeDiagram(aiSummary.walkthroughDiagram());
+    if (diagram == null) {
+      return;
+    }
+    sb.append("### Control-Flow Diagram\n");
+    sb.append("<details>\n");
+    sb.append("<summary>🔀 Show diagram</summary>\n\n");
+    sb.append("```mermaid\n");
+    sb.append(diagram).append("\n");
+    sb.append("```\n\n");
+    sb.append("</details>\n\n");
+  }
+
+  /**
+   * Returns render-ready Mermaid source, or {@code null} when there is nothing safe to render.
+   * Strips any backtick fences the model may have wrapped around the source (which would otherwise
+   * let it escape the ```mermaid block), then accepts the result only if it opens with a known
+   * Mermaid diagram keyword and stays within the size bound.
+   */
+  private static String sanitizeDiagram(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return null;
+    }
+    // Drop every backtick run: Mermaid source never contains one, and removing them both unwraps an
+    // accidental ```mermaid ... ``` and prevents a stray ``` from closing our fence early.
+    String cleaned = raw.replace("`", "").strip();
+    // Unwrapping a ```mermaid fence leaves a bare "mermaid" language tag as the first line; drop it
+    // so the diagram keyword underneath is what gets validated.
+    if (cleaned.regionMatches(true, 0, "mermaid", 0, "mermaid".length())) {
+      int firstBreak = cleaned.indexOf('\n');
+      cleaned = firstBreak < 0 ? "" : cleaned.substring(firstBreak + 1).strip();
+    }
+    if (cleaned.isEmpty() || cleaned.length() > MAX_DIAGRAM_CHARS) {
+      return null;
+    }
+    String firstLine = cleaned.lines().findFirst().orElse("").strip().toLowerCase(Locale.ROOT);
+    boolean recognized = MERMAID_PREFIXES.stream().anyMatch(firstLine::startsWith);
+    return recognized ? cleaned : null;
   }
 
   /** Renders a signed line count, avoiding the awkward "+0"/"-0". */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -24,6 +24,7 @@ import dev.thiagogonzaga.thrillhousebot.dashboard.SessionEventBroadcaster;
 import dev.thiagogonzaga.thrillhousebot.github.*;
 import dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewService;
 import dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService;
+import dev.thiagogonzaga.thrillhousebot.review.ai.PrReviewPrompts;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -266,9 +267,15 @@ public class ReviewOrchestrator {
       // {{repoInstructions}} slot; the label section is escaped (it carries repo label names),
       // the instructions section escapes its own maintainer content.
       String labelGuidance = PrLabeler.buildLabelGuidance(repoLabels, labeler.allowNewLabels());
+      // The diagram request is fixed guidance (no repo content), so it needs no escaping; its
+      // presence is what gates the model's walkthrough_diagram field.
+      String diagramGuidance =
+          config.review().diagram().enabled() ? PrReviewPrompts.DIAGRAM_REQUEST : "";
       String trailingGuidance =
           combineSections(
-              labelGuidance.isBlank() ? "" : PromptTemplateEscaper.escape(labelGuidance),
+              combineSections(
+                  labelGuidance.isBlank() ? "" : PromptTemplateEscaper.escape(labelGuidance),
+                  diagramGuidance),
               buildInstructionsSection(instructions));
       var promptInputs =
           new AiReviewService.PromptInputs(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -283,7 +283,8 @@ public class FindingVerificationService {
         original.prPurpose(),
         original.descriptionGaps(),
         original.suggestedLabels(),
-        original.fileSummaries());
+        original.fileSummaries(),
+        original.walkthroughDiagram());
   }
 
   private static int countRisk(List<ReviewResponse.Finding> findings, RiskLevel risk) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -159,6 +159,10 @@ public final class PrReviewPrompts {
               Follow that section's guidance on which labels you may use, pick the few most
               relevant (typically 1-3), and emit an empty array if none clearly apply. Omit the
               field entirely when no such section is present.
+            - walkthrough_diagram: ONLY when a "Control-Flow Diagram Request" section is provided,
+              a single Mermaid diagram of the affected control flow, following that section's size
+              and format rules; use an empty string for trivial changes. Omit the field entirely
+              when no such section is present.
 
             If no issues found: return empty findings array and total_findings: 0.
 
@@ -215,6 +219,26 @@ public final class PrReviewPrompts {
             {{repoInstructions}}
             {{/if}}
             """;
+
+  /**
+   * Trailing-guidance block that turns on the optional Mermaid control-flow diagram. Injected into
+   * the prompt's {@code repoInstructions} slot only when the diagram feature is enabled, so the
+   * model self-gates the {@code walkthrough_diagram} field on its presence (mirroring how the label
+   * section gates {@code suggested_labels}). No extra AI call — it rides the existing review pass.
+   */
+  public static final String DIAGRAM_REQUEST =
+      """
+            ## Control-Flow Diagram Request
+            When — and only when — this change is non-trivial (it alters control flow, adds or
+            reorders interactions between components, or introduces a new multi-step path),
+            populate summary.walkthrough_diagram with a single Mermaid diagram of the AFFECTED
+            control flow:
+            - Use a `flowchart TD` or a `sequenceDiagram` — nothing else.
+            - Keep it small: at most ~12 nodes / participants, modelling only the changed path,
+              not the whole system.
+            - Emit ONLY the raw Mermaid source: no ``` fences, no prose, no Markdown around it.
+            - For trivial changes (small local edits, dependency bumps, doc-only changes), leave
+              walkthrough_diagram as an empty string.""";
 
   private PrReviewPrompts() {}
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponse.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponse.java
@@ -76,7 +76,11 @@ public record ReviewResponse(
       @JsonProperty("pr_purpose") String prPurpose,
       @JsonProperty("description_gaps") List<String> descriptionGaps,
       @JsonProperty("suggested_labels") List<String> suggestedLabels,
-      @JsonProperty("file_summaries") List<FileSummary> fileSummaries) {
+      @JsonProperty("file_summaries") List<FileSummary> fileSummaries,
+      // Optional Mermaid source for a control-flow diagram of the change (no ``` fences). Populated
+      // only when the diagram feature is enabled and the change is non-trivial; null/blank
+      // otherwise.
+      @JsonProperty("walkthrough_diagram") String walkthroughDiagram) {
     public Summary {
       // The AI may emit null elements inside these arrays (e.g. ["bug", null]); a bare List.copyOf
       // would throw an NPE that fails the whole review, even though both lists are best-effort
@@ -134,7 +138,34 @@ public record ReviewResponse(
           prPurpose,
           descriptionGaps,
           suggestedLabels,
-          List.of());
+          List.of(),
+          null);
+    }
+
+    /** Convenience constructor for callers (and responses) that predate the walkthrough diagram. */
+    public Summary(
+        int totalFindings,
+        int critical,
+        int high,
+        int medium,
+        int low,
+        String overallAssessment,
+        String prPurpose,
+        List<String> descriptionGaps,
+        List<String> suggestedLabels,
+        List<FileSummary> fileSummaries) {
+      this(
+          totalFindings,
+          critical,
+          high,
+          medium,
+          low,
+          overallAssessment,
+          prPurpose,
+          descriptionGaps,
+          suggestedLabels,
+          fileSummaries,
+          null);
     }
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -88,6 +88,11 @@ thrillhousebot.review.labels.apply=${REVIEW_LABELS_APPLY:false}
 thrillhousebot.review.labels.allow-create=${REVIEW_LABELS_ALLOW_CREATE:false}
 thrillhousebot.review.labels.max-labels=${REVIEW_LABELS_MAX:3}
 
+# Mermaid control-flow diagram in the PR summary (opt-in). When enabled, the model emits a small
+# Mermaid diagram of the affected control flow for non-trivial changes, rendered as a collapsible
+# block in the summary comment. Rides the existing review call (a few extra output tokens).
+thrillhousebot.review.diagram.enabled=${REVIEW_DIAGRAM_ENABLED:false}
+
 # Database (H2 for dev, PostgreSQL for prod)
 quarkus.datasource.db-kind=${DATASOURCE_DB_KIND:h2}
 quarkus.datasource.jdbc.url=jdbc:h2:mem:thrillhouse;DB_CLOSE_DELAY=-1

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -457,6 +457,87 @@ class PrSummaryGeneratorTest {
 
   private static ReviewResponse.Summary summaryWithFiles(ReviewResponse.FileSummary... files) {
     return new ReviewResponse.Summary(
-        0, 0, 0, 0, 0, "ok", null, List.of(), List.of(), List.of(files));
+        0, 0, 0, 0, 0, "ok", null, List.of(), List.of(), List.of(files), null);
+  }
+
+  @Test
+  void shouldRenderWalkthroughDiagramAsCollapsibleMermaidBlock() {
+    var aiSummary = summaryWithDiagram("flowchart TD\n  A[Start] --> B[End]");
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
+
+    assertTrue(summary.contains("### Control-Flow Diagram"));
+    assertTrue(summary.contains("<details>"));
+    assertTrue(summary.contains("```mermaid\nflowchart TD"));
+    assertTrue(summary.contains("A[Start] --> B[End]"));
+    assertTrue(summary.contains("</details>"));
+  }
+
+  @Test
+  void shouldOmitDiagramSectionWhenBlankOrNull() {
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    for (var aiSummary : List.of(summaryWithDiagram(null), summaryWithDiagram("   "))) {
+      var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
+      assertFalse(summary.contains("Control-Flow Diagram"));
+      assertFalse(summary.contains("```mermaid"));
+    }
+  }
+
+  @Test
+  void shouldStripBacktickFencesSoTheDiagramCannotBreakOut() {
+    // A model that ignores the "no fences" rule and wraps the source must not escape our block.
+    var aiSummary = summaryWithDiagram("```mermaid\nflowchart TD\n  A --> B\n```");
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
+
+    // Exactly one opening and one closing fence — the wrapper backticks were stripped.
+    assertEquals(1, countOccurrences(summary, "```mermaid"));
+    assertEquals(2, countOccurrences(summary, "```"));
+    assertTrue(summary.contains("flowchart TD"));
+  }
+
+  @Test
+  void shouldDropUnrecognizedDiagramSource() {
+    // Prose that is not a Mermaid diagram would render as a broken block, so it is dropped.
+    var aiSummary = summaryWithDiagram("This change refactors the parser and adds a cache.");
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
+
+    assertFalse(summary.contains("Control-Flow Diagram"));
+  }
+
+  @Test
+  void shouldDropOversizedDiagram() {
+    var huge = "flowchart TD\n" + "  A --> B\n".repeat(PrSummaryGenerator.MAX_DIAGRAM_CHARS);
+    var aiSummary = summaryWithDiagram(huge);
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
+
+    assertFalse(summary.contains("Control-Flow Diagram"));
+  }
+
+  private static ReviewResponse.Summary summaryWithDiagram(String diagram) {
+    return new ReviewResponse.Summary(
+        0, 0, 0, 0, 0, "ok", null, List.of(), List.of(), List.of(), diagram);
+  }
+
+  private static int countOccurrences(String haystack, String needle) {
+    int count = 0;
+    for (int i = haystack.indexOf(needle);
+        i >= 0;
+        i = haystack.indexOf(needle, i + needle.length())) {
+      count++;
+    }
+    return count;
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -526,6 +526,19 @@ class PrSummaryGeneratorTest {
     assertFalse(summary.contains("Control-Flow Diagram"));
   }
 
+  @Test
+  void shouldDropDiagramThatIsOnlyAFenceTag() {
+    // An empty ```mermaid fence collapses to a bare "mermaid" tag with nothing after it; stripping
+    // the tag leaves an empty string, which must be dropped rather than rendered.
+    var aiSummary = summaryWithDiagram("```mermaid```");
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+
+    var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
+
+    assertFalse(summary.contains("Control-Flow Diagram"));
+  }
+
   private static ReviewResponse.Summary summaryWithDiagram(String diagram) {
     return new ReviewResponse.Summary(
         0, 0, 0, 0, 0, "ok", null, List.of(), List.of(), List.of(), diagram);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -53,6 +53,9 @@ class ReviewOrchestratorTest {
 
   @Mock private ThrillhouseConfig.ReviewConfig reviewConfig;
 
+  // Created in setUp() (not @Mock) so individual tests can opt into the diagram feature.
+  private ThrillhouseConfig.DiagramConfig diagramConfig;
+
   @Mock private GitHubAuthClient authClient;
 
   @Mock private GitHubCheckRunClient checkRunClient;
@@ -102,6 +105,9 @@ class ReviewOrchestratorTest {
     orchestrator = newOrchestrator(mapper);
     when(config.review()).thenReturn(reviewConfig);
     when(reviewConfig.maxReviewComments()).thenReturn(10);
+    // Walkthrough diagram is off by default; individual tests opt in by re-stubbing enabled().
+    diagramConfig = mock(ThrillhouseConfig.DiagramConfig.class);
+    when(reviewConfig.diagram()).thenReturn(diagramConfig);
     // Mimic the real create(): persist assigns an id to new entities only
     doAnswer(
             invocation -> {
@@ -864,6 +870,70 @@ class ReviewOrchestratorTest {
         var instructionsSection = inputsCaptor.getValue().repoInstructions();
         assertTrue(instructionsSection.contains(PromptTemplateEscaper.escape("Focus on security")));
         assertTrue(instructionsSection.contains("(from .github/thrillhousebot.md)"));
+      }
+    }
+
+    @Test
+    void shouldInjectDiagramRequestIntoPromptWhenDiagramEnabled() {
+      when(diagramConfig.enabled()).thenReturn(true);
+
+      assertTrue(captureRepoInstructions().contains("Control-Flow Diagram Request"));
+    }
+
+    @Test
+    void shouldNotInjectDiagramRequestWhenDiagramDisabled() {
+      // diagramConfig.enabled() defaults to false from setUp()
+      assertFalse(captureRepoInstructions().contains("Control-Flow Diagram Request"));
+    }
+
+    /** Runs review() far enough to capture the prompt and returns its repoInstructions slot. */
+    private String captureRepoInstructions() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getPrTitle()).thenReturn("Test PR");
+        when(session.getCommitSha()).thenReturn("abcdefgh");
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        when(authClient.getAuthHeader(123L)).thenReturn("Bearer test");
+        when(checkRunClient.createCheckRun(
+                anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(new GitHubCheckRunClient.CheckRunResponse(1L, "http://check"));
+        when(prClient.getPullRequestFiles(
+                anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of());
+        when(prClient.compareCommits(
+                anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
+        when(reviewClient.listReviews(anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of());
+        when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
+            .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
+        // Stop right after the prompt is built so the test stays focused on prompt assembly.
+        when(aiReviewService.review(any(ReviewSession.class), any()))
+            .thenThrow(new RuntimeException("stop early"));
+
+        orchestrator.review(
+            new ReviewOrchestrator.ReviewRequest(
+                "owner",
+                "repo",
+                42,
+                "abcdefgh",
+                "Test PR",
+                "",
+                "base1234567",
+                "main",
+                123L,
+                false));
+
+        var inputsCaptor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
+        verify(aiReviewService).review(eq(session), inputsCaptor.capture());
+        return inputsCaptor.getValue().repoInstructions();
       }
     }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseTest.java
@@ -87,14 +87,17 @@ class ReviewResponseTest {
   }
 
   @Test
-  void summaryConvenienceConstructorsDefaultFileSummariesToEmpty() {
-    // Callers (and older AI responses) that predate file summaries must still construct cleanly.
+  void summaryConvenienceConstructorsDefaultNewFieldsToEmpty() {
+    // Callers (and older AI responses) that predate file summaries and the walkthrough diagram
+    // must still construct cleanly.
     var noLabels = new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", "purpose", List.of());
     var withLabels =
         new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", "purpose", List.of(), List.of("bug"));
 
     assertTrue(noLabels.fileSummaries().isEmpty());
     assertTrue(withLabels.fileSummaries().isEmpty());
+    assertNull(noLabels.walkthroughDiagram());
+    assertNull(withLabels.walkthroughDiagram());
   }
 
   @Test
@@ -130,5 +133,18 @@ class ReviewResponseTest {
     assertEquals(1, response.summary().fileSummaries().size());
     assertEquals("src/A.java", response.summary().fileSummaries().get(0).path());
     assertEquals("adds guard", response.summary().fileSummaries().get(0).summary());
+  }
+
+  @Test
+  void shouldDeserializeWalkthroughDiagramFromJson() throws Exception {
+    var json =
+        """
+        {"summary": {"total_findings": 0, "overall_assessment": "ok",
+         "walkthrough_diagram": "flowchart TD\\n A-->B"}}
+        """;
+
+    var response = new ObjectMapper().readValue(json, ReviewResponse.class);
+
+    assertEquals("flowchart TD\n A-->B", response.summary().walkthroughDiagram());
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature

## Description

The PR summary already has a risk breakdown and (on `release/v0.3.0`) a file-by-file walkthrough (#39), but no **visual**. For non-trivial changes, a rendered diagram of the affected control flow helps reviewers grasp the change quickly.

This adds an **opt-in Mermaid control-flow diagram** to the summary comment:

- **Opt-in** via a master switch, off by default — `thrillhousebot.review.diagram.enabled` (`REVIEW_DIAGRAM_ENABLED`), mirroring the existing context-aware labels feature.
- **No extra AI cost** — when enabled, the model emits a new `walkthrough_diagram` field as part of the *existing* review JSON (gated by a `DIAGRAM_REQUEST` block injected into the prompt's trailing guidance). It rides the existing review call; a few extra output tokens only.
- **Model self-gates on triviality** — the prompt asks for a small (`flowchart`/`sequenceDiagram`, ≤~12 nodes) diagram of the *affected* control flow for non-trivial changes only, and an empty string otherwise.
- **Rendered as a collapsible block** (GitHub renders Mermaid natively):

```markdown
### Control-Flow Diagram
<details>
<summary>🔀 Show diagram</summary>

​```mermaid
flowchart TD
  A[Start] --> B[End]
​```

</details>
```

**Safety / robustness in the renderer** (`PrSummaryGenerator`):
- Strips any backtick fences the model may wrap around the source, so a stray ` ``` ` cannot break out of our `mermaid` block.
- Drops a leftover ` ```mermaid ` language tag, then accepts the source only if it opens with a known Mermaid diagram keyword (otherwise prose would render as a broken block).
- Enforces a 4000-char cap — oversized/truncated output is dropped rather than posted.

## Related Issues

Closes #54

## How Has This Been Tested?

- [x] Unit tests

New tests cover rendering as a collapsible block, omit-when-blank/null, backtick-fence stripping (break-out prevention), unrecognized-source rejection, oversized-diagram drop, the prompt-injection on/off gating in `ReviewOrchestrator`, and `walkthrough_diagram` JSON deserialization + back-compat constructors.

Full suite: **1205 passing**. Spotless clean, SpotBugs (Max effort) reports 0 bugs.

> Note: tests were run with the JaCoCo coverage agent disabled (`-Djacoco.skip=true -Dquarkus.jacoco.enabled=false`) because JaCoCo 0.8.15 crashes the JVM at startup on Java 25 — a pre-existing, unrelated environment issue.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

**Targets `release/v0.3.0`** (not `main`) because it builds directly on the #39 walkthrough already merged there. The two features are layered cleanly: `ReviewResponse.Summary` now carries **both** `file_summaries` (#39) and `walkthrough_diagram` (#54), and the summary renders both the changed-files table and the diagram. A 10-arg convenience constructor was added so existing #39 callers continue to compile.
