### PR TITLE
fix(reply): only answer review comments that explicitly @-mention the bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ code review.
 - Inline code suggestions on review comments that you can apply with one click
 - Every finding is tagged `critical`, `high`, `medium`, or `low`
 - Follow-up reviews track whether earlier findings were addressed or justified
-- Conversational replies: reply to a finding or `@thrillhousebot` it in a PR thread and the bot answers in context
+- Conversational replies: `@thrillhousebot` it in a PR thread or finding reply and the bot answers in context
 - A summary comment on the first run, with a risk breakdown
 - Operable from the PR with comment commands — `/help`, `/review`, `/summary`, `/resolve`, `/pause`, `/resume`
 - Live dashboard (Next.js) with a WebSocket activity feed, cost charts, and token tracking
@@ -190,7 +190,7 @@ variables are the ones you will change per provider:
 | `WEBHOOK_EXCLUDED_LABELS` | Comma-separated labels; skip auto-review of PRs carrying any (wins over required) | _(empty)_ |
 | `WEBHOOK_BASE_BRANCHES` | Comma-separated globs; only auto-review PRs whose base branch matches one (e.g. `main,release/*`). Globs are gitignore-style: `*` does **not** cross `/`, so use `**` to span slashes (`**` alone matches every branch) | _(empty — all branches)_ |
 | `WEBHOOK_IGNORED_BASE_BRANCHES` | Comma-separated globs; skip auto-review of PRs whose base branch matches one (wins over allowlist; same `*`/`**` rule — match nested branches with `**`, e.g. `dependabot/**`) | _(empty)_ |
