### PR TITLE
chore: trim narrating comments that reference past changes

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -148,9 +148,7 @@ public class StartupConfigValidator {
   private void logDashboardStatus() {
     var hasClientId = config.dashboard().clientId().filter(s -> !s.isBlank()).isPresent();
     var hasClientSecret = config.dashboard().clientSecret().filter(s -> !s.isBlank()).isPresent();
-    // Keeping the message and log level on the enum makes dispatch a single boolean check. That
-    // avoids the extra, never-exercised branch arcs that an enum-based switch or a per-constant
-    // comparison chain would introduce, keeping patch coverage at 100 percent.
+    // Message and log level live on the enum, so dispatch is a single boolean check.
     var status = dashboardOauthStatus(hasClientId, hasClientSecret);
     if (status.warn) {
       log.warn(status.message);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -96,7 +96,7 @@ public interface ThrillhouseConfig {
     interface TriggerFilters {
       /**
        * Skip auto-review while a PR is a draft. Pairs with the {@code ready_for_review} trigger so
-       * a draft is reviewed once it is marked ready (#72).
+       * a draft is reviewed once it is marked ready.
        */
       @WithDefault("false")
       @WithName("skip-drafts")

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
@@ -42,7 +42,7 @@ public interface GitHubCommentClient {
   // oldest-first and the summary is posted on the first review, so it normally sits among the
   // earliest comments — but on a PR that already had many comments before that first review the
   // summary can fall past page 1, and a single-page fetch would miss it and re-post a duplicate
-  // summary (#183).
+  // summary.
   int COMMENTS_PER_PAGE = 100;
   int MAX_COMMENT_PAGES = 10;
 
@@ -63,7 +63,7 @@ public interface GitHubCommentClient {
    * first, walking pages of {@value #COMMENTS_PER_PAGE} up to {@value #MAX_COMMENT_PAGES} pages so
    * a busy PR's comments are not silently truncated. Used to detect a summary comment the bot
    * already posted so a re-review never duplicates it; a single-page fetch could miss the summary
-   * on a busy PR and re-post it (#183). Stops at the first short/empty page.
+   * on a busy PR and re-post it. Stops at the first short/empty page.
    */
   default List<IssueComment> listComments(
       String auth, String accept, String owner, String repo, int issueNumber) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubPullRequestClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubPullRequestClient.java
@@ -56,7 +56,7 @@ public interface GitHubPullRequestClient {
   /**
    * Every changed file in the PR, walking pages of {@value #FILES_PER_PAGE} up to {@value
    * #MAX_FILE_PAGES} pages. Without pagination GitHub returns only the first 30 files, silently
-   * truncating the diff (and therefore the review) for larger PRs (#190).
+   * truncating the diff (and therefore the review) for larger PRs.
    */
   default List<FileDiff> getPullRequestFiles(
       String auth, String accept, String owner, String repo, int pullNumber) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -162,8 +162,8 @@ public final class DiffLineResolver {
    * that name, so the result is decided from it alone and no variant is consulted — a same-suffix
    * file that merely shares the path must never resurrect a finding whose code changed away in its
    * own file. The variant fallback runs only when the exact entry is absent <em>or empty</em>: a
-   * deletion-only patch stores an empty right side under its exact key, which previously
-   * short-circuited the fallback and masked a variant that held the real data (#132a).
+   * deletion-only patch stores an empty right side under its exact key, so the fallback must still
+   * consult the variants that may hold the real data.
    *
    * <p>The fallback inspects <em>every</em> matching variant rather than the first the backing
    * {@link HashMap} happens to iterate, so an ambiguous shortened path — two changed files sharing

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PromptTemplateEscaper.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PromptTemplateEscaper.java
@@ -69,13 +69,6 @@ public final class PromptTemplateEscaper {
    * <<<DIFF_START>>>} / {@code <<<DIFF_END>>>} delimiters the prompts wrap the diff in, so PR
    * content can never fake the end of the diff section and smuggle in instructions after it.
    *
-   * <p>This used to additionally wrap the value in a Qute unparsed section ({@code {|...|}}) to
-   * survive a second Qute pass. That pass does not happen for data-bound variables — the wrapper
-   * leaked into the prompt literally and corrupted any content containing {@code |}} — so it was
-   * removed once the templates moved their {@code @UserMessage} to the method (where {@code @V}
-   * variables are interpolated rather than the first parameter being rendered as a template
-   * itself).
-   *
    * <p>Self-referential edge: code that itself contains the three-bracket marker strings — this
    * class, its tests, the prompt templates — necessarily renders with them neutralized, so the
    * model reviews a slightly altered copy of exactly this one pattern and may misread the

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
@@ -49,9 +49,8 @@ public class ReviewResponseParser {
 
   /**
    * Models sometimes emit {@code previous_findings_status} as an object — a single status, or a map
-   * keyed by finding id — instead of the array the schema asks for. A whole review used to be lost
-   * (and retried at full token cost) over that shape mismatch, so normalize to the array form
-   * instead of failing.
+   * keyed by finding id — instead of the array the schema asks for. Normalize it to the array form
+   * so the shape mismatch does not fail the whole review (and force a full-cost retry).
    */
   private void normalizePreviousFindingsStatus(JsonNode root) {
     if (!(root instanceof ObjectNode rootObject)) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -292,8 +292,7 @@ public class WebhookController {
       log.debug("Ignoring bot mention with missing repository or installation");
       return true;
     }
-    // A /pause silences the bot on this PR — stay quiet rather than spend a paid reply, honoring
-    // the command's "silence the bot" contract just like the automatic-review path.
+    // A /pause silences the bot on this PR — stay quiet rather than spend a paid reply.
     if (prPauseService.isPaused(repo.owner().login(), repo.name(), payload.issue().number())) {
       log.info(
           "Skipping conversational mention on paused PR #{} in {}",
@@ -365,8 +364,7 @@ public class WebhookController {
       return true;
     }
 
-    // A /pause silences the bot on this PR — stay quiet rather than spend a paid reply, honoring
-    // the command's "silence the bot" contract just like the automatic-review path.
+    // A /pause silences the bot on this PR — stay quiet rather than spend a paid reply.
     if (prPauseService.isPaused(repo.owner().login(), repo.name(), pr.number())) {
       log.info(
           "Skipping conversational review-thread reply on paused PR #{} in {}",


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor

## Description

Comment-only cleanup: removes narrating comments that describe *changes* (comparative / historical / meta), keeping the explanatory ones. No logic touched.

**Trimmed (change-narration):**
- `StartupConfigValidator` — dropped the "keeps patch coverage at 100 percent" / rejected-alternative meta on the OAuth-status enum.
- `PromptTemplateEscaper` — removed the "this used to additionally wrap the value in a Qute unparsed section …" paragraph (narrates a removed approach; the current behavior is already explained above it).
- `WebhookController` — dropped "honoring the command's contract just like the automatic-review path" from both `/pause` guards.
- `ReviewResponseParser` — reworded "a whole review used to be lost …" to the current rationale.
- `DiffLineResolver` — dropped the "which previously short-circuited the fallback and masked a variant …" historical aside (kept the rule it explains).
- `GitHubCommentClient` / `GitHubPullRequestClient` / `ThrillhouseConfig` — stripped bare trailing `(#NNN)` changelog tags from self-contained comments.

**Deliberately kept:** the explanatory comments in the complex review-quality backstop code (`DiffLineResolver`, `FindingQuoteValidator`, `FollowUpAnalyzer`), where the issue references name documented edge cases the logic handles — these are the "explanatory on complex code" comments, not change-narration.

## How Has This Been Tested?

Comment-only; no source logic changed. `./mvnw spotless:check` passes.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
