### PR TITLE
fix(review): don't post a "retry" notice after the result is already posted (#220)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -211,6 +211,11 @@ public class ReviewOrchestrator {
     // the same failure path as any other error — comment, failed session, broadcast.
     var req = request;
     var checkRunId = -1L;
+    // Once the check-run verdict is committed, the review result is visible to the user; a failure
+    // in
+    // any later step must not flip that verdict to failure nor post a "retry" notice over it
+    // (#220).
+    var resultSurfaced = false;
     try {
       var resolved = resolveMissingPrDetails(auth, request);
       req = resolved;
@@ -363,6 +368,10 @@ public class ReviewOrchestrator {
               checkTitle,
               checkSummary,
               sessionUrl(session)));
+      // The verdict is now on the check run — the authoritative, user-visible result. From here a
+      // late failure (summary/review post, thread resolution, labels, persistence, broadcast) is a
+      // post-result hiccup, not a reason to retract the verdict or ask the user to re-run (#220).
+      resultSurfaced = true;
 
       // Summary goes first so it tops the PR conversation, before the inline finding comments.
       // Posted on clean first reviews too: the celebration line lives inside the summary
@@ -398,7 +407,18 @@ public class ReviewOrchestrator {
           "Review complete for %s/%s #%d: %d findings, state=%s",
           req.owner(), req.repo(), req.prNumber(), result.totalFindings(), result.reviewState());
     } catch (RuntimeException e) {
-      handleReviewFailure(auth, req, session, checkRunId, e);
+      if (resultSurfaced) {
+        // The result is already posted; log the trailing failure but leave the verdict intact so we
+        // don't overwrite it with a misleading "could not be completed — retry" notice (#220).
+        Log.warnf(
+            e,
+            "Review for %s/%s #%d was posted, but a post-result step failed",
+            req.owner(),
+            req.repo(),
+            req.prNumber());
+      } else {
+        handleReviewFailure(auth, req, session, checkRunId, e);
+      }
     }
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -1279,6 +1279,83 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void shouldNotPostRetryNoticeWhenAStepFailsAfterTheResultIsPosted() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getPrTitle()).thenReturn("Test PR");
+        when(session.getCommitSha()).thenReturn("abcdefgh");
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        when(authClient.getAuthHeader(123L)).thenReturn("Bearer test");
+        when(checkRunClient.createCheckRun(
+                anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(new GitHubCheckRunClient.CheckRunResponse(1L, "http://check"));
+        doNothing()
+            .when(checkRunClient)
+            .updateCheckRun(anyString(), anyString(), anyString(), anyString(), anyLong(), any());
+        when(prClient.getPullRequestFiles(
+                anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of());
+        when(prClient.compareCommits(
+                anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
+        when(reviewClient.listReviews(anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of());
+        when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
+            .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
+        when(labeler.fetchExistingLabels(anyString(), anyString(), anyString()))
+            .thenReturn(List.of());
+        var summary =
+            new ReviewResponse.Summary(
+                0, 0, 0, 0, 0, "looks good", "adds a thing", List.of(), List.of());
+        when(aiReviewService.review(any(ReviewSession.class), any()))
+            .thenReturn(new ReviewResponse(List.of(), List.of(), summary));
+        // A trailing step blows up only AFTER the verdict, summary and review are already posted.
+        doThrow(new RuntimeException("labeler boom")).when(labeler).applyOrSuggest(any());
+
+        orchestrator.review(
+            new ReviewOrchestrator.ReviewRequest(
+                "owner",
+                "repo",
+                42,
+                "abcdefgh",
+                "Test PR",
+                "",
+                "base1234567",
+                "main",
+                123L,
+                false));
+
+        // The clean approval was posted — the result is surfaced.
+        verify(reviewClient)
+            .createReview(
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyInt(),
+                argThat(req -> "APPROVE".equals(req.event())));
+        // ...so the post-result failure must NOT post a "could not be completed — retry" notice,
+        // flip the session to failed, or broadcast a failure over the posted result (#220).
+        verify(commentClient, never())
+            .createComment(
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyInt(),
+                argThat(req -> req.body().contains("could not be completed")));
+        verify(session, never()).setStatus(ReviewSession.STATUS_FAILED);
+      }
+    }
+
+    @Test
     void shouldPersistAiResponseJsonWhenUpdatingCompletedSession() {
       try (var mockedStatic = mockStatic(ReviewSession.class)) {
         var session = mock(ReviewSession.class);


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Once `review()` finalized the check-run verdict (`updateCheckRun` → `completed`), a failure in **any later step** — summary/review post, thread resolution, labels, persistence, or broadcast — fell into the *same* `catch` as a pre-result failure. `handleReviewFailure` then flipped the check to **failure** and posted a **"review could not be completed — please retry"** comment *over an already-posted result*, confusing the author (the verdict and inline findings were right there).

Fix: track a `resultSurfaced` flag, set the moment the check-run verdict is committed. In the `catch`:
- **post-result** failure → log it, but leave the posted verdict intact (no retry comment, no check flip);
- **pre-result** failure → unchanged: full failure path (check → failure, retry comment, failed session, broadcast).

## Related Issues

Fixes #220

## How Has This Been Tested?

- [x] Unit tests

- New `ReviewOrchestratorTest#shouldNotPostRetryNoticeWhenAStepFailsAfterTheResultIsPosted`: drives a clean approval, makes a trailing step (`labeler.applyOrSuggest`) throw, and asserts the review **was** posted while **no** "could not be completed" comment is posted and the session is **not** flipped to `FAILED`.
- The pre-result failure path stays covered by existing tests (PR-file fetch failure, check-run update failure), so both `catch` branches are exercised.
- Full suite: **1228 passing**, spotbugs + spotless clean (JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (no doc change needed)
- [x] My changes generate no new warnings or errors

## Additional Notes

Final issue of the pre-v0.3.0 review-path correctness batch (#211–#220), targeted at `main`.
