### PR TITLE
fix(review): cap PR labels per-PR instead of per-review

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLabelClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLabelClient.java
@@ -36,6 +36,19 @@ public interface GitHubLabelClient {
       @QueryParam("per_page") int perPage,
       @QueryParam("page") int page);
 
+  /** Lists the labels currently on a PR (PRs are issues for the labels API). */
+  @GET
+  @Path("/repos/{owner}/{repo}/issues/{issueNumber}/labels")
+  @Produces(MediaType.APPLICATION_JSON)
+  List<Label> listIssueLabels(
+      @HeaderParam("Authorization") String auth,
+      @HeaderParam("Accept") String accept,
+      @PathParam("owner") String owner,
+      @PathParam("repo") String repo,
+      @PathParam("issueNumber") int issueNumber,
+      @QueryParam("per_page") int perPage,
+      @QueryParam("page") int page);
+
   /**
    * Adds labels to a PR (PRs are issues for the labels API). Idempotent — labels already present
    * are left untouched. Names must already exist in the repo or GitHub rejects the request.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrLabeler.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrLabeler.java
@@ -250,10 +250,33 @@ public class PrLabeler {
   }
 
   private void applyLabels(LabelRequest request, List<String> resolved) {
+    // GitHub's add-labels endpoint is additive, so without this guard a re-review with shifting
+    // suggestions would keep piling labels onto the PR — pushing it well past max-labels over time
+    // (max-labels is documented as a per-PR bound). Bound the additions against the labels already
+    // on the PR: skip ones already present and only top the PR up to max-labels in total.
+    var current = currentLabelKeys(request);
+    int max = Math.max(0, config.review().labels().maxLabels());
+    int budget = Math.max(0, max - current.size());
+    if (budget == 0) {
+      return;
+    }
+    var toAdd = new ArrayList<String>();
+    for (var name : resolved) {
+      if (current.contains(name.toLowerCase(Locale.ROOT))) {
+        continue; // already on the PR — adding again is a no-op that wastes the budget
+      }
+      toAdd.add(name);
+      if (toAdd.size() >= budget) {
+        break;
+      }
+    }
+    if (toAdd.isEmpty()) {
+      return;
+    }
     // In allow-create mode, drop any label whose creation failed — GitHub 422s the whole
     // add-labels request if a single name doesn't exist, which would apply nothing at all.
     List<String> applicable =
-        config.review().labels().allowCreate() ? ensureLabelsExist(request, resolved) : resolved;
+        config.review().labels().allowCreate() ? ensureLabelsExist(request, toAdd) : toAdd;
     if (applicable.isEmpty()) {
       return;
     }
@@ -267,6 +290,44 @@ public class PrLabeler {
     Log.infof(
         "Applied %d label(s) to %s/%s #%d: %s",
         applicable.size(), request.owner(), request.repo(), request.prNumber(), applicable);
+  }
+
+  /**
+   * Lower-cased names of the labels currently on the PR, used to keep additive re-reviews from
+   * exceeding max-labels. Best-effort: if the lookup fails we return an empty set, which simply
+   * falls back to applying the reconciled suggestions for this review.
+   */
+  private Set<String> currentLabelKeys(LabelRequest request) {
+    try {
+      var labels =
+          labelClient.listIssueLabels(
+              request.auth(),
+              ACCEPT,
+              request.owner(),
+              request.repo(),
+              request.prNumber(),
+              LABELS_PER_PAGE,
+              1);
+      if (labels == null || labels.isEmpty()) {
+        return Set.of();
+      }
+      var keys = new HashSet<String>();
+      for (var label : labels) {
+        var name = label.name();
+        if (name != null && !name.isBlank()) {
+          keys.add(name.strip().toLowerCase(Locale.ROOT));
+        }
+      }
+      return keys;
+    } catch (RuntimeException e) {
+      Log.debugf(
+          e,
+          "Could not read current labels for %s/%s #%d; applying suggestions without a cap check",
+          request.owner(),
+          request.repo(),
+          request.prNumber());
+      return Set.of();
+    }
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrLabeler.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrLabeler.java
@@ -308,7 +308,7 @@ public class PrLabeler {
               request.prNumber(),
               LABELS_PER_PAGE,
               1);
-      if (labels == null || labels.isEmpty()) {
+      if (labels == null) {
         return Set.of();
       }
       var keys = new HashSet<String>();

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrLabelerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrLabelerTest.java
@@ -313,6 +313,37 @@ class PrLabelerTest {
     }
 
     @Test
+    void shouldNotCallAddLabelsWhenEverySuggestionIsAlreadyOnThePr() {
+      when(labelsConfig.maxLabels()).thenReturn(3);
+      // The only matching suggestion is already on the PR, so there is nothing new to add.
+      when(labelClient.listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+          .thenReturn(List.of(label("bug")));
+
+      labeler.applyOrSuggest(request(false, List.of("bug"), List.of(label("bug"))));
+
+      verify(labelClient, never())
+          .addLabels(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+    }
+
+    @Test
+    void shouldIgnoreCurrentLabelsWithNullOrBlankNames() {
+      when(labelsConfig.maxLabels()).thenReturn(3);
+      // Defensive: a PR label with a null/blank name must not count against the budget.
+      when(labelClient.listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+          .thenReturn(java.util.Arrays.asList(label(null), label(" "), label("bug")));
+
+      labeler.applyOrSuggest(request(false, List.of("docs"), List.of(label("docs"))));
+
+      var captor = ArgumentCaptor.forClass(GitHubLabelClient.AddLabelsRequest.class);
+      verify(labelClient)
+          .addLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), captor.capture());
+      assertEquals(List.of("docs"), captor.getValue().labels());
+    }
+
+    @Test
     void shouldStillApplyWhenCurrentLabelLookupFails() {
       when(labelClient.listIssueLabels(
               anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt()))

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrLabelerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrLabelerTest.java
@@ -261,6 +261,71 @@ class PrLabelerTest {
               anyString(), anyString(), anyString(), anyString(), anyInt(), captor.capture());
       assertEquals(List.of("bug"), captor.getValue().labels());
     }
+
+    @Test
+    void shouldNotAddLabelsWhenPrIsAlreadyAtMax() {
+      when(labelsConfig.maxLabels()).thenReturn(3);
+      // The PR already carries max labels from earlier reviews — adding more would exceed the cap.
+      when(labelClient.listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+          .thenReturn(List.of(label("a"), label("b"), label("c")));
+
+      labeler.applyOrSuggest(request(false, List.of("d"), List.of(label("d"))));
+
+      verify(labelClient, never())
+          .addLabels(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+    }
+
+    @Test
+    void shouldOnlyTopUpToMaxAgainstLabelsAlreadyOnThePr() {
+      when(labelsConfig.maxLabels()).thenReturn(3);
+      // Two labels already present, so only one more may be added regardless of how many match.
+      when(labelClient.listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+          .thenReturn(List.of(label("a"), label("b")));
+
+      labeler.applyOrSuggest(request(false, List.of("c", "d"), List.of(label("c"), label("d"))));
+
+      var captor = ArgumentCaptor.forClass(GitHubLabelClient.AddLabelsRequest.class);
+      verify(labelClient)
+          .addLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), captor.capture());
+      assertEquals(List.of("c"), captor.getValue().labels());
+    }
+
+    @Test
+    void shouldSkipLabelsAlreadyOnThePrWithoutSpendingBudget() {
+      when(labelsConfig.maxLabels()).thenReturn(3);
+      // "bug" is already on the PR; re-adding it is a no-op, so its budget slot frees up for
+      // "docs".
+      when(labelClient.listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+          .thenReturn(List.of(label("bug")));
+
+      labeler.applyOrSuggest(
+          request(false, List.of("bug", "docs"), List.of(label("bug"), label("docs"))));
+
+      var captor = ArgumentCaptor.forClass(GitHubLabelClient.AddLabelsRequest.class);
+      verify(labelClient)
+          .addLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), captor.capture());
+      assertEquals(List.of("docs"), captor.getValue().labels());
+    }
+
+    @Test
+    void shouldStillApplyWhenCurrentLabelLookupFails() {
+      when(labelClient.listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+          .thenThrow(new RuntimeException("rate limited"));
+
+      labeler.applyOrSuggest(request(false, List.of("bug"), List.of(label("bug"))));
+
+      var captor = ArgumentCaptor.forClass(GitHubLabelClient.AddLabelsRequest.class);
+      verify(labelClient)
+          .addLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), captor.capture());
+      assertEquals(List.of("bug"), captor.getValue().labels());
+    }
   }
 
   @Nested

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrLabelerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrLabelerTest.java
@@ -344,6 +344,22 @@ class PrLabelerTest {
     }
 
     @Test
+    void shouldApplyWhenCurrentLabelLookupReturnsNull() {
+      // GitHub may deserialize an empty body to null; treat it as "no labels yet" and apply.
+      when(labelClient.listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+          .thenReturn(null);
+
+      labeler.applyOrSuggest(request(false, List.of("bug"), List.of(label("bug"))));
+
+      var captor = ArgumentCaptor.forClass(GitHubLabelClient.AddLabelsRequest.class);
+      verify(labelClient)
+          .addLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), captor.capture());
+      assertEquals(List.of("bug"), captor.getValue().labels());
+    }
+
+    @Test
     void shouldStillApplyWhenCurrentLabelLookupFails() {
       when(labelClient.listIssueLabels(
               anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt()))


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

PR-label application was capped **per review**, not **per PR**. Over successive re-reviews with shifting model suggestions, a PR could accumulate labels well past `max-labels` (`REVIEW_LABELS_MAX`).

Three things combined to cause this:
- `PrLabeler.applyLabels` runs on **every** review — only the *suggest* path is `isFirstReview`-gated.
- `reconcile` caps suggestions against the **repo's** label set, never against the labels already on the PR.
- GitHub's add-labels endpoint is **additive** (`POST .../issues/{n}/labels`).

So review 1 adds A,B,C; a re-review suggesting D,E,F adds those too → 6 labels with `max-labels=3`. The `LabelsConfig.maxLabels()` Javadoc explicitly documents this as a bound "for one PR," so this was a real divergence from intent.

**Fix:** `applyLabels` now bounds its additions against the PR's current labels:
- New best-effort `listIssueLabels` (`GET .../issues/{n}/labels`) reads what's already on the PR.
- Computes `budget = max - currentCount`, skips labels already present (so re-adds don't waste budget), and only tops the PR up to `max-labels` total.
- If the lookup fails, it degrades to the prior behavior for that single review rather than blocking — labelling is best-effort and never fails a review.

Re-review labeling is **intentional** (the existing `shouldAddLabelsInApplyMode` test exercises a follow-up review), so `applyLabels` is *bounded* rather than gated to the first review.

## Related Issues

N/A

## How Has This Been Tested?

Ran the affected unit tests locally with JaCoCo disabled (known SMB-mount file-lock issue on this checkout):

```
./mvnw -o test -Djacoco.skip=true -Dquarkus.jacoco.enabled=false -Dtest='PrLabelerTest,GitHubLabelClientTest'
```

Result: **41 run, 0 failures, 0 errors.** Added four cases to `PrLabelerTest`:
- PR already at max → nothing added
- partial budget → only tops up to max
- label already present → skipped without spending budget
- current-label lookup failure → still applies (graceful fallback)

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

**Judgment call for reviewers:** all labels on the PR count against the budget, including any a human added manually — the bot can't reliably tell its own labels from user/other-bot labels without persistent provenance tracking. This guarantees the PR never exceeds `max-labels`, but a heavily hand-labeled PR may receive fewer (or no) bot labels. If bot-only accounting is preferred, that would need label-provenance tracking.

No breaking changes; the labels feature is opt-in (`apply` defaults to false).
