### PR TITLE
fix(review): surface findings on a follow-up when none anchor inline (#215)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -1047,8 +1047,7 @@ public class ReviewOrchestrator {
     var sb = new StringBuilder();
     sb.append("ThrillhouseBot found ")
         .append(result.findings().size())
-        .append(result.findings().size() == 1 ? " issue" : " issues")
-        .append(" that could not be anchored to the current diff:\n\n");
+        .append(" issue(s) that could not be anchored to the current diff:\n\n");
     for (Finding f : result.findings()) {
       sb.append("- **")
           .append(f.risk().name())

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -1010,10 +1010,57 @@ public class ReviewOrchestrator {
               "REQUEST_CHANGES",
               List.of()));
     } else if (posted == 0) {
+      // Inline anchoring failed for every finding (e.g. all lines fell outside the diff after a
+      // force-push). Surface them in the review body so they are not invisible: a follow-up review
+      // posts no summary comment, so without this the findings would show only as a red check
+      // (#215).
       Log.warnf(
-          "No inline comments posted for %s/%s #%d — findings are in the PR summary comment only",
+          "No inline comments posted for %s/%s #%d — surfacing findings in the review body",
           owner, repo, prNumber);
+      String body =
+          result.isFirstReview()
+              ? "ThrillhouseBot found "
+                  + result.findings().size()
+                  + " issue(s) that could not be anchored to the current diff — see the PR summary"
+                  + " comment above for details."
+              : unanchoredFindingsBody(result);
+      createReviewWithFallback(
+          auth,
+          owner,
+          repo,
+          prNumber,
+          new GitHubReviewClient.CreateReviewRequest(
+              commitSha,
+              body,
+              result.reviewState() == ReviewState.REQUEST_CHANGES ? "REQUEST_CHANGES" : "COMMENT",
+              List.of()));
     }
+  }
+
+  /**
+   * A review-body list of findings, used when none could be anchored as inline comments (their
+   * lines fell outside the current diff). It keeps the findings visible on a follow-up review,
+   * which posts no summary comment — without it the findings would surface only as a red check run
+   * (#215).
+   */
+  private static String unanchoredFindingsBody(ReviewResult result) {
+    var sb = new StringBuilder();
+    sb.append("ThrillhouseBot found ")
+        .append(result.findings().size())
+        .append(result.findings().size() == 1 ? " issue" : " issues")
+        .append(" that could not be anchored to the current diff:\n\n");
+    for (Finding f : result.findings()) {
+      sb.append("- **")
+          .append(f.risk().name())
+          .append(":** ")
+          .append(f.title())
+          .append(" (`")
+          .append(f.file())
+          .append(":")
+          .append(f.line())
+          .append("`)\n");
+    }
+    return sb.toString();
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -61,6 +61,11 @@ public class ReviewOrchestrator {
   // Check run conclusion constants
   private static final String CONCLUSION_FAILURE = "failure";
 
+  // PR review event types submitted via createReview.
+  private static final String EVENT_APPROVE = "APPROVE";
+  private static final String EVENT_REQUEST_CHANGES = "REQUEST_CHANGES";
+  private static final String EVENT_COMMENT = "COMMENT";
+
   // CI check evaluation constants
   private static final String CI_SUCCESS = "success";
   private static final String CI_PENDING = "pending";
@@ -1007,7 +1012,7 @@ public class ReviewOrchestrator {
           new GitHubReviewClient.CreateReviewRequest(
               commitSha,
               "ThrillhouseBot requested changes — see inline comments on the diff.",
-              "REQUEST_CHANGES",
+              EVENT_REQUEST_CHANGES,
               List.of()));
     } else if (posted == 0) {
       // Inline anchoring failed for every finding (e.g. all lines fell outside the diff after a
@@ -1032,7 +1037,9 @@ public class ReviewOrchestrator {
           new GitHubReviewClient.CreateReviewRequest(
               commitSha,
               body,
-              result.reviewState() == ReviewState.REQUEST_CHANGES ? "REQUEST_CHANGES" : "COMMENT",
+              result.reviewState() == ReviewState.REQUEST_CHANGES
+                  ? EVENT_REQUEST_CHANGES
+                  : EVENT_COMMENT,
               List.of()));
     }
   }
@@ -1072,7 +1079,10 @@ public class ReviewOrchestrator {
       // carries no body; follow-ups post no summary and keep the message here.
       var req =
           new GitHubReviewClient.CreateReviewRequest(
-              commitSha, result.isFirstReview() ? "" : ZERO_ISSUES_MESSAGE, "APPROVE", List.of());
+              commitSha,
+              result.isFirstReview() ? "" : ZERO_ISSUES_MESSAGE,
+              EVENT_APPROVE,
+              List.of());
       createReviewWithFallback(auth, owner, repo, prNumber, req);
       return;
     }
