### PR TITLE
fix(auth): strip whitespace from app id used as JWT issuer

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClient.java
@@ -71,7 +71,10 @@ public class GitHubAuthClient {
       // the same way as its Date-based builder methods — this keeps java.util.Date out
       var claims =
           new JWTClaimsSet.Builder()
-              .issuer(config.github().appId())
+              // Strip surrounding whitespace to match StartupConfigValidator, which accepts a
+              // padded-but-numeric app id; without this an id that passes boot validation would
+              // still yield an "iss" GitHub rejects on the first call.
+              .issuer(config.github().appId().strip())
               .claim("iat", now.getEpochSecond())
               .claim("exp", now.plus(10, ChronoUnit.MINUTES).getEpochSecond())
               .build();

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClientTest.java
@@ -99,6 +99,18 @@ class GitHubAuthClientTest {
   }
 
   @Test
+  void shouldStripWhitespaceFromAppIdInIssuer() throws Exception {
+    // StartupConfigValidator accepts a padded-but-numeric app id; the minted JWT must carry the
+    // stripped value as "iss" so GitHub does not reject it on the first call.
+    when(githubConfig.appId()).thenReturn("  123456  ");
+
+    var jwt = authClient.generateAppJwt();
+
+    var issuer = com.nimbusds.jwt.SignedJWT.parse(jwt).getJWTClaimsSet().getIssuer();
+    assertEquals("123456", issuer);
+  }
+
+  @Test
   void shouldParsePrivateKeyWithNewlineEscapes() {
     // The private key contains \\n escape sequences — generateAppJwt() must parse them
     var jwt = authClient.generateAppJwt();


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [x] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`StartupConfigValidator.validateAppId` strips surrounding whitespace before its numeric check, and a dedicated test (`passesWhenAppIdIsNumericWithSurroundingWhitespace`) enshrines that a padded-but-numeric id like `"  12345  "` passes boot validation. But `GitHubAuthClient` used the **raw** config value as the JWT `iss` claim, so a whitespace-padded `GITHUB_APP_ID` booted cleanly yet minted a JWT GitHub rejects on the first call — exactly the late failure the validator exists to prevent.

This honors the validator's whitespace tolerance end-to-end by stripping the id where it is consumed as the issuer (`GitHubAuthClient.java:74`), rather than tightening the validator (env-var paste artifacts are the reason the tolerance exists). The only other `appId()` consumer is the validator itself; `GitHubCheckRunClient`'s `appId` is an unrelated `Long` record field.

## Related Issues

N/A

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Added `shouldStripWhitespaceFromAppIdInIssuer`, which parses the minted JWT and asserts `iss == "123456"` for a padded `"  123456  "` input. The pre-existing `passesWhenAppIdIsNumericWithSurroundingWhitespace` validator test still passes — that lenient acceptance is now backed by a runtime that produces a JWT GitHub will actually accept.

Ran the two affected test classes (JaCoCo skipped per the known local SMB file-lock limitation):

```
./mvnw -o test -Djacoco.skip=true -Dquarkus.jacoco.enabled=false \
  -Dtest='GitHubAuthClientTest,StartupConfigValidatorTest'
```

Result: `Tests run: 24, Failures: 0, Errors: 0, Skipped: 0` — BUILD SUCCESS.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A — backend-only change with no user-visible output.

## Additional Notes

No breaking changes or migration steps. Behavior change is limited to whitespace-padded `GITHUB_APP_ID` values, which previously booted but failed at the first GitHub call and now work as expected; a correctly-set (unpadded) app id is unaffected.
