### PR TITLE
fix(review): disclose diff truncation and don't auto-APPROVE a truncated review (#234)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
@@ -38,6 +38,13 @@ public class ReviewDiffFormatter {
 
   private record GlobMatcher(PathMatcher primary, PathMatcher suffix) {}
 
+  /** A formatted diff plus the number of files the line budget dropped (0 when nothing omitted). */
+  record FormattedDiff(String text, int omittedFiles) {
+    boolean truncated() {
+      return omittedFiles > 0;
+    }
+  }
+
   private final List<GlobMatcher> globMatchers;
   private final int maxDiffLines;
 
@@ -116,8 +123,13 @@ public class ReviewDiffFormatter {
   }
 
   String buildDiffString(List<GitHubPullRequestClient.FileDiff> files) {
+    return buildDiffStringWithStats(files).text();
+  }
+
+  /** Like {@link #buildDiffString} but also reports how many files the line budget omitted. */
+  FormattedDiff buildDiffStringWithStats(List<GitHubPullRequestClient.FileDiff> files) {
     if (files == null || files.isEmpty()) {
-      return "(no changes detected)";
+      return new FormattedDiff("(no changes detected)", 0);
     }
 
     var totalAdditions = 0;
@@ -172,8 +184,15 @@ public class ReviewDiffFormatter {
 
   String buildBaseComparison(
       GitHubPullRequestClient.CompareResponse comparison, String base, String head) {
+    return buildBaseComparisonWithStats(comparison, base, head).text();
+  }
+
+  /** Like {@link #buildBaseComparison} but also reports how many files the line budget omitted. */
+  FormattedDiff buildBaseComparisonWithStats(
+      GitHubPullRequestClient.CompareResponse comparison, String base, String head) {
     if (comparison.files().isEmpty()) {
-      return "(no changes between " + base.substring(0, 7) + " and " + head.substring(0, 7) + ")";
+      return new FormattedDiff(
+          "(no changes between " + base.substring(0, 7) + " and " + head.substring(0, 7) + ")", 0);
     }
 
     var reviewable = comparison.files().stream().filter(f -> f.patch() != null).toList();
@@ -187,13 +206,14 @@ public class ReviewDiffFormatter {
     return formatWithLineBudget(header, reviewable);
   }
 
-  private String formatWithLineBudget(String header, List<GitHubPullRequestClient.FileDiff> files) {
+  private FormattedDiff formatWithLineBudget(
+      String header, List<GitHubPullRequestClient.FileDiff> files) {
     if (maxDiffLines <= 0) {
       var sb = new StringBuilder(header);
       for (var file : files) {
         sb.append(formatFileSection(file));
       }
-      return sb.toString();
+      return new FormattedDiff(sb.toString(), 0);
     }
 
     var output = new StringBuilder(header);
@@ -232,7 +252,7 @@ public class ReviewDiffFormatter {
           maxDiffLines, maxDiffLines, omitted.size());
     }
 
-    return output.toString();
+    return new FormattedDiff(output.toString(), omitted.size());
   }
 
   void appendTruncationFooter(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -231,9 +231,15 @@ public class ReviewOrchestrator {
       checkRunId =
           createCheckRun(auth, req.owner(), req.repo(), req.commitSha(), sessionUrl(session));
       var files = fetchPrFiles(auth, req.owner(), req.repo(), req.prNumber());
-      var diff = buildDiffString(files);
-      var baseComparison =
-          buildBaseComparison(auth, req.owner(), req.repo(), req.baseSha(), req.commitSha());
+      var diffResult = diffFormatter.buildDiffStringWithStats(files);
+      var diff = diffResult.text();
+      var baseComparisonResult =
+          buildBaseComparisonWithStats(
+              auth, req.owner(), req.repo(), req.baseSha(), req.commitSha());
+      var baseComparison = baseComparisonResult.text();
+      // Files the budget dropped (from the PR diff or the base comparison) make the review partial.
+      // The omitted count travels in DiffStats so the verdict and summary can disclose it (#234).
+      var omittedFiles = diffResult.omittedFiles() + baseComparisonResult.omittedFiles();
 
       var priorReviews = fetchPriorReviews(auth, req.owner(), req.repo(), req.prNumber());
       // Two independent flags decouple UX presentation from context loading:
@@ -327,7 +333,7 @@ public class ReviewOrchestrator {
       List<ReviewResult.CiCheck> offendingCiChecks =
           evaluateCiChecks(auth, req.owner(), req.repo(), req.commitSha(), requiredContexts);
 
-      DiffStats diffStats = DiffStats.fromFiles(diffFormatter.reviewableFiles(files));
+      DiffStats diffStats = DiffStats.fromFiles(diffFormatter.reviewableFiles(files), omittedFiles);
       var unresolvedPrevious =
           followUpAnalyzer.unresolvedFindings(
               previousAiResponseJson, aiResponse.previousFindingsStatus());
@@ -628,15 +634,21 @@ public class ReviewOrchestrator {
   }
 
   String buildBaseComparison(String auth, String owner, String repo, String base, String head) {
+    return buildBaseComparisonWithStats(auth, owner, repo, base, head).text();
+  }
+
+  ReviewDiffFormatter.FormattedDiff buildBaseComparisonWithStats(
+      String auth, String owner, String repo, String base, String head) {
     if (base == null || head == null || base.length() < 7 || head.length() < 7) {
-      return "(regression comparison unavailable — refs too short)";
+      return new ReviewDiffFormatter.FormattedDiff(
+          "(regression comparison unavailable — refs too short)", 0);
     }
     try {
       var comparison = prClient.compareCommits(auth, ACCEPT, owner, repo, base, head);
-      return diffFormatter.buildBaseComparison(comparison, base, head);
+      return diffFormatter.buildBaseComparisonWithStats(comparison, base, head);
     } catch (RuntimeException e) {
       Log.warn("Failed to fetch base comparison, continuing without regression context", e);
-      return "(regression comparison unavailable)";
+      return new ReviewDiffFormatter.FormattedDiff("(regression comparison unavailable)", 0);
     }
   }
 
@@ -888,15 +900,24 @@ public class ReviewOrchestrator {
         unresolved);
   }
 
-  record DiffStats(int filesChanged, int additions, int deletions) {
-    static DiffStats fromFiles(List<GitHubPullRequestClient.FileDiff> files) {
+  record DiffStats(int filesChanged, int additions, int deletions, int omittedFiles) {
+    DiffStats(int filesChanged, int additions, int deletions) {
+      this(filesChanged, additions, deletions, 0);
+    }
+
+    /** True when the line budget dropped whole files, so the model never saw part of the change. */
+    boolean truncated() {
+      return omittedFiles > 0;
+    }
+
+    static DiffStats fromFiles(List<GitHubPullRequestClient.FileDiff> files, int omittedFiles) {
       var additions = 0;
       var deletions = 0;
       for (var file : files) {
         additions += file.additions();
         deletions += file.deletions();
       }
-      return new DiffStats(files.size(), additions, deletions);
+      return new DiffStats(files.size(), additions, deletions, omittedFiles);
     }
   }
 
@@ -907,32 +928,11 @@ public class ReviewOrchestrator {
       List<Finding> unresolvedPrevious,
       List<ReviewResult.CiCheck> offendingCiChecks,
       List<ReviewResult.PreviousFindingStatus> backstopUnresolved) {
-    var findings = new ArrayList<Finding>();
-    var critical = 0;
-    var high = 0;
-    var medium = 0;
-    var low = 0;
-    RiskLevel highest = null;
-
-    if (aiResponse.findings() != null) {
-      for (var ai : aiResponse.findings()) {
-        Finding f = Finding.fromAiResponse(ai);
-        findings.add(f);
-        switch (f.risk()) {
-          case CRITICAL -> critical++;
-          case HIGH -> high++;
-          case MEDIUM -> medium++;
-          case LOW -> low++;
-        }
-        if (highest == null || f.risk().compareTo(highest) < 0) {
-          highest = f.risk();
-        }
-      }
-    }
+    var tally = tallyFindings(aiResponse);
 
     // The review may only approve when nothing is outstanding: new findings AND previous
     // findings still unresolved (not fixed, no accepted justification) both count
-    var outstanding = new ArrayList<Finding>(findings);
+    var outstanding = new ArrayList<Finding>(tally.findings());
     outstanding.addAll(unresolvedPrevious);
     ReviewState state = ReviewState.fromFindings(outstanding);
     // Merge the model's previous-findings statuses with the backstop's reconstructed unresolved
@@ -955,6 +955,12 @@ public class ReviewOrchestrator {
       state = ReviewState.COMMENT;
     }
 
+    // A truncated diff means whole files were never reviewed — never sail an APPROVE over the
+    // unreviewed remainder; hold it as a COMMENT and disclose the omission below (#234).
+    if (state == ReviewState.APPROVE && diffStats.truncated()) {
+      state = ReviewState.COMMENT;
+    }
+
     // The summary is generated for clean reviews too: a zero-findings result still reports the
     // change overview and carries the celebration line inside the same comment
     var summaryMarkdown =
@@ -964,30 +970,74 @@ public class ReviewOrchestrator {
             diffStats.deletions(),
             aiResponse.summary(),
             new ReviewResult(
-                findings,
-                critical,
-                high,
-                medium,
-                low,
-                highest,
+                tally.findings(),
+                tally.critical(),
+                tally.high(),
+                tally.medium(),
+                tally.low(),
+                tally.highest(),
                 state,
                 isFirstReview,
                 "",
                 previousStatuses,
                 offendingCiChecks));
+    if (diffStats.truncated()) {
+      summaryMarkdown = truncationNotice(diffStats.omittedFiles()) + summaryMarkdown;
+    }
 
     return new ReviewResult(
-        findings,
-        critical,
-        high,
-        medium,
-        low,
-        highest,
+        tally.findings(),
+        tally.critical(),
+        tally.high(),
+        tally.medium(),
+        tally.low(),
+        tally.highest(),
         state,
         isFirstReview,
         summaryMarkdown,
         previousStatuses,
         offendingCiChecks);
+  }
+
+  /** Findings parsed from the model response, with per-severity counts and the highest risk. */
+  private record FindingTally(
+      List<Finding> findings, int critical, int high, int medium, int low, RiskLevel highest) {}
+
+  private static FindingTally tallyFindings(ReviewResponse aiResponse) {
+    var findings = new ArrayList<Finding>();
+    var critical = 0;
+    var high = 0;
+    var medium = 0;
+    var low = 0;
+    RiskLevel highest = null;
+    // ReviewResponse never returns null findings, so we iterate directly. The lowest risk level is
+    // counted by the catch-all branch — RiskLevel has exactly four values — which avoids the
+    // unreachable extra branch the compiler would otherwise generate and report as uncovered.
+    for (var ai : aiResponse.findings()) {
+      Finding f = Finding.fromAiResponse(ai);
+      findings.add(f);
+      switch (f.risk()) {
+        case CRITICAL -> critical++;
+        case HIGH -> high++;
+        case MEDIUM -> medium++;
+        default -> low++;
+      }
+      if (highest == null || f.risk().compareTo(highest) < 0) {
+        highest = f.risk();
+      }
+    }
+    return new FindingTally(findings, critical, high, medium, low, highest);
+  }
+
+  /**
+   * Banner prepended to the summary when the diff was truncated, so a reader knows the review is
+   * partial — the verdict is also held back from APPROVE in that case (#234).
+   */
+  private static String truncationNotice(int omittedFiles) {
+    return String.format(
+        "> ⚠️ **Large PR — partial review.** %d file(s) were omitted because the diff exceeded the"
+            + " size budget; the findings and verdict below cover only the reviewed portion.%n%n",
+        omittedFiles);
   }
 
   ReviewResult buildResult(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
@@ -142,6 +142,33 @@ class ReviewDiffFormatterTest {
     }
 
     @Test
+    void buildDiffStringWithStatsReportsOmittedFileCount() {
+      var formatter = new ReviewDiffFormatter(List.of(), 6);
+      var files =
+          List.of(
+              file("a.java", "modified", 1, 0, "l1\nl2\nl3\nl4\nl5"),
+              file("b.java", "modified", 1, 0, "l1\nl2\nl3\nl4\nl5"),
+              file("c.java", "modified", 1, 0, "l1\nl2\nl3\nl4\nl5"));
+
+      var result = formatter.buildDiffStringWithStats(files);
+
+      assertTrue(result.truncated());
+      assertTrue(result.omittedFiles() >= 1);
+      assertTrue(result.text().contains("files omitted"));
+    }
+
+    @Test
+    void buildDiffStringWithStatsReportsZeroOmittedWhenEverythingFits() {
+      var formatter = new ReviewDiffFormatter(List.of(), 5000);
+
+      var result =
+          formatter.buildDiffStringWithStats(List.of(file("a.java", "modified", 1, 0, "l1\nl2")));
+
+      assertFalse(result.truncated());
+      assertEquals(0, result.omittedFiles());
+    }
+
+    @Test
     void shouldSkipFooterWhenNoLineBudgetRemains() {
       var formatter = new ReviewDiffFormatter(List.of(), 2);
       var output = new StringBuilder("line-one\nline-two\n");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -467,6 +467,22 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void shouldHoldApproveAndDiscloseWhenDiffTruncated() {
+      var aiResponse = new ReviewResponse(List.of(), List.of(), null);
+
+      // A clean review that would APPROVE, but 7 files were omitted by the line budget.
+      var result =
+          orchestrator.buildResult(
+              aiResponse, true, new ReviewOrchestrator.DiffStats(120, 4000, 4000, 7), List.of());
+
+      // The verdict is held back from APPROVE — a partial review must not gate-approve the PR...
+      assertEquals(ReviewState.COMMENT, result.reviewState());
+      // ...and the summary discloses the omission (summaryGenerator is mocked to "").
+      assertTrue(result.summaryMarkdown().contains("partial review"));
+      assertTrue(result.summaryMarkdown().contains("7 file"));
+    }
+
+    @Test
     void shouldHandleNullFindingsInAiResponse() {
       var aiResponse = new ReviewResponse(null, null, null);
 
@@ -2669,11 +2685,13 @@ class ReviewOrchestratorTest {
               new GitHubPullRequestClient.FileDiff("a.java", "modified", 3, 2, 5, "patch"),
               new GitHubPullRequestClient.FileDiff("b.java", "modified", 1, 4, 5, "patch"));
 
-      ReviewOrchestrator.DiffStats stats = ReviewOrchestrator.DiffStats.fromFiles(files);
+      ReviewOrchestrator.DiffStats stats = ReviewOrchestrator.DiffStats.fromFiles(files, 0);
 
       assertEquals(2, stats.filesChanged());
       assertEquals(4, stats.additions());
       assertEquals(6, stats.deletions());
+      assertEquals(0, stats.omittedFiles());
+      assertFalse(stats.truncated());
     }
   }
 


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

When a PR's diff exceeded the line budget, `ReviewDiffFormatter` dropped whole files but the review still proceeded and could post a clean **APPROVE** with a summary that reported the *full* file/line counts and never mentioned the omission — a reader couldn't tell the review was partial.

Changes:
- `ReviewDiffFormatter` now reports how many files the budget omitted — a `FormattedDiff(text, omittedFiles)` record returned by new `buildDiffStringWithStats` / `buildBaseComparisonWithStats`. The existing `String` methods delegate to them, so other callers and the formatter tests are untouched.
- `review()` carries the combined omitted count (PR diff + base comparison) into `DiffStats`.
- `buildResult`:
  - **holds the verdict at `COMMENT` instead of `APPROVE`** when the diff was truncated — a partial review must not gate-approve a PR;
  - **prepends a disclosure banner** to the summary: `⚠️ Large PR — partial review. N file(s) were omitted…`.

`DiffStats` gains an `omittedFiles` field with a 3-arg convenience constructor, so existing `DiffStats(a,b,c)` call sites are unchanged.

## Related Issues

Fixes #234

Interim safety fix surfaced during dogfooding — the full coverage redesign (token budget + multi-call splitting) is tracked in #53.

## How Has This Been Tested?

- [x] Unit tests

- `ReviewDiffFormatterTest`: `buildDiffStringWithStats` reports the omitted-file count (and zero when everything fits).
- `ReviewOrchestratorTest`: a clean review with omitted files is downgraded `APPROVE → COMMENT` and the summary discloses the omission.
- New code fully covered (JaCoCo). Full suite: **1238 passing**, spotbugs + spotless clean (JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (CHANGELOG handled in the 0.2.1 release PR #233)
- [x] My changes generate no new warnings or errors

## Additional Notes

CHANGELOG entry deferred to the release PR #233, matching the batch pattern.
