### PR TITLE
fix(github): request statuses:read so CI-aware gating can read combined status (#236)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Create a GitHub App before starting the bot; you'll need its credentials for `.e
 |---|---|
 | Webhook URL | `https://<your-host>/api/webhook` |
 | Webhook Secret | Random string |
-| Repository Permissions | Pull Requests: R/W, Checks: R/W, Contents: Read, Issues: R/W, Actions: Read |
+| Repository Permissions | Pull Requests: R/W, Checks: R/W, Contents: Read, Issues: R/W, Actions: Read, Commit Statuses: Read |
 | Subscribe to Events | Pull Request, Issue comment, Pull request review comment |
 | Identifying & authorizing users | Enabled (for dashboard login) |
 | Callback URL | `https://<your-host>/api/auth/callback` |

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,8 @@
     "pull_requests": "write",
     "contents": "read",
     "issues": "write",
-    "actions": "read"
+    "actions": "read",
+    "statuses": "read"
   },
   "request_oauth_on_install": false
 }

--- a/src/main/resources/META-INF/resources/install.html
+++ b/src/main/resources/META-INF/resources/install.html
@@ -61,13 +61,16 @@
       public: false,
       default_events: [
         "pull_request",
-        "issue_comment"
+        "issue_comment",
+        "pull_request_review_comment"
       ],
       default_permissions: {
         checks: "write",
         pull_requests: "write",
         contents: "read",
-        issues: "write"
+        issues: "write",
+        actions: "read",
+        statuses: "read"
       },
       request_oauth_on_install: false
     };


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`getCombinedStatus` calls the **legacy commit Statuses API** (`GET /repos/{owner}/{repo}/commits/{ref}/status`), which requires the App's **Commit statuses: Read** permission. The manifest never declared it, so the call **403'd on every review** and CI-aware approval gating silently fell back (observed on every PR during dogfooding).

- Add `"statuses": "read"` to `manifest.json` and the README permission table.
- **Also reconcile `install.html`** (the manifest-flow registration page), which had drifted from `manifest.json`: it was missing `actions: read` (added in #95) **and** the `pull_request_review_comment` event (added in #31). A fresh install through it would have had **CI gating *and* conversational replies silently broken**. `install.html` now matches `manifest.json` exactly (events + permissions).

## Related Issues

Fixes #236

## How Has This Been Tested?

- [x] `manifest.json` validated as JSON; `default_permissions` now `checks/pull_requests/contents/issues/actions/statuses`, events `pull_request/issue_comment/pull_request_review_comment`.
- [x] `install.html` permissions/events now identical to `manifest.json`.
- [x] `spotless:check` clean. No Java changes.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests (n/a — App manifest + docs)
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (README permission table)
- [x] My changes generate no new warnings or errors

## Additional Notes

⚠️ **Existing installs must re-accept the updated permissions** (GitHub prompts the owner). CHANGELOG entry deferred to the 0.2.1 release PR #233. The `install.html` drift fix is in scope because it's the same registration concern — without it, statuses would be declared in one registration path but not the other.
