### PR TITLE
fix(review): don't APPROVE on a failed PR-files fetch (#211)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -588,12 +588,11 @@ public class ReviewOrchestrator {
 
   List<GitHubPullRequestClient.FileDiff> fetchPrFiles(
       String auth, String owner, String repo, int prNumber) {
-    try {
-      return prClient.getPullRequestFiles(auth, ACCEPT, owner, repo, prNumber);
-    } catch (RuntimeException e) {
-      Log.warn("Failed to fetch PR files, continuing with empty diff", e);
-      return List.of();
-    }
+    // A fetch failure must propagate to review()'s handler (failed check + "could not complete"
+    // notice). Swallowing it into an empty list is indistinguishable from a PR with no changes and
+    // produces a false APPROVE + green check on code that was never read (#211). A genuinely empty
+    // PR returns an empty list with no exception and still takes the normal path.
+    return prClient.getPullRequestFiles(auth, ACCEPT, owner, repo, prNumber);
   }
 
   String buildDiffString(List<GitHubPullRequestClient.FileDiff> files) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -367,25 +367,24 @@ class ReviewOrchestratorTest {
   class FetchPrFiles {
 
     @Test
-    void shouldReturnEmptyListOnException() {
+    void shouldPropagateExceptionSoTheReviewFailsInsteadOfApproving() {
       when(prClient.getPullRequestFiles(any(), any(), eq("owner"), eq("repo"), eq(42)))
           .thenThrow(new RuntimeException("GitHub API error"));
 
-      var result = orchestrator.fetchPrFiles("auth", "owner", "repo", 42);
-
-      assertNotNull(result);
-      assertTrue(result.isEmpty());
+      // Swallowing the failure into an empty list would yield an empty diff and a false APPROVE on
+      // unreviewed code (#211); it must propagate so review() takes the failure path.
+      assertThrows(
+          RuntimeException.class, () -> orchestrator.fetchPrFiles("auth", "owner", "repo", 42));
     }
 
     @Test
-    void shouldReturnEmptyListOnNotAuthorized() {
+    void shouldPropagateNotAuthorizedRatherThanReturnEmpty() {
       when(prClient.getPullRequestFiles(any(), any(), eq("owner"), eq("repo"), eq(123)))
           .thenThrow(new jakarta.ws.rs.NotAuthorizedException("Bad credentials"));
 
-      var result = orchestrator.fetchPrFiles("auth", "owner", "repo", 123);
-
-      assertNotNull(result);
-      assertTrue(result.isEmpty());
+      assertThrows(
+          jakarta.ws.rs.NotAuthorizedException.class,
+          () -> orchestrator.fetchPrFiles("auth", "owner", "repo", 123));
     }
 
     @Test
@@ -1092,6 +1091,57 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void shouldNotApproveWhenPrFilesFetchFails() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getPrTitle()).thenReturn("Test PR");
+        when(session.getCommitSha()).thenReturn("abcdefgh");
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        when(authClient.getAuthHeader(123L)).thenReturn("Bearer test");
+        when(checkRunClient.createCheckRun(
+                anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(new GitHubCheckRunClient.CheckRunResponse(1L, "http://check"));
+        // A transient files-fetch failure must not be swallowed into an empty diff + false APPROVE.
+        when(prClient.getPullRequestFiles(
+                anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenThrow(new RuntimeException("500 Server Error"));
+
+        orchestrator.review(
+            new ReviewOrchestrator.ReviewRequest(
+                "owner",
+                "repo",
+                42,
+                "abcdefgh",
+                "Test PR",
+                "",
+                "base1234567",
+                "main",
+                123L,
+                false));
+
+        // No review event of any kind (no APPROVE); the review takes the failure path instead.
+        verify(reviewClient, never())
+            .createReview(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+        verify(session).setStatus(ReviewSession.STATUS_FAILED);
+        verify(commentClient)
+            .createComment(
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyInt(),
+                argThat(req -> req.body().contains("could not be completed")));
+      }
+    }
+
+    @Test
     void shouldApproveWithBodylessReviewAndPostCelebrationInsideSummaryWhenNoFindings() {
       try (var mockedStatic = mockStatic(ReviewSession.class)) {
         var session = mock(ReviewSession.class);
@@ -1597,60 +1647,6 @@ class ReviewOrchestratorTest {
         verify(reviewClient)
             .createPullRequestComment(
                 anyString(), anyString(), anyString(), anyString(), anyInt(), any());
-        verify(session).setStatus(ReviewSession.STATUS_COMPLETED);
-      }
-    }
-
-    @Test
-    void shouldContinueReviewWhenFetchPrFilesThrows() {
-      try (var mockedStatic = mockStatic(ReviewSession.class)) {
-        var session = mock(ReviewSession.class);
-        session.id = 1L;
-        when(session.getRepository()).thenReturn("owner/repo");
-        when(session.getPrNumber()).thenReturn(42);
-        when(session.getPrTitle()).thenReturn("Test PR");
-        when(session.getCommitSha()).thenReturn("abcdefgh");
-        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
-        mockedStatic
-            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
-            .thenReturn(session);
-
-        when(authClient.getAuthHeader(123L)).thenReturn("Bearer test");
-        when(checkRunClient.createCheckRun(
-                anyString(), anyString(), anyString(), anyString(), any()))
-            .thenReturn(new GitHubCheckRunClient.CheckRunResponse(1L, "http://check"));
-        doNothing()
-            .when(checkRunClient)
-            .updateCheckRun(anyString(), anyString(), anyString(), anyString(), anyLong(), any());
-
-        when(prClient.getPullRequestFiles(
-                anyString(), anyString(), anyString(), anyString(), anyInt()))
-            .thenThrow(new RuntimeException("GitHub API error"));
-        when(prClient.compareCommits(
-                anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
-            .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
-        when(reviewClient.listReviews(anyString(), anyString(), anyString(), anyString(), anyInt()))
-            .thenReturn(List.of());
-        when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
-            .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
-
-        when(aiReviewService.review(any(ReviewSession.class), any()))
-            .thenReturn(new ReviewResponse(List.of(), List.of(), null));
-
-        orchestrator.review(
-            new ReviewOrchestrator.ReviewRequest(
-                "owner",
-                "repo",
-                42,
-                "abcdefgh",
-                "Test PR",
-                "",
-                "base1234567",
-                "main",
-                123L,
-                false));
-
-        verify(aiReviewService).review(any(ReviewSession.class), any());
         verify(session).setStatus(ReviewSession.STATUS_COMPLETED);
       }
     }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔒 Security

## Description

`ReviewOrchestrator.fetchPrFiles` caught any `getPullRequestFiles` failure and returned an empty list ("continuing with empty diff"). A transient fetch error (500, secondary rate-limit, mid-pagination) was then indistinguishable from a PR with no changes: the diff was empty, the AI returned zero findings, the review resolved to **APPROVE**, the check run completed **green**, and an APPROVE review was posted on code that was never read. On a repo whose branch protection requires the bot's check/approval, this could let unreviewed code merge.

The fix lets the failure propagate to `review()`'s existing `catch → handleReviewFailure` (failed check + "could not be completed" retry notice). A genuinely empty PR returns an empty list with **no** exception and still takes the normal path, so that benign case is unchanged.

## Related Issues

Fixes #211

## How Has This Been Tested?

- [x] Unit tests

- `ReviewOrchestratorTest.fetchPrFiles`: the two former "returns empty on exception/not-authorized" cases now assert the exception **propagates** (regression guard against re-introducing the swallow).
- New `shouldNotApproveWhenPrFilesFetchFails`: drives `review()` end-to-end with a throwing `getPullRequestFiles` and asserts **no** review event is created (no APPROVE), the session is marked `FAILED`, and the "could not be completed" notice is posted.
- Removed the obsolete `shouldContinueReviewWhenFetchPrFilesThrows`, which pinned the old (buggy) continue-and-complete behavior.
- Full suite: **1219 passing**, `spotbugs:check` + `spotless:check` clean (JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (no doc change needed)
- [x] My changes generate no new warnings or errors

## Additional Notes

Pre-existing bug (present since v0.1.0), targeted at `main`. Complementary to #25 (rate-limit retry/backoff would reduce how often the failure path fires, but does not remove the false-approve).
