### PR TITLE
fix(review): paginate listReviews so reviews past page 1 are not missed (#219)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -36,15 +36,46 @@ public interface GitHubReviewClient {
       @PathParam("pullNumber") int pullNumber,
       CreateReviewRequest request);
 
+  // GitHub serves 30 reviews per page by default; request the 100 max and walk a bounded number of
+  // pages so first-review detection, the approve backstop, and dismissing a stale pending bot
+  // review
+  // all see the whole set — a pending bot review past page one would otherwise be missed (#219).
+  int REVIEWS_PER_PAGE = 100;
+  int MAX_REVIEW_PAGES = 10;
+
   @GET
   @Path("/repos/{owner}/{repo}/pulls/{pullNumber}/reviews")
   @Produces(MediaType.APPLICATION_JSON)
-  List<ReviewResponse> listReviews(
+  List<ReviewResponse> listReviewsPage(
       @HeaderParam("Authorization") String auth,
       @HeaderParam("Accept") String accept,
       @PathParam("owner") String owner,
       @PathParam("repo") String repo,
-      @PathParam("pullNumber") int pullNumber);
+      @PathParam("pullNumber") int pullNumber,
+      @QueryParam("per_page") int perPage,
+      @QueryParam("page") int page);
+
+  /**
+   * Lists a PR's reviews, walking pages of {@value #REVIEWS_PER_PAGE} up to {@value
+   * #MAX_REVIEW_PAGES} pages so a long-lived PR's reviews are not silently truncated. A single-page
+   * fetch caps at GitHub's 30-per-page default, which would hide a prior bot review (skewing
+   * first-review detection and the backstop) and leave a pending bot review past page one
+   * undismissed. Stops at the first short/empty page.
+   */
+  default List<ReviewResponse> listReviews(
+      String auth, String accept, String owner, String repo, int pullNumber) {
+    var all = new ArrayList<ReviewResponse>();
+    List<ReviewResponse> batch;
+    int page = 1;
+    do {
+      batch = listReviewsPage(auth, accept, owner, repo, pullNumber, REVIEWS_PER_PAGE, page);
+      if (batch != null) {
+        all.addAll(batch);
+      }
+      page++;
+    } while (batch != null && batch.size() == REVIEWS_PER_PAGE && page <= MAX_REVIEW_PAGES);
+    return all;
+  }
 
   // GitHub serves 30 inline review comments per page by default; request the 100 max and walk a
   // bounded number of pages so follow-up dedup, /resolve and the unresolved-status backstop never

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClientTest.java
@@ -25,16 +25,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.PullRequestComment;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.ReviewResponse;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 /**
- * Covers the {@code listPullRequestComments} default pagination loop: GitHub returns only 30 inline
- * review comments per page by default, so follow-up dedup, {@code /resolve} and the
- * unresolved-status backstop would run on a silently truncated set on a busy PR. Comments are
- * assembled by walking pages of {@value GitHubReviewClient#COMMENTS_PER_PAGE}, bounded by {@value
- * GitHubReviewClient#MAX_COMMENT_PAGES}.
+ * Covers the default pagination loops. GitHub serves only 30 rows per page by default, so a
+ * single-page fetch would silently truncate on a busy/long-lived PR: {@code
+ * listPullRequestComments} feeds follow-up dedup, {@code /resolve} and the unresolved-status
+ * backstop, and {@code listReviews} feeds first-review detection, the approve backstop, and
+ * dismissing a stale pending bot review. Each walks pages of its {@code *_PER_PAGE} bounded by its
+ * {@code MAX_*_PAGES}.
  */
 class GitHubReviewClientTest {
 
@@ -106,5 +108,68 @@ class GitHubReviewClientTest {
     when(client.listPullRequestCommentsPage("auth", "json", "o", "r", 7, 100, 1)).thenReturn(null);
 
     assertEquals(0, client.listPullRequestComments("auth", "json", "o", "r", 7).size());
+  }
+
+  private static List<ReviewResponse> reviewPage(int count) {
+    return IntStream.range(0, count)
+        .mapToObj(
+            i -> new ReviewResponse(i, "body", "COMMENTED", "sha", new ReviewResponse.User("u")))
+        .toList();
+  }
+
+  /** A mock whose default {@code listReviews} runs the real pagination loop. */
+  private static GitHubReviewClient reviewPagingClient() {
+    var client = mock(GitHubReviewClient.class);
+    when(client.listReviews(anyString(), anyString(), anyString(), anyString(), anyInt()))
+        .thenCallRealMethod();
+    return client;
+  }
+
+  @Test
+  void walksEveryReviewPageUntilAShortPage() {
+    var client = reviewPagingClient();
+    when(client.listReviewsPage("auth", "json", "o", "r", 7, 100, 1)).thenReturn(reviewPage(100));
+    when(client.listReviewsPage("auth", "json", "o", "r", 7, 100, 2)).thenReturn(reviewPage(30));
+
+    var all = client.listReviews("auth", "json", "o", "r", 7);
+
+    // 130 reviews across 2 pages — a pending bot review past page one is not missed.
+    assertEquals(130, all.size());
+    verify(client).listReviewsPage("auth", "json", "o", "r", 7, 100, 2);
+    verify(client, never()).listReviewsPage("auth", "json", "o", "r", 7, 100, 3);
+  }
+
+  @Test
+  void stopsAfterOneReviewPageWhenNotFull() {
+    var client = reviewPagingClient();
+    when(client.listReviewsPage("auth", "json", "o", "r", 7, 100, 1)).thenReturn(reviewPage(5));
+
+    assertEquals(5, client.listReviews("auth", "json", "o", "r", 7).size());
+    verify(client, times(1))
+        .listReviewsPage(
+            anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt());
+  }
+
+  @Test
+  void reviewsAreBoundedByMaxPages() {
+    var client = reviewPagingClient();
+    when(client.listReviewsPage(
+            anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+        .thenReturn(reviewPage(100));
+
+    var all = client.listReviews("auth", "json", "o", "r", 7);
+
+    assertEquals(100 * GitHubReviewClient.MAX_REVIEW_PAGES, all.size());
+    verify(client, times(GitHubReviewClient.MAX_REVIEW_PAGES))
+        .listReviewsPage(
+            anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt());
+  }
+
+  @Test
+  void toleratesANullReviewPage() {
+    var client = reviewPagingClient();
+    when(client.listReviewsPage("auth", "json", "o", "r", 7, 100, 1)).thenReturn(null);
+
+    assertEquals(0, client.listReviews("auth", "json", "o", "r", 7).size());
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`GitHubReviewClient.listReviews` fetched only GitHub's first page (30 reviews). On a long-lived PR with more reviews:
- `fetchPriorReviews` under-counted, skewing first-review detection and the approve backstop, and
- `dismissPendingBotReviews` could leave a **pending bot review beyond page 1 undismissed**, so the next `createReview` hits GitHub's "one pending review per user" limit.

Mirrors the `getPullRequestFiles` / `listPullRequestComments` precedent: add `listReviewsPage` and make `listReviews` a `default` method that walks pages of `REVIEWS_PER_PAGE` (100) up to `MAX_REVIEW_PAGES` (10). Both callers already use the 5-arg `listReviews`, so they now paginate with **no call-site change**.

## Related Issues

Fixes #219

Note: #74 (have `dismissPendingBotReviews` **reuse** the already-fetched reviews instead of re-fetching) is a separate *perf* optimization and is intentionally left to that issue — this change keeps both fetches but does not entrench the double fetch.

## How Has This Been Tested?

- [x] Unit tests

- `GitHubReviewClientTest` now covers the `listReviews` page-walk: full pages assembled across pages, stop at a short page, bound at `MAX_REVIEW_PAGES`, and a null page tolerated.
- Existing `listReviews` stubs (5-arg) are unaffected — they stub the default method directly.
- Full suite: **1227 passing**, spotbugs + spotless clean (JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (no doc change needed)
- [x] My changes generate no new warnings or errors

## Additional Notes

Pre-existing single-page-truncation bug (the last of the bot's own list fetches), targeted at `main`.
