### PR TITLE
fix(review): treat an unknown CI status state as pending, not success (#217)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -1482,13 +1482,16 @@ public class ReviewOrchestrator {
 
   /** Maps a commit-status state to one of success/pending/failing. */
   private static String classifyStatus(String state) {
-    if (CI_PENDING.equalsIgnoreCase(state)) {
-      return CI_PENDING;
+    if (CI_SUCCESS.equalsIgnoreCase(state)) {
+      return CI_SUCCESS;
     }
     if (CONCLUSION_FAILURE.equalsIgnoreCase(state) || "error".equalsIgnoreCase(state)) {
       return CI_FAILING;
     }
-    return CI_SUCCESS;
+    // "pending", null, or any unrecognized state is not a confirmed pass: classify it as pending so
+    // an indeterminate required check holds the approval rather than being mistaken for success
+    // (#217). Only an explicit "success" clears the gate.
+    return CI_PENDING;
   }
 
   private boolean isThrillhouseBotCheck(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -3651,6 +3651,31 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void shouldHoldApprovalWhenAStatusStateIsUnrecognized() {
+      // A commit status whose state is neither success/pending/failure/error (here a malformed
+      // value; null behaves identically) is not a confirmed pass — it must surface as a pending
+      // offending check so it holds the approval rather than clearing the gate (#217).
+      var passRun =
+          new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+              1L, "build", "completed", "success", null);
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CheckRunsResponse(1, List.of(passRun)));
+      var unknownStatus =
+          new GitHubCheckRunClient.CombinedStatus.StatusDetail(2L, "weird", "deploy", "desc");
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(
+              new GitHubCheckRunClient.CombinedStatus("pending", 1, List.of(unknownStatus)));
+
+      var result = orchestrator.evaluateCiChecks("auth", "owner", "repo", "sha", null);
+
+      assertEquals(1, result.size());
+      var check = result.get(0);
+      assertEquals("deploy", check.name());
+      assertTrue(check.isPending());
+      assertFalse(check.isFailing());
+    }
+
+    @Test
     void shouldFilterByRequiredContextsWhenProvided() {
       // All four checks are failing; only the two in requiredContexts must surface as offending.
       var run1 =


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`ReviewOrchestrator.classifyStatus` returned `CI_SUCCESS` for any state that wasn't `pending`, `failure`, or `error` — so a **null or unrecognized** commit-status state was treated as a confirmed pass and could not hold the approval. An indeterminate required check therefore silently cleared the gate.

Now only an explicit `success` clears it; `pending`, `null`, and any unrecognized state are classified `pending`, so an indeterminate required check holds the approval rather than being mistaken for success.

## Related Issues

Fixes #217

## How Has This Been Tested?

- [x] Unit tests

- Added `shouldHoldApprovalWhenAStatusStateIsUnrecognized`: a status with a malformed state (null behaves identically) surfaces as a **pending** offending check (`isPending()` true, `isFailing()` false), so it holds the gate.
- Existing success→success and failure/error→failing cases are unchanged and still pass.
- Full suite: **1222 passing**, spotbugs + spotless clean (JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (no doc change needed)
- [x] My changes generate no new warnings or errors

## Additional Notes

Pre-existing bug, targeted at `main`.
