### PR TITLE
perf(review): reuse fetched reviews when dismissing pending bot reviews (#74)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -385,6 +385,9 @@ public class ReviewOrchestrator {
             new GitHubCommentClient.CreateCommentRequest(result.summaryMarkdown()));
       }
 
+      // Dismiss any stale pending review this bot left before posting the new one, reusing the
+      // reviews already fetched for this run rather than re-listing them (#74).
+      dismissPendingBotReviews(auth, req.owner(), req.repo(), req.prNumber(), priorReviews);
       postReview(auth, req.owner(), req.repo(), req.prNumber(), req.commitSha(), result, files);
 
       resolveAddressedThreads(
@@ -1013,8 +1016,6 @@ public class ReviewOrchestrator {
       String commitSha,
       ReviewResult result,
       List<GitHubPullRequestClient.FileDiff> files) {
-    dismissPendingBotReviews(auth, owner, repo, prNumber);
-
     if (!result.hasIssues()) {
       postNoIssuesReview(auth, owner, repo, prNumber, commitSha, result);
       return;
@@ -1245,10 +1246,18 @@ public class ReviewOrchestrator {
 
   /**
    * Deletes any pending review left by this bot — GitHub allows only one pending review per user.
+   * Reuses the reviews already fetched for this run instead of re-listing: no review is created
+   * between that fetch and here, so a second {@code listReviews} would only spend extra rate-limit
+   * budget (#74).
    */
-  void dismissPendingBotReviews(String auth, String owner, String repo, int prNumber) {
+  void dismissPendingBotReviews(
+      String auth,
+      String owner,
+      String repo,
+      int prNumber,
+      List<GitHubReviewClient.ReviewResponse> priorReviews) {
     try {
-      for (var review : reviewClient.listReviews(auth, ACCEPT, owner, repo, prNumber)) {
+      for (var review : priorReviews) {
         if ("PENDING".equals(review.state()) && botIdentity.matches(review.user().login())) {
           reviewClient.deletePendingReview(auth, ACCEPT, owner, repo, prNumber, review.id());
           Log.debugf(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -1356,6 +1356,73 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void shouldReuseFetchedReviewsToDismissPendingInsteadOfReListing() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getPrTitle()).thenReturn("Test PR");
+        when(session.getCommitSha()).thenReturn("abcdefgh");
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        when(authClient.getAuthHeader(123L)).thenReturn("Bearer test");
+        when(checkRunClient.createCheckRun(
+                anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(new GitHubCheckRunClient.CheckRunResponse(1L, "http://check"));
+        doNothing()
+            .when(checkRunClient)
+            .updateCheckRun(anyString(), anyString(), anyString(), anyString(), anyLong(), any());
+        when(prClient.getPullRequestFiles(
+                anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of());
+        when(prClient.compareCommits(
+                anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
+        // A stale pending review left by the bot, returned by the single listReviews fetch.
+        var pending =
+            new GitHubReviewClient.ReviewResponse(
+                99L, "", "PENDING", "sha", new GitHubReviewClient.ReviewResponse.User(BOT_LOGIN));
+        when(reviewClient.listReviews(anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of(pending));
+        when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
+            .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
+        when(labeler.fetchExistingLabels(anyString(), anyString(), anyString()))
+            .thenReturn(List.of());
+        var summary =
+            new ReviewResponse.Summary(
+                0, 0, 0, 0, 0, "looks good", "adds a thing", List.of(), List.of());
+        when(aiReviewService.review(any(ReviewSession.class), any()))
+            .thenReturn(new ReviewResponse(List.of(), List.of(), summary));
+
+        orchestrator.review(
+            new ReviewOrchestrator.ReviewRequest(
+                "owner",
+                "repo",
+                42,
+                "abcdefgh",
+                "Test PR",
+                "",
+                "base1234567",
+                "main",
+                123L,
+                false));
+
+        // listReviews is fetched exactly once for the whole run — dismissal reuses that list
+        // (#74)...
+        verify(reviewClient, times(1))
+            .listReviews(anyString(), anyString(), anyString(), anyString(), anyInt());
+        // ...and the bot's stale pending review is still dismissed from the reused list.
+        verify(reviewClient)
+            .deletePendingReview(
+                anyString(), anyString(), eq("owner"), eq("repo"), eq(42), eq(99L));
+      }
+    }
+
+    @Test
     void shouldPersistAiResponseJsonWhenUpdatingCompletedSession() {
       try (var mockedStatic = mockStatic(ReviewSession.class)) {
         var session = mock(ReviewSession.class);
@@ -1890,10 +1957,8 @@ class ReviewOrchestratorTest {
           new GitHubReviewClient.ReviewResponse(
               2L, "", "PENDING", "sha", new GitHubReviewClient.ReviewResponse.User("other-user"));
 
-      when(reviewClient.listReviews(anyString(), anyString(), anyString(), anyString(), anyInt()))
-          .thenReturn(List.of(pending, approved, pendingHuman));
-
-      orchestrator.dismissPendingBotReviews("Bearer tok", "owner", "repo", 7);
+      orchestrator.dismissPendingBotReviews(
+          "Bearer tok", "owner", "repo", 7, List.of(pending, approved, pendingHuman));
 
       verify(reviewClient)
           .deletePendingReview(
@@ -1908,15 +1973,19 @@ class ReviewOrchestratorTest {
 
     @Test
     void shouldContinueWhenDismissPendingReviewsFails() {
-      when(reviewClient.listReviews(anyString(), anyString(), anyString(), anyString(), anyInt()))
-          .thenThrow(new RuntimeException("GitHub unavailable"));
-
-      assertDoesNotThrow(
-          () -> orchestrator.dismissPendingBotReviews("Bearer tok", "owner", "repo", 7));
-      // When listing fails there is nothing to dismiss — no delete may be attempted
-      verify(reviewClient, never())
+      var pending =
+          new GitHubReviewClient.ReviewResponse(
+              99L, "", "PENDING", "sha", new GitHubReviewClient.ReviewResponse.User(BOT_LOGIN));
+      doThrow(new RuntimeException("GitHub unavailable"))
+          .when(reviewClient)
           .deletePendingReview(
               anyString(), anyString(), anyString(), anyString(), anyInt(), anyLong());
+
+      // A delete that fails (e.g. GitHub unavailable) must not propagate out of dismissal.
+      assertDoesNotThrow(
+          () ->
+              orchestrator.dismissPendingBotReviews(
+                  "Bearer tok", "owner", "repo", 7, List.of(pending)));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] ⚡ Performance / refactor

## Description

`review()` fetched the PR's reviews **twice** per run: once via `fetchPriorReviews`, and again inside `dismissPendingBotReviews` during `postReview`. No review is created between the two calls, so the second `listReviews` was redundant — it only spent extra GitHub rate-limit budget, now amplified since `listReviews` paginates ([#219](https://github.com/devops-thiago/ThrillhouseBot/issues/219)).

Thread the already-fetched `priorReviews` through `postReview` into `dismissPendingBotReviews` and drop the re-list. Behavior is unchanged: a stale pending bot review present in the fetched set is still dismissed.

## Related Issues

Fixes #74

## How Has This Been Tested?

- [x] Unit tests

- New `ReviewOrchestratorTest#shouldReuseFetchedReviewsToDismissPendingInsteadOfReListing`: a full `review()` run asserts `listReviews` is called **exactly once** and still dismisses the bot's stale pending review from the reused list.
- The `dismissPendingBotReviews` tests now pass the list directly; the failure-path test drives the `catch` via a failing `deletePendingReview` (the only remaining call inside).
- Full suite: **1229 passing**, spotbugs + spotless clean (JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (no doc change needed)
- [x] My changes generate no new warnings or errors

## Additional Notes

Follow-up to the #211–#220 review-path batch — the perf optimization deferred from [#219](https://github.com/devops-thiago/ThrillhouseBot/issues/219). Targeted at `main`.