-| `REVIEW_CONVERSATIONAL_REPLIES_ENABLED` | Answer maintainer replies to findings and `@thrillhousebot` mentions in PR threads with an AI reply | `true` |
+| `REVIEW_CONVERSATIONAL_REPLIES_ENABLED` | Answer `@thrillhousebot` mentions in PR threads (including finding replies) with an AI reply | `true` |
 | `REVIEW_LABELS_ENABLED` | Opt in to context-aware PR labels (see [PR labels](#pr-labels)) | `false` |
 | `REVIEW_LABELS_APPLY` | When labels are enabled, add them to the PR instead of only suggesting them in a comment | `false` |
 | `REVIEW_LABELS_ALLOW_CREATE` | Allow the bot to create suggested labels that don't exist yet | `false` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -150,7 +150,7 @@ sequenceDiagram
     Note over TB: Full re-review even if this SHA was already reviewed
 ```
 
-### Conversational reply (reply to a finding or `@thrillhousebot` mention)
+### Conversational reply (`@thrillhousebot` mention)
 
 ```mermaid
 sequenceDiagram
@@ -158,10 +158,10 @@ sequenceDiagram
     participant GH as GitHub
     participant TB as ThrillhouseBot
 
-    Dev->>GH: Replies to a finding / mentions @thrillhousebot
+    Dev->>GH: Mentions @thrillhousebot (in a PR thread or finding reply)
     GH->>TB: POST /api/webhook (pull_request_review_comment or issue_comment: created)
 
-    Note over TB: Bot-loop guard → mention/reply detected → ACK 200
+    Note over TB: Bot-loop guard → mention detected → ACK 200
     Note over TB: Async on review executor: authorize (write access)
     Note over TB: Build threaded prompt (finding + diff hunk + thread)
     TB->>GH: POST reply in the review thread (or a PR comment)

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -324,9 +324,9 @@ public class WebhookController {
   }
 
   /**
-   * Handles {@code pull_request_review_comment} events — a maintainer replying inside an inline
-   * review thread, or mentioning the bot on a diff line. A reply on the bot's own finding thread
-   * (or any inline comment mentioning the bot) gets a contextual answer.
+   * Handles {@code pull_request_review_comment} events — a maintainer mentioning the bot on a diff
+   * line or inside an inline review thread. Only an explicit {@code @}-mention gets a contextual
+   * answer; a bare reply (even on the bot's own finding thread) is ignored.
    *
    * @return {@code false} only when a reply was attempted but the dispatcher rejected it (so the
    *     dedup slot should be rolled back); {@code true} when the event was handled or ignored.
@@ -358,12 +358,10 @@ public class WebhookController {
       return true;
     }
 
-    boolean mentioned = triggerDetector.containsBotMention(comment.body());
-    boolean isReply = comment.inReplyToId() != null;
-    // Only a reply (possibly to the bot's finding — confirmed downstream) or an explicit mention is
-    // addressed to the bot; a brand-new inline comment from a human is not.
-    if (!mentioned && !isReply) {
-      log.debug("Ignoring review comment that neither replies to a thread nor mentions the bot");
+    // Only an explicit @-mention addresses the bot; a bare reply on a thread (even the bot's own
+    // finding) must not pull it in.
+    if (!triggerDetector.containsBotMention(comment.body())) {
+      log.debug("Ignoring review comment that does not mention the bot");
       return true;
     }
 
@@ -377,8 +375,9 @@ public class WebhookController {
       return true;
     }
 
-    // The thread root is the reply target; a top-level comment that mentions the bot is its own
-    // root.
+    // The thread root is the reply target; a mention that is itself a reply targets the thread it
+    // replies to, otherwise the mention comment is its own root.
+    boolean isReply = comment.inReplyToId() != null;
     Long rootCommentId = isReply ? comment.inReplyToId() : comment.id();
     log.info(
         "Conversational review-thread reply from @{} on PR #{}",
@@ -398,7 +397,7 @@ public class WebhookController {
             true,
             rootCommentId,
             comment.id(),
-            mentioned,
+            true,
             comment.diffHunk()));
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -701,15 +701,24 @@ class WebhookControllerTest {
   }
 
   @Test
-  void shouldDispatchReplyForReviewCommentReply() {
+  void shouldDispatchReplyForReviewCommentMentionInReply() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
     when(triggerDetector.isBotComment("octocat")).thenReturn(false);
-    when(triggerDetector.containsBotMention("Why is this flagged?")).thenReturn(false);
+    when(triggerDetector.containsBotMention("@thrillhousebot why is this flagged?"))
+        .thenReturn(true);
     when(replyDispatcher.dispatch(any(MaintainerReplyService.ReplyTask.class))).thenReturn(true);
 
+    // A mention that is itself a reply targets the thread root it replies to (in_reply_to_id 99),
+    // not the mention comment.
     var body =
         buildReviewCommentPayload(
-                "created", 42, "owner/repo", "octocat", "Why is this flagged?", 99L, 1000L)
+                "created",
+                42,
+                "owner/repo",
+                "octocat",
+                "@thrillhousebot why is this flagged?",
+                99L,
+                1000L)
             .getBytes(StandardCharsets.UTF_8);
 
     var response =
@@ -726,13 +735,13 @@ class WebhookControllerTest {
                 12345L,
                 "octocat",
                 "OWNER",
-                "Why is this flagged?",
+                "@thrillhousebot why is this flagged?",
                 "PR Title",
                 "PR body",
                 true,
                 99L,
                 1000L,
-                false,
+                true,
                 "@@ -1 +1 @@"));
   }
 
@@ -777,12 +786,20 @@ class WebhookControllerTest {
   void shouldSkipReviewCommentReplyOnPausedPr() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
     when(triggerDetector.isBotComment("octocat")).thenReturn(false);
-    when(triggerDetector.containsBotMention("Why is this flagged?")).thenReturn(false);
+    when(triggerDetector.containsBotMention("@thrillhousebot why is this flagged?"))
+        .thenReturn(true);
     when(prPauseService.isPaused("owner", "repo", 42)).thenReturn(true);
 
+    // A mention clears the trigger gate; the pause check is what must suppress the reply here.
     var body =
         buildReviewCommentPayload(
-                "created", 42, "owner/repo", "octocat", "Why is this flagged?", 99L, 1000L)
+                "created",
+                42,
+                "owner/repo",
+                "octocat",
+                "@thrillhousebot why is this flagged?",
+                99L,
+                1000L)
             .getBytes(StandardCharsets.UTF_8);
 
     var response =
@@ -827,6 +844,15 @@ class WebhookControllerTest {
           TriggerDetector triggerDetector, ThrillhouseConfig.ReviewConfig reviewConfig) {
         when(triggerDetector.isBotComment("octocat")).thenReturn(false);
         when(triggerDetector.containsBotMention("looks good")).thenReturn(false);
+      }
+    },
+    // A bare reply (even on the bot's finding thread) without a mention must not pull the bot in.
+    REPLY_WITHOUT_MENTION("octocat", "Why is this flagged?", 99L, 1000L) {
+      @Override
+      void applySetup(
+          TriggerDetector triggerDetector, ThrillhouseConfig.ReviewConfig reviewConfig) {
+        when(triggerDetector.isBotComment("octocat")).thenReturn(false);
+        when(triggerDetector.containsBotMention("Why is this flagged?")).thenReturn(false);
       }
     },
     OWN_COMMENT("thrillhousebot[bot]", "follow-up", 99L, 4000L) {


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The bot was replying to review-thread comments that did **not** mention it. The `pull_request_review_comment` trigger in `WebhookController.handleReviewComment` fired on an **OR** condition — an explicit `@`-mention *or* any reply on a thread. So when a maintainer replied to one of the bot's own findings (e.g. "verified against the docs, keeping as-is"), the reply pulled the bot back into the conversation even though no one addressed it.

This change gates the review-comment path on an **explicit `@`-mention only**:

- A bare reply on a thread (even the bot's own finding thread) is now ignored.
- A mention that is itself a reply still targets the thread root, so the answer lands in-thread with the original finding included as context.
- The top-level PR-comment path (`maybeDispatchConversationalMention`) already required a mention, so its behavior is unchanged.
- `MaintainerReplyService` is untouched — the webhook is the single entry point and now only ever dispatches mention-triggered tasks.

Docs (`README.md`, `docs/ARCHITECTURE.md`) updated to describe the mention-only behavior.

## Related Issues

N/A — observed on devops-thiago/ThrillhouseBot#198 (the bot conceded on a finding reply that did not mention it).

## How Has This Been Tested?

- [x] Unit tests

`WebhookControllerTest` + `MaintainerReplyServiceTest` — **79 tests, 0 failures** (run locally with JaCoCo disabled due to the SMB-mount file-lock constraint).

- Converted the old "bare reply dispatches" test into `shouldDispatchReplyForReviewCommentMentionInReply` (a mention that is a reply targets the thread root).
- Added a `REPLY_WITHOUT_MENTION` ignore scenario covering the exact regression: a reply on the bot's finding thread with no mention is no longer answered.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

This only affects future webhook deliveries; it does not alter any existing PR thread. No config or behavioral change for the `@thrillhousebot` mention flow.
