### PR TITLE
fix(review): stop re-posting the PR summary comment on re-reviews

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
@@ -18,6 +18,7 @@ package dev.thiagogonzaga.thrillhousebot.github;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import java.util.List;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 @RegisterRestClient(configKey = "github-api")
@@ -35,7 +36,29 @@ public interface GitHubCommentClient {
       @PathParam("issueNumber") int issueNumber,
       CreateCommentRequest request);
 
+  /**
+   * Lists a PR's issue comments (the conversation thread, not the inline diff comments), oldest
+   * first. Used to detect a summary comment the bot already posted so a re-review never duplicates
+   * it; {@code perPage} is sized to cover the bot's summary, which is posted on the first review
+   * and so sits among the earliest comments.
+   */
+  @GET
+  @Path("/repos/{owner}/{repo}/issues/{issueNumber}/comments")
+  @Produces(MediaType.APPLICATION_JSON)
+  List<IssueComment> listComments(
+      @HeaderParam("Authorization") String auth,
+      @HeaderParam("Accept") String accept,
+      @PathParam("owner") String owner,
+      @PathParam("repo") String repo,
+      @PathParam("issueNumber") int issueNumber,
+      @QueryParam("per_page") int perPage);
+
   record CreateCommentRequest(String body) {}
 
   record CommentResponse(long id, @JsonProperty("html_url") String htmlUrl) {}