@@ -1093,7 +1103,9 @@ public class ReviewOrchestrator {
         new GitHubReviewClient.CreateReviewRequest(
             commitSha,
             noIssuesBody(result),
-            result.reviewState() == ReviewState.REQUEST_CHANGES ? "REQUEST_CHANGES" : "COMMENT",
+            result.reviewState() == ReviewState.REQUEST_CHANGES
+                ? EVENT_REQUEST_CHANGES
+                : EVENT_COMMENT,
             List.of());
     createReviewWithFallback(auth, owner, repo, prNumber, req);
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2233,23 +2233,78 @@ class ReviewOrchestratorTest {
     }
 
     @Test
-    void shouldWarnWhenNoInlineCommentsPosted() {
+    void shouldPointToSummaryInReviewBodyWhenNoneAnchorInlineOnFirstReview() {
+      // The finding's file is not in the diff, so no inline comment anchors (posted == 0). On a
+      // first review the findings are in the summary comment, so the review body points there — but
+      // a
+      // review event is still posted so the findings never vanish behind a bare check (#215).
       var finding = new Finding(RiskLevel.MEDIUM, "missing.java", 10, "Bug", "desc", null, null);
-      var result = resultWithFinding(finding, ReviewState.COMMENT);
+      var result = resultWithFinding(finding, ReviewState.COMMENT); // isFirstReview = true
 
-      assertDoesNotThrow(
-          () ->
-              orchestrator.postReview(
-                  "Bearer tok",
-                  "owner",
-                  "repo",
-                  7,
-                  "sha",
-                  result,
-                  List.of(fileDiffWithLine("src/Main.java", 10))));
+      orchestrator.postReview(
+          "Bearer tok",
+          "owner",
+          "repo",
+          7,
+          "sha",
+          result,
+          List.of(fileDiffWithLine("src/Main.java", 10)));
 
-      verify(reviewClient, never())
-          .createReview(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+      verify(reviewClient)
+          .createReview(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(
+                  req ->
+                      "COMMENT".equals(req.event())
+                          && req.body().contains("could not be anchored")
+                          && req.body().contains("PR summary")));
+    }
+
+    @Test
+    void shouldListFindingsInReviewBodyWhenNoneAnchorInlineOnFollowUp() {
+      // Regression (#215): on a follow-up review (which posts no summary comment) findings whose
+      // lines fall outside the diff must still be listed in the review body, not show only as a red
+      // check run.
+      var finding =
+          new Finding(RiskLevel.CRITICAL, "missing.java", 10, "Auth bypass", "desc", null, null);
+      var result =
+          new ReviewResult(
+              List.of(finding),
+              1,
+              0,
+              0,
+              0,
+              RiskLevel.CRITICAL,
+              ReviewState.REQUEST_CHANGES,
+              false, // follow-up: no summary comment is posted
+              "",
+              List.of());
+
+      orchestrator.postReview(
+          "Bearer tok",
+          "owner",
+          "repo",
+          7,
+          "sha",
+          result,
+          List.of(fileDiffWithLine("src/Main.java", 10)));
+
+      verify(reviewClient)
+          .createReview(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(
+                  req ->
+                      "REQUEST_CHANGES".equals(req.event())
+                          && req.body().contains("Auth bypass")
+                          && req.body().contains("missing.java:10")));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

When a review had findings but **every** inline comment was rejected (`posted == 0` — e.g. all anchor lines fell outside the current diff after a force-push), `ReviewOrchestrator.postReview` only logged a warning. No review event was submitted, and a **follow-up** review posts no summary comment, so the blocking findings were visible nowhere except a terse red check run. (Merge was still gated by the check, so this was a visibility gap, not an approval bypass.)

`postReview` now submits a `REQUEST_CHANGES`/`COMMENT` review when `posted == 0`:
- **First review**: the body points to the summary comment (which already lists the findings).
- **Follow-up**: the body lists the findings inline (title + `file:line`) via a new `unanchoredFindingsBody` helper.

## Related Issues

Fixes #215

## How Has This Been Tested?

- [x] Unit tests

- Replaced `shouldWarnWhenNoInlineCommentsPosted` (which pinned the no-review-event behavior) with:
  - `shouldPointToSummaryInReviewBodyWhenNoneAnchorInlineOnFirstReview` — a COMMENT review is posted whose body references the PR summary.
  - `shouldListFindingsInReviewBodyWhenNoneAnchorInlineOnFollowUp` — a REQUEST_CHANGES review is posted whose body lists the finding title and `missing.java:10`.
- Full suite: **1219 passing**, spotbugs + spotless clean (JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (no doc change needed)
- [x] My changes generate no new warnings or errors

## Additional Notes

Pre-existing visibility gap, targeted at `main`.
