### PR TITLE
feat(review): trace runtime-crash claims and reject those an in-diff guard refutes (#112)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
@@ -26,9 +26,12 @@ public final class FindingVerifierPrompts {
 
             For each candidate finding, return a verdict:
             - "confirmed" — the issue is real and verifiable from the provided diff and context.
-            - "downgraded" — plausible but not verifiable from the provided material, or the
-              severity is inflated. Provide the corrected risk and confidence.
-            - "rejected" — the finding is wrong or fails any check below.
+            - "downgraded" — plausible but not verifiable from the provided material (remembered
+              framework or library behavior, artifacts not shown in the diff), or the severity is
+              inflated. Provide the corrected risk and confidence. Do not downgrade a finding the
+              diff itself refutes — that is a rejection, not a hedge.
+            - "rejected" — the finding is wrong or fails any check below. A claim the provided
+              diff contradicts is rejected, never downgraded.
 
             Reject a finding when any of these hold:
             - The claim depends on remembered external framework or library behavior (API
@@ -50,8 +53,19 @@ public final class FindingVerifierPrompts {
               scopes) without the finding acknowledging it.
             - The finding misstates language semantics — for example, claiming the string
               escape "\\n" produces a literal backslash and n rather than a newline.
-            - The diff already guards against the condition the finding claims is unhandled
-              (e.g. an existing null check around the flagged line).
+            - The diff already guards against the condition the finding claims is unhandled —
+              not only an adjacent literal check (an existing null check on the flagged line) but
+              an upstream guard earlier in the same method, including one on a value derived from
+              the flagged one. Worked example: a finding claims `raw.charAt(0)` throws on an empty
+              line, but the method returns at `if (normalized.isEmpty())` two statements earlier
+              and a non-empty normalized body implies a non-empty raw line — reject it.
+            - The finding claims the code will fail at runtime (NullPointerException,
+              IndexOutOfBoundsException, division by zero, bad cast, and the like) but does not
+              construct the triggering input and trace it from the enclosing method's entry to the
+              crash line; or such a trace shows an earlier statement — an early
+              return/continue/throw, or a guard on a value derived from the flagged one — makes
+              that line unreachable for the input. Reject it; a runtime-crash claim the diff
+              refutes is a rejection, not a downgrade.
             - The finding repeats a previous-round finding that a maintainer already answered
               (see the previous findings section when present) while the relevant lines are
               unchanged — at any severity; restating it with a higher severity is still a

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -76,9 +76,20 @@ public final class PrReviewPrompts {
             - Re-read the flagged lines in the diff and confirm the issue exists in the code as
               written, not in a paraphrase of it. Quote the flagged lines exactly as they appear
               in the diff; if the exact text you are about to quote cannot be found
-              there, the finding is invalid. If the surrounding diff already guards against
-              the condition you claim is unhandled (e.g. a null check around the flagged line),
-              the finding is invalid.
+              there, the finding is invalid. If the diff already guards against the condition you
+              claim is unhandled, the finding is invalid — and "already guards" is not only an
+              adjacent literal check (a null check on the flagged line) but an upstream guard
+              earlier in the same method, including one on a value derived from the flagged one.
+              Worked example: a finding that `raw.charAt(0)` throws on an empty line is invalid
+              when the method returns at `if (normalized.isEmpty())` two statements earlier and a
+              non-empty normalized body implies a non-empty raw line, so that line is unreachable
+              for an empty input.
+            - Any claim that the code will fail at runtime (NullPointerException,
+              IndexOutOfBoundsException, division by zero, bad cast, and the like) must construct
+              the concrete input that triggers the failure and trace it line by line from the
+              enclosing method's entry to the crash line. If an earlier statement makes that line
+              unreachable for that input — an early return/continue/throw, or a guard on a value
+              derived from the flagged one — the line cannot crash and the finding is invalid.
             - A claim that two places are inconsistent ("X does this but Y does not") must quote
               both places verbatim from the provided material and confirm they belong to the
               same enclosing unit (the same function, block, or scope). When the two places are


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature

## Description

Hardens the review prompts so a runtime-failure finding that the diff itself refutes is dropped (generator) or rejected (verifier) instead of being posted as a low-confidence "verify before acting" inline comment.

Dogfood evidence (PR #100): the verifier emitted a MEDIUM *"Empty line in diff input causes `IndexOutOfBoundsException`"* against `FindingQuoteValidator.appendBodyLine`, claiming `raw.charAt(0)` throws on an empty line. It does not — `appendBodyLine` returns at `if (normalized.isEmpty())` first, and `normalized` is derived from `raw` (`bodyOf(raw).strip()`), so an empty `raw` means an empty `normalized` and the `charAt(0)` line is unreachable for that input. The claim was refutable from the diff alone, yet it was *downgraded to low confidence* (not rejected) and still posted inline.

Two prompts change, symmetrically:

- **`PrReviewPrompts`** (generator self-check)
  - **Input-trace requirement**: any runtime-failure claim (NPE, `IndexOutOfBoundsException`, division by zero, bad cast) must construct the concrete triggering input and trace it line-by-line from the enclosing method's entry to the crash line. If an earlier statement — an early `return`/`continue`/`throw`, or a guard on a value *derived* from the flagged one — makes that line unreachable for the input, the finding is invalid.
  - **Broadened "already guarded" rule**: no longer limited to an *adjacent literal* check; it now explicitly includes **upstream guards** and **guards on derived values**, with the `appendBodyLine` / `normalized.isEmpty()` → `charAt(0)` case as a worked example.

- **`FindingVerifierPrompts`** (verifier)
  - **Reject, don't downgrade, when the diff contradicts the claim**: "downgrade" is now reserved for *unverifiable* claims (remembered framework behavior, artifacts not shown in the diff); a claim the diff *refutes* must be **rejected**. This is the specific behavior the PR #100 miss got wrong.
  - Mirrors the broadened "already guarded" rule (same worked example) and adds a reject rule for runtime-crash claims that lack an input trace, or whose trace proves the line unreachable.

## Related Issues

Fixes #112

## How Has This Been Tested?

- [x] Unit tests

`AiServicePromptRenderingTest` drives the real quarkus-langchain4j + Qute rendering pipeline over both edited prompts and passes, confirming the new backtick/code wording renders cleanly and every `@V` context variable still reaches the model. Run locally with JaCoCo disabled (the SMB-mounted checkout aborts the forked JVM otherwise — unrelated to this change):

```
./mvnw -o test -Djacoco.skip=true -Dquarkus.jacoco.enabled=false -Dtest='AiServicePromptRenderingTest'
```

This is a prompt-wording change with no dedicated wording-assertion suite; building that labeled regression corpus is tracked separately in #113.

## Additional Notes

- Scope: prompt text only — no behavioral/Java logic changes.
- The two `WebhookController` cases noted in the #112 comment are recall seeds for the #113 eval corpus and are intentionally out of scope here, though the new "upstream early-return guard" wording generalizes to cover them.