+
+  /** A PR conversation comment, carrying just the body and author needed to spot the bot's own. */
+  record IssueComment(String body, User user) {
+    public record User(String login) {}
+  }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -27,6 +27,12 @@ public class PrSummaryGenerator {
   public static final String ZERO_ISSUES_MESSAGE =
       "Everything's coming up Thrillhouse! 🎉\n\nNo issues found in this PR.";
 
+  /**
+   * The first line of every generated summary. Doubles as the marker used to recognize a summary
+   * comment the bot already posted on a PR, so a re-review never duplicates it.
+   */
+  public static final String SUMMARY_HEADING = "## 🤖 ThrillhouseBot PR Summary";
+
   public String generate(
       int filesChanged,
       int additions,
@@ -34,7 +40,7 @@ public class PrSummaryGenerator {
       ReviewResponse.Summary aiSummary,
       ReviewResult result) {
     var sb = new StringBuilder();
-    sb.append("## 🤖 ThrillhouseBot PR Summary\n\n");
+    sb.append(SUMMARY_HEADING).append("\n\n");
 
     appendPrPurpose(sb, aiSummary);
     appendDescriptionGaps(sb, aiSummary);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -52,6 +52,10 @@ public class ReviewOrchestrator {
   private static final String CHECK_NAME = "ThrillhouseBot Review";
   private static final String BOT_LOGIN = "thrillhousebot[bot]";
   private static final String ZERO_ISSUES_MESSAGE = PrSummaryGenerator.ZERO_ISSUES_MESSAGE;
+  private static final String SUMMARY_HEADING = PrSummaryGenerator.SUMMARY_HEADING;
+  // One page comfortably covers the bot's summary: it is posted on the first review, so it sits
+  // among the earliest issue comments returned oldest-first.
+  private static final int ISSUE_COMMENTS_PER_PAGE = 100;
 
   // Check run status constants
   private static final String CHECK_STATUS_COMPLETED = "completed";
@@ -221,8 +225,13 @@ public class ReviewOrchestrator {
 
       var priorReviews = fetchPriorReviews(auth, req.owner(), req.repo(), req.prNumber());
       // Two independent flags decouple UX presentation from context loading (#134):
-      //  • isFirstVisibleReview — true when no bot-authored review exists on the PR.
-      //    Gates the first-review summary issue-comment and the APPROVE celebration body.
+      //  • isFirstVisibleReview — true when the bot has posted nothing user-visible on the PR yet:
+      //    neither a review nor a summary comment. Gates the first-review summary issue-comment and
+      //    the APPROVE celebration body. A review alone is not a reliable proxy: a first round held
+      //    back only by pending CI posts the summary comment but no review (#175), so keying off
+      // the
+      //    review would re-post the summary every round until one finally creates a review. The
+      //    summary comment is the artifact we must not duplicate, so we look for it directly.
       //  • hasContext — true when persistence holds prior AI responses (surviving force-push/
       //    rebase). Gates previous-findings context loading, inline comment fetching, and the
       //    deterministic backstop. A persisted-but-unreviewed prior round (e.g. createReview
@@ -231,7 +240,8 @@ public class ReviewOrchestrator {
       List<String> priorAiResponseJsons =
           sessionPersistence.findAllPriorAiResponseJsons(repository, req.prNumber(), session.id);
       var isFirstVisibleReview =
-          priorReviews.stream().noneMatch(r -> BOT_LOGIN.equals(r.user().login()));
+          priorReviews.stream().noneMatch(r -> BOT_LOGIN.equals(r.user().login()))
+              && !botSummaryCommentExists(auth, req.owner(), req.repo(), req.prNumber());
       var hasContext = !priorAiResponseJsons.isEmpty();
       String previousAiResponseJson =
           priorAiResponseJsons.isEmpty() ? null : priorAiResponseJsons.get(0);
@@ -609,6 +619,38 @@ public class ReviewOrchestrator {
       return reviewClient.listReviews(auth, ACCEPT, owner, repo, prNumber);
     } catch (RuntimeException e) {
       Log.debug("No prior reviews found (this is normal for first review)", e);
+      return List.of();
+    }
+  }
+
+  /**
+   * Whether the bot has already posted its PR summary comment on this PR. Used to suppress a
+   * duplicate summary on a re-review when a prior round left a summary comment but no review (e.g.
+   * a first round held back only by pending CI). Best-effort: on a fetch failure it returns {@code
+   * false}, falling back to the review-based signal rather than blocking the summary.
+   */
+  boolean botSummaryCommentExists(String auth, String owner, String repo, int prNumber) {
+    for (var comment : fetchIssueComments(auth, owner, repo, prNumber)) {
+      var user = comment.user();
+      var body = comment.body();
+      if (user != null
+          && BOT_LOGIN.equals(user.login())
+          && body != null
+          && body.stripLeading().startsWith(SUMMARY_HEADING)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  List<GitHubCommentClient.IssueComment> fetchIssueComments(
+      String auth, String owner, String repo, int prNumber) {
+    try {
+      var comments =
+          commentClient.listComments(auth, ACCEPT, owner, repo, prNumber, ISSUE_COMMENTS_PER_PAGE);
+      return comments != null ? comments : List.of();
+    } catch (RuntimeException e) {
+      Log.debug("Could not fetch PR issue comments (continuing as if none exist)", e);
       return List.of();
     }
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -1549,6 +1549,85 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void shouldSkipSummaryWhenABotSummaryCommentAlreadyExistsButNoReviewDoes() {
+      // Regression for the duplicate-summary bug: a first round held back only by pending CI posts
+      // the summary issue-comment but leaves no review (#175). On the next round no bot review
+      // exists, yet the summary must not be re-posted — the prior summary comment is the signal.
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getPrTitle()).thenReturn("Test PR");
+        when(session.getCommitSha()).thenReturn("abcdefgh");
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        when(authClient.getAuthHeader(123L)).thenReturn("Bearer test");
+        when(checkRunClient.createCheckRun(
+                anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(new GitHubCheckRunClient.CheckRunResponse(1L, "http://check"));
+        doNothing()
+            .when(checkRunClient)
+            .updateCheckRun(anyString(), anyString(), anyString(), anyString(), anyLong(), any());
+        when(prClient.getPullRequestFiles(
+                anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of(fileDiffWithLine("src/Main.java", 10)));
+        when(prClient.compareCommits(
+                anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
+        // No bot review on the PR ...
+        when(reviewClient.listReviews(anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of());
+        // ... but the bot already posted its summary comment on an earlier round.
+        when(commentClient.listComments(
+                anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt()))
+            .thenReturn(
+                List.of(
+                    new GitHubCommentClient.IssueComment(
+                        PrSummaryGenerator.SUMMARY_HEADING + "\n\nAlready posted earlier",
+                        new GitHubCommentClient.IssueComment.User("thrillhousebot[bot]"))));
+        when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
+            .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
+        when(summaryGenerator.generate(eq(1), eq(1), eq(1), any(), any()))
+            .thenReturn(PrSummaryGenerator.SUMMARY_HEADING);
+        when(suggestionFormatter.formatReviewComment(any())).thenReturn("**Medium** — fix this");
+        when(aiReviewService.review(any(ReviewSession.class), any()))
+            .thenReturn(
+                new ReviewResponse(
+                    List.of(
+                        new ReviewResponse.Finding(
+                            "medium", "src/Main.java", 10, "Style", "Improve naming", null, null)),
+                    List.of(),
+                    null));
+
+        orchestrator.review(
+            new ReviewOrchestrator.ReviewRequest(
+                "owner",
+                "repo",
+                42,
+                "abcdefgh",
+                "Test PR",
+                "",
+                "base1234567",
+                "main",
+                123L,
+                false));
+
+        // The summary issue-comment is NOT posted a second time ...
+        verify(commentClient, never())
+            .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+        // ... but the rest of the review still runs: the finding is posted inline.
+        verify(reviewClient)
+            .createPullRequestComment(
+                anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+        verify(session).setStatus(ReviewSession.STATUS_COMPLETED);
+      }
+    }
+
+    @Test
     void shouldContinueReviewWhenFetchPrFilesThrows() {
       try (var mockedStatic = mockStatic(ReviewSession.class)) {
         var session = mock(ReviewSession.class);
@@ -3370,6 +3449,97 @@ class ReviewOrchestratorTest {
 
       assertEquals(
           List.of(comment), orchestrator.fetchPullRequestComments("auth", "owner", "repo", 1));
+    }
+  }
+
+  @Nested
+  class BotSummaryCommentDetection {
+
+    private GitHubCommentClient.IssueComment comment(String body, String login) {
+      return new GitHubCommentClient.IssueComment(
+          body, login == null ? null : new GitHubCommentClient.IssueComment.User(login));
+    }
+
+    private void stubComments(GitHubCommentClient.IssueComment... comments) {
+      when(commentClient.listComments(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt()))
+          .thenReturn(List.of(comments));
+    }
+
+    @Test
+    void shouldDetectABotSummaryComment() {
+      stubComments(
+          comment("@thrillhousebot please review", "someuser"),
+          comment(PrSummaryGenerator.SUMMARY_HEADING + "\n\nbody", "thrillhousebot[bot]"));
+
+      assertTrue(orchestrator.botSummaryCommentExists("auth", "owner", "repo", 1));
+    }
+
+    @Test
+    void shouldTolerateLeadingWhitespaceBeforeTheHeading() {
+      stubComments(
+          comment("\n  " + PrSummaryGenerator.SUMMARY_HEADING + "\n", "thrillhousebot[bot]"));
+
+      assertTrue(orchestrator.botSummaryCommentExists("auth", "owner", "repo", 1));
+    }
+
+    @Test
+    void shouldIgnoreASummaryHeadingPostedBySomeoneElse() {
+      // A human (or another bot) quoting the heading must not be mistaken for the bot's own
+      // summary.
+      stubComments(comment(PrSummaryGenerator.SUMMARY_HEADING + "\n\nspoof", "impersonator"));
+
+      assertFalse(orchestrator.botSummaryCommentExists("auth", "owner", "repo", 1));
+    }
+
+    @Test
+    void shouldIgnoreBotCommentsThatAreNotTheSummary() {
+      // The bot also posts conversational replies (e.g. answering /review questions); only the
+      // summary heading counts.
+      stubComments(comment("I don't have enough context to answer that.", "thrillhousebot[bot]"));
+
+      assertFalse(orchestrator.botSummaryCommentExists("auth", "owner", "repo", 1));
+    }
+
+    @Test
+    void shouldReturnFalseForEmptyComments() {
+      stubComments();
+
+      assertFalse(orchestrator.botSummaryCommentExists("auth", "owner", "repo", 1));
+    }
+
+    @Test
+    void shouldNotMatchTheHeadingMidComment() {
+      // Only a comment that *starts* with the heading is the bot's summary; an embedded mention is
+      // a
+      // quote in a discussion, not the summary artifact.
+      stubComments(
+          comment("As noted in the " + PrSummaryGenerator.SUMMARY_HEADING, "thrillhousebot[bot]"));
+
+      assertFalse(orchestrator.botSummaryCommentExists("auth", "owner", "repo", 1));
+    }
+
+    @Test
+    void shouldTolerateNullUserAndNullBody() {
+      stubComments(
+          comment("body without user", null),
+          comment(null, "thrillhousebot[bot]"),
+          comment(PrSummaryGenerator.SUMMARY_HEADING, "thrillhousebot[bot]"));
+
+      assertTrue(orchestrator.botSummaryCommentExists("auth", "owner", "repo", 1));
+    }
+
+    @Test
+    void shouldBeBestEffortWhenFetchFailsOrReturnsNull() {
+      when(commentClient.listComments(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt()))
+          .thenReturn(null)
+          .thenThrow(new RuntimeException("boom"));
+
+      // A null page and a thrown fetch both fall back to "no summary seen" rather than blocking.
+      assertFalse(orchestrator.botSummaryCommentExists("auth", "owner", "repo", 1));
+      assertFalse(orchestrator.botSummaryCommentExists("auth", "owner", "repo", 1));
+      assertTrue(orchestrator.fetchIssueComments("auth", "owner", "repo", 1).isEmpty());
     }
   }
 


### PR DESCRIPTION
Closes #185.

## What

The bot was posting its **PR Summary** issue-comment more than once on the same PR. On [#180](https://github.com/devops-thiago/ThrillhouseBot/pull/180) three identical `## 🤖 ThrillhouseBot PR Summary` comments piled up — on PR open, on a later push, and again on a manual `/review`.

## Root cause

The first-review summary is gated on `isFirstVisibleReview`, which was computed solely from prior **reviews**:

```java
var isFirstVisibleReview =
    priorReviews.stream().noneMatch(r -> BOT_LOGIN.equals(r.user().login()));
```

But a first round held back **only by pending/failed CI** posts the summary issue-comment and then returns from `postNoIssuesReview` *without creating any review* (the deliberate skip added in #175). So on the next round no bot review exists, `isFirstVisibleReview` is still `true`, and the summary is posted again — repeating every round until one finally creates a review. On #180 the first two rounds were clean-but-CI-pending (no surviving review), so the summary was re-posted each time.

## Fix

Gate the summary on the **artifact we must not duplicate** — a prior summary comment — not on a review that may never have been created:

```java
var isFirstVisibleReview =
    priorReviews.stream().noneMatch(r -> BOT_LOGIN.equals(r.user().login()))
        && !botSummaryCommentExists(auth, req.owner(), req.repo(), req.prNumber());
```

- New `GitHubCommentClient.listComments` reads the PR conversation; `botSummaryCommentExists` matches a comment authored by the bot whose body starts with the summary heading (now a shared `PrSummaryGenerator.SUMMARY_HEADING` constant).
- Best-effort (a fetch failure falls back to the old review-based signal) and short-circuited so it only runs when no bot review exists — at most one extra API call on a genuine first round.
- Strictly more correct than the review-only proxy: a round that *persisted but failed before posting the summary* still has no summary comment, so the first user-visible summary is preserved (the `#134` case).

This also corrects two follow-on behaviors keyed off the same flag: a re-review's APPROVE now carries the zero-issues message instead of an empty body, and label *suggestions* are no longer re-posted every round.

`/summary` is unaffected — it uses a separate persistence signal (`hasCompletedReview`) and dispatches through this same orchestrator gate.

## Tests

- **Regression** (`ReviewErrorPaths`): no surviving bot review but a prior summary comment exists → the summary is **not** re-posted, while the rest of the review (inline finding comment) still runs.
- **Edge cases** (`BotSummaryCommentDetection`): happy-path detection, anti-spoof (heading posted by another author is ignored), bot non-summary replies ignored, empty comment list, heading mid-body (not at start), null user/body tolerated, and best-effort behavior on a thrown/null fetch.
- Existing `shouldPostSummaryIssueCommentOnFirstReview…`, `shouldSkipSummaryIssueCommentOnFollowUpReview…`, and `shouldPostSummaryOnPersistedButUnreviewedPr` still pass.

Full suite: **BUILD SUCCESS** (JaCoCo disabled locally per the known SMB file-lock limitation; CI runs coverage).
