### PR TITLE
fix(review): fully wire GITHUB_BOT_LOGINS via shared BotIdentity

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/BotIdentity.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/BotIdentity.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.config;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The GitHub login(s) this App's bot posts under, normalized for matching.
+ *
+ * <p>Built from {@link ThrillhouseConfig.GitHubConfig#botLogins()} and shared by every component
+ * that must recognize the bot's own activity — comment-trigger filtering, summary dedup,
+ * prior-review detection, and follow-up thread matching — so they can never disagree on who the bot
+ * is. A single deployment runs under exactly one {@code <app-slug>[bot]} login, but the project
+ * ships defaults for both slugs it may use; matching against the whole set (not one hardcoded slug)
+ * is what keeps the bot from re-reviewing itself or re-raising resolved findings when deployed
+ * under the alternate slug.
+ */
+public record BotIdentity(Set<String> logins) {
+
+  /**
+   * Built-in bot logins used when none are configured. Mirrors the {@code @WithDefault} on {@link
+   * ThrillhouseConfig.GitHubConfig#botLogins()}.
+   */
+  public static final List<String> DEFAULT_LOGINS =
+      List.of("thrillhousebot[bot]", "thrillhouse-bot[bot]");
+
+  /**
+   * Normalizes the supplied logins (trimmed, lower-cased, blanks dropped). The stored set is never
+   * empty: an empty set would make {@link #matches} always false and let the bot answer its own
+   * comments in an infinite loop, so it falls back to {@link #DEFAULT_LOGINS}.
+   */
+  public BotIdentity {
+    var normalized = normalize(logins);
+    logins = Set.copyOf(normalized.isEmpty() ? normalize(DEFAULT_LOGINS) : normalized);
+  }
+
+  /** Builds an identity from a configured list; a {@code null} list yields the defaults. */
+  public static BotIdentity from(List<String> configuredLogins) {
+    return new BotIdentity(
+        configuredLogins == null ? Set.of() : new LinkedHashSet<>(configuredLogins));
+  }
+
+  /** Convenience factory for tests and fixed wiring. */
+  public static BotIdentity of(String... logins) {
+    return from(Arrays.asList(logins));
+  }
+
+  /** Whether {@code login} is one of the bot's own logins, compared case-insensitively. */
+  public boolean matches(String login) {
+    return login != null && logins.contains(login.toLowerCase(Locale.ROOT));
+  }
+
+  private static Set<String> normalize(Collection<String> logins) {
+    return logins.stream()
+        .filter(s -> s != null && !s.isBlank())
+        .map(s -> s.strip().toLowerCase(Locale.ROOT))
+        .collect(Collectors.toSet());
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -64,9 +64,11 @@ public interface ThrillhouseConfig {
     String webhookSecret();
 
     /**
-     * GitHub login(s) of this App's bot account, used to skip the bot's own comments and avoid
-     * infinite reply loops. Defaults to the names this project ships under; override when the App
-     * is deployed under a different slug (its bot login is {@code <app-slug>[bot]}).
+     * GitHub login(s) of this App's bot account. Used everywhere the bot must recognize its own
+     * activity — skipping its own comments to avoid infinite reply loops, summary-comment dedup,
+     * prior-review detection, and follow-up thread matching (resolved via {@link BotIdentity}).
+     * Defaults to the names this project ships under; override when the App is deployed under a
+     * different slug (its bot login is {@code <app-slug>[bot]}).
      */
     @WithName("bot-logins")
     @WithDefault("thrillhousebot[bot],thrillhouse-bot[bot]")

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -17,6 +17,7 @@ package dev.thiagogonzaga.thrillhousebot.review;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
@@ -69,8 +70,9 @@ public class FollowUpAnalyzer {
   public String buildPreviousFindingsContext(
       String previousAiResponseJson,
       List<GitHubReviewClient.ReviewResponse> priorReviews,
-      String botLogin) {
-    return buildPreviousFindingsContext(previousAiResponseJson, priorReviews, List.of(), botLogin);
+      BotIdentity botIdentity) {
+    return buildPreviousFindingsContext(
+        previousAiResponseJson, priorReviews, List.of(), botIdentity);
   }
 
   /**
@@ -81,9 +83,9 @@ public class FollowUpAnalyzer {
       String previousAiResponseJson,
       List<GitHubReviewClient.ReviewResponse> priorReviews,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
+      BotIdentity botIdentity) {
     return buildPreviousFindingsContext(
-        previousAiResponseJson, priorReviews, inlineComments, List.of(), botLogin);
+        previousAiResponseJson, priorReviews, inlineComments, List.of(), botIdentity);
   }
 
   /**
@@ -98,13 +100,13 @@ public class FollowUpAnalyzer {
       List<GitHubReviewClient.ReviewResponse> priorReviews,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       List<String> olderAiResponseJsons,
-      String botLogin) {
-    var structured = formatStructuredFindings(previousAiResponseJson, inlineComments, botLogin);
-    var answered = formatAnsweredEarlier(olderAiResponseJsons, inlineComments, botLogin);
+      BotIdentity botIdentity) {
+    var structured = formatStructuredFindings(previousAiResponseJson, inlineComments, botIdentity);
+    var answered = formatAnsweredEarlier(olderAiResponseJsons, inlineComments, botIdentity);
     if (!structured.isEmpty()) {
       return structured + answered;
     }
-    var fallback = buildPreviousFindingsContext(priorReviews, botLogin);
+    var fallback = buildPreviousFindingsContext(priorReviews, botIdentity);
     return fallback + answered;
   }
 
@@ -116,7 +118,7 @@ public class FollowUpAnalyzer {
   private String formatAnsweredEarlier(
       List<String> olderAiResponseJsons,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
+      BotIdentity botIdentity) {
     if (olderAiResponseJsons == null || olderAiResponseJsons.isEmpty()) {
       return "";
     }
@@ -124,7 +126,7 @@ public class FollowUpAnalyzer {
     var seen = new HashSet<String>();
     for (String json : olderAiResponseJsons) {
       for (var finding : parsePreviousFindings(json)) {
-        appendAnsweredEntry(sb, seen, finding, inlineComments, botLogin);
+        appendAnsweredEntry(sb, seen, finding, inlineComments, botIdentity);
       }
     }
     return sb.toString();
@@ -140,14 +142,14 @@ public class FollowUpAnalyzer {
       Set<String> seen,
       ReviewResponse.Finding finding,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
+      BotIdentity botIdentity) {
     if (finding.file() == null || finding.title() == null) {
       return;
     }
     if (!seen.add(finding.file() + "#" + finding.title())) {
       return;
     }
-    Long rootId = answeredRootComment(finding, inlineComments, botLogin);
+    Long rootId = answeredRootComment(finding, inlineComments, botIdentity);
     if (rootId == null) {
       return;
     }
@@ -172,7 +174,7 @@ public class FollowUpAnalyzer {
   private String formatStructuredFindings(
       String aiResponseJson,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
+      BotIdentity botIdentity) {
     var previous = parsePreviousFindings(aiResponseJson);
     if (previous.isEmpty()) {
       return "";
@@ -194,7 +196,7 @@ public class FollowUpAnalyzer {
       if (finding.description() != null && !finding.description().isBlank()) {
         sb.append("   ").append(finding.description()).append("\n");
       }
-      appendThreadReplies(sb, finding, id, inlineComments, botLogin);
+      appendThreadReplies(sb, finding, id, inlineComments, botIdentity);
       id++;
     }
     return sb.toString();
@@ -205,8 +207,8 @@ public class FollowUpAnalyzer {
       ReviewResponse.Finding finding,
       int findingId,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
-    Long rootId = rootCommentId(finding, findingId, inlineComments, botLogin);
+      BotIdentity botIdentity) {
+    Long rootId = rootCommentId(finding, findingId, inlineComments, botIdentity);
     if (rootId == null) {
       return;
     }
@@ -236,12 +238,12 @@ public class FollowUpAnalyzer {
       ReviewResponse.Finding finding,
       int findingId,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
-    Long markerRoot = markerRootComment(finding, findingId, false, inlineComments, botLogin);
+      BotIdentity botIdentity) {
+    Long markerRoot = markerRootComment(finding, findingId, false, inlineComments, botIdentity);
     if (markerRoot != null) {
       return markerRoot;
     }
-    return rootCommentByTitle(finding, inlineComments, botLogin);
+    return rootCommentByTitle(finding, inlineComments, botIdentity);
   }
 
   /**
@@ -267,10 +269,10 @@ public class FollowUpAnalyzer {
       int findingId,
       boolean requireOwnContent,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
+      BotIdentity botIdentity) {
     String marker = SuggestionFormatter.findingMarker(findingId);
     var markerMatches =
-        botRootComments(inlineComments, botLogin)
+        botRootComments(inlineComments, botIdentity)
             .filter(c -> c.body() != null && c.body().contains(marker))
             .filter(c -> finding.file() == null || FilePaths.same(finding.file(), c.path()))
             .filter(c -> !requireOwnContent || bodyCarriesOwnContent(finding, c.body()))
@@ -309,8 +311,8 @@ public class FollowUpAnalyzer {
   private static Long rootCommentByTitle(
       ReviewResponse.Finding finding,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
-    List<Long> matches = rootCommentsByTitle(finding, inlineComments, botLogin);
+      BotIdentity botIdentity) {
+    List<Long> matches = rootCommentsByTitle(finding, inlineComments, botIdentity);
     return matches.isEmpty() ? null : matches.get(matches.size() - 1);
   }
 
@@ -322,9 +324,9 @@ public class FollowUpAnalyzer {
   private static Long answeredRootComment(
       ReviewResponse.Finding finding,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
-    for (Long rootId : rootCommentsByTitle(finding, inlineComments, botLogin)) {
-      if (hasHumanReply(rootId, inlineComments, botLogin)) {
+      BotIdentity botIdentity) {
+    for (Long rootId : rootCommentsByTitle(finding, inlineComments, botIdentity)) {
+      if (hasHumanReply(rootId, inlineComments, botIdentity)) {
         return rootId;
       }
     }
@@ -336,7 +338,7 @@ public class FollowUpAnalyzer {
    * backstop's newest-prior-round case. The finding's own {@code thrillhousebot:finding=N} marked
    * thread is authoritative: when one exists, only a reply on <em>it</em> clears the hold. The
    * marker is title-independent, so a {@code null}-title finding's thread is seen — the title-only
-   * {@link #answeredRootComment(ReviewResponse.Finding, List, String)} consults {@link
+   * {@link #answeredRootComment(ReviewResponse.Finding, List, BotIdentity)} consults {@link
    * #rootCommentsByTitle}, which returns {@code List.of()} for a null title and can never find the
    * reply, leaving the backstop to hold the finding every round with no human escape (#133b). It
    * also keeps a reply on a same-title sibling's thread (a different index) from clearing this
@@ -360,26 +362,26 @@ public class FollowUpAnalyzer {
       ReviewResponse.Finding finding,
       int findingId,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
-    Long own = markerRootComment(finding, findingId, true, inlineComments, botLogin);
+      BotIdentity botIdentity) {
+    Long own = markerRootComment(finding, findingId, true, inlineComments, botIdentity);
     if (own != null) {
-      return hasHumanReply(own, inlineComments, botLogin) ? own : null;
+      return hasHumanReply(own, inlineComments, botIdentity) ? own : null;
     }
-    if (markerRootComment(finding, findingId, false, inlineComments, botLogin) != null) {
+    if (markerRootComment(finding, findingId, false, inlineComments, botIdentity) != null) {
       return null;
     }
-    return answeredRootComment(finding, inlineComments, botLogin);
+    return answeredRootComment(finding, inlineComments, botIdentity);
   }
 
   /** All bot root comments matching the finding's file and title, oldest first. */
   private static List<Long> rootCommentsByTitle(
       ReviewResponse.Finding finding,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
+      BotIdentity botIdentity) {
     if (finding.title() == null || finding.file() == null) {
       return List.of();
     }
-    return botRootComments(inlineComments, botLogin)
+    return botRootComments(inlineComments, botIdentity)
         .filter(c -> FilePaths.same(finding.file(), c.path()))
         .filter(c -> c.body() != null && c.body().contains(finding.title()))
         .map(GitHubReviewClient.PullRequestComment::id)
@@ -387,10 +389,10 @@ public class FollowUpAnalyzer {
   }
 
   private static Stream<GitHubReviewClient.PullRequestComment> botRootComments(
-      List<GitHubReviewClient.PullRequestComment> inlineComments, String botLogin) {
+      List<GitHubReviewClient.PullRequestComment> inlineComments, BotIdentity botIdentity) {
     return inlineComments.stream()
         .filter(c -> c.inReplyToId() == null)
-        .filter(c -> c.user() != null && botLogin.equals(c.user().login()));
+        .filter(c -> c.user() != null && botIdentity.matches(c.user().login()));
   }
 
   /** Lines a finding may drift between revisions and still count as the same location. */
@@ -409,7 +411,7 @@ public class FollowUpAnalyzer {
       ReviewResponse response,
       List<String> priorAiResponseJsons,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
+      BotIdentity botIdentity) {
     if (response.findings().isEmpty() || inlineComments.isEmpty()) {
       return response;
     }
@@ -422,7 +424,7 @@ public class FollowUpAnalyzer {
     var dropped = false;
     for (ReviewResponse.Finding finding : response.findings()) {
       ReviewResponse.Finding duplicateOf =
-          findRepliedDuplicate(finding, priorRounds, inlineComments, botLogin);
+          findRepliedDuplicate(finding, priorRounds, inlineComments, botIdentity);
       if (duplicateOf == null) {
         kept.add(finding);
         continue;
@@ -460,7 +462,7 @@ public class FollowUpAnalyzer {
       ReviewResponse.Finding finding,
       List<List<ReviewResponse.Finding>> priorRounds,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
+      BotIdentity botIdentity) {
     for (List<ReviewResponse.Finding> previous : priorRounds) {
       for (var prior : previous) {
         if (!isSameFinding(finding, prior)) {
@@ -468,7 +470,7 @@ public class FollowUpAnalyzer {
         }
         // Marker indices are only meaningful within their own round; across rounds the same
         // index names unrelated findings, so the thread is located by file and title instead
-        if (answeredRootComment(prior, inlineComments, botLogin) != null) {
+        if (answeredRootComment(prior, inlineComments, botIdentity) != null) {
           return prior;
         }
       }
@@ -496,24 +498,26 @@ public class FollowUpAnalyzer {
   }
 
   private static boolean hasHumanReply(
-      Long rootId, List<GitHubReviewClient.PullRequestComment> inlineComments, String botLogin) {
+      Long rootId,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      BotIdentity botIdentity) {
     return inlineComments.stream()
         .anyMatch(
             c ->
                 rootId.equals(c.inReplyToId())
                     && c.user() != null
-                    && !botLogin.equals(c.user().login()));
+                    && !botIdentity.matches(c.user().login()));
   }
 
   /** Maps each previous finding's prompt id to its bot root comment, for thread resolution. */
   public Map<Integer, Long> matchFindingThreads(
       String previousAiResponseJson,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      String botLogin) {
+      BotIdentity botIdentity) {
     var previous = parsePreviousFindings(previousAiResponseJson);
     var threads = new HashMap<Integer, Long>();
     for (var i = 0; i < previous.size(); i++) {
-      Long rootId = rootCommentId(previous.get(i), i + 1, inlineComments, botLogin);
+      Long rootId = rootCommentId(previous.get(i), i + 1, inlineComments, botIdentity);
       if (rootId != null) {
         threads.put(i + 1, rootId);
       }
@@ -605,14 +609,14 @@ public class FollowUpAnalyzer {
       List<ReviewResponse.PreviousFindingStatus> currentStatuses,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       DiffLineResolver lineResolver,
-      String botLogin) {
+      BotIdentity botIdentity) {
     if (priorAiResponseJsons == null || priorAiResponseJsons.isEmpty() || lineResolver == null) {
       return List.of();
     }
     var chrono = toChronological(priorAiResponseJsons);
     var open = openFindingsAcrossRounds(chrono, currentStatuses);
     var clusters = clusterByIdentity(open);
-    return heldFromClusters(clusters, inlineComments, lineResolver, botLogin);
+    return heldFromClusters(clusters, inlineComments, lineResolver, botIdentity);
   }
 
   /**
@@ -673,10 +677,10 @@ public class FollowUpAnalyzer {
       List<List<OpenFinding>> clusters,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       DiffLineResolver lineResolver,
-      String botLogin) {
+      BotIdentity botIdentity) {
     var held = new ArrayList<ReviewResult.PreviousFindingStatus>();
     for (var cluster : clusters) {
-      OpenFinding target = holdableTarget(cluster, inlineComments, lineResolver, botLogin);
+      OpenFinding target = holdableTarget(cluster, inlineComments, lineResolver, botIdentity);
       if (target != null) {
         held.add(
             new ReviewResult.PreviousFindingStatus(
@@ -699,7 +703,7 @@ public class FollowUpAnalyzer {
       List<OpenFinding> cluster,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       DiffLineResolver lineResolver,
-      String botLogin) {
+      BotIdentity botIdentity) {
     OpenFinding target = null;
     boolean anyReplied = false;
     for (var member : cluster) {
@@ -708,7 +712,7 @@ public class FollowUpAnalyzer {
           && lineResolver.isFindingPresent(finding.file(), finding.suggestionOld())) {
         target = member;
       }
-      if (answeredRootComment(finding, member.id(), inlineComments, botLogin) != null) {
+      if (answeredRootComment(finding, member.id(), inlineComments, botIdentity) != null) {
         anyReplied = true;
       }
     }
@@ -849,12 +853,12 @@ public class FollowUpAnalyzer {
    * response. The body carries no structured findings, so this is best-effort only.
    */
   public String buildPreviousFindingsContext(
-      List<GitHubReviewClient.ReviewResponse> priorReviews, String botLogin) {
+      List<GitHubReviewClient.ReviewResponse> priorReviews, BotIdentity botIdentity) {
     if (priorReviews == null || priorReviews.isEmpty()) return "";
 
     var lastBotReview =
         priorReviews.stream()
-            .filter(r -> botLogin.equals(r.user().login()))
+            .filter(r -> botIdentity.matches(r.user().login()))
             .reduce((first, second) -> second); // get last
 
     if (lastBotReview.isEmpty()) return "";

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -17,6 +17,7 @@ package dev.thiagogonzaga.thrillhousebot.review;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSessionPersistence;
@@ -50,7 +51,6 @@ public class ReviewOrchestrator {
 
   private static final String ACCEPT = "application/vnd.github+json";
   private static final String CHECK_NAME = "ThrillhouseBot Review";
-  private static final String BOT_LOGIN = "thrillhousebot[bot]";
   private static final String ZERO_ISSUES_MESSAGE = PrSummaryGenerator.ZERO_ISSUES_MESSAGE;
   private static final String SUMMARY_HEADING = PrSummaryGenerator.SUMMARY_HEADING;
   // One page comfortably covers the bot's summary: it is posted on the first review, so it sits
@@ -81,6 +81,10 @@ public class ReviewOrchestrator {
   static final int CI_MAX_PAGES = 50;
 
   private final ThrillhouseConfig config;
+  // The login(s) the bot posts under, resolved once from config so that summary dedup, first-review
+  // detection, and follow-up matching all recognize the bot's own activity regardless of which
+  // <app-slug>[bot] this deployment runs under (#165).
+  private final BotIdentity botIdentity;
   private final GitHubAuthClient authClient;
   private final GitHubCheckRunClient checkRunClient;
 
@@ -160,6 +164,7 @@ public class ReviewOrchestrator {
       PrLabeler labeler,
       ObjectMapper mapper) {
     this.config = config;
+    this.botIdentity = BotIdentity.from(config.github().botLogins());
     this.authClient = authClient;
     this.checkRunClient = checkRunClient;
     this.reviewClient = reviewClient;
@@ -240,7 +245,7 @@ public class ReviewOrchestrator {
       List<String> priorAiResponseJsons =
           sessionPersistence.findAllPriorAiResponseJsons(repository, req.prNumber(), session.id);
       var isFirstVisibleReview =
-          priorReviews.stream().noneMatch(r -> BOT_LOGIN.equals(r.user().login()))
+          priorReviews.stream().noneMatch(r -> botIdentity.matches(r.user().login()))
               && !botSummaryCommentExists(auth, req.owner(), req.repo(), req.prNumber());
       var hasContext = !priorAiResponseJsons.isEmpty();
       String previousAiResponseJson =
@@ -260,7 +265,7 @@ public class ReviewOrchestrator {
                   priorReviews,
                   inlineComments,
                   olderAiResponseJsons,
-                  BOT_LOGIN)
+                  botIdentity)
               : "";
 
       var instructions =
@@ -304,7 +309,7 @@ public class ReviewOrchestrator {
               aiResponse, fencedDiff, escapedStack, PromptTemplateEscaper.escape(previousFindings));
       aiResponse =
           followUpAnalyzer.dropRepliedDuplicates(
-              aiResponse, priorAiResponseJsons, inlineComments, BOT_LOGIN);
+              aiResponse, priorAiResponseJsons, inlineComments, botIdentity);
       var lineResolver = new DiffLineResolver(patchesByFile(files));
       aiResponse = populateMissingAnchors(aiResponse, lineResolver);
       persistAiResponse(session, aiResponse);
@@ -330,7 +335,7 @@ public class ReviewOrchestrator {
                   aiResponse.previousFindingsStatus(),
                   inlineComments,
                   lineResolver,
-                  BOT_LOGIN)
+                  botIdentity)
               : List.<ReviewResult.PreviousFindingStatus>of();
       var result =
           buildResult(
@@ -634,7 +639,7 @@ public class ReviewOrchestrator {
       var user = comment.user();
       var body = comment.body();
       if (user != null
-          && BOT_LOGIN.equals(user.login())
+          && botIdentity.matches(user.login())
           && body != null
           && body.stripLeading().startsWith(SUMMARY_HEADING)) {
         return true;
@@ -690,7 +695,7 @@ public class ReviewOrchestrator {
         return;
       }
       var rootByFinding =
-          followUpAnalyzer.matchFindingThreads(previousAiResponseJson, inlineComments, BOT_LOGIN);
+          followUpAnalyzer.matchFindingThreads(previousAiResponseJson, inlineComments, botIdentity);
       var threads =
           reviewThreadService.threadsByRootComment(auth, req.owner(), req.repo(), req.prNumber());
       var resolved = 0;
@@ -1171,7 +1176,7 @@ public class ReviewOrchestrator {
   void dismissPendingBotReviews(String auth, String owner, String repo, int prNumber) {
     try {
       for (var review : reviewClient.listReviews(auth, ACCEPT, owner, repo, prNumber)) {
-        if ("PENDING".equals(review.state()) && BOT_LOGIN.equals(review.user().login())) {
+        if ("PENDING".equals(review.state()) && botIdentity.matches(review.user().login())) {
           reviewClient.deletePendingReview(auth, ACCEPT, owner, repo, prNumber, review.id());
           Log.debugf(
               "Dismissed pending review %d on %s/%s #%d", review.id(), owner, repo, prNumber);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
@@ -15,23 +15,17 @@
  */
 package dev.thiagogonzaga.thrillhousebot.webhook;
 
+import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class TriggerDetector {
-
-  /** Default GitHub App bot logins used when none are configured. */
-  static final List<String> DEFAULT_BOT_LOGINS =
-      List.of("thrillhousebot[bot]", "thrillhouse-bot[bot]");
 
   /**
    * Command word → its matching patterns, in detection precedence order. A comment carrying more
@@ -51,7 +45,7 @@ public class TriggerDetector {
   private static final Pattern BLOCKQUOTE_LINE = Pattern.compile("(?m)^[ \\t]*>.*$");
   private static final Pattern INLINE_CODE = Pattern.compile("`[^`\\n]*`");
 
-  private final Set<String> botLogins;
+  private final BotIdentity botIdentity;
 
   @Inject
   public TriggerDetector(ThrillhouseConfig config) {
@@ -60,24 +54,11 @@ public class TriggerDetector {
 
   /** Default detector wired with the built-in bot logins (used in tests and as a fallback). */
   public TriggerDetector() {
-    this(DEFAULT_BOT_LOGINS);
+    this((List<String>) null);
   }
 
   TriggerDetector(List<String> configuredBotLogins) {
-    var normalized =
-        (configuredBotLogins == null ? DEFAULT_BOT_LOGINS : configuredBotLogins)
-            .stream()
-                .filter(s -> s != null && !s.isBlank())
-                .map(s -> s.strip().toLowerCase(Locale.ROOT))
-                .collect(Collectors.toUnmodifiableSet());
-    // Never end up with an empty set: that would make isBotComment always false and let the bot
-    // answer its own replies (an infinite loop). Fall back to the built-in logins instead.
-    this.botLogins =
-        normalized.isEmpty()
-            ? DEFAULT_BOT_LOGINS.stream()
-                .map(s -> s.toLowerCase(Locale.ROOT))
-                .collect(Collectors.toUnmodifiableSet())
-            : normalized;
+    this.botIdentity = BotIdentity.from(configuredBotLogins);
   }
 
   private static Map<CommentCommand, List<Pattern>> buildPatterns() {
@@ -150,9 +131,6 @@ public class TriggerDetector {
 
   /** Checks whether the comment author is the bot itself. Prevents infinite review loops. */
   public boolean isBotComment(String authorLogin) {
-    if (authorLogin == null) {
-      return false;
-    }
-    return botLogins.contains(authorLogin.toLowerCase(Locale.ROOT));
+    return botIdentity.matches(authorLogin);
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/BotIdentityTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/BotIdentityTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class BotIdentityTest {
+
+  @Test
+  void shouldMatchAnyConfiguredLoginCaseInsensitively() {
+    var identity = BotIdentity.of("my-app[bot]", "Other[Bot]");
+
+    assertTrue(identity.matches("my-app[bot]"));
+    assertTrue(identity.matches("MY-APP[BOT]"));
+    assertTrue(identity.matches("other[bot]")); // normalized on the way in
+    assertFalse(identity.matches("thrillhousebot[bot]"));
+  }
+
+  @Test
+  void shouldNeverMatchNull() {
+    assertFalse(BotIdentity.of("my-app[bot]").matches(null));
+  }
+
+  @Test
+  void shouldTrimAndDeduplicateLogins() {
+    var identity = BotIdentity.of("  Bot[Bot]  ", "bot[bot]");
+
+    assertEquals(1, identity.logins().size());
+    assertTrue(identity.logins().contains("bot[bot]"));
+    assertTrue(identity.matches("bot[bot]"));
+  }
+
+  @Test
+  void shouldFallBackToDefaultsWhenNull() {
+    var identity = BotIdentity.from(null);
+
+    assertTrue(identity.matches("thrillhousebot[bot]"));
+    assertTrue(identity.matches("thrillhouse-bot[bot]"));
+  }
+
+  @Test
+  void shouldFallBackToDefaultsWhenEmptyOrAllBlank() {
+    // An empty identity would make matches() always false and let the bot loop on its own replies.
+    assertTrue(BotIdentity.from(List.of()).matches("thrillhousebot[bot]"));
+    assertTrue(BotIdentity.from(Arrays.asList(null, "  ", "")).matches("thrillhousebot[bot]"));
+  }
+
+  @Test
+  void identitiesWithTheSameLoginsAreEqual() {
+    assertEquals(
+        BotIdentity.of("thrillhousebot[bot]"), BotIdentity.from(List.of("thrillhousebot[bot]")));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import java.util.List;
@@ -34,6 +35,10 @@ class FollowUpAnalyzerTest {
   private final FollowUpAnalyzer analyzer = new FollowUpAnalyzer(new ObjectMapper());
 
   private static final String BOT = "thrillhousebot";
+
+  // The bot's identity for analyzer calls; comment(...) authors keep using the raw BOT login
+  // string.
+  private static final BotIdentity BOT_ID = BotIdentity.of(BOT);
 
   private static final String PREVIOUS_JSON =
       """
@@ -59,7 +64,7 @@ class FollowUpAnalyzerTest {
             comment(101L, 100L, "src/A.java", "Fixed in abc123", "maintainer"),
             comment(102L, 100L, "src/A.java", "Confirmed", BOT));
 
-    var context = analyzer.buildPreviousFindingsContext(PREVIOUS_JSON, List.of(), comments, BOT);
+    var context = analyzer.buildPreviousFindingsContext(PREVIOUS_JSON, List.of(), comments, BOT_ID);
 
     assertTrue(context.contains("Thread replies:"));
     assertTrue(context.contains("- @maintainer: Fixed in abc123"));
@@ -70,7 +75,7 @@ class FollowUpAnalyzerTest {
   void contextShouldOmitRepliesSectionWhenThreadHasNone() {
     var comments = List.of(comment(100L, null, "src/A.java", "**CRITICAL — SQL injection**", BOT));
 
-    var context = analyzer.buildPreviousFindingsContext(PREVIOUS_JSON, List.of(), comments, BOT);
+    var context = analyzer.buildPreviousFindingsContext(PREVIOUS_JSON, List.of(), comments, BOT_ID);
 
     assertFalse(context.contains("Thread replies:"));
   }
@@ -84,7 +89,7 @@ class FollowUpAnalyzerTest {
             comment(300L, null, "src/A.java", "unrelated comment", BOT),
             comment(301L, 300L, "src/A.java", "reply to unrelated", "maintainer"));
 
-    var context = analyzer.buildPreviousFindingsContext(PREVIOUS_JSON, List.of(), comments, BOT);
+    var context = analyzer.buildPreviousFindingsContext(PREVIOUS_JSON, List.of(), comments, BOT_ID);
 
     assertFalse(context.contains("Thread replies:"));
   }
@@ -109,7 +114,7 @@ class FollowUpAnalyzerTest {
             new GitHubReviewClient.PullRequestComment(
                 101L, 100L, "src/A.java", "anonymous reply", null));
 
-    var context = analyzer.buildPreviousFindingsContext(json, List.of(), comments, BOT);
+    var context = analyzer.buildPreviousFindingsContext(json, List.of(), comments, BOT_ID);
 
     // Null bodies and null users never match as roots; null-user replies render as @unknown
     assertTrue(context.contains("- @unknown: anonymous reply"));
@@ -123,7 +128,7 @@ class FollowUpAnalyzerTest {
             comment(101L, 100L, "src/A.java", "a reply", "maintainer"),
             comment(200L, null, "src/B.java", "**MEDIUM — Missing null check**", BOT));
 
-    var threads = analyzer.matchFindingThreads(PREVIOUS_JSON, comments, BOT);
+    var threads = analyzer.matchFindingThreads(PREVIOUS_JSON, comments, BOT_ID);
 
     assertEquals(100L, threads.get(1));
     assertEquals(200L, threads.get(2));
@@ -156,7 +161,7 @@ class FollowUpAnalyzerTest {
                 "**MEDIUM — Missing null check**\n<!-- thrillhousebot:finding=2 -->",
                 BOT));
 
-    var threads = analyzer.matchFindingThreads(json, comments, BOT);
+    var threads = analyzer.matchFindingThreads(json, comments, BOT_ID);
 
     assertEquals(100L, threads.get(1));
     assertEquals(200L, threads.get(2));
@@ -173,7 +178,7 @@ class FollowUpAnalyzerTest {
             List.of(),
             null);
 
-    assertSame(withFinding, analyzer.dropRepliedDuplicates(withFinding, null, comments, BOT));
+    assertSame(withFinding, analyzer.dropRepliedDuplicates(withFinding, null, comments, BOT_ID));
   }
 
   @Test
@@ -193,7 +198,7 @@ class FollowUpAnalyzerTest {
                 "**LOW — No file**\n<!-- thrillhousebot:finding=1 -->",
                 BOT));
 
-    var threads = analyzer.matchFindingThreads(json, comments, BOT);
+    var threads = analyzer.matchFindingThreads(json, comments, BOT_ID);
 
     assertEquals(100L, threads.get(1));
   }
@@ -213,7 +218,7 @@ class FollowUpAnalyzerTest {
             List.of(),
             null);
 
-    var result = analyzer.dropRepliedDuplicates(reRaised, List.of(PREVIOUS_JSON), comments, BOT);
+    var result = analyzer.dropRepliedDuplicates(reRaised, List.of(PREVIOUS_JSON), comments, BOT_ID);
 
     assertTrue(result.findings().isEmpty());
   }
@@ -258,7 +263,7 @@ class FollowUpAnalyzerTest {
             List.of(),
             null);
 
-    var result = analyzer.dropRepliedDuplicates(paraphrased, List.of(priorJson), comments, BOT);
+    var result = analyzer.dropRepliedDuplicates(paraphrased, List.of(priorJson), comments, BOT_ID);
 
     assertTrue(result.findings().isEmpty());
   }
@@ -302,7 +307,7 @@ class FollowUpAnalyzerTest {
             null);
 
     assertSame(
-        distinct, analyzer.dropRepliedDuplicates(distinct, List.of(priorJson), comments, BOT));
+        distinct, analyzer.dropRepliedDuplicates(distinct, List.of(priorJson), comments, BOT_ID));
   }
 
   @Test
@@ -323,7 +328,7 @@ class FollowUpAnalyzerTest {
                 "**LOW — Unrelated thing**\n<!-- thrillhousebot:finding=1 -->",
                 BOT));
 
-    var threads = analyzer.matchFindingThreads(json, comments, BOT);
+    var threads = analyzer.matchFindingThreads(json, comments, BOT_ID);
 
     assertTrue(threads.isEmpty());
   }
@@ -344,7 +349,7 @@ class FollowUpAnalyzerTest {
             comment(100L, null, "src/A.java", "**CRITICAL — SQL injection**", BOT),
             comment(200L, null, "src/A.java", "**CRITICAL — SQL injection**", BOT));
 
-    var threads = analyzer.matchFindingThreads(json, comments, BOT);
+    var threads = analyzer.matchFindingThreads(json, comments, BOT_ID);
 
     assertEquals(200L, threads.get(1));
   }
@@ -366,7 +371,7 @@ class FollowUpAnalyzerTest {
             List.of(),
             null);
 
-    var result = analyzer.dropRepliedDuplicates(reRaised, List.of(PREVIOUS_JSON), comments, BOT);
+    var result = analyzer.dropRepliedDuplicates(reRaised, List.of(PREVIOUS_JSON), comments, BOT_ID);
 
     assertTrue(result.findings().isEmpty());
   }
@@ -375,7 +380,7 @@ class FollowUpAnalyzerTest {
   void matchFindingThreadsShouldSkipFindingsWithoutMatchingComment() {
     var comments = List.of(comment(100L, null, "src/A.java", "**CRITICAL — SQL injection**", BOT));
 
-    var threads = analyzer.matchFindingThreads(PREVIOUS_JSON, comments, BOT);
+    var threads = analyzer.matchFindingThreads(PREVIOUS_JSON, comments, BOT_ID);
 
     assertEquals(1, threads.size());
     assertFalse(threads.containsKey(2));
@@ -397,7 +402,7 @@ class FollowUpAnalyzerTest {
             List.of(),
             new ReviewResponse.Summary(2, 0, 1, 1, 0, "assessment", "purpose", List.of()));
 
-    var result = analyzer.dropRepliedDuplicates(reRaised, List.of(PREVIOUS_JSON), comments, BOT);
+    var result = analyzer.dropRepliedDuplicates(reRaised, List.of(PREVIOUS_JSON), comments, BOT_ID);
 
     assertEquals(1, result.findings().size());
     assertEquals("Genuinely new bug", result.findings().get(0).title());
@@ -423,7 +428,8 @@ class FollowUpAnalyzerTest {
             null);
 
     assertSame(
-        reRaised, analyzer.dropRepliedDuplicates(reRaised, List.of(PREVIOUS_JSON), comments, BOT));
+        reRaised,
+        analyzer.dropRepliedDuplicates(reRaised, List.of(PREVIOUS_JSON), comments, BOT_ID));
   }
 
   @Test
@@ -450,7 +456,8 @@ class FollowUpAnalyzerTest {
             List.of(),
             null);
 
-    var result = analyzer.dropRepliedDuplicates(escalated, List.of(PREVIOUS_JSON), comments, BOT);
+    var result =
+        analyzer.dropRepliedDuplicates(escalated, List.of(PREVIOUS_JSON), comments, BOT_ID);
 
     assertTrue(result.findings().isEmpty());
   }
@@ -477,7 +484,7 @@ class FollowUpAnalyzerTest {
 
     var result =
         analyzer.dropRepliedDuplicates(
-            reRaised, List.of(latestRoundJson, PREVIOUS_JSON), comments, BOT);
+            reRaised, List.of(latestRoundJson, PREVIOUS_JSON), comments, BOT_ID);
 
     assertTrue(result.findings().isEmpty());
   }
@@ -507,7 +514,7 @@ class FollowUpAnalyzerTest {
     // The same round passed twice must not duplicate entries
     var context =
         analyzer.buildPreviousFindingsContext(
-            PREVIOUS_JSON, List.of(), comments, List.of(olderJson, olderJson), BOT);
+            PREVIOUS_JSON, List.of(), comments, List.of(olderJson, olderJson), BOT_ID);
 
     assertTrue(context.contains("Answered in earlier rounds"));
     assertTrue(context.contains("src/C.java:7 — Scan does not gate"));
@@ -521,12 +528,13 @@ class FollowUpAnalyzerTest {
   @Test
   void contextWithoutOlderRoundsHasNoAnsweredSection() {
     var context =
-        analyzer.buildPreviousFindingsContext(PREVIOUS_JSON, List.of(), List.of(), List.of(), BOT);
+        analyzer.buildPreviousFindingsContext(
+            PREVIOUS_JSON, List.of(), List.of(), List.of(), BOT_ID);
 
     assertFalse(context.contains("Answered in earlier rounds"));
 
     var nullOlder =
-        analyzer.buildPreviousFindingsContext(PREVIOUS_JSON, List.of(), List.of(), null, BOT);
+        analyzer.buildPreviousFindingsContext(PREVIOUS_JSON, List.of(), List.of(), null, BOT_ID);
     assertFalse(nullOlder.contains("Answered in earlier rounds"));
   }
 
@@ -546,7 +554,8 @@ class FollowUpAnalyzerTest {
 
     // No structured previous response and no prior reviews: only the answered list renders
     var context =
-        analyzer.buildPreviousFindingsContext(null, List.of(), comments, List.of(olderJson), BOT);
+        analyzer.buildPreviousFindingsContext(
+            null, List.of(), comments, List.of(olderJson), BOT_ID);
 
     assertTrue(context.contains("Answered in earlier rounds"));
     assertTrue(context.contains("src/C.java:7 — Scan does not gate"));
@@ -568,7 +577,7 @@ class FollowUpAnalyzerTest {
 
     var context =
         analyzer.buildPreviousFindingsContext(
-            PREVIOUS_JSON, List.of(), comments, List.of(olderJson), BOT);
+            PREVIOUS_JSON, List.of(), comments, List.of(olderJson), BOT_ID);
 
     assertFalse(context.contains("Answered in earlier rounds"));
   }
@@ -588,7 +597,8 @@ class FollowUpAnalyzerTest {
             null);
 
     assertSame(
-        fileless, analyzer.dropRepliedDuplicates(fileless, List.of(PREVIOUS_JSON), comments, BOT));
+        fileless,
+        analyzer.dropRepliedDuplicates(fileless, List.of(PREVIOUS_JSON), comments, BOT_ID));
   }
 
   @Test
@@ -614,7 +624,7 @@ class FollowUpAnalyzerTest {
 
     assertSame(
         different,
-        analyzer.dropRepliedDuplicates(different, List.of(PREVIOUS_JSON), comments, BOT));
+        analyzer.dropRepliedDuplicates(different, List.of(PREVIOUS_JSON), comments, BOT_ID));
   }
 
   @Test
@@ -639,7 +649,8 @@ class FollowUpAnalyzerTest {
             null);
 
     assertSame(
-        response, analyzer.dropRepliedDuplicates(response, List.of(PREVIOUS_JSON), comments, BOT));
+        response,
+        analyzer.dropRepliedDuplicates(response, List.of(PREVIOUS_JSON), comments, BOT_ID));
   }
 
   @Test
@@ -651,11 +662,12 @@ class FollowUpAnalyzerTest {
 
     assertSame(
         noFindings,
-        analyzer.dropRepliedDuplicates(noFindings, List.of(PREVIOUS_JSON), comments, BOT));
+        analyzer.dropRepliedDuplicates(noFindings, List.of(PREVIOUS_JSON), comments, BOT_ID));
     assertSame(
         withFinding,
-        analyzer.dropRepliedDuplicates(withFinding, List.of(PREVIOUS_JSON), List.of(), BOT));
-    assertSame(withFinding, analyzer.dropRepliedDuplicates(withFinding, List.of(), comments, BOT));
+        analyzer.dropRepliedDuplicates(withFinding, List.of(PREVIOUS_JSON), List.of(), BOT_ID));
+    assertSame(
+        withFinding, analyzer.dropRepliedDuplicates(withFinding, List.of(), comments, BOT_ID));
   }
 
   @Test
@@ -731,7 +743,7 @@ class FollowUpAnalyzerTest {
 
     var held =
         analyzer.unreportedUnresolvedStatuses(
-            List.of(PREVIOUS_JSON), List.of(), List.of(), resolver, BOT);
+            List.of(PREVIOUS_JSON), List.of(), List.of(), resolver, BOT_ID);
 
     assertEquals(List.of(1, 2), heldIds(held));
     assertTrue(held.stream().allMatch(s -> "unresolved".equals(s.status())));
@@ -751,7 +763,7 @@ class FollowUpAnalyzerTest {
                     new ReviewResponse.PreviousFindingStatus(2, "justified", "intentional")),
                 List.of(),
                 resolver,
-                BOT)
+                BOT_ID)
             .isEmpty());
 
     // Finding one is reported and the existing gate already holds it; finding two is omitted, so
@@ -762,7 +774,7 @@ class FollowUpAnalyzerTest {
             List.of(new ReviewResponse.PreviousFindingStatus(1, "unresolved", "still")),
             List.of(),
             resolver,
-            BOT);
+            BOT_ID);
     assertEquals(List.of(2), heldIds(held));
   }
 
@@ -783,7 +795,7 @@ class FollowUpAnalyzerTest {
                   new ReviewResponse.PreviousFindingStatus(2, "resolved", "fixed")),
               List.of(),
               resolver,
-              BOT);
+              BOT_ID);
       // #2 carries a recognized status and is accounted for; only #1 (junk status) is held.
       assertEquals(
           List.of(1), heldIds(held), "status \"" + junk + "\" must not suppress the backstop");
@@ -806,7 +818,7 @@ class FollowUpAnalyzerTest {
                     new ReviewResponse.PreviousFindingStatus(2, "Justified", "intentional")),
                 List.of(),
                 resolver,
-                BOT)
+                BOT_ID)
             .isEmpty());
   }
 
@@ -820,7 +832,7 @@ class FollowUpAnalyzerTest {
 
     var held =
         analyzer.unreportedUnresolvedStatuses(
-            List.of(PREVIOUS_JSON), List.of(), comments, resolver, BOT);
+            List.of(PREVIOUS_JSON), List.of(), comments, resolver, BOT_ID);
 
     // Finding #1's thread carries a maintainer reply → defer to the human; only #2 is held.
     assertEquals(List.of(2), heldIds(held));
@@ -852,7 +864,7 @@ class FollowUpAnalyzerTest {
             comment(101L, 100L, "src/A.java", "intentional, won't fix", "maintainer"));
 
     var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
+        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT_ID);
 
     assertTrue(
         held.isEmpty(),
@@ -988,7 +1000,7 @@ class FollowUpAnalyzerTest {
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
 
     var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
+        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT_ID);
 
     assertEquals(List.of(1), heldIds(held));
   }
@@ -1025,7 +1037,7 @@ class FollowUpAnalyzerTest {
             comment(201L, 200L, "src/A.java", "intentional", "maintainer"));
 
     var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
+        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT_ID);
 
     assertEquals(List.of(1), heldIds(held));
   }
@@ -1057,7 +1069,7 @@ class FollowUpAnalyzerTest {
             comment(101L, 100L, "src/A.java", "tracking this", BOT));
 
     var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT);
+        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), comments, resolver, BOT_ID);
 
     assertEquals(List.of(1), heldIds(held));
   }
@@ -1078,7 +1090,8 @@ class FollowUpAnalyzerTest {
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
 
     var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), List.of(), resolver, BOT);
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(json), List.of(), List.of(), resolver, BOT_ID);
 
     assertEquals(List.of(1), heldIds(held));
   }
@@ -1090,7 +1103,7 @@ class FollowUpAnalyzerTest {
     // src/B.java is absent from this round's diff → finding #2's code is gone; only #1 is held.
     var held =
         analyzer.unreportedUnresolvedStatuses(
-            List.of(PREVIOUS_JSON), List.of(), List.of(), resolver, BOT);
+            List.of(PREVIOUS_JSON), List.of(), List.of(), resolver, BOT_ID);
 
     assertEquals(List.of(1), heldIds(held));
   }
@@ -1100,24 +1113,28 @@ class FollowUpAnalyzerTest {
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
 
     assertTrue(
-        analyzer.unreportedUnresolvedStatuses(null, List.of(), List.of(), resolver, BOT).isEmpty());
-    assertTrue(
         analyzer
-            .unreportedUnresolvedStatuses(List.of(), List.of(), List.of(), resolver, BOT)
+            .unreportedUnresolvedStatuses(null, List.of(), List.of(), resolver, BOT_ID)
             .isEmpty());
     assertTrue(
         analyzer
-            .unreportedUnresolvedStatuses(List.of("not json"), List.of(), List.of(), resolver, BOT)
+            .unreportedUnresolvedStatuses(List.of(), List.of(), List.of(), resolver, BOT_ID)
             .isEmpty());
     assertTrue(
         analyzer
-            .unreportedUnresolvedStatuses(List.of(PREVIOUS_JSON), List.of(), List.of(), null, BOT)
+            .unreportedUnresolvedStatuses(
+                List.of("not json"), List.of(), List.of(), resolver, BOT_ID)
+            .isEmpty());
+    assertTrue(
+        analyzer
+            .unreportedUnresolvedStatuses(
+                List.of(PREVIOUS_JSON), List.of(), List.of(), null, BOT_ID)
             .isEmpty());
     // Null statuses ⇒ the model reported nothing ⇒ every present finding is a silent drop.
     assertEquals(
         2,
         analyzer
-            .unreportedUnresolvedStatuses(List.of(PREVIOUS_JSON), null, List.of(), resolver, BOT)
+            .unreportedUnresolvedStatuses(List.of(PREVIOUS_JSON), null, List.of(), resolver, BOT_ID)
             .size());
   }
 
@@ -1135,7 +1152,7 @@ class FollowUpAnalyzerTest {
             List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed B")),
             List.of(),
             resolver,
-            BOT);
+            BOT_ID);
 
     // B is cleared by the current round; only the older, silently dropped A is held.
     assertEquals(1, held.size());
@@ -1152,7 +1169,7 @@ class FollowUpAnalyzerTest {
             roundJson("src/B.java", 5, "B finding", "resolved"), roundJson("src/A.java", 10, "A"));
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
 
-    var held = analyzer.unreportedUnresolvedStatuses(prior, List.of(), List.of(), resolver, BOT);
+    var held = analyzer.unreportedUnresolvedStatuses(prior, List.of(), List.of(), resolver, BOT_ID);
 
     assertEquals(1, held.size());
   }
@@ -1192,7 +1209,7 @@ class FollowUpAnalyzerTest {
     // finding.
     var held =
         analyzer.unreportedUnresolvedStatuses(
-            List.of(round3, round2, round1), List.of(), List.of(), resolver, BOT);
+            List.of(round3, round2, round1), List.of(), List.of(), resolver, BOT_ID);
 
     // Re-raised and the flagged code still present → held (safe, downgrade-only).
     assertEquals(1, held.size());
@@ -1207,7 +1224,7 @@ class FollowUpAnalyzerTest {
             roundJson("src/B.java", 5, "B finding", "justified"), roundJson("src/A.java", 10, "A"));
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
 
-    var held = analyzer.unreportedUnresolvedStatuses(prior, List.of(), List.of(), resolver, BOT);
+    var held = analyzer.unreportedUnresolvedStatuses(prior, List.of(), List.of(), resolver, BOT_ID);
 
     assertEquals(1, held.size());
   }
@@ -1229,7 +1246,7 @@ class FollowUpAnalyzerTest {
             List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed B")),
             List.of(),
             resolver,
-            BOT);
+            BOT_ID);
 
     assertEquals(1, held.size());
   }
@@ -1240,7 +1257,7 @@ class FollowUpAnalyzerTest {
     var prior = List.of(roundJson("src/A.java", 10, "A"), roundJson("src/A.java", 10, "A"));
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
 
-    var held = analyzer.unreportedUnresolvedStatuses(prior, List.of(), List.of(), resolver, BOT);
+    var held = analyzer.unreportedUnresolvedStatuses(prior, List.of(), List.of(), resolver, BOT_ID);
 
     assertEquals(1, held.size());
   }
@@ -1262,7 +1279,8 @@ class FollowUpAnalyzerTest {
             Map.of("src/A.java", "@@ -10,1 +10,1 @@\n-o\n+n\n@@ -80,1 +80,1 @@\n-o\n+n"));
 
     var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), List.of(), resolver, BOT);
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(json), List.of(), List.of(), resolver, BOT_ID);
 
     assertEquals(2, held.size());
   }
@@ -1299,7 +1317,7 @@ class FollowUpAnalyzerTest {
     // not.
     var held =
         analyzer.unreportedUnresolvedStatuses(
-            List.of(SHARED_ANCHOR_PAIR_JSON), List.of(), List.of(), sharedAnchorResolver(), BOT);
+            List.of(SHARED_ANCHOR_PAIR_JSON), List.of(), List.of(), sharedAnchorResolver(), BOT_ID);
 
     assertEquals(List.of(1, 2), heldIds(held));
     assertTrue(held.stream().allMatch(s -> "unresolved".equals(s.status())));
@@ -1318,7 +1336,7 @@ class FollowUpAnalyzerTest {
             List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed #1")),
             List.of(),
             sharedAnchorResolver(),
-            BOT);
+            BOT_ID);
 
     assertEquals(List.of(2), heldIds(held));
   }
@@ -1350,7 +1368,7 @@ class FollowUpAnalyzerTest {
 
     var held =
         analyzer.unreportedUnresolvedStatuses(
-            List.of(round2, round1), List.of(), List.of(), resolver, BOT);
+            List.of(round2, round1), List.of(), List.of(), resolver, BOT_ID);
 
     // A's deleted anchor is gone from the right side → not held; only the still-present B is held.
     assertEquals(1, held.size());
@@ -1369,7 +1387,7 @@ class FollowUpAnalyzerTest {
             List.of(new ReviewResponse.PreviousFindingStatus(1, "pending", "in progress")),
             List.of(),
             resolver,
-            BOT);
+            BOT_ID);
 
     // Finding #1 carries an unrecognized verdict and is still held alongside the unreported #2.
     assertEquals(List.of(1, 2), heldIds(held));
@@ -1400,7 +1418,7 @@ class FollowUpAnalyzerTest {
                 new ReviewResponse.PreviousFindingStatus(99, "resolved", "out of range")),
             List.of(),
             resolver,
-            BOT);
+            BOT_ID);
 
     // Only the null-title (C) and titled (D) findings survive; the null-file one is dropped.
     assertEquals(2, held.size());
@@ -1430,7 +1448,8 @@ class FollowUpAnalyzerTest {
 
     assertFalse(resolver.isLineInDiff("src/A.java", 10, 3)); // old line drifted out of range
     var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), List.of(), resolver, BOT);
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(json), List.of(), List.of(), resolver, BOT_ID);
 
     assertEquals(List.of(1), heldIds(held));
   }
@@ -1464,7 +1483,8 @@ class FollowUpAnalyzerTest {
     // Stale line 42 is within ±3 of the surviving context line now at right-line 41.
     assertTrue(resolver.isLineInDiff("src/A.java", 42, 3)); // raw proxy would over-block here
     var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), List.of(), resolver, BOT);
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(json), List.of(), List.of(), resolver, BOT_ID);
 
     assertTrue(held.isEmpty());
   }
@@ -1499,14 +1519,15 @@ class FollowUpAnalyzerTest {
             Map.of("dir/Main.java", deletionOnly, "src/dir/Main.java", variantWithAnchor));
 
     var held =
-        analyzer.unreportedUnresolvedStatuses(List.of(json), List.of(), List.of(), resolver, BOT);
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(json), List.of(), List.of(), resolver, BOT_ID);
 
     assertEquals(List.of(1), heldIds(held));
   }
 
   @Test
   void buildPreviousFindingsContextShouldReturnEmptyForNull() {
-    assertEquals("", analyzer.buildPreviousFindingsContext(null, "thrillhousebot"));
+    assertEquals("", analyzer.buildPreviousFindingsContext(null, BOT_ID));
   }
 
   @Test
@@ -1514,18 +1535,14 @@ class FollowUpAnalyzerTest {
     var reviews =
         List.of(
             new GitHubReviewClient.ReviewResponse(
-                1L,
-                null,
-                "COMMENTED",
-                "abc",
-                new GitHubReviewClient.ReviewResponse.User("thrillhousebot")));
+                1L, null, "COMMENTED", "abc", new GitHubReviewClient.ReviewResponse.User(BOT)));
 
-    assertEquals("", analyzer.buildPreviousFindingsContext(reviews, "thrillhousebot"));
+    assertEquals("", analyzer.buildPreviousFindingsContext(reviews, BOT_ID));
   }
 
   @Test
   void buildPreviousFindingsContextShouldReturnEmptyForEmptyList() {
-    assertEquals("", analyzer.buildPreviousFindingsContext(List.of(), "thrillhousebot"));
+    assertEquals("", analyzer.buildPreviousFindingsContext(List.of(), BOT_ID));
   }
 
   @Test
@@ -1539,7 +1556,7 @@ class FollowUpAnalyzerTest {
                 "abc",
                 new GitHubReviewClient.ReviewResponse.User("other-user")));
 
-    assertEquals("", analyzer.buildPreviousFindingsContext(reviews, "thrillhousebot"));
+    assertEquals("", analyzer.buildPreviousFindingsContext(reviews, BOT_ID));
   }
 
   @Test
@@ -1551,15 +1568,15 @@ class FollowUpAnalyzerTest {
                 "first review",
                 "COMMENTED",
                 "abc",
-                new GitHubReviewClient.ReviewResponse.User("thrillhousebot")),
+                new GitHubReviewClient.ReviewResponse.User(BOT)),
             new GitHubReviewClient.ReviewResponse(
                 2L,
                 "second review body",
                 "REQUEST_CHANGES",
                 "def",
-                new GitHubReviewClient.ReviewResponse.User("thrillhousebot")));
+                new GitHubReviewClient.ReviewResponse.User(BOT)));
 
-    var context = analyzer.buildPreviousFindingsContext(reviews, "thrillhousebot");
+    var context = analyzer.buildPreviousFindingsContext(reviews, BOT_ID);
 
     assertTrue(context.contains("second review body"));
     assertFalse(context.contains("first review"));
@@ -1577,7 +1594,7 @@ class FollowUpAnalyzerTest {
         ], "previous_findings_status": [], "summary": null}
         """;
 
-    var context = analyzer.buildPreviousFindingsContext(json, List.of(), "thrillhousebot");
+    var context = analyzer.buildPreviousFindingsContext(json, List.of(), BOT_ID);
 
     assertTrue(context.contains("1. [HIGH] src/A.java:10 — SQL injection"));
     assertTrue(context.contains("Concatenated query"));
@@ -1593,7 +1610,7 @@ class FollowUpAnalyzerTest {
         ], "previous_findings_status": [], "summary": null}
         """;
 
-    var context = analyzer.buildPreviousFindingsContext(json, List.of(), "thrillhousebot");
+    var context = analyzer.buildPreviousFindingsContext(json, List.of(), BOT_ID);
 
     assertTrue(context.contains("1. [UNKNOWN] src/C.java:3 — Mystery issue"));
     // No description line is emitted when the finding has none
@@ -1609,16 +1626,12 @@ class FollowUpAnalyzerTest {
                 "body findings",
                 "COMMENTED",
                 "abc",
-                new GitHubReviewClient.ReviewResponse.User("thrillhousebot")));
+                new GitHubReviewClient.ReviewResponse.User(BOT)));
 
     assertTrue(
-        analyzer
-            .buildPreviousFindingsContext(null, reviews, "thrillhousebot")
-            .contains("body findings"));
+        analyzer.buildPreviousFindingsContext(null, reviews, BOT_ID).contains("body findings"));
     assertTrue(
-        analyzer
-            .buildPreviousFindingsContext("  ", reviews, "thrillhousebot")
-            .contains("body findings"));
+        analyzer.buildPreviousFindingsContext("  ", reviews, BOT_ID).contains("body findings"));
   }
 
   @Test
@@ -1630,9 +1643,9 @@ class FollowUpAnalyzerTest {
                 "body findings",
                 "COMMENTED",
                 "abc",
-                new GitHubReviewClient.ReviewResponse.User("thrillhousebot")));
+                new GitHubReviewClient.ReviewResponse.User(BOT)));
 
-    var context = analyzer.buildPreviousFindingsContext("{not json", reviews, "thrillhousebot");
+    var context = analyzer.buildPreviousFindingsContext("{not json", reviews, BOT_ID);
 
     assertTrue(context.contains("body findings"));
   }
@@ -1644,7 +1657,7 @@ class FollowUpAnalyzerTest {
         {"findings": [], "previous_findings_status": [], "summary": null}
         """;
 
-    assertEquals("", analyzer.buildPreviousFindingsContext(json, List.of(), "thrillhousebot"));
+    assertEquals("", analyzer.buildPreviousFindingsContext(json, List.of(), BOT_ID));
   }
 
   @Test
@@ -1746,7 +1759,7 @@ class FollowUpAnalyzerTest {
 
     var held =
         analyzer.unreportedUnresolvedStatuses(
-            List.of(round2, round1), List.of(), List.of(), resolver, BOT);
+            List.of(round2, round1), List.of(), List.of(), resolver, BOT_ID);
 
     // Only one status is held (deduplicated).
     assertEquals(1, held.size());
@@ -1786,7 +1799,7 @@ class FollowUpAnalyzerTest {
 
     var held =
         analyzer.unreportedUnresolvedStatuses(
-            List.of(round2, round1), List.of(), comments, resolver, BOT);
+            List.of(round2, round1), List.of(), comments, resolver, BOT_ID);
 
     // One of the cluster members has a reply → entire cluster is considered replied → empty held
     // list.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSessionPersistence;
@@ -48,6 +49,10 @@ import org.mockito.MockitoAnnotations;
 class ReviewOrchestratorTest {
 
   private static final String SESSION_URL = "https://bot.example/session/test-public-id";
+
+  // The bot login this test deployment runs under; the orchestrator resolves it from config.
+  private static final String BOT_LOGIN = "thrillhousebot[bot]";
+  private static final BotIdentity BOT_ID = BotIdentity.of(BOT_LOGIN);
 
   @Mock private ThrillhouseConfig config;
 
@@ -98,6 +103,11 @@ class ReviewOrchestratorTest {
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
+    // The orchestrator resolves its BotIdentity from config in the constructor, so stub github()
+    // before building it.
+    ThrillhouseConfig.GitHubConfig githubConfig = mock(ThrillhouseConfig.GitHubConfig.class);
+    when(config.github()).thenReturn(githubConfig);
+    when(githubConfig.botLogins()).thenReturn(List.of(BOT_LOGIN));
     diffFormatter = new ReviewDiffFormatter(List.of(), 5000);
     orchestrator = newOrchestrator(mapper);
     when(config.review()).thenReturn(reviewConfig);
@@ -124,7 +134,7 @@ class ReviewOrchestratorTest {
     // The verifier and dedup pass findings through untouched unless a test overrides them
     when(findingVerificationService.verify(any(), any(), any(), any()))
         .thenAnswer(invocation -> invocation.getArgument(0));
-    when(followUpAnalyzer.dropRepliedDuplicates(any(), any(), any(), anyString()))
+    when(followUpAnalyzer.dropRepliedDuplicates(any(), any(), any(), any()))
         .thenAnswer(invocation -> invocation.getArgument(0));
     when(reviewClient.createPullRequestComment(
             anyString(), anyString(), anyString(), anyString(), anyInt(), any()))
@@ -1498,8 +1508,7 @@ class ReviewOrchestratorTest {
                         new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]"))));
         when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
             .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
-        when(followUpAnalyzer.buildPreviousFindingsContext(
-                any(), any(), any(), any(), eq("thrillhousebot[bot]")))
+        when(followUpAnalyzer.buildPreviousFindingsContext(any(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn("Previous finding context");
         // Two prior rounds: the newest becomes the numbered context, the rest the history
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
@@ -1533,17 +1542,10 @@ class ReviewOrchestratorTest {
         // The newest prior round feeds the numbered context; the older ones the answered list
         verify(followUpAnalyzer)
             .buildPreviousFindingsContext(
-                eq("{\"round\":2}"),
-                any(),
-                any(),
-                eq(List.of("{\"round\":1}")),
-                eq("thrillhousebot[bot]"));
+                eq("{\"round\":2}"), any(), any(), eq(List.of("{\"round\":1}")), eq(BOT_ID));
         verify(followUpAnalyzer)
             .dropRepliedDuplicates(
-                any(),
-                eq(List.of("{\"round\":2}", "{\"round\":1}")),
-                any(),
-                eq("thrillhousebot[bot]"));
+                any(), eq(List.of("{\"round\":2}", "{\"round\":1}")), any(), eq(BOT_ID));
         verify(session).setStatus(ReviewSession.STATUS_COMPLETED);
       }
     }
@@ -3216,15 +3218,13 @@ class ReviewOrchestratorTest {
                         new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]"))));
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
-        when(followUpAnalyzer.buildPreviousFindingsContext(
-                any(), any(), any(), any(), eq("thrillhousebot[bot]")))
+        when(followUpAnalyzer.buildPreviousFindingsContext(any(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn("1. [MEDIUM] src/Main.java:10 — Dropped finding");
         // The model silently drops the still-open prior finding: no new findings, empty status.
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
         // The deterministic backstop reconstructs it as unresolved from persistence.
-        when(followUpAnalyzer.unreportedUnresolvedStatuses(
-                any(), any(), any(), any(), eq("thrillhousebot[bot]")))
+        when(followUpAnalyzer.unreportedUnresolvedStatuses(any(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn(
                 List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still present")));
 
@@ -3250,8 +3250,7 @@ class ReviewOrchestratorTest {
         // its findings — context must still be reconstructed for follow-up analysis. (#118)
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
-        when(followUpAnalyzer.buildPreviousFindingsContext(
-                any(), any(), any(), any(), eq("thrillhousebot[bot]")))
+        when(followUpAnalyzer.buildPreviousFindingsContext(any(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn("previous context");
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -3260,7 +3259,7 @@ class ReviewOrchestratorTest {
 
         // Previous-findings context IS reconstructed without any formal bot review
         verify(followUpAnalyzer)
-            .buildPreviousFindingsContext(any(), any(), any(), any(), eq("thrillhousebot[bot]"));
+            .buildPreviousFindingsContext(any(), any(), any(), any(), eq(BOT_ID));
       }
     }
 
@@ -3275,8 +3274,7 @@ class ReviewOrchestratorTest {
         // The summary must still be posted: isFirstVisibleReview is true. (#134)
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
-        when(followUpAnalyzer.buildPreviousFindingsContext(
-                any(), any(), any(), any(), eq("thrillhousebot[bot]")))
+        when(followUpAnalyzer.buildPreviousFindingsContext(any(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn("previous context");
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -3296,7 +3294,7 @@ class ReviewOrchestratorTest {
                 argThat(req -> req.body().contains("ThrillhouseBot PR Summary")));
         // Context IS still loaded from persistence
         verify(followUpAnalyzer)
-            .buildPreviousFindingsContext(any(), any(), any(), any(), eq("thrillhousebot[bot]"));
+            .buildPreviousFindingsContext(any(), any(), any(), any(), eq(BOT_ID));
       }
     }
 
@@ -3362,7 +3360,7 @@ class ReviewOrchestratorTest {
               new ReviewResponse.PreviousFindingStatus(2, "justified", "intentional"),
               new ReviewResponse.PreviousFindingStatus(3, "unresolved", "still"),
               new ReviewResponse.PreviousFindingStatus(4, "resolved", "fixed"));
-      when(followUpAnalyzer.matchFindingThreads(any(), any(), anyString()))
+      when(followUpAnalyzer.matchFindingThreads(any(), any(), any()))
           .thenReturn(Map.of(1, 100L, 2, 200L, 3, 300L, 4, 400L));
       when(reviewThreadService.threadsByRootComment(AUTH, "owner", "repo", 5))
           .thenReturn(
@@ -3387,7 +3385,7 @@ class ReviewOrchestratorTest {
     @Test
     void shouldSkipFindingsWithoutAMatchedThread() {
       var statuses = List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed"));
-      when(followUpAnalyzer.matchFindingThreads(any(), any(), anyString())).thenReturn(Map.of());
+      when(followUpAnalyzer.matchFindingThreads(any(), any(), any())).thenReturn(Map.of());
       when(reviewThreadService.threadsByRootComment(AUTH, "owner", "repo", 5)).thenReturn(Map.of());
 
       orchestrator.resolveAddressedThreads(AUTH, request(), "{}", List.of(rootComment()), statuses);
@@ -3411,8 +3409,7 @@ class ReviewOrchestratorTest {
     @Test
     void shouldSwallowThreadResolutionFailures() {
       var statuses = List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed"));
-      when(followUpAnalyzer.matchFindingThreads(any(), any(), anyString()))
-          .thenReturn(Map.of(1, 100L));
+      when(followUpAnalyzer.matchFindingThreads(any(), any(), any())).thenReturn(Map.of(1, 100L));
       when(reviewThreadService.threadsByRootComment(
               anyString(), anyString(), anyString(), anyInt()))
           .thenThrow(new RuntimeException("graphql down"));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -1839,17 +1839,18 @@ class ReviewOrchestratorTest {
     void shouldDismissPendingBotReviews() {
       var pending =
           new GitHubReviewClient.ReviewResponse(
-              99L,
-              "",
-              "PENDING",
-              "sha",
-              new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]"));
+              99L, "", "PENDING", "sha", new GitHubReviewClient.ReviewResponse.User(BOT_LOGIN));
       var approved =
           new GitHubReviewClient.ReviewResponse(
               1L, "", "APPROVED", "sha", new GitHubReviewClient.ReviewResponse.User("other-user"));
+      // A pending review by a human must be left alone: state is PENDING but the author is not the
+      // bot, so only the bot-identity check (not the state check) keeps it.
+      var pendingHuman =
+          new GitHubReviewClient.ReviewResponse(
+              2L, "", "PENDING", "sha", new GitHubReviewClient.ReviewResponse.User("other-user"));
 
       when(reviewClient.listReviews(anyString(), anyString(), anyString(), anyString(), anyInt()))
-          .thenReturn(List.of(pending, approved));
+          .thenReturn(List.of(pending, approved, pendingHuman));
 
       orchestrator.dismissPendingBotReviews("Bearer tok", "owner", "repo", 7);
 
@@ -1859,6 +1860,9 @@ class ReviewOrchestratorTest {
       verify(reviewClient, never())
           .deletePendingReview(
               anyString(), anyString(), anyString(), anyString(), anyInt(), eq(1L));
+      verify(reviewClient, never())
+          .deletePendingReview(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), eq(2L));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔧 Refactor

## Description

`GITHUB_BOT_LOGINS` was only half-wired. `TriggerDetector.isBotComment` honored the configurable `botLogins` (default lists both `thrillhousebot[bot]` and `thrillhouse-bot[bot]`), but `ReviewOrchestrator` still hardcoded `BOT_LOGIN = "thrillhousebot[bot]"` in **8 places** — first-review detection, the #183 summary-comment dedup (`botSummaryCommentExists`), all #118 follow-up finding matching, and pending-review dismissal.

Consequence: when the App is deployed under the alternate slug `thrillhouse-bot[bot]` — a default the README explicitly promises works — summary dedup, prior-review detection, and the entire follow-up-tracking machinery silently broke, producing **duplicate summary comments and re-raised resolved findings**. The advertised #165 fix was incomplete.

### Fix

Rather than scatter the config read across classes (which is how they drifted out of sync in the first place), this introduces one shared value object so the trigger filter and the review pipeline can never again disagree on who the bot is:

- **New `BotIdentity`** — normalizes the configured login(s) (trim, lower-case, blank-drop), never stores an empty set (an empty set would make the bot answer its own comments in a loop, so it falls back to the defaults), and exposes `matches(login)`.
- **`TriggerDetector`** — refactored to delegate to `BotIdentity`; behavior identical, public API unchanged.
- **`ReviewOrchestrator`** — resolves a `BotIdentity` once from `config.github().botLogins()` and matches against the whole configured set instead of one hardcoded slug, in all 8 spots.
- **`FollowUpAnalyzer`** — the `String botLogin` parameter became `BotIdentity botIdentity`; author comparisons now use case-insensitive set membership.
- **`ThrillhouseConfig.botLogins()`** — javadoc broadened; the prior under-documentation ("skip the bot's own comments") is exactly what masked that it also governs dedup and follow-up tracking.

`THRILLHOUSEBOT_TOKEN` (CI check-name matching) is intentionally left as-is — it matches the bot's own hardcoded check name, not comment authorship, so it's unaffected by the deployment slug.

## Related Issues

Completes #165 (the bot-login configurability fix that was only partially applied).

## How Has This Been Tested?

- [x] Unit tests

- Full unit suite: **1203 tests, 0 failures** (run with JaCoCo disabled per this checkout's SMB file-locking constraint).
- New `BotIdentityTest` (6 tests): case-insensitivity, trim/dedup, null login, and the never-empty fallback (null / empty / all-blank inputs).
- Updated `FollowUpAnalyzerTest` (80) and `ReviewOrchestratorTest` (168) to pass a `BotIdentity`; the orchestrator test now stubs `config.github().botLogins()`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

SpotBugs runs in CI's `verify` (which can't run locally here due to the JaCoCo/SMB crash). `BotIdentity` mirrors the existing `VerificationResponse` record precedent — `Set.copyOf` on the stored component — so `EI_EXPOSE_REP` shouldn't trigger and no exclude is needed.
