### PR TITLE
refactor(github): reuse the shared User record in IssueComment

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
@@ -58,7 +58,5 @@ public interface GitHubCommentClient {
   record CommentResponse(long id, @JsonProperty("html_url") String htmlUrl) {}
 
   /** A PR conversation comment, carrying just the body and author needed to spot the bot's own. */
-  record IssueComment(String body, User user) {
-    public record User(String login) {}
-  }
+  record IssueComment(String body, GitHubReviewClient.ReviewResponse.User user) {}
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -1588,7 +1588,7 @@ class ReviewOrchestratorTest {
                 List.of(
                     new GitHubCommentClient.IssueComment(
                         PrSummaryGenerator.SUMMARY_HEADING + "\n\nAlready posted earlier",
-                        new GitHubCommentClient.IssueComment.User("thrillhousebot[bot]"))));
+                        new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]"))));
         when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
             .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
         when(summaryGenerator.generate(eq(1), eq(1), eq(1), any(), any()))
@@ -3457,7 +3457,7 @@ class ReviewOrchestratorTest {
 
     private GitHubCommentClient.IssueComment comment(String body, String login) {
       return new GitHubCommentClient.IssueComment(
-          body, login == null ? null : new GitHubCommentClient.IssueComment.User(login));
+          body, login == null ? null : new GitHubReviewClient.ReviewResponse.User(login));
     }
 
     private void stubComments(GitHubCommentClient.IssueComment... comments) {


### PR DESCRIPTION
## What

Follow-up cleanup to #183. The `IssueComment` DTO introduced there declared its own nested `User(String login)` record, duplicating `GitHubReviewClient.ReviewResponse.User` — which `PullRequestComment` (same package) already reuses. This points `IssueComment` at the shared record instead.

```diff
-  record IssueComment(String body, User user) {
-    public record User(String login) {}
-  }
+  record IssueComment(String body, GitHubReviewClient.ReviewResponse.User user) {}
```

## Why

- Matches the existing convention (`PullRequestComment` already reuses `ReviewResponse.User`).
- Removes a redundant DTO type and recovers the minor coverage cost of an extra record's generated members (the small dip noted on #183).

## Notes

- No behavior change. `botSummaryCommentExists` still reads `comment.user().login()` — the shared record exposes the same `login()` accessor.
- `ReviewOrchestratorTest` updated to construct the shared `User`. Full `ReviewOrchestratorTest` suite passes locally.
