### PR TITLE
fix(review): paginate the inline review-comment fetch and drop the single-page variant (#212)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -18,6 +18,7 @@ package dev.thiagogonzaga.thrillhousebot.github;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
@@ -45,25 +46,16 @@ public interface GitHubReviewClient {
       @PathParam("repo") String repo,
       @PathParam("pullNumber") int pullNumber);
 
-  @GET
-  @Path("/repos/{owner}/{repo}/pulls/{pullNumber}/comments")
-  @Produces(MediaType.APPLICATION_JSON)
-  List<PullRequestComment> listPullRequestComments(
-      @HeaderParam("Authorization") String auth,
-      @HeaderParam("Accept") String accept,
-      @PathParam("owner") String owner,
-      @PathParam("repo") String repo,
-      @PathParam("pullNumber") int pullNumber);
+  // GitHub serves 30 inline review comments per page by default; request the 100 max and walk a
+  // bounded number of pages so follow-up dedup, /resolve and the unresolved-status backstop never
+  // run on a silently truncated set on a busy PR.
+  int COMMENTS_PER_PAGE = 100;
+  int MAX_COMMENT_PAGES = 10;
 
-  /**
-   * Paged variant of {@link #listPullRequestComments}. GitHub serves 30 comments per page by
-   * default; callers that need every comment (e.g. {@code /resolve}) must request a larger {@code
-   * per_page} and walk the pages until a short one.
-   */
   @GET
   @Path("/repos/{owner}/{repo}/pulls/{pullNumber}/comments")
   @Produces(MediaType.APPLICATION_JSON)
-  List<PullRequestComment> listPullRequestComments(
+  List<PullRequestComment> listPullRequestCommentsPage(
       @HeaderParam("Authorization") String auth,
       @HeaderParam("Accept") String accept,
       @PathParam("owner") String owner,
@@ -71,6 +63,30 @@ public interface GitHubReviewClient {
       @PathParam("pullNumber") int pullNumber,
       @QueryParam("per_page") int perPage,
       @QueryParam("page") int page);
+
+  /**
+   * Lists a PR's inline review comments, walking pages of {@value #COMMENTS_PER_PAGE} up to {@value
+   * #MAX_COMMENT_PAGES} pages so a busy PR's threads are not silently truncated. A single-page
+   * fetch caps at GitHub's 30-per-page default and drops everything past page one, which would make
+   * follow-up dedup re-raise replied findings and leave addressed threads unresolved. Stops at the
+   * first short/empty page.
+   */
+  default List<PullRequestComment> listPullRequestComments(
+      String auth, String accept, String owner, String repo, int pullNumber) {
+    var all = new ArrayList<PullRequestComment>();
+    List<PullRequestComment> batch;
+    int page = 1;
+    do {
+      batch =
+          listPullRequestCommentsPage(
+              auth, accept, owner, repo, pullNumber, COMMENTS_PER_PAGE, page);
+      if (batch != null) {
+        all.addAll(batch);
+      }
+      page++;
+    } while (batch != null && batch.size() == COMMENTS_PER_PAGE && page <= MAX_COMMENT_PAGES);
+    return all;
+  }
 
   @POST
   @Path("/repos/{owner}/{repo}/pulls/{pullNumber}/comments")

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
@@ -26,7 +26,6 @@ import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
-import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -44,11 +43,6 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 public class MaintainerReplyService {
 
   private static final String ACCEPT = "application/vnd.github+json";
-
-  // GitHub serves 30 review comments per page by default; request the 100 max and walk a bounded
-  // number of pages so a busy thread's root comment and prior replies are not missed past page one.
-  private static final int COMMENTS_PER_PAGE = 100;
-  private static final int MAX_COMMENT_PAGES = 10;
 
   private final GitHubAuthClient authClient;
   private final ManualReviewAuthorizer authorizer;
@@ -235,23 +229,13 @@ public class MaintainerReplyService {
   }
 
   private List<GitHubReviewClient.PullRequestComment> listReviewComments(String auth, ReplyTask t) {
-    var all = new ArrayList<GitHubReviewClient.PullRequestComment>();
+    // The client walks every page, so the reply context sees the whole thread, not just page 1.
     try {
-      List<GitHubReviewClient.PullRequestComment> batch;
-      int page = 1;
-      do {
-        batch =
-            reviewClient.listPullRequestComments(
-                auth, ACCEPT, t.owner(), t.repo(), t.prNumber(), COMMENTS_PER_PAGE, page);
-        if (batch != null) {
-          all.addAll(batch);
-        }
-        page++;
-      } while (batch != null && batch.size() == COMMENTS_PER_PAGE && page <= MAX_COMMENT_PAGES);
+      return reviewClient.listPullRequestComments(auth, ACCEPT, t.owner(), t.repo(), t.prNumber());
     } catch (RuntimeException e) {
       Log.warn("Failed to list PR review comments for reply context", e);
+      return List.of();
     }
-    return all;
   }
 
   private static GitHubReviewClient.PullRequestComment findRoot(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -657,8 +657,9 @@ public class ReviewOrchestrator {
   List<GitHubReviewClient.PullRequestComment> fetchPullRequestComments(
       String auth, String owner, String repo, int prNumber) {
     try {
-      var comments = reviewClient.listPullRequestComments(auth, ACCEPT, owner, repo, prNumber);
-      return comments != null ? comments : List.<GitHubReviewClient.PullRequestComment>of();
+      // The client walks every page and never returns null, so the only failure to absorb here is
+      // the fetch throwing.
+      return reviewClient.listPullRequestComments(auth, ACCEPT, owner, repo, prNumber);
     } catch (RuntimeException e) {
       Log.warn("Failed to fetch PR inline comments, continuing without thread context", e);
       return List.of();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
@@ -44,11 +44,6 @@ public class CommentCommandService {
 
   private static final String ACCEPT = "application/vnd.github+json";
 
-  // GitHub serves 30 review comments per page by default; request the 100 max and walk a bounded
-  // number of pages so /resolve covers every bot finding thread, not just the first page.
-  private static final int COMMENTS_PER_PAGE = 100;
-  private static final int MAX_COMMENT_PAGES = 10;
-
   /** Posted when a review-generating command lands on a paused PR. */
   static final String PAUSED_NOTICE =
       "⏸️ ThrillhouseBot is paused on this PR. Comment `/resume` to re-enable reviews.";
@@ -291,24 +286,17 @@ public class CommentCommandService {
    */
   private List<Long> botRootCommentIds(String auth, CommandContext ctx) {
     var ids = new ArrayList<Long>();
-    List<GitHubReviewClient.PullRequestComment> comments;
-    int page = 1;
-    do {
-      comments =
-          reviewClient.listPullRequestComments(
-              auth, ACCEPT, ctx.owner(), ctx.repo(), ctx.prNumber(), COMMENTS_PER_PAGE, page);
-      if (comments != null) {
-        for (var c : comments) {
-          if (c.inReplyToId() == null
-              && c.user() != null
-              && triggerDetector.isBotComment(c.user().login())) {
-            ids.add(c.id());
-          }
-        }
+    // The client walks every page, so a PR with many comments does not leave later-page bot threads
+    // unresolved.
+    for (var c :
+        reviewClient.listPullRequestComments(
+            auth, ACCEPT, ctx.owner(), ctx.repo(), ctx.prNumber())) {
+      if (c.inReplyToId() == null
+          && c.user() != null
+          && triggerDetector.isBotComment(c.user().login())) {
+        ids.add(c.id());
       }
-      page++;
-      // A short (or absent) page is GitHub's last-page marker; a full page means walk the next one.
-    } while (comments != null && comments.size() == COMMENTS_PER_PAGE && page <= MAX_COMMENT_PAGES);
+    }
     return ids;
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClientTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.PullRequestComment;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the {@code listPullRequestComments} default pagination loop: GitHub returns only 30 inline
+ * review comments per page by default, so follow-up dedup, {@code /resolve} and the
+ * unresolved-status backstop would run on a silently truncated set on a busy PR. Comments are
+ * assembled by walking pages of {@value GitHubReviewClient#COMMENTS_PER_PAGE}, bounded by {@value
+ * GitHubReviewClient#MAX_COMMENT_PAGES}.
+ */
+class GitHubReviewClientTest {
+
+  private static List<PullRequestComment> page(int count) {
+    return IntStream.range(0, count)
+        .mapToObj(i -> new PullRequestComment(i, null, "src/Foo.java", "comment " + i, null))
+        .toList();
+  }
+
+  /** A mock whose default {@code listPullRequestComments} runs the real pagination loop. */
+  private static GitHubReviewClient pagingClient() {
+    var client = mock(GitHubReviewClient.class);
+    when(client.listPullRequestComments(
+            anyString(), anyString(), anyString(), anyString(), anyInt()))
+        .thenCallRealMethod();
+    return client;
+  }
+
+  @Test
+  void walksEveryPageUntilAShortPage() {
+    var client = pagingClient();
+    when(client.listPullRequestCommentsPage("auth", "json", "o", "r", 7, 100, 1))
+        .thenReturn(page(100));
+    when(client.listPullRequestCommentsPage("auth", "json", "o", "r", 7, 100, 2))
+        .thenReturn(page(100));
+    when(client.listPullRequestCommentsPage("auth", "json", "o", "r", 7, 100, 3))
+        .thenReturn(page(42));
+
+    var all = client.listPullRequestComments("auth", "json", "o", "r", 7);
+
+    // 242 comments across 3 pages — not silently truncated to the first page.
+    assertEquals(242, all.size());
+    verify(client).listPullRequestCommentsPage("auth", "json", "o", "r", 7, 100, 3);
+    verify(client, never()).listPullRequestCommentsPage("auth", "json", "o", "r", 7, 100, 4);
+  }
+
+  @Test
+  void stopsAfterOnePageWhenNotFull() {
+    var client = pagingClient();
+    when(client.listPullRequestCommentsPage("auth", "json", "o", "r", 7, 100, 1))
+        .thenReturn(page(10));
+
+    var all = client.listPullRequestComments("auth", "json", "o", "r", 7);
+
+    assertEquals(10, all.size());
+    verify(client, times(1))
+        .listPullRequestCommentsPage(
+            anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt());
+  }
+
+  @Test
+  void isBoundedByMaxPagesSoAFullLastPageCannotLoopForever() {
+    var client = pagingClient();
+    when(client.listPullRequestCommentsPage(
+            anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+        .thenReturn(page(100));
+
+    var all = client.listPullRequestComments("auth", "json", "o", "r", 7);
+
+    assertEquals(100 * GitHubReviewClient.MAX_COMMENT_PAGES, all.size());
+    verify(client, times(GitHubReviewClient.MAX_COMMENT_PAGES))
+        .listPullRequestCommentsPage(
+            anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt());
+  }
+
+  @Test
+  void toleratesANullPageWithoutFailing() {
+    var client = pagingClient();
+    when(client.listPullRequestCommentsPage("auth", "json", "o", "r", 7, 100, 1)).thenReturn(null);
+
+    assertEquals(0, client.listPullRequestComments("auth", "json", "o", "r", 7).size());
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
@@ -26,7 +26,6 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReplyAssistant;
 import dev.thiagogonzaga.thrillhousebot.webhook.ManualReviewAuthorizer;
 import dev.thiagogonzaga.thrillhousebot.webhook.TriggerDetector;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -134,7 +133,7 @@ class MaintainerReplyServiceTest {
   void replyOnBotThreadPostsAnswerWithFindingAndPriorRepliesAsContext() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(
             List.of(
                 comment(99L, null, BOT, "**CRITICAL — possible NPE** on user lookup"),
@@ -177,70 +176,10 @@ class MaintainerReplyServiceTest {
   }
 
   @Test
-  void walksAllCommentPagesToFindARootBeyondTheFirstPage() {
-    authorize();
-    // Page 1 is full (100 comments) so a second page is fetched; the bot finding root is on page 2.
-    var firstPage = new ArrayList<GitHubReviewClient.PullRequestComment>();
-    for (int i = 0; i < 100; i++) {
-      firstPage.add(comment(2000L + i, 77L, "octocat", "noise " + i));
-    }
-    when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), eq(100), eq(1)))
-        .thenReturn(firstPage);
-    when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), eq(100), eq(2)))
-        .thenReturn(List.of(comment(99L, null, BOT, "**finding** on page two")));
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("Answer.");
-
-    service.handle(reviewThreadTask(false));
-
-    // Root comment 99 lived on page 2; without pagination the bot would have stayed silent.
-    verify(reviewClient)
-        .listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), eq(100), eq(2));
-    verify(reviewClient)
-        .replyToReviewComment(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), eq(99L), any());
-  }
-
-  @Test
-  void nullCommentPageIsTreatedAsEmptyAndPostsNothing() {
-    authorize();
-    when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
-        .thenReturn(null);
-
-    service.handle(reviewThreadTask(false));
-
-    // No comments resolve a root, and the reply was not an explicit mention, so the bot stays
-    // silent.
-    verifyNoInteractions(replyAssistant);
-  }
-
-  @Test
-  void stopsAtTheCommentPageBoundOnAVeryLongThread() {
-    authorize();
-    // Every page is full, so only the page bound can stop the walk.
-    var fullPage = new ArrayList<GitHubReviewClient.PullRequestComment>();
-    for (int i = 0; i < 100; i++) {
-      fullPage.add(comment(3000L + i, 88L, "octocat", "noise " + i));
-    }
-    when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
-        .thenReturn(fullPage);
-
-    service.handle(reviewThreadTask(false));
-
-    verify(reviewClient, times(10))
-        .listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt());
-  }
-
-  @Test
   void replyOnHumanThreadWithoutMentionPostsNothing() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(
             List.of(
                 comment(99L, null, "someone", "I think this is wrong"),
@@ -257,7 +196,7 @@ class MaintainerReplyServiceTest {
   void replyOnHumanThreadWithMentionStillAnswers() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of(comment(99L, null, "someone", "what does the bot think?")));
     when(replyAssistant.reply(any(), any(), any(), any(), any()))
         .thenReturn("My take: looks fine.");
@@ -299,7 +238,7 @@ class MaintainerReplyServiceTest {
   void blankAssistantReplyPostsNothing() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
     when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("   ");
 
@@ -313,7 +252,7 @@ class MaintainerReplyServiceTest {
   void assistantFailureIsSwallowed() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
     when(replyAssistant.reply(any(), any(), any(), any(), any()))
         .thenThrow(new RuntimeException("model down"));
@@ -356,7 +295,7 @@ class MaintainerReplyServiceTest {
   void listCommentsFailureStillAnswersAnExplicitMention() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenThrow(new RuntimeException("GitHub 503"));
     when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("Still here.");
 
@@ -406,7 +345,7 @@ class MaintainerReplyServiceTest {
   void postFailureIsSwallowedByOuterHandler() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
     when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("answer");
     doThrow(new RuntimeException("GitHub 422"))
@@ -434,7 +373,7 @@ class MaintainerReplyServiceTest {
   void botThreadReplyWithNullDiffHunkSendsEmptyCodeContext() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
     when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("ok");
     var task =
@@ -456,7 +395,7 @@ class MaintainerReplyServiceTest {
   void threadRenderingSkipsOtherThreadsAndHandlesAnonymousReplies() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(
             List.of(
                 comment(99L, null, BOT, "**finding**"),
@@ -485,7 +424,7 @@ class MaintainerReplyServiceTest {
     // The root exists but its author is unknown (e.g. deleted account): it must not count as the
     // bot's thread, so an unmentioned reply on it is left alone.
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of(commentNoUser(99L, null, "author is null")));
 
     service.handle(reviewThreadTask(false));
@@ -499,7 +438,7 @@ class MaintainerReplyServiceTest {
   void nullAssistantReplyPostsNothing() {
     authorize();
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
     when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(null);
 
@@ -510,28 +449,11 @@ class MaintainerReplyServiceTest {
   }
 
   @Test
-  void nullCommentListIsTreatedAsEmpty() {
-    authorize();
-    // GitHub returning a null body (vs an empty list) must not NPE — it falls back to no context.
-    when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
-        .thenReturn(null);
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("ok");
-
-    // Mentioned, so it still answers even though the root could not be loaded.
-    service.handle(reviewThreadTask(true));
-
-    verify(reviewClient)
-        .replyToReviewComment(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), eq(99L), any());
-  }
-
-  @Test
   void findRootScansPastNonMatchingComments() {
     authorize();
     // The root is not first in the list, so the id filter must skip a non-matching comment first.
     when(reviewClient.listPullRequestComments(
-            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), anyInt(), anyInt()))
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(
             List.of(
                 comment(500L, 88L, "x", "unrelated thread"),

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -3388,13 +3388,13 @@ class ReviewOrchestratorTest {
   class FetchPullRequestComments {
 
     @Test
-    void shouldReturnEmptyListWhenClientReturnsNullOrThrows() {
+    void shouldReturnEmptyListWhenClientThrows() {
+      // The paginating client never returns null, so the only failure to absorb is the fetch
+      // throwing — it degrades to an empty list rather than aborting the review.
       when(reviewClient.listPullRequestComments(
               anyString(), anyString(), anyString(), anyString(), anyInt()))
-          .thenReturn(null)
           .thenThrow(new RuntimeException("boom"));
 
-      assertTrue(orchestrator.fetchPullRequestComments("auth", "owner", "repo", 1).isEmpty());
       assertTrue(orchestrator.fetchPullRequestComments("auth", "owner", "repo", 1).isEmpty());
     }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
@@ -28,7 +28,6 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.ReviewResponse
 import dev.thiagogonzaga.thrillhousebot.github.ReviewThreadService;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestrator;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -161,8 +160,7 @@ class CommentCommandServiceTest {
     var botReply = comment(101L, 100L, "thrillhousebot[bot]");
     var humanRoot = comment(200L, null, "octocat");
     var authorless = new PullRequestComment(300L, null, "src/Foo.java", "body", null);
-    when(reviewClient.listPullRequestComments(
-            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(1)))
+    when(reviewClient.listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(7)))
         .thenReturn(List.of(botRoot, botRoot2, botReply, humanRoot, authorless));
     when(reviewThreadService.threadsByRootComment(any(), eq("owner"), eq("repo"), eq(7)))
         .thenReturn(
@@ -186,37 +184,13 @@ class CommentCommandServiceTest {
   @Test
   void resolveReportsNothingToDoWhenNoBotThreads() {
     authorize(true);
-    when(reviewClient.listPullRequestComments(
-            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(1)))
+    when(reviewClient.listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(7)))
         .thenReturn(List.of(comment(200L, null, "octocat")));
 
     service.handle(ctx(CommentCommand.RESOLVE));
 
     verify(reviewThreadService, never()).threadsByRootComment(any(), any(), any(), anyInt());
     assertTrue(postedBody().contains("No open"));
-  }
-
-  @Test
-  void resolveWalksAllCommentPages() {
-    authorize(true);
-    var page1 = new ArrayList<PullRequestComment>();
-    for (int i = 1; i <= 100; i++) {
-      page1.add(comment(i, null, "thrillhousebot[bot]"));
-    }
-    when(reviewClient.listPullRequestComments(
-            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(1)))
-        .thenReturn(page1);
-    when(reviewClient.listPullRequestComments(
-            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(2)))
-        .thenReturn(List.of());
-    when(reviewThreadService.threadsByRootComment(any(), eq("owner"), eq("repo"), eq(7)))
-        .thenReturn(Map.of());
-
-    service.handle(ctx(CommentCommand.RESOLVE));
-
-    // A full first page must force a second-page fetch so later-page bot threads are not missed.
-    verify(reviewClient)
-        .listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(2));
   }
 
   @Test
@@ -299,8 +273,7 @@ class CommentCommandServiceTest {
   @Test
   void resolveContinuesWhenOneThreadResolutionThrows() {
     authorize(true);
-    when(reviewClient.listPullRequestComments(
-            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(1)))
+    when(reviewClient.listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(7)))
         .thenReturn(
             List.of(
                 comment(100L, null, "thrillhousebot[bot]"),
@@ -323,8 +296,7 @@ class CommentCommandServiceTest {
   @Test
   void resolveSkipsAlreadyResolvedThreads() {
     authorize(true);
-    when(reviewClient.listPullRequestComments(
-            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(1)))
+    when(reviewClient.listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(7)))
         .thenReturn(List.of(comment(100L, null, "thrillhousebot[bot]")));
     when(reviewThreadService.threadsByRootComment(any(), eq("owner"), eq("repo"), eq(7)))
         .thenReturn(Map.of(100L, new ReviewThreadService.ThreadRef("T100", true)));
@@ -337,45 +309,12 @@ class CommentCommandServiceTest {
   }
 
   @Test
-  void resolveStopsAtMaxCommentPages() {
-    authorize(true);
-    var fullPage = new ArrayList<PullRequestComment>();
-    for (int i = 1; i <= 100; i++) {
-      fullPage.add(comment(i, null, "octocat"));
-    }
-    // Every page is full, so the walk is bounded by the page cap rather than a short page.
-    when(reviewClient.listPullRequestComments(
-            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), anyInt()))
-        .thenReturn(fullPage);
-
-    service.handle(ctx(CommentCommand.RESOLVE));
-
-    verify(reviewClient, times(10))
-        .listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), anyInt());
-    assertTrue(postedBody().contains("No open"));
-  }
-
-  @Test
-  void resolveHandlesNullCommentsPage() {
-    authorize(true);
-    when(reviewClient.listPullRequestComments(
-            any(), any(), eq("owner"), eq("repo"), eq(7), eq(100), eq(1)))
-        .thenReturn(null);
-
-    service.handle(ctx(CommentCommand.RESOLVE));
-
-    verify(reviewThreadService, never()).threadsByRootComment(any(), any(), any(), anyInt());
-    assertTrue(postedBody().contains("No open"));
-  }
-
-  @Test
   void resolveIgnoredWhenUnauthorized() {
     authorize(false);
 
     service.handle(ctx(CommentCommand.RESOLVE));
 
-    verify(reviewClient, never())
-        .listPullRequestComments(any(), any(), any(), any(), anyInt(), anyInt(), anyInt());
+    verify(reviewClient, never()).listPullRequestComments(any(), any(), any(), any(), anyInt());
     verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
   }
 


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔧 Refactor

## Description

`ReviewOrchestrator.fetchPullRequestComments` used the **non-paginated** `listPullRequestComments`, which caps at GitHub's 30-comments-per-page default. On a PR with >30 inline comments, the follow-up logic that consumes this list — `dropRepliedDuplicates`, `resolveAddressedThreads`, the `unreportedUnresolvedStatuses` backstop, and `buildPreviousFindingsContext` — ran on a silently truncated set, so the bot re-raised already-replied findings and left addressed threads unresolved. This is the same single-page-truncation pattern the reviewer flags in others' code (#166), left in the bot's own fetch since v0.1.0.

The fix mirrors the established `getPullRequestFiles` / `GitHubCommentClient.listComments` precedent:
- The 7-arg method becomes `listPullRequestCommentsPage`, and a `default listPullRequestComments(5-arg)` walks pages of `COMMENTS_PER_PAGE` (100) up to `MAX_COMMENT_PAGES` (10).
- The **non-paginated 5-arg REST method is removed** (it had no remaining caller and was a silent-truncation footgun with no round-trip benefit).
- `CommentCommandService` and `MaintainerReplyService` drop their **duplicated** page-walk loops and call the shared default; the orchestrator's call now paginates with no call-site change.

## Related Issues

Fixes #212

## How Has This Been Tested?

- [x] Unit tests

- New `GitHubReviewClientTest` covers the default page-walk: full pages assembled, stop at a short page, bound at `MAX_COMMENT_PAGES`, and a null page tolerated.
- The per-page pagination cases that previously lived in `CommentCommandServiceTest` / `MaintainerReplyServiceTest` moved to the client test; those service tests now stub the 5-arg default.
- Full suite: **1216 passing**, `spotbugs:check` + `spotless:check` clean (JDK 25). (SpotBugs also flagged a now-redundant null check in `fetchPullRequestComments`, removed.)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (no doc change needed)
- [x] My changes generate no new warnings or errors

## Additional Notes

Pre-existing (since v0.1.0), targeted at `main`. Completes the #166/#191/#199 single-page-truncation remediation for the last of the bot's own list fetches. The `listReviews` fetch (the remaining single-page one) is tracked separately in #219.
