### PR TITLE
fix(review): getLineText returns null on an ambiguous suffix collision (#218)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -102,15 +102,24 @@ public final class DiffLineResolver {
     if (exact != null && !exact.isEmpty()) {
       return exact.get(line);
     }
+    // Variant fallback: resolve to the UNIQUE FilePaths.same variant. On a suffix collision (two
+    // diff keys both matching, e.g. a/Handler.java and b/Handler.java) return null rather than
+    // guess
+    // whichever entry the map iterates first — mirrors resolveRightSideLinesForFileOrVariant, the
+    // safe direction (#218).
+    Map<Integer, String> resolved = null;
     for (var entry : rightSideLineTextByFile.entrySet()) {
       var value = entry.getValue();
       if (!entry.getKey().equals(file)
           && !value.isEmpty()
           && FilePaths.same(file, entry.getKey())) {
-        return value.get(line);
+        if (resolved != null) {
+          return null;
+        }
+        resolved = value;
       }
     }
-    return null;
+    return resolved != null ? resolved.get(line) : null;
   }
 
   /** Whether {@code needle} appears as a contiguous, in-order run within {@code haystack}. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
@@ -689,4 +689,22 @@ class DiffLineResolverTest {
     assertNull(emptyResolver.getLineText("dir/Main.java", 11));
     assertNull(emptyResolver.getLineText("Main.java", 11));
   }
+
+  @Test
+  void getLineTextReturnsNullOnAmbiguousSuffixCollision() {
+    // Both a/dir/Main.java and b/dir/Main.java carry right-side text and are FilePaths.same to the
+    // queried "dir/Main.java". With no unique resolution, getLineText must return null rather than
+    // guess whichever entry the map happens to iterate first (#218).
+    var other =
+        """
+        @@ -10,3 +10,4 @@
+         def unchanged():
+        -    old_line()
+        +    other_line()
+        +    added_line()
+        """;
+    var resolver = new DiffLineResolver(Map.of("a/dir/Main.java", PATCH, "b/dir/Main.java", other));
+
+    assertNull(resolver.getLineText("dir/Main.java", 11));
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`DiffLineResolver.getLineText`'s path-variant fallback returned `value.get(line)` from the **first** `HashMap`-iterated entry whose path was `FilePaths.same` — so two suffix-colliding diff keys (e.g. `a/Handler.java` and `b/Handler.java`) resolved to whichever the map happened to iterate first, giving a wrong-file (or null) result. The sibling `resolveRightSideLinesForFileOrVariant` already guards exactly this.

`getLineText` now resolves to the **unique** matching variant and returns `null` when more than one matches, so it never binds to the wrong file on genuine ambiguity. A single-variant match still resolves as before.

## Related Issues

Fixes #218

## How Has This Been Tested?

- [x] Unit tests

- Added `getLineTextReturnsNullOnAmbiguousSuffixCollision`: two suffix-colliding files both carrying right-side text for the queried path return `null` (no wrong-file binding), regardless of map order.
- The existing `shouldReturnLineTextAcrossPathVariants` (single non-empty variant resolves; bare filename doesn't bind; empty variants) still passes.
- Full suite: **1223 passing**, spotbugs + spotless clean (JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (no doc change needed)
- [x] My changes generate no new warnings or errors

## Additional Notes

Pre-existing bug, targeted at `main`.
