### PR TITLE
fix(review): even-cluster duplicate merge no longer downgrades severity (#213)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingDeduplicator.java
@@ -31,8 +31,9 @@ import java.util.Set;
  * underlying defect several times — dogfooding produced the same issue three times in one review at
  * three different severities. Findings are considered duplicates when they sit on the same file
  * within a small line tolerance and their titles describe the same thing; the merged finding keeps
- * the richest description and the median severity of the cluster, so one outlier rating (high or
- * low) cannot decide the posted severity.
+ * the richest description and the cluster's median severity (the more severe of the two central
+ * values for an even cluster), so a single outlier cannot decide the posted severity or downgrade a
+ * blocking finding.
  */
 @ApplicationScoped
 public class FindingDeduplicator {
@@ -153,9 +154,11 @@ public class FindingDeduplicator {
   }
 
   /**
-   * Richest description wins; severity is the cluster's median so outliers cannot decide it. When
-   * the richest copy carries no suggestion (for example after quote validation stripped it), the
-   * suggestion of another cluster member is kept instead of being lost in the merge.
+   * Richest description wins; severity is the cluster's median (for an even cluster, the more
+   * severe of the two central values, so a single hedged duplicate cannot downgrade a blocking
+   * finding). When the richest copy carries no suggestion (for example after quote validation
+   * stripped it), the suggestion of another cluster member is kept instead of being lost in the
+   * merge.
    */
   private static ReviewResponse.Finding merge(List<ReviewResponse.Finding> cluster) {
     if (cluster.size() == 1) {
@@ -176,20 +179,27 @@ public class FindingDeduplicator {
             .map(f -> RiskLevel.fromString(f.risk()))
             .sorted(Comparator.naturalOrder())
             .toList();
-    RiskLevel median = ranked.get(ranked.size() / 2);
-    // Confidence stays paired with the chosen risk: the highest confidence among the members
-    // that carry the median risk. Taking it from an arbitrary member could either defuse a
-    // blocking critical/high-confidence finding via a hedged duplicate, or synthesize a
-    // blocking pair no single member ever asserted. Confidence is declared most-certain-first
-    // (HIGH < MEDIUM < LOW in natural order), so min() selects the highest confidence.
+    // The list is sorted most-severe first (RiskLevel natural order is CRITICAL..LOW). An odd
+    // cluster uses the true median so a lone outlier cannot decide the severity; an even cluster
+    // has
+    // no single middle, so take the more severe of the two central values (the lower index) — never
+    // the less severe — so a single hedged duplicate cannot downgrade a blocking finding (#213).
+    int mid = ranked.size() / 2;
+    RiskLevel severity = ranked.size() % 2 == 0 ? ranked.get(mid - 1) : ranked.get(mid);
+    // Confidence stays paired with the chosen severity: the highest confidence among the members
+    // that carry it. Taking it from an arbitrary member could either defuse a blocking
+    // critical/high-confidence finding via a hedged duplicate, or synthesize a blocking pair no
+    // single member ever asserted. Confidence is declared most-certain-first (HIGH < MEDIUM < LOW
+    // in
+    // natural order), so min() selects the highest confidence.
     Confidence confidence =
         cluster.stream()
-            .filter(f -> RiskLevel.fromString(f.risk()) == median)
+            .filter(f -> RiskLevel.fromString(f.risk()) == severity)
             .map(f -> Confidence.fromString(f.confidence()))
             .min(Comparator.naturalOrder())
             .orElse(Confidence.fromString(richest.confidence()));
     return new ReviewResponse.Finding(
-        median.name().toLowerCase(Locale.ROOT),
+        severity.name().toLowerCase(Locale.ROOT),
         confidence.name().toLowerCase(Locale.ROOT),
         richest.file(),
         richest.line(),

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingDeduplicatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingDeduplicatorTest.java
@@ -97,13 +97,30 @@ class FindingDeduplicatorTest {
   }
 
   @Test
-  void twoDuplicatesKeepTheLowerOfTheTwoSeverities() {
-    // Median of two = second after sorting by rank (critical < high) — the less severe one,
-    // so a single escalated duplicate cannot raise the posted severity
+  void twoDuplicatesKeepTheMoreSevereSeverity() {
+    // An even cluster has no single median; the more severe of the two central values wins, so a
+    // single hedged (lower-severity) duplicate cannot downgrade a blocking finding (#213).
     var response =
         response(
             finding("critical", "src/A.java", 5, "Unbounded recursion in parser", "short"),
             finding("high", "src/A.java", 5, "Unbounded recursion in parser", "short too"));
+
+    var result = deduplicator.dedupe(response);
+
+    assertEquals(1, result.findings().size());
+    assertEquals("critical", result.findings().get(0).risk());
+  }
+
+  @Test
+  void evenClusterTakesTheMoreSevereOfTheTwoCentralSeverities() {
+    // Sorted [critical, high, medium, low]; the two central values are high and medium, so the more
+    // severe (high) is chosen — never the less severe (medium).
+    var response =
+        response(
+            finding("critical", "src/A.java", 5, "Unbounded recursion in parser", "a"),
+            finding("high", "src/A.java", 5, "Unbounded recursion in parser", "b"),
+            finding("medium", "src/A.java", 6, "Unbounded recursion in parser", "c"),
+            finding("low", "src/A.java", 6, "Unbounded recursion in parser", "d"));
 
     var result = deduplicator.dedupe(response);
 


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`FindingDeduplicator.merge` computed the merged severity of a duplicate cluster as `ranked.get(ranked.size() / 2)`. `RiskLevel`'s natural order is `CRITICAL < HIGH < MEDIUM < LOW`, so for an **even-sized** cluster `size/2` is the **less severe** of the two central values: `[critical, medium]` merged to `medium`. A single hedged duplicate could therefore defuse a blocking finding — exactly what the adjacent confidence-selection logic explicitly tries to prevent.

Odd clusters keep the true median (a lone outlier still cannot decide the severity). Even clusters now take the **more severe** of the two central values (the lower index), never the less severe. The local was renamed `severity` since it's no longer strictly the median.

## Related Issues

Fixes #213

## How Has This Been Tested?

- [x] Unit tests

- Rewrote `twoDuplicatesKeepTheLowerOfTheTwoSeverities` (which pinned the buggy behavior) into `twoDuplicatesKeepTheMoreSevereSeverity`: `[critical, high]` now merges to **critical**.
- Added `evenClusterTakesTheMoreSevereOfTheTwoCentralSeverities`: `[critical, high, medium, low]` merges to **high** (the more severe central).
- The odd-cluster median test and both confidence-pairing tests are unaffected and still pass.
- Full suite: **1217 passing**, spotbugs + spotless clean (JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (no doc change needed)
- [x] My changes generate no new warnings or errors

## Additional Notes

Pre-existing severity-gating bug, targeted at `main`.
