### PR TITLE
ci(release): attach SLSA provenance as a release asset for Scorecard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,9 +248,12 @@ jobs:
           (cd dist && sha256sum ./*.tar.gz > checksums.txt)
           ls -la dist/
       - name: Attest binary provenance
+        id: attest
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: dist/*.tar.gz
+      - name: Stage provenance as a release asset
+        run: cp "${{ steps.attest.outputs.bundle-path }}" dist/provenance.intoto.jsonl
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Sign artifacts
         run: |
@@ -277,7 +280,7 @@ jobs:
           UPDATE_LATEST: ${{ needs.promote.outputs.update_latest }}
         run: |
           shopt -s nullglob
-          artifacts=( dist/*.tar.gz dist/checksums.txt dist/*.sigstore )
+          artifacts=( dist/*.tar.gz dist/checksums.txt dist/*.sigstore dist/*.intoto.jsonl )
           if [ "${#artifacts[@]}" -eq 0 ]; then
             echo "::error::No release artifacts found in dist/"
             exit 1

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://codecov.io/gh/devops-thiago/ThrillhouseBot"><img src="https://codecov.io/gh/devops-thiago/ThrillhouseBot/branch/main/graph/badge.svg" alt="Coverage" /></a>
   <a href="https://sonarcloud.io/dashboard?id=devops-thiago_ThrillhouseBot"><img src="https://sonarcloud.io/api/project_badges/measure?project=devops-thiago_ThrillhouseBot&metric=alert_status" alt="Quality Gate" /></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/devops-thiago/ThrillhouseBot"><img src="https://api.securityscorecards.dev/projects/github.com/devops-thiago/ThrillhouseBot/badge" alt="OpenSSF Scorecard" /></a>
+  <a href="https://www.bestpractices.dev/projects/13330"><img src="https://www.bestpractices.dev/projects/13330/badge"></a>
   <a href="https://github.com/devops-thiago/ThrillhouseBot/releases"><img src="https://img.shields.io/github/v/release/devops-thiago/ThrillhouseBot" alt="Release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/devops-thiago/ThrillhouseBot" alt="License" /></a>
 </p>


### PR DESCRIPTION
## What type of PR is this?

- [x] 🏗️ CI/CD
- [x] 🔒 Security

## Description

OpenSSF Scorecard's **Signed-Releases** check scores each release out of 10: **8 points** for a signature asset and **2 points** for a SLSA **provenance** asset, the latter matched purely by the `.intoto.jsonl` filename suffix. The check inspects only files attached to the GitHub Release — not the attestations API, GHCR, or the OCI registry.

Our release job already runs `actions/attest-build-provenance` on the binaries, but that bundle only lands in GitHub's attestation store, so the release page carried no provenance asset. Scorecard logged `release artifact ... does not have provenance` and withheld the 2 points — leaving the score at 8/10.

This PR:
- Adds `id: attest` to the existing attestation step and copies its bundle to `dist/provenance.intoto.jsonl`.
- Adds `dist/*.intoto.jsonl` to the release asset list so Scorecard can see it.

No new tooling, signing, or permissions — it just surfaces provenance we were already generating as a downloadable release asset.

## Related Issues

N/A

## How Has This Been Tested?

- [x] Manual review

Static review of the workflow only (release flow runs on tag push):
- The provenance file is staged **before** the cosign step, which signs an explicit list (`dist/*.tar.gz dist/checksums.txt`) rather than a wildcard — so the `.intoto.jsonl` gets no stray `.sigstore` sibling, and the `dist/*.sigstore` glob doesn't pick it up.
- `attest-build-provenance` emits one bundle covering all `dist/*.tar.gz` subjects, so a single `provenance.intoto.jsonl` asset covers both arch tarballs.

## Additional Notes

Takes effect on the **next** release. Scorecard averages recent releases, so the Signed-Releases score climbs to 10/10 as new tags ship; existing v0.1.0/v0.1.1/v0.2.0 stay at 8 unless re-released (the `workflow_dispatch` `version` input supports re-running an old tag).
