### PR TITLE
fix(webhook): enforce /pause on conversational @mention and review-thread replies

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -292,6 +292,15 @@ public class WebhookController {
       log.debug("Ignoring bot mention with missing repository or installation");
       return true;
     }
+    // A /pause silences the bot on this PR — stay quiet rather than spend a paid reply, honoring
+    // the command's "silence the bot" contract just like the automatic-review path.
+    if (prPauseService.isPaused(repo.owner().login(), repo.name(), payload.issue().number())) {
+      log.info(
+          "Skipping conversational mention on paused PR #{} in {}",
+          payload.issue().number(),
+          repo.fullName());
+      return true;
+    }
     log.info(
         "Conversational mention from @{} on PR #{}",
         payload.comment().user().login(),
@@ -355,6 +364,16 @@ public class WebhookController {
     // addressed to the bot; a brand-new inline comment from a human is not.
     if (!mentioned && !isReply) {
       log.debug("Ignoring review comment that neither replies to a thread nor mentions the bot");
+      return true;
+    }
+
+    // A /pause silences the bot on this PR — stay quiet rather than spend a paid reply, honoring
+    // the command's "silence the bot" contract just like the automatic-review path.
+    if (prPauseService.isPaused(repo.owner().login(), repo.name(), pr.number())) {
+      log.info(
+          "Skipping conversational review-thread reply on paused PR #{} in {}",
+          pr.number(),
+          repo.fullName());
       return true;
     }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -662,6 +662,28 @@ class WebhookControllerTest {
   }
 
   @Test
+  void shouldSkipConversationalMentionOnPausedPr() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(triggerDetector.detectCommand("@thrillhousebot is this thread-safe?"))
+        .thenReturn(CommentCommand.NONE);
+    when(triggerDetector.isBotComment("octocat")).thenReturn(false);
+    when(triggerDetector.containsBotMention("@thrillhousebot is this thread-safe?"))
+        .thenReturn(true);
+    when(prPauseService.isPaused("owner", "repo", 77)).thenReturn(true);
+
+    var body =
+        buildIssueCommentPayload(
+                "created", 77, "owner/repo", "octocat", "@thrillhousebot is this thread-safe?")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, DELIVERY, body);
+    assertEquals(200, response.getStatus());
+
+    // /pause silences the bot, so a mention must not spend a paid conversational reply.
+    verify(replyDispatcher, never()).dispatch(any(MaintainerReplyService.ReplyTask.class));
+  }
+
+  @Test
   void shouldNotDispatchReplyForMentionWhenRepliesDisabled() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
     when(reviewConfig.conversationalRepliesEnabled()).thenReturn(false);
@@ -749,6 +771,27 @@ class WebhookControllerTest {
                 2000L,
                 true,
                 "@@ -1 +1 @@"));
+  }
+
+  @Test
+  void shouldSkipReviewCommentReplyOnPausedPr() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(triggerDetector.isBotComment("octocat")).thenReturn(false);
+    when(triggerDetector.containsBotMention("Why is this flagged?")).thenReturn(false);
+    when(prPauseService.isPaused("owner", "repo", 42)).thenReturn(true);
+
+    var body =
+        buildReviewCommentPayload(
+                "created", 42, "owner/repo", "octocat", "Why is this flagged?", 99L, 1000L)
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response =
+        controller.handleWebhook(
+            "sha256=valid", "pull_request_review_comment", null, DELIVERY, body);
+    assertEquals(200, response.getStatus());
+
+    // /pause silences the bot, so a review-thread reply must not spend a paid conversational reply.
+    verify(replyDispatcher, never()).dispatch(any(MaintainerReplyService.ReplyTask.class));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`/pause` is documented to **"silence the bot on this PR"** (both the `/help` copy and the pause confirmation say reviews are silenced). The pause gate was enforced on the automatic-review path (`handlePullRequest`) and the manual `/review` path (`handleReviewCommand`) — but **not** on the two conversational reply paths:

- `maybeDispatchConversationalMention` — a bare `@thrillhousebot` mention on a PR comment
- `handleReviewComment` — a review-thread reply or inline mention

As a result, a "silenced" PR still dispatched **paid LLM replies** on every `@mention` and thread reply, contradicting the command's own copy and spending the operator's API budget.

This PR adds an `isPaused` guard to both paths. They **stay silent** (log + return) rather than posting a paused notice — matching the automatic-review path. Posting a notice on every reply across a thread would be its own form of noise and would itself contradict "silence the bot"; the `/review` path posts a notice because it's a one-shot command, whereas conversational threads can have many messages.

Placement details:
- The check sits after the existing `repository`/`installation` null-guards (so PR coordinates are available).
- On `handleReviewComment` it sits *after* the mention/reply filter, so the "skipping — paused" line is logged only for comments actually addressed to the bot.

## Related Issues

N/A

## How Has This Been Tested?

Added two tests to `WebhookControllerTest`:
- `shouldSkipConversationalMentionOnPausedPr` — paused PR + bare mention → `replyDispatcher` never dispatched
- `shouldSkipReviewCommentReplyOnPausedPr` — paused PR + review-thread reply → `replyDispatcher` never dispatched

Full class passes (58/58). Run locally with JaCoCo disabled (`-Djacoco.skip=true -Dquarkus.jacoco.enabled=false`) due to a known JaCoCo file-lock crash on the SMB-mounted checkout; CI runs coverage normally.

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

The `/help` copy `| /pause | Silence the bot on this PR (no automatic or manual reviews) |` was left unchanged — with this fix "silence the bot" is now literally accurate. Happy to broaden the parenthetical to mention conversational replies if preferred.
