### PR TITLE
fix(review): require a contiguous run for a FULL multi-line quote (#216)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -68,21 +68,7 @@ public class FindingQuoteValidator {
     var kept = new ArrayList<ReviewResponse.Finding>(response.findings().size());
     var changed = false;
     for (ReviewResponse.Finding finding : response.findings()) {
-      List<String> quoted = normalizedLines(finding.suggestionOld());
-      QuoteMatch match = matchQuote(quoted, index.linesFor(finding.file()));
-      // matchQuote judges presence per line by set membership, which cannot tell a genuine
-      // multi-line block from a recombination of real-but-scattered lines. Require a contiguous
-      // in-order run for a multi-line FULL verdict, demoting a scattered quote so a fabricated
-      // suggestion is not kept (#216). Single-line quotes are trivially contiguous and unaffected.
-      if (match == QuoteMatch.FULL
-          && quoted.size() >= 2
-          && !appearsContiguous(index.diffLinesFor(finding.file()), quoted)) {
-        match = QuoteMatch.PARTIAL;
-      }
-      if (match == QuoteMatch.FULL) {
-        match = checkAmbiguity(quoted, finding.line(), index.diffLinesFor(finding.file()));
-      }
-      switch (match) {
+      switch (classifyQuote(finding, index)) {
         case FULL, NO_QUOTE -> {
           if (descriptionCitesAbsentCode(finding, index)) {
             Log.infof(
@@ -132,6 +118,27 @@ public class FindingQuoteValidator {
         kept,
         response.previousFindingsStatus(),
         FindingVerificationService.recount(response.summary(), kept));
+  }
+
+  /**
+   * The quote verdict for one finding. Starts from {@link #matchQuote}'s per-line presence, then
+   * tightens a multi-line FULL verdict to also require a contiguous in-order run on one side of the
+   * diff — a recombination of real-but-scattered lines is demoted to PARTIAL so a fabricated
+   * suggestion is not kept (#216); single-line quotes are trivially contiguous and unaffected.
+   * Finally a FULL quote is disambiguated by line when it appears in multiple locations.
+   */
+  private QuoteMatch classifyQuote(ReviewResponse.Finding finding, DiffIndex index) {
+    List<String> quoted = normalizedLines(finding.suggestionOld());
+    QuoteMatch match = matchQuote(quoted, index.linesFor(finding.file()));
+    if (match == QuoteMatch.FULL
+        && quoted.size() >= 2
+        && !appearsContiguous(index.diffLinesFor(finding.file()), quoted)) {
+      return QuoteMatch.PARTIAL;
+    }
+    if (match == QuoteMatch.FULL) {
+      return checkAmbiguity(quoted, finding.line(), index.diffLinesFor(finding.file()));
+    }
+    return match;
   }
 
   enum QuoteMatch {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -70,6 +70,15 @@ public class FindingQuoteValidator {
     for (ReviewResponse.Finding finding : response.findings()) {
       List<String> quoted = normalizedLines(finding.suggestionOld());
       QuoteMatch match = matchQuote(quoted, index.linesFor(finding.file()));
+      // matchQuote judges presence per line by set membership, which cannot tell a genuine
+      // multi-line block from a recombination of real-but-scattered lines. Require a contiguous
+      // in-order run for a multi-line FULL verdict, demoting a scattered quote so a fabricated
+      // suggestion is not kept (#216). Single-line quotes are trivially contiguous and unaffected.
+      if (match == QuoteMatch.FULL
+          && quoted.size() >= 2
+          && !appearsContiguous(index.diffLinesFor(finding.file()), quoted)) {
+        match = QuoteMatch.PARTIAL;
+      }
       if (match == QuoteMatch.FULL) {
         match = checkAmbiguity(quoted, finding.line(), index.diffLinesFor(finding.file()));
       }
@@ -434,13 +443,31 @@ public class FindingQuoteValidator {
    * The diff lines that {@code suggestion_old} can match: context and deletions, never additions.
    */
   private static List<DiffLine> retainedLines(List<DiffLine> diffLines) {
+    return linesExcludingMarker(diffLines, '+');
+  }
+
+  /** Diff lines keeping every marker except {@code excluded}, preserving order. */
+  private static List<DiffLine> linesExcludingMarker(List<DiffLine> diffLines, char excluded) {
     var filtered = new ArrayList<DiffLine>();
     for (DiffLine dl : diffLines) {
-      if (dl.marker() != '+') {
+      if (dl.marker() != excluded) {
         filtered.add(dl);
       }
     }
     return filtered;
+  }
+
+  /**
+   * Whether {@code quoted} appears as a contiguous in-order run on at least one side of the diff:
+   * the original side (context + deletions) for replaced code, or the new side (context +
+   * additions) for code this PR added. A quote contiguous on neither side is a recombination of
+   * real-but- scattered lines, not a genuine block — additions interleaved between two original
+   * lines (or deletions between two added lines) do not break a genuine block because each side is
+   * checked with the other's marker filtered out.
+   */
+  private static boolean appearsContiguous(List<DiffLine> diffLines, List<String> quoted) {
+    return !contiguousMatchStarts(linesExcludingMarker(diffLines, '+'), quoted).isEmpty()
+        || !contiguousMatchStarts(linesExcludingMarker(diffLines, '-'), quoted).isEmpty();
   }
 
   /** Start indices where {@code quoted} appears as a contiguous run in {@code lines}. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -443,6 +443,33 @@ class FindingQuoteValidatorTest {
   }
 
   @Test
+  void multiLineQuoteOfContiguousAddedCodeIsKept() {
+    // suggestion_old may quote code this PR added (to replace a just-added bug). Those lines are
+    // contiguous on the new side (context + additions) but absent from the original side (context +
+    // deletions), so the multi-line contiguity gate must still keep them (#216).
+    var diff =
+        """
+        ### src/New.java (modified, +2 -0)
+        ```diff
+        @@ -1,1 +1,3 @@
+         existing();
+        +    addedOne();
+        +    addedTwo();
+        ```
+        """;
+    var quote = "addedOne();\naddedTwo();";
+    var finding =
+        new ReviewResponse.Finding(
+            "critical", "high", "src/New.java", 2, "Title", "Description", quote, "replacement");
+
+    var result = validator.validate(response(finding), diff);
+
+    assertEquals(1, result.findings().size());
+    assertEquals(quote, result.findings().get(0).suggestionOld());
+    assertEquals("high", result.findings().get(0).confidence());
+  }
+
+  @Test
   void ambiguousAcrossFilesWhenFindingFileUnresolved() {
     var diff =
         """

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -108,6 +108,24 @@ class FindingQuoteValidatorTest {
   }
 
   @Test
+  void stripsSuggestionWhenMultiLineQuoteIsScatteredNotContiguous() {
+    // Both lines exist in the diff ("}" last, "public class Main {" first) but never as a
+    // contiguous in-order run — a recombination of real lines that matchQuote's per-line set
+    // membership wrongly accepts as FULL. It must be demoted so the fabricated suggestion is
+    // not kept (#216).
+    var response = response(finding("}\npublic class Main {"));
+
+    var result = validator.validate(response, DIFF);
+
+    assertEquals(1, result.findings().size());
+    var kept = result.findings().get(0);
+    assertNull(kept.suggestionOld());
+    assertNull(kept.suggestionNew());
+    assertEquals("low", kept.confidence());
+    assertEquals("critical", kept.risk());
+  }
+
+  @Test
   void skipsTriviallyEmptyInputs() {
     var noFindings = response();
     assertSame(noFindings, validator.validate(noFindings, DIFF));


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`FindingQuoteValidator.matchQuote` judged a `suggestion_old` present by **per-line set membership**, so a multi-line quote whose lines each exist *scattered* across the diff — but never as a contiguous in-order run — was accepted as `FULL` and kept its suggestion. `checkAmbiguity` then left it `FULL` ("anything not matched contiguously stays FULL"), so a recombined/fabricated quote slipped through the anti-fabrication gate.

A multi-line `FULL` verdict now also requires the quote to appear as a **contiguous in-order run on at least one side of the diff**:
- the **original side** (context + deletions) for replaced code, or
- the **new side** (context + additions) for code this PR added.

A quote contiguous on neither side is demoted to `PARTIAL` (suggestion stripped, confidence capped). Each side is checked with the *other's* marker filtered out, so a genuine block whose lines are interleaved with insertions on the opposite side is preserved. Single-line quotes are trivially contiguous and unaffected.

## Related Issues

Fixes #216

## How Has This Been Tested?

- [x] Unit tests

- Added `stripsSuggestionWhenMultiLineQuoteIsScatteredNotContiguous`: a 2-line quote whose lines exist in the diff but never contiguously is demoted (suggestion stripped, confidence `low`).
- The existing `quoteWithInterleavedAdditionsIsKept` (original-code quote split by an inserted line) and the contiguous multi-line keep-cases still pass — verifying no legitimate quote is demoted.
- Full suite: **1220 passing**, spotbugs + spotless clean (JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (no doc change needed)
- [x] My changes generate no new warnings or errors

## Additional Notes

Pre-existing anti-fabrication gap, targeted at `main`. Surfaced by the same class of validator stress-testing tracked in #123.
