### PR TITLE
fix(review): tolerate unescaped control characters in model JSON output (#235)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
@@ -111,7 +111,50 @@ public class ReviewResponseParser {
       trimmed = trimmed.substring(start);
     }
 
-    return trimmed;
+    return escapeControlCharsInStrings(trimmed);
+  }
+
+  /**
+   * Escapes raw control characters (U+0000–U+001F) that appear inside JSON string literals. Models
+   * sometimes emit a literal tab or newline inside a string field — for example verbatim source in
+   * {@code suggestion_old}/{@code suggestion_new}, escaping {@code \n} but leaving a tab raw —
+   * which strict JSON parsing rejects, failing the whole review and forcing a full-cost retry.
+   * Control characters outside string literals are valid JSON whitespace and are left untouched, as
+   * are already-escaped sequences.
+   */
+  static String escapeControlCharsInStrings(String json) {
+    var out = new StringBuilder(json.length() + 16);
+    var inString = false;
+    var escaped = false;
+    for (var i = 0; i < json.length(); i++) {
+      var c = json.charAt(i);
+      if (escaped) {
+        out.append(c);
+        escaped = false;
+      } else if (c == '\\') {
+        out.append(c);
+        escaped = true;
+      } else if (c == '"') {
+        inString = !inString;
+        out.append(c);
+      } else if (inString && c < 0x20) {
+        appendEscapedControlChar(out, c);
+      } else {
+        out.append(c);
+      }
+    }
+    return out.toString();
+  }
+
+  private static void appendEscapedControlChar(StringBuilder out, char c) {
+    switch (c) {
+      case '\t' -> out.append("\\t");
+      case '\n' -> out.append("\\n");
+      case '\r' -> out.append("\\r");
+      case '\b' -> out.append("\\b");
+      case '\f' -> out.append("\\f");
+      default -> out.append(String.format("\\u%04x", (int) c));
+    }
   }
 
   /** Index of whichever JSON opener comes first; -1 when neither is present. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -219,6 +219,22 @@ class FindingVerificationServiceTest {
   }
 
   @Test
+  void shouldTolerateRawControlCharsInVerifierResponse() {
+    // The verifier sometimes echoes code in its reason with a raw tab/newline left unescaped; the
+    // verdict must still be applied (the downgrade below only lands if the response parsed).
+    ReviewResponse original = response(finding("critical", "high", "Speculative"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            "{\"verdicts\": [{\"id\": 1, \"verdict\": \"downgraded\", \"risk\": \"medium\","
+                + " \"confidence\": \"low\", \"reason\": \"guard\tmissing\nhere\"}]}");
+
+    var result = service.verify(original, "diff", "stack", "");
+
+    assertEquals("medium", result.findings().get(0).risk());
+    assertEquals("low", result.findings().get(0).confidence());
+  }
+
+  @Test
   void downgradeShouldNeverRaiseRiskOrConfidence() {
     ReviewResponse original = response(finding("medium", "low", "Already modest"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParserTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParserTest.java
@@ -227,4 +227,44 @@ class ReviewResponseParserTest {
     String json = ReviewResponseParser.extractJson("Here is the list: [1, 2, 3]");
     assertEquals("[1, 2, 3]", json);
   }
+
+  @Test
+  void shouldParsePayloadWithRawControlCharsInsideStringValue() {
+    // Models sometimes emit a literal tab/newline inside a code-bearing field (escaping \n but not
+    // the tab); strict JSON would reject the whole response and force a full-cost retry.
+    var raw =
+        "{\"findings\": [{\"risk\": \"low\", \"confidence\": \"low\", \"file\": \"f\","
+            + " \"line\": 1, \"title\": \"t\", \"description\": \"line1\tline2\nline3\"}]}";
+
+    var response = parser.parse(raw);
+
+    assertEquals(1, response.findings().size());
+    assertTrue(response.findings().get(0).description().contains("line2"));
+  }
+
+  @Test
+  void shouldEscapeRawControlCharsInsideStringLiterals() {
+    assertEquals("{\"d\":\"a\\tb\\nc\"}", ReviewResponseParser.extractJson("{\"d\":\"a\tb\nc\"}"));
+  }
+
+  @Test
+  void shouldEscapeEveryControlCharForm() {
+    // carriage-return, backspace, form-feed and an arbitrary control char cover every arm.
+    var input = "{\"d\":\"" + (char) 0x0d + (char) 0x08 + (char) 0x0c + (char) 0x01 + "\"}";
+    assertEquals("{\"d\":\"\\r\\b\\f\\u0001\"}", ReviewResponseParser.extractJson(input));
+  }
+
+  @Test
+  void shouldLeaveControlCharsOutsideStringsUntouched() {
+    // A newline between tokens is valid JSON whitespace, not inside a string — leave it alone.
+    var in = "{\n\"findings\":[]\n}";
+    assertEquals(in, ReviewResponseParser.extractJson(in));
+  }
+
+  @Test
+  void shouldNotDoubleEscapeAlreadyEscapedSequences() {
+    // \n, \" and \\ are already valid escapes and must pass through unchanged.
+    var in = "{\"d\":\"a\\nb\\\"c\\\\d\"}";
+    assertEquals(in, ReviewResponseParser.extractJson(in));
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The model sometimes emits a **raw control character** — most often a literal TAB (`U+0009`) or newline — inside a JSON string value (e.g. `suggestion_old`, which carries verbatim source: it escapes `\n` but leaves the tab raw). Strict JSON parsing rejected the **entire** response, failing the review attempt and forcing a full-cost retry. In a dogfooding run this failed two attempts **identically** before succeeding on the third — had all retries hit it, the review would have failed outright.

`extractJson` now escapes raw control characters that appear **inside string literals** (leaving JSON whitespace between tokens, and already-escaped sequences, untouched). Both parse paths route through `extractJson`, so the review parser (`ReviewResponseParser`) **and** the verifier (`FindingVerificationService`) are fixed in one place. This mirrors the existing tolerance in `normalizePreviousFindingsStatus` ("a shape mismatch does not fail the whole review and force a full-cost retry").

## Related Issues

Fixes #235

## How Has This Been Tested?

- [x] Unit tests

- `ReviewResponseParserTest`: parses a payload with a raw tab/newline inside a string value; `extractJson` escapes control chars inside strings, leaves them untouched outside strings (valid whitespace), and never double-escapes `\n` / `\"` / `\\`.
- `FindingVerificationServiceTest`: a verifier verdict whose `reason` carries raw control chars is parsed and applied (the downgrade only lands if parsing succeeded).
- Full suite: **1234 passing**, spotbugs + spotless clean (JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (CHANGELOG handled in the 0.2.1 release PR #233)
- [x] My changes generate no new warnings or errors

## Additional Notes

One of the v0.2.1 reliability fixes surfaced during dogfooding. CHANGELOG entry is intentionally deferred to the release PR #233 (which finalizes the `[0.2.1]` section), matching the prior batch's pattern.
