### PR TITLE
perf(review): pre-filter human-to-human inline replies before the paginated fetch + auth

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -72,6 +72,21 @@ public interface GitHubReviewClient {
       @QueryParam("per_page") int perPage,
       @QueryParam("page") int page);
 
+  /**
+   * Fetches a single review comment by id. A cheap one-call alternative to paging the whole
+   * review-comment list when a caller only needs the one comment (e.g. resolving a thread's root
+   * author before deciding whether heavier work is warranted).
+   */
+  @GET
+  @Path("/repos/{owner}/{repo}/pulls/comments/{commentId}")
+  @Produces(MediaType.APPLICATION_JSON)
+  PullRequestComment getReviewComment(
+      @HeaderParam("Authorization") String auth,
+      @HeaderParam("Accept") String accept,
+      @PathParam("owner") String owner,
+      @PathParam("repo") String repo,
+      @PathParam("commentId") long commentId);
+
   @POST
   @Path("/repos/{owner}/{repo}/pulls/{pullNumber}/comments")
   @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
@@ -121,22 +121,10 @@ public class MaintainerReplyService {
   @ActivateRequestContext
   public void handle(ReplyTask task) {
     try {
-      if (!authorizer.isAuthorized(
-          task.owner(),
-          task.repo(),
-          task.installationId(),
-          task.commenterLogin(),
-          task.authorAssociation())) {
-        Log.infof(
-            "Ignoring conversational reply request from @%s on %s/%s #%d — not authorized",
-            task.commenterLogin(), task.owner(), task.repo(), task.prNumber());
-        return;
-      }
-      var auth = authClient.getAuthHeader(task.installationId());
       if (task.reviewThread()) {
-        handleReviewThreadReply(auth, task);
+        handleReviewThreadReply(task);
       } else {
-        handleMention(auth, task);
+        handleMention(task);
       }
     } catch (RuntimeException e) {
       Log.warnf(
@@ -148,25 +136,33 @@ public class MaintainerReplyService {
     }
   }
 
-  private void handleReviewThreadReply(String auth, ReplyTask task) {
-    var comments = listReviewComments(auth, task);
-    var root = findRoot(comments, task.rootCommentId());
-    boolean rootIsBot =
-        root != null && root.user() != null && triggerDetector.isBotComment(root.user().login());
+  private void handleReviewThreadReply(ReplyTask task) {
+    if (task.rootCommentId() == null) {
+      Log.debugf("Skipping review-thread reply with no resolvable root comment");
+      return;
+    }
+    var auth = authClient.getAuthHeader(task.installationId());
+
     // Only answer when the maintainer is actually addressing the bot: a reply on the bot's own
     // finding thread, or an explicit mention. A reply between two humans on a human-started thread
-    // must not pull the bot in.
-    if (!task.mentioned() && !rootIsBot) {
+    // must not pull the bot in. For the no-mention case, resolve "is this the bot's thread?" with a
+    // single GET on the root comment and bail here — before the authorizer round-trip and the
+    // paginated comment list — so human-to-human replies on busy PRs don't amplify GitHub API
+    // traffic.
+    if (!task.mentioned() && !rootCommentIsBot(auth, task)) {
       Log.debugf(
           "Skipping review-thread reply on %s/%s #%d — not a bot thread and no mention",
           task.owner(), task.repo(), task.prNumber());
       return;
     }
-    if (task.rootCommentId() == null) {
-      Log.debugf("Skipping review-thread reply with no resolvable root comment");
+    if (!authorized(task)) {
       return;
     }
 
+    var comments = listReviewComments(auth, task);
+    var root = findRoot(comments, task.rootCommentId());
+    boolean rootIsBot =
+        root != null && root.user() != null && triggerDetector.isBotComment(root.user().login());
     String finding = rootIsBot ? root.body() : "";
     String thread = renderThread(comments, task.rootCommentId(), task.triggeringCommentId());
 
@@ -193,7 +189,11 @@ public class MaintainerReplyService {
         task.rootCommentId(), task.owner(), task.repo(), task.prNumber());
   }
 
-  private void handleMention(String auth, ReplyTask task) {
+  private void handleMention(ReplyTask task) {
+    if (!authorized(task)) {
+      return;
+    }
+    var auth = authClient.getAuthHeader(task.installationId());
     String reply =
         generateReply(task.question(), buildPrContext(task), "", fetchDiff(auth, task), "");
     if (reply == null) {
@@ -209,6 +209,44 @@ public class MaintainerReplyService {
     Log.infof(
         "Posted conversational reply to mention on %s/%s #%d",
         task.owner(), task.repo(), task.prNumber());
+  }
+
+  /**
+   * Confirms the commenter may spend the operator's API/AI budget on a reply, logging a rejection.
+   * A bot-thread reply still has to clear this gate before the bot posts anything back.
+   */
+  private boolean authorized(ReplyTask task) {
+    if (authorizer.isAuthorized(
+        task.owner(),
+        task.repo(),
+        task.installationId(),
+        task.commenterLogin(),
+        task.authorAssociation())) {
+      return true;
+    }
+    Log.infof(
+        "Ignoring conversational reply request from @%s on %s/%s #%d — not authorized",
+        task.commenterLogin(), task.owner(), task.repo(), task.prNumber());
+    return false;
+  }
+
+  /**
+   * Cheap pre-filter: fetches only the thread's root comment to decide whether it is one of the
+   * bot's own findings, instead of paging the entire review-comment list. Fails soft — a root that
+   * cannot be fetched is treated as not the bot's, so an unmentioned reply on it is left alone.
+   */
+  private boolean rootCommentIsBot(String auth, ReplyTask task) {
+    GitHubReviewClient.PullRequestComment root;
+    try {
+      root =
+          reviewClient.getReviewComment(
+              auth, ACCEPT, task.owner(), task.repo(), task.rootCommentId());
+    } catch (RuntimeException e) {
+      Log.warn(
+          "Failed to fetch review-thread root comment for pre-filter — treating as non-bot", e);
+      return false;
+    }
+    return root != null && root.user() != null && triggerDetector.isBotComment(root.user().login());
   }
 
   /** Calls the assistant with already-raw inputs, escaping each for templating. Null on failure. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
@@ -558,6 +558,27 @@ class MaintainerReplyServiceTest {
   }
 
   @Test
+  void mentionWhereListRootHasNullAuthorCitesNoFinding() {
+    authorize();
+    // A mention bypasses the pre-filter, so the listed root is consulted for the finding. Its
+    // author is unknown (e.g. deleted account), so it is not treated as a bot finding — the reply
+    // still posts, but with no finding text.
+    when(reviewClient.listPullRequestComments(
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+        .thenReturn(List.of(commentNoUser(99L, null, "author is null")));
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("ok");
+
+    service.handle(reviewThreadTask(true));
+
+    var finding = ArgumentCaptor.forClass(String.class);
+    verify(replyAssistant).reply(any(), any(), finding.capture(), any(), any());
+    assertTrue(finding.getValue() == null || finding.getValue().isEmpty());
+    verify(reviewClient)
+        .replyToReviewComment(
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), eq(99L), any());
+  }
+
+  @Test
   void nullAssistantReplyPostsNothing() {
     authorize();
     stubRootComment(comment(99L, null, BOT, "**HIGH — bug**"));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
@@ -80,6 +80,16 @@ class MaintainerReplyServiceTest {
     return new GitHubReviewClient.PullRequestComment(id, inReplyToId, "src/Foo.java", body, null);
   }
 
+  /**
+   * Stubs the cheap single-GET pre-filter to return {@code root} as the thread's root comment, so
+   * an unmentioned review-thread reply gets past the bot-thread check and on to the heavier work.
+   */
+  private void stubRootComment(GitHubReviewClient.PullRequestComment root) {
+    when(reviewClient.getReviewComment(
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(root.id())))
+        .thenReturn(root);
+  }
+
   private MaintainerReplyService.ReplyTask reviewThreadTask(boolean mentioned) {
     return new MaintainerReplyService.ReplyTask(
         "owner",
@@ -121,18 +131,68 @@ class MaintainerReplyServiceTest {
   }
 
   @Test
-  void unauthorizedRequestPostsNothing() {
+  void unauthorizedMentionPostsNothing() {
     when(authorizer.isAuthorized(any(), any(), anyLong(), any(), any())).thenReturn(false);
 
-    service.handle(reviewThreadTask(false));
+    service.handle(mentionTask());
 
+    // The mention path rejects before minting a token or touching any GitHub client.
     verifyNoInteractions(reviewClient, commentClient, replyAssistant);
     verify(authClient, never()).getAuthHeader(anyLong());
   }
 
   @Test
+  void unauthorizedMentionedReviewReplyPostsNothing() {
+    when(authorizer.isAuthorized(any(), any(), anyLong(), any(), any())).thenReturn(false);
+
+    // An explicit mention skips the bot-thread pre-filter, so the authorizer is the gate; once it
+    // denies, the bot must not list comments or post anything.
+    service.handle(reviewThreadTask(true));
+
+    verifyNoInteractions(replyAssistant, commentClient);
+    verify(reviewClient, never())
+        .listPullRequestComments(any(), any(), any(), any(), anyInt(), anyInt(), anyInt());
+    verify(reviewClient, never())
+        .replyToReviewComment(any(), any(), any(), any(), anyInt(), anyLong(), any());
+  }
+
+  @Test
+  void unmentionedReplyOnHumanThreadSkipsBeforeListingAndAuthorizing() {
+    // The cheap single-GET pre-filter sees a human-authored root and bails before the authorizer
+    // round-trip and the paginated comment list — a human-to-human reply must not amplify API
+    // traffic.
+    stubRootComment(comment(99L, null, "someone", "I think this is wrong"));
+
+    service.handle(reviewThreadTask(false));
+
+    verify(reviewClient).getReviewComment(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(99L));
+    verify(reviewClient, never())
+        .listPullRequestComments(any(), any(), any(), any(), anyInt(), anyInt(), anyInt());
+    verifyNoInteractions(authorizer, replyAssistant, commentClient);
+    verify(reviewClient, never())
+        .replyToReviewComment(any(), any(), any(), any(), anyInt(), anyLong(), any());
+  }
+
+  @Test
+  void preFilterFailSoftSkipsWhenRootFetchThrows() {
+    // If the single-GET root lookup fails, an unmentioned reply is treated as not-the-bot's thread
+    // and left alone rather than falling through to the expensive list.
+    when(reviewClient.getReviewComment(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(99L)))
+        .thenThrow(new RuntimeException("GitHub 503"));
+
+    service.handle(reviewThreadTask(false));
+
+    verify(reviewClient, never())
+        .listPullRequestComments(any(), any(), any(), any(), anyInt(), anyInt(), anyInt());
+    verifyNoInteractions(replyAssistant);
+    verify(reviewClient, never())
+        .replyToReviewComment(any(), any(), any(), any(), anyInt(), anyLong(), any());
+  }
+
+  @Test
   void replyOnBotThreadPostsAnswerWithFindingAndPriorRepliesAsContext() {
     authorize();
+    stubRootComment(comment(99L, null, BOT, "**CRITICAL — possible NPE** on user lookup"));
     when(reviewClient.listPullRequestComments(
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(
@@ -179,6 +239,7 @@ class MaintainerReplyServiceTest {
   @Test
   void walksAllCommentPagesToFindARootBeyondTheFirstPage() {
     authorize();
+    stubRootComment(comment(99L, null, BOT, "**finding** on page two"));
     // Page 1 is full (100 comments) so a second page is fetched; the bot finding root is on page 2.
     var firstPage = new ArrayList<GitHubReviewClient.PullRequestComment>();
     for (int i = 0; i < 100; i++) {
@@ -204,23 +265,25 @@ class MaintainerReplyServiceTest {
   }
 
   @Test
-  void nullCommentPageIsTreatedAsEmptyAndPostsNothing() {
+  void unmentionedReplyWithUnresolvableRootPostsNothing() {
     authorize();
-    when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+    // The single-GET pre-filter returns null (e.g. the root was deleted), so a non-mention reply is
+    // treated as not the bot's thread and the bot stays silent without paging the comment list.
+    when(reviewClient.getReviewComment(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(99L)))
         .thenReturn(null);
 
     service.handle(reviewThreadTask(false));
 
-    // No comments resolve a root, and the reply was not an explicit mention, so the bot stays
-    // silent.
     verifyNoInteractions(replyAssistant);
+    verify(reviewClient, never())
+        .listPullRequestComments(any(), any(), any(), any(), anyInt(), anyInt(), anyInt());
   }
 
   @Test
   void stopsAtTheCommentPageBoundOnAVeryLongThread() {
     authorize();
-    // Every page is full, so only the page bound can stop the walk.
+    // Every page is full, so only the page bound can stop the walk. Use an explicit mention so the
+    // bot-thread pre-filter is bypassed and the full paginated walk is exercised.
     var fullPage = new ArrayList<GitHubReviewClient.PullRequestComment>();
     for (int i = 0; i < 100; i++) {
       fullPage.add(comment(3000L + i, 88L, "octocat", "noise " + i));
@@ -229,7 +292,7 @@ class MaintainerReplyServiceTest {
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(fullPage);
 
-    service.handle(reviewThreadTask(false));
+    service.handle(reviewThreadTask(true));
 
     verify(reviewClient, times(10))
         .listPullRequestComments(
@@ -239,12 +302,8 @@ class MaintainerReplyServiceTest {
   @Test
   void replyOnHumanThreadWithoutMentionPostsNothing() {
     authorize();
-    when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
-        .thenReturn(
-            List.of(
-                comment(99L, null, "someone", "I think this is wrong"),
-                comment(1000L, 99L, "octocat", "Why is this flagged?")));
+    // The thread root is human-authored, so the pre-filter leaves an unmentioned reply alone.
+    stubRootComment(comment(99L, null, "someone", "I think this is wrong"));
 
     service.handle(reviewThreadTask(false));
 
@@ -298,6 +357,7 @@ class MaintainerReplyServiceTest {
   @Test
   void blankAssistantReplyPostsNothing() {
     authorize();
+    stubRootComment(comment(99L, null, BOT, "**HIGH — bug**"));
     when(reviewClient.listPullRequestComments(
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
@@ -312,6 +372,7 @@ class MaintainerReplyServiceTest {
   @Test
   void assistantFailureIsSwallowed() {
     authorize();
+    stubRootComment(comment(99L, null, BOT, "**HIGH — bug**"));
     when(reviewClient.listPullRequestComments(
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
@@ -405,6 +466,7 @@ class MaintainerReplyServiceTest {
   @Test
   void postFailureIsSwallowedByOuterHandler() {
     authorize();
+    stubRootComment(comment(99L, null, BOT, "**HIGH — bug**"));
     when(reviewClient.listPullRequestComments(
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
@@ -433,6 +495,7 @@ class MaintainerReplyServiceTest {
   @Test
   void botThreadReplyWithNullDiffHunkSendsEmptyCodeContext() {
     authorize();
+    stubRootComment(comment(99L, null, BOT, "**HIGH — bug**"));
     when(reviewClient.listPullRequestComments(
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
@@ -455,6 +518,7 @@ class MaintainerReplyServiceTest {
   @Test
   void threadRenderingSkipsOtherThreadsAndHandlesAnonymousReplies() {
     authorize();
+    stubRootComment(comment(99L, null, BOT, "**finding**"));
     when(reviewClient.listPullRequestComments(
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(
@@ -483,10 +547,8 @@ class MaintainerReplyServiceTest {
   void rootWithNullAuthorIsNotTreatedAsBotThread() {
     authorize();
     // The root exists but its author is unknown (e.g. deleted account): it must not count as the
-    // bot's thread, so an unmentioned reply on it is left alone.
-    when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
-        .thenReturn(List.of(commentNoUser(99L, null, "author is null")));
+    // bot's thread, so an unmentioned reply on it is left alone by the pre-filter.
+    stubRootComment(commentNoUser(99L, null, "author is null"));
 
     service.handle(reviewThreadTask(false));
 
@@ -498,6 +560,7 @@ class MaintainerReplyServiceTest {
   @Test
   void nullAssistantReplyPostsNothing() {
     authorize();
+    stubRootComment(comment(99L, null, BOT, "**HIGH — bug**"));
     when(reviewClient.listPullRequestComments(
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
@@ -529,6 +592,7 @@ class MaintainerReplyServiceTest {
   @Test
   void findRootScansPastNonMatchingComments() {
     authorize();
+    stubRootComment(comment(99L, null, BOT, "**finding**"));
     // The root is not first in the list, so the id filter must skip a non-matching comment first.
     when(reviewClient.listPullRequestComments(
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))


### PR DESCRIPTION
## What type of PR is this?

- [x] 🚀 Performance
- [x] ✅ Test

## Description

On a watched PR, **every** inline review-comment reply (`comment.inReplyToId != null`) was dispatched to `MaintainerReplyService`, which then ran the authorizer (a collaborator-permission API call) **and** walked up to 10 paginated pages of the review-comments API — only *then* discovering the thread is human-to-human with no `@thrillhousebot` mention, and posting nothing. So two maintainers chatting on a human-started inline thread cost ~1 auth round-trip + up to 10 list calls per reply, for zero output — meaningful GitHub REST rate-limit and cost amplification on busy PRs.

This adds a cheap pre-filter to the review-thread path:

- New `GitHubReviewClient.getReviewComment(...)` — a single `GET /repos/{owner}/{repo}/pulls/comments/{id}`.
- For a reply that does **not** mention the bot, `MaintainerReplyService` now fetches just the thread **root** comment and decides `rootIsBot` from that one call, bailing **before** the authorizer round-trip and the paginated list. Mentions and confirmed bot-threads proceed exactly as before.
- Authorization moved into an `authorized()` helper, consulted only once we've decided we'd actually post.
- The pre-filter fails soft: a root that can't be fetched is treated as not-the-bot's, so the reply is left alone.

**Net for a human-to-human reply: ~11 GitHub calls + an auth round-trip collapse to a single cheap GET, and the authorizer is never consulted.** The remaining cost is the queued executor task itself — eliminating that would require a blocking GitHub call on the webhook ACK path (which must return within 10s), so it stays in the async handler.

Side benefit: an unmentioned reply on a bot thread whose root sits **beyond** the 10-page list bound is now still answered (the single GET resolves it directly) instead of being silently dropped.

## Related Issues

N/A

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

`MaintainerReplyServiceTest` (26/26), `MaintainerReplyDispatcherTest` (2/2), and `WebhookControllerTest` (58/58) pass locally. Run with JaCoCo disabled per the known SMB-mount file-locking issue on this checkout; CI runs full coverage on local disk:

```
./mvnw -o test -Djacoco.skip=true -Dquarkus.jacoco.enabled=false \
  -Dtest='MaintainerReplyServiceTest,MaintainerReplyDispatcherTest,WebhookControllerTest'
```

New/updated tests:
- `unmentionedReplyOnHumanThreadSkipsBeforeListingAndAuthorizing` — only the single GET runs; no list, no authorizer, nothing posted.
- `preFilterFailSoftSkipsWhenRootFetchThrows` — a failed root GET is treated as non-bot and skips.
- `unmentionedReplyWithUnresolvableRootPostsNothing`, `mentionWhereListRootHasNullAuthorCitesNoFinding`, plus split mention vs. review-thread unauthorized cases.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

The source comments deliberately omit an issue/PR number (none was fabricated). No behavior change for mentions or for replies on the bot's own finding threads — only human-to-human, no-mention replies are now short-circuited earlier and more cheaply.
