### PR TITLE
feat(review): flag single-page GitHub list/collection fetches that silently truncate (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This release makes the bot interactive and controllable from the PR — conversa
 - **Review on ready-for-review**: a draft PR marked "Ready for review" is reviewed immediately, pairing with `WEBHOOK_SKIP_DRAFTS` so drafts can be skipped until they are ready (#72)
 - **Fail-fast configuration validation**: required configuration (`GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET`, `AI_API_KEY`) is validated at startup, and the app refuses to boot with a single message naming every missing or malformed value — including a non-numeric App id or a private key that is not valid PEM RSA — instead of failing later on the first webhook (#27)
 - **Configurable bot identity**: the bot's own account login(s) are configurable via `GITHUB_BOT_LOGINS`, so loop protection and `/resolve` keep working when the App is deployed under a different slug (#165)
+- **Reviewer flags single-page collection fetches**: the review prompt now has a pagination/truncation dimension, so a diff that lists a paginated collection (a GitHub REST endpoint or a GraphQL connection) and then consumes the result as if complete — searched, counted, iterated, or used to drive an action like `/resolve` — without walking every page is reported as a silent-truncation finding. The bot had been catching one such case while missing analogous REST and GraphQL ones (including in the same PR) because no dimension prompted the pattern; severity scales with what is dropped and confidence stays calibrated for the page-size assumption (#166)
 
 ### Changed
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -30,6 +30,22 @@ public final class PrReviewPrompts {
             4. COMMENT CONSISTENCY: Comments that contradict code. Outdated comments. Missing comments where logic is complex.
                Excessive/obvious comments (e.g., "i++ // increment i"). TODO/FIXME without resolution.
             5. CODE QUALITY: Maintainability, naming, DRY, error handling, performance.
+            6. PAGINATION / TRUNCATION: When the diff adds or changes a call that lists a paginated
+               collection — a GitHub REST endpoint (e.g. .../comments, .../reviews, .../files,
+               .../issues) or a GraphQL connection (a first:/nodes field) — and its result is then
+               consumed as if it were the complete set (searched with findFirst/contains, counted,
+               mapped, iterated, or used to drive an action such as /resolve), flag it unless it
+               walks every page: REST loops with per_page until a short page; GraphQL follows
+               pageInfo { hasNextPage endCursor } with an after cursor. A single-page fetch
+               silently truncates at the API's default page size and drops everything past page one,
+               so the consumer sees a partial set with no error. The missing-paging shape (a list
+               call feeding a findFirst/contains/loop with no surrounding page walk or cursor) is
+               visible in the diff; that one page truncates rests on the API's page-size default, so
+               this is a confidence "medium"/"low" finding per the calibration below and the
+               description must name the page size to verify. Not a finding when a comment justifies
+               that one page suffices or the call intentionally caps the result. Scale severity by
+               what is dropped: a lost review thread, finding, or changed file that alters a decision
+               is medium or higher; a cosmetic list is low.
 
             For each finding, provide:
             - risk: "critical" | "high" | "medium" | "low"


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature

## Description

The reviewer graded a GitHub list/collection API call by the happy-path correctness of the first page it got back — it had **no rule** that an un-paginated fetch *silently truncates* at the API's default page size. Across the v0.2.0 milestone this produced inconsistent recall: the bot caught one un-paginated fetch and missed two analogous ones, one of them in the *same PR* (all later fixed in #165):

- **Caught** — `CommentCommandService.botRootCommentIds` (REST default first page) → correctly flagged.
- **Missed (REST)** — `MaintainerReplyService.listReviewComments` used the non-paged 4-arg client (30/page default), dropping the thread root and prior replies on busy threads.
- **Missed (GraphQL)** — `ReviewThreadService.threadsByRootComment` queried `reviewThreads(first: 100)` with no cursor, so `/resolve` couldn't reach bot threads past the first 100 — defeating the very REST-side fix flagged on the same PR.

Catching the REST case while missing the analogous REST and GraphQL cases is a missing *systematic* check, not a one-off. Knowing the 30/page default is "memory of external API behavior" (already routed to medium/low confidence), but **no review dimension prompted the model to look for the pattern**, so the finding was never generated.

This PR adds a sixth review dimension — **PAGINATION / TRUNCATION** — to `PrReviewPrompts.SYSTEM`: when a diff adds or changes a call that lists a paginated collection (a GitHub REST endpoint such as `.../comments`, `.../reviews`, `.../files`, `.../issues`, or a GraphQL connection / `nodes` field) and consumes the result as if complete (`findFirst`/`contains`, counted, mapped, iterated, or used to drive an action like `/resolve`) **without** walking every page (REST `per_page` loop; GraphQL `pageInfo { hasNextPage endCursor }` + `after`), it is reported as a silent-truncation finding. The missing-paging *shape* is diff-local; the truncation rests on the API's page-size default, so confidence stays calibrated per the existing rules and severity scales with what is dropped (a lost review thread/finding/file is medium+, a cosmetic list is low). Single-page calls with an explicit justification or an intentional cap are carved out.

### Scope decisions
- **No verifier change** — the dogfood evidence shows the verifier already posted PR #160's pagination finding, so loosening `FindingVerifierPrompts` would only add false-positive risk.
- **No #113 corpus seeding** — that eval/fixture infrastructure doesn't exist yet, and the repo has no precedent for tests that pin prompt *wording* (only mechanical render/escape tests). The change is additive prompt prose only.

## Related Issues

Fixes #166

## How Has This Been Tested?

- [x] Unit tests

`AiServicePromptRenderingTest` — which drives the real quarkus-langchain4j template → escaper → render pipeline over `PrReviewPrompts` — passes (exit 0) with the new dimension. The added curly braces (`pageInfo { hasNextPage endCursor }`) are safe: the SYSTEM prompt already contains JSON-brace examples.

```
./mvnw -Djacoco.skip=true -Dquarkus.jacoco.enabled=false -Dtest=AiServicePromptRenderingTest test
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

This is a prompt-only change (plus a CHANGELOG entry). No application code paths are modified. A full eval/regression assertion for this dimension belongs to the unbuilt #113 corpus and is intentionally out of scope here.
