### PR TITLE
fix(compose): single source of truth for DB credentials (DB_USER/DB_PASSWORD)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,8 +62,10 @@ GITHUB_CLIENT_SECRET=your_oauth_client_secret
 #WEBSOCKET_KEEPALIVE_MS=25000
 
 # Docker Compose deployment (docker-compose.yml) — optional overrides.
-# Defaults are fine for a first run, but change POSTGRES_PASSWORD before
-# exposing the database, and set DATABASE_URL to use managed Postgres.
-#POSTGRES_USER=thrillhouse
-#POSTGRES_PASSWORD=change-me
+# DB_USER / DB_PASSWORD are the single source of truth: both the bot's datasource
+# and the postgres container derive their credentials from them. Defaults are fine
+# for a first run, but change DB_PASSWORD before exposing the database, and set
+# DATABASE_URL to use managed Postgres.
+#DB_USER=thrillhouse
+#DB_PASSWORD=change-me
 #DATABASE_URL=jdbc:postgresql://db:5432/thrillhouse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@
 # https://<your-host>/api/webhook (see README "GitHub App Setup").
 services:
   thrillhousebot:
-    image: ghcr.io/devops-thiago/thrillhousebot:latest
+    image: ghcr.io/devops-thiago/thrillhousebot:${IMAGE_TAG:-latest}
+    container_name: thrillhousebot
     ports:
       - "8080:8080"
     env_file: .env
@@ -15,8 +16,11 @@ services:
       DASHBOARD_URL: ${DASHBOARD_URL:-http://localhost:8080}
       DATASOURCE_DB_KIND: postgresql
       DATABASE_URL: ${DATABASE_URL:-jdbc:postgresql://db:5432/thrillhouse}
-      QUARKUS_DATASOURCE_USERNAME: ${POSTGRES_USER:-thrillhouse}
-      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-thrillhouse}
+      # Single source of truth for DB creds: set DB_USER / DB_PASSWORD in .env and
+      # both the bot's datasource (here) and the postgres container (below) derive
+      # from them — no need to also set QUARKUS_DATASOURCE_* in .env.
+      QUARKUS_DATASOURCE_USERNAME: ${DB_USER:-thrillhouse}
+      QUARKUS_DATASOURCE_PASSWORD: ${DB_PASSWORD:-thrillhouse}
     depends_on:
       db:
         condition: service_healthy
@@ -24,14 +28,15 @@ services:
 
   db:
     image: postgres:16-alpine
+    container_name: thrillhousebot-db
     environment:
       POSTGRES_DB: thrillhouse
-      POSTGRES_USER: ${POSTGRES_USER:-thrillhouse}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-thrillhouse}
+      POSTGRES_USER: ${DB_USER:-thrillhouse}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-thrillhouse}
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-thrillhouse}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-thrillhouse} -d thrillhouse"]
       interval: 5s
       timeout: 5s
       retries: 12

--- a/scripts/GenEnv.java
+++ b/scripts/GenEnv.java
@@ -50,11 +50,9 @@ void main(String[] args) throws Exception {
       AI_BASE_URL=https://api.deepseek.com/v1
       AI_MODEL=deepseek-chat
 
-      # --- Database ---
+      # --- Database (single source of truth; compose derives QUARKUS_DATASOURCE_* from these) ---
       DB_USER=thrillhouse
       DB_PASSWORD=
-      QUARKUS_DATASOURCE_USERNAME=thrillhouse
-      QUARKUS_DATASOURCE_PASSWORD=
       DATABASE_URL=jdbc:postgresql://db:5432/thrillhouse
 
       # --- Dashboard OAuth (GitHub) ---
@@ -87,7 +85,7 @@ void main(String[] args) throws Exception {
     IO.println("   Host        : ⚠️ no --host given — replace <your-host> in DASHBOARD_URL");
   }
   IO.println("");
-  IO.println("👉 Still needed: AI_API_KEY, DB_PASSWORD, QUARKUS_DATASOURCE_PASSWORD");
+  IO.println("👉 Still needed: AI_API_KEY, DB_PASSWORD");
 }
 
 /// First numeric value for the key (the conversion response has the app id first).


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔧 Refactor

## Description

Commits the docker-compose improvement (single-source DB credentials) and brings `.env.example` + `scripts/GenEnv.java` into line with it. Previously the three files disagreed: compose read `POSTGRES_USER`/`POSTGRES_PASSWORD`, `.env.example` documented the same, but `GenEnv.java` emitted `DB_USER`/`DB_PASSWORD` (which nothing read) **plus** redundant `QUARKUS_DATASOURCE_*`.

Now **`DB_USER` / `DB_PASSWORD` are the single source of truth** — both the bot's datasource and the postgres container derive from them, so the DB password is set once.

### Changes
- **`docker-compose.yml`**: `QUARKUS_DATASOURCE_USERNAME/PASSWORD` and `POSTGRES_USER/PASSWORD` both come from `${DB_USER}`/`${DB_PASSWORD}`. Added `container_name`, `image: …:${IMAGE_TAG:-latest}`, and a db-scoped healthcheck (`pg_isready … -d thrillhouse`).
- **`.env.example`**: `POSTGRES_USER`/`POSTGRES_PASSWORD` → `DB_USER`/`DB_PASSWORD`.
- **`scripts/GenEnv.java`**: dropped the redundant `QUARKUS_DATASOURCE_*` lines (compose derives them) and fixed the closing hint.

### Scope note
The source improvement was reverse-proxy-only (no published ports, external `root_proxy` network, `db_data` volume rename). Those were intentionally **left out** of the public quick-start file so a fresh `docker compose up -d` still works on `localhost:8080` without a pre-existing network and without orphaning existing `pgdata` volumes. Only the DB-creds + container/restart/healthcheck improvements were taken.

## How Has This Been Tested?

`docker`/`yamllint` weren't available in the dev sandbox; validated structure manually and cross-checked that `docker-compose.yml`, `.env.example`, and `GenEnv.java` all reference `DB_USER`/`DB_PASSWORD` with no stale `POSTGRES_*`/`QUARKUS_DATASOURCE_*` inputs. Worth a quick `docker compose config` on a machine with Docker before merge.
