### PR TITLE
fix(review): stop isSameFinding over-merging by severity + proximity (#214)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -481,10 +481,15 @@ public class FollowUpAnalyzer {
     if (finding.file() == null || !FilePaths.same(finding.file(), prior.file())) {
       return false;
     }
+    // Same file + close lines + similar title is the same finding re-raised. Severity is NOT part
+    // of identity: two distinct findings that merely share a severity (or both carry null/unknown
+    // risk, which maps to LOW) near the same line are different defects and must not be collapsed —
+    // doing so silently dropped a new finding whenever a same-severity neighbour had been replied
+    // to (#214). A paraphrased re-raise whose title drifted is still caught by the content-overlap
+    // fallback below.
     if (Math.abs(finding.line() - prior.line()) <= DUPLICATE_LINE_TOLERANCE
-        && (RiskLevel.fromString(finding.risk()) == RiskLevel.fromString(prior.risk())
-            || FindingDeduplicator.titleSimilarity(finding.title(), prior.title())
-                >= FindingDeduplicator.TITLE_SIMILARITY_THRESHOLD)) {
+        && FindingDeduplicator.titleSimilarity(finding.title(), prior.title())
+            >= FindingDeduplicator.TITLE_SIMILARITY_THRESHOLD) {
       return true;
     }
     // Paraphrased re-raises drift in both wording and line numbers as the PR evolves

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -311,6 +311,43 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void dropRepliedDuplicatesShouldKeepDistinctNearbyFindingOfTheSameSeverity() {
+    // Regression (#214): severity must not be part of finding identity. A different defect a couple
+    // of lines from a replied prior finding of the same severity must still post — not be dropped
+    // as
+    // a re-raise just because the severities match.
+    var priorJson =
+        """
+        {"findings": [
+          {"risk": "medium", "file": "src/B.java", "line": 40,
+           "title": "SQL injection in query builder",
+           "description": "User input is concatenated directly into the SQL string"}
+        ]}
+        """;
+    var comments =
+        List.of(
+            comment(100L, null, "src/B.java", "**MEDIUM — SQL injection in query builder**", BOT),
+            comment(101L, 100L, "src/B.java", "Declining for now.", "maintainer"));
+    var distinct =
+        new ReviewResponse(
+            List.of(
+                new ReviewResponse.Finding(
+                    "medium",
+                    "high",
+                    "src/B.java",
+                    42,
+                    "Missing null check on the response",
+                    "The response object may be null when the upstream call times out",
+                    null,
+                    null)),
+            List.of(),
+            null);
+
+    assertSame(
+        distinct, analyzer.dropRepliedDuplicates(distinct, List.of(priorJson), comments, BOT_ID));
+  }
+
+  @Test
   void markerOnADifferentFileDoesNotBind() {
     var json =
         """
@@ -396,7 +433,7 @@ class FollowUpAnalyzerTest {
         new ReviewResponse(
             List.of(
                 new ReviewResponse.Finding(
-                    "medium", "high", "src/B.java", 7, "Null check still absent", "d", null, null),
+                    "medium", "high", "src/B.java", 7, "Missing null check", "d", null, null),
                 new ReviewResponse.Finding(
                     "high", "high", "src/C.java", 30, "Genuinely new bug", "d", null, null)),
             List.of(),
@@ -602,7 +639,7 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
-  void dropRepliedDuplicatesShouldRequireSameLocationAndSeverity() {
+  void dropRepliedDuplicatesShouldRequireSameLocationAndTitle() {
     var comments =
         List.of(
             comment(100L, null, "src/B.java", "**MEDIUM — Missing null check**", BOT),
@@ -610,13 +647,13 @@ class FollowUpAnalyzerTest {
     var different =
         new ReviewResponse(
             List.of(
-                // Same spot but different severity — a genuinely worse issue must post
+                // Same spot but an unrelated title — a different defect must post
                 new ReviewResponse.Finding(
                     "critical", "high", "src/B.java", 5, "Injection here", "d", null, null),
-                // Same severity but far away
+                // Same title but far away
                 new ReviewResponse.Finding(
                     "medium", "high", "src/B.java", 50, "Missing null check", "d", null, null),
-                // Same severity and line but different file
+                // Same title and line but different file
                 new ReviewResponse.Finding(
                     "medium", "high", "src/Z.java", 5, "Missing null check", "d", null, null)),
             List.of(),


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`FollowUpAnalyzer.isSameFinding` treated two findings as the same defect when they sat within `DUPLICATE_LINE_TOLERANCE` lines **and** merely shared a severity (`RiskLevel.fromString` maps null/unknown → `LOW`), ignoring title and content. So a distinct new finding a couple of lines from a replied prior finding of the same severity was dropped as a "re-raise" — silently losing it (e.g. a `medium` "missing null check" dropped because a `medium` "SQL injection" two lines away had a maintainer reply).

Severity is no longer part of identity. The proximity branch now requires a **title-similarity** signal (matching `FindingDeduplicator.sameDefect`), and a paraphrased re-raise whose title drifted is still caught by the existing **content-overlap** fallback.

## Related Issues

Fixes #214

## How Has This Been Tested?

- [x] Unit tests

- Added `dropRepliedDuplicatesShouldKeepDistinctNearbyFindingOfTheSameSeverity`: a same-severity, nearby, unrelated-title finding is **kept** even when a neighbouring prior thread was replied to (failed before the fix).
- Renamed `dropRepliedDuplicatesShouldRequireSameLocationAndSeverity` → `...AndTitle` (severity is no longer a criterion) and updated its inline comments.
- `dropRepliedDuplicatesShouldDropReRaisedFindingWithHumanReply` now identifies the re-raise by its (similar) title — the legitimate signal — rather than bare severity.
- Legitimate re-raise detection via title similarity and content overlap remains covered by the existing escalated/paraphrased tests.
- Full suite: **1218 passing**, spotbugs + spotless clean (JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (no doc change needed)
- [x] My changes generate no new warnings or errors

## Additional Notes

Pre-existing bug, targeted at `main`. Same `#118` follow-up subsystem as the open test-hardening (#136) and perf (#135) issues.
