### PR TITLE
chore(review): trim narrating comments from the review path

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -36,10 +36,7 @@ public interface GitHubReviewClient {
       @PathParam("pullNumber") int pullNumber,
       CreateReviewRequest request);
 
-  // GitHub serves 30 reviews per page by default; request the 100 max and walk a bounded number of
-  // pages so first-review detection, the approve backstop, and dismissing a stale pending bot
-  // review
-  // all see the whole set — a pending bot review past page one would otherwise be missed (#219).
+  // GitHub serves 30 reviews per page by default; request the 100 max and bound the page walk.
   int REVIEWS_PER_PAGE = 100;
   int MAX_REVIEW_PAGES = 10;
 
@@ -77,9 +74,7 @@ public interface GitHubReviewClient {
     return all;
   }
 
-  // GitHub serves 30 inline review comments per page by default; request the 100 max and walk a
-  // bounded number of pages so follow-up dedup, /resolve and the unresolved-status backstop never
-  // run on a silently truncated set on a busy PR.
+  // GitHub serves 30 inline comments per page by default; request the 100 max and bound the walk.
   int COMMENTS_PER_PAGE = 100;
   int MAX_COMMENT_PAGES = 10;
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -106,7 +106,7 @@ public final class DiffLineResolver {
     // diff keys both matching, e.g. a/Handler.java and b/Handler.java) return null rather than
     // guess
     // whichever entry the map iterates first — mirrors resolveRightSideLinesForFileOrVariant, the
-    // safe direction (#218).
+    // safe direction.
     Map<Integer, String> resolved = null;
     for (var entry : rightSideLineTextByFile.entrySet()) {
       var value = entry.getValue();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingDeduplicator.java
@@ -183,7 +183,7 @@ public class FindingDeduplicator {
     // cluster uses the true median so a lone outlier cannot decide the severity; an even cluster
     // has
     // no single middle, so take the more severe of the two central values (the lower index) — never
-    // the less severe — so a single hedged duplicate cannot downgrade a blocking finding (#213).
+    // the less severe — so a single hedged duplicate cannot downgrade a blocking finding.
     int mid = ranked.size() / 2;
     RiskLevel severity = ranked.size() % 2 == 0 ? ranked.get(mid - 1) : ranked.get(mid);
     // Confidence stays paired with the chosen severity: the highest confidence among the members

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -127,8 +127,8 @@ public class FindingQuoteValidator {
    * The quote verdict for one finding. Starts from {@link #matchQuote}'s per-line presence, then
    * tightens a multi-line FULL verdict to also require a contiguous in-order run on one side of the
    * diff — a recombination of real-but-scattered lines is demoted to PARTIAL so a fabricated
-   * suggestion is not kept (#216); single-line quotes are trivially contiguous and unaffected.
-   * Finally a FULL quote is disambiguated by line when it appears in multiple locations.
+   * suggestion is not kept; single-line quotes are trivially contiguous and unaffected. Finally a
+   * FULL quote is disambiguated by line when it appears in multiple locations.
    */
   private QuoteMatch classifyQuote(ReviewResponse.Finding finding, DiffIndex index) {
     List<String> quoted = normalizedLines(finding.suggestionOld());

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -485,7 +485,7 @@ public class FollowUpAnalyzer {
     // of identity: two distinct findings that merely share a severity (or both carry null/unknown
     // risk, which maps to LOW) near the same line are different defects and must not be collapsed —
     // doing so silently dropped a new finding whenever a same-severity neighbour had been replied
-    // to (#214). A paraphrased re-raise whose title drifted is still caught by the content-overlap
+    // to. A paraphrased re-raise whose title drifted is still caught by the content-overlap
     // fallback below.
     if (Math.abs(finding.line() - prior.line()) <= DUPLICATE_LINE_TOLERANCE
         && FindingDeduplicator.titleSimilarity(finding.title(), prior.title())

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -211,10 +211,6 @@ public class ReviewOrchestrator {
     // the same failure path as any other error — comment, failed session, broadcast.
     var req = request;
     var checkRunId = -1L;
-    // Once the check-run verdict is committed, the review result is visible to the user; a failure
-    // in
-    // any later step must not flip that verdict to failure nor post a "retry" notice over it
-    // (#220).
     var resultSurfaced = false;
     try {
       var resolved = resolveMissingPrDetails(auth, request);
@@ -237,8 +233,6 @@ public class ReviewOrchestrator {
           buildBaseComparisonWithStats(
               auth, req.owner(), req.repo(), req.baseSha(), req.commitSha());
       var baseComparison = baseComparisonResult.text();
-      // Files the budget dropped (from the PR diff or the base comparison) make the review partial.
-      // The omitted count travels in DiffStats so the verdict and summary can disclose it (#234).
       var omittedFiles = diffResult.omittedFiles() + baseComparisonResult.omittedFiles();
 
       var priorReviews = fetchPriorReviews(auth, req.owner(), req.repo(), req.prNumber());
@@ -359,7 +353,6 @@ public class ReviewOrchestrator {
               offendingCiChecks,
               backstopUnresolved);
 
-      // Finalize check run before posting PR review — avoid approving then failing later
       String conclusion = conclusionForResult(result);
       String checkTitle = checkTitleForResult(result);
       String checkSummary = checkSummaryForResult(result);
@@ -374,13 +367,8 @@ public class ReviewOrchestrator {
               checkTitle,
               checkSummary,
               sessionUrl(session)));
-      // The verdict is now on the check run — the authoritative, user-visible result. From here a
-      // late failure (summary/review post, thread resolution, labels, persistence, broadcast) is a
-      // post-result hiccup, not a reason to retract the verdict or ask the user to re-run (#220).
       resultSurfaced = true;
 
-      // Summary goes first so it tops the PR conversation, before the inline finding comments.
-      // Posted on clean first reviews too: the celebration line lives inside the summary
       if (isFirstVisibleReview && !result.summaryMarkdown().isBlank()) {
         commentClient.createComment(
             auth,
@@ -391,8 +379,6 @@ public class ReviewOrchestrator {
             new GitHubCommentClient.CreateCommentRequest(result.summaryMarkdown()));
       }
 
-      // Dismiss any stale pending review this bot left before posting the new one, reusing the
-      // reviews already fetched for this run rather than re-listing them (#74).
       dismissPendingBotReviews(auth, req.owner(), req.repo(), req.prNumber(), priorReviews);
       postReview(auth, req.owner(), req.repo(), req.prNumber(), req.commitSha(), result, files);
 
@@ -417,8 +403,6 @@ public class ReviewOrchestrator {
           req.owner(), req.repo(), req.prNumber(), result.totalFindings(), result.reviewState());
     } catch (RuntimeException e) {
       if (resultSurfaced) {
-        // The result is already posted; log the trailing failure but leave the verdict intact so we
-        // don't overwrite it with a misleading "could not be completed — retry" notice (#220).
         Log.warnf(
             e,
             "Review for %s/%s #%d was posted, but a post-result step failed",
@@ -624,7 +608,7 @@ public class ReviewOrchestrator {
       String auth, String owner, String repo, int prNumber) {
     // A fetch failure must propagate to review()'s handler (failed check + "could not complete"
     // notice). Swallowing it into an empty list is indistinguishable from a PR with no changes and
-    // produces a false APPROVE + green check on code that was never read (#211). A genuinely empty
+    // produces a false APPROVE + green check on code that was never read. A genuinely empty
     // PR returns an empty list with no exception and still takes the normal path.
     return prClient.getPullRequestFiles(auth, ACCEPT, owner, repo, prNumber);
   }
@@ -950,19 +934,14 @@ public class ReviewOrchestrator {
       state = ReviewState.COMMENT;
     }
 
-    // Gating approval verdict on CI status:
     if (state == ReviewState.APPROVE && !offendingCiChecks.isEmpty()) {
       state = ReviewState.COMMENT;
     }
 
-    // A truncated diff means whole files were never reviewed — never sail an APPROVE over the
-    // unreviewed remainder; hold it as a COMMENT and disclose the omission below (#234).
     if (state == ReviewState.APPROVE && diffStats.truncated()) {
       state = ReviewState.COMMENT;
     }
 
-    // The summary is generated for clean reviews too: a zero-findings result still reports the
-    // change overview and carries the celebration line inside the same comment
     var summaryMarkdown =
         summaryGenerator.generate(
             diffStats.filesChanged(),
@@ -1031,7 +1010,7 @@ public class ReviewOrchestrator {
 
   /**
    * Banner prepended to the summary when the diff was truncated, so a reader knows the review is
-   * partial — the verdict is also held back from APPROVE in that case (#234).
+   * partial — the verdict is also held back from APPROVE in that case.
    */
   private static String truncationNotice(int omittedFiles) {
     return String.format(
@@ -1089,7 +1068,7 @@ public class ReviewOrchestrator {
       // Inline anchoring failed for every finding (e.g. all lines fell outside the diff after a
       // force-push). Surface them in the review body so they are not invisible: a follow-up review
       // posts no summary comment, so without this the findings would show only as a red check
-      // (#215).
+      // .
       Log.warnf(
           "No inline comments posted for %s/%s #%d — surfacing findings in the review body",
           owner, repo, prNumber);
@@ -1119,7 +1098,7 @@ public class ReviewOrchestrator {
    * A review-body list of findings, used when none could be anchored as inline comments (their
    * lines fell outside the current diff). It keeps the findings visible on a follow-up review,
    * which posts no summary comment — without it the findings would surface only as a red check run
-   * (#215).
+   * .
    */
   private static String unanchoredFindingsBody(ReviewResult result) {
     var sb = new StringBuilder();
@@ -1298,7 +1277,7 @@ public class ReviewOrchestrator {
    * Deletes any pending review left by this bot — GitHub allows only one pending review per user.
    * Reuses the reviews already fetched for this run instead of re-listing: no review is created
    * between that fetch and here, so a second {@code listReviews} would only spend extra rate-limit
-   * budget (#74).
+   * budget.
    */
   void dismissPendingBotReviews(
       String auth,
@@ -1356,7 +1335,6 @@ public class ReviewOrchestrator {
    * {@link Optional} — which the caller maps to {@code null}, gating on every check — only when
    * neither mechanism governs the branch or both lookups fail.
    */
-  // Package-private so each resolution branch can be exercised directly in tests.
   Optional<List<String>> resolveRequiredContexts(String auth, ReviewRequest req) {
     String branch;
     try {
@@ -1569,7 +1547,7 @@ public class ReviewOrchestrator {
     }
     // "pending", null, or any unrecognized state is not a confirmed pass: classify it as pending so
     // an indeterminate required check holds the approval rather than being mistaken for success
-    // (#217). Only an explicit "success" clears the gate.
+    // . Only an explicit "success" clears the gate.
     return CI_PENDING;
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
@@ -694,7 +694,7 @@ class DiffLineResolverTest {
   void getLineTextReturnsNullOnAmbiguousSuffixCollision() {
     // Both a/dir/Main.java and b/dir/Main.java carry right-side text and are FilePaths.same to the
     // queried "dir/Main.java". With no unique resolution, getLineText must return null rather than
-    // guess whichever entry the map happens to iterate first (#218).
+    // guess whichever entry the map happens to iterate first.
     var other =
         """
         @@ -10,3 +10,4 @@

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingDeduplicatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingDeduplicatorTest.java
@@ -99,7 +99,7 @@ class FindingDeduplicatorTest {
   @Test
   void twoDuplicatesKeepTheMoreSevereSeverity() {
     // An even cluster has no single median; the more severe of the two central values wins, so a
-    // single hedged (lower-severity) duplicate cannot downgrade a blocking finding (#213).
+    // single hedged (lower-severity) duplicate cannot downgrade a blocking finding.
     var response =
         response(
             finding("critical", "src/A.java", 5, "Unbounded recursion in parser", "short"),

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -112,7 +112,7 @@ class FindingQuoteValidatorTest {
     // Both lines exist in the diff ("}" last, "public class Main {" first) but never as a
     // contiguous in-order run — a recombination of real lines that matchQuote's per-line set
     // membership wrongly accepts as FULL. It must be demoted so the fabricated suggestion is
-    // not kept (#216).
+    // not kept.
     var response = response(finding("}\npublic class Main {"));
 
     var result = validator.validate(response, DIFF);
@@ -446,7 +446,7 @@ class FindingQuoteValidatorTest {
   void multiLineQuoteOfContiguousAddedCodeIsKept() {
     // suggestion_old may quote code this PR added (to replace a just-added bug). Those lines are
     // contiguous on the new side (context + additions) but absent from the original side (context +
-    // deletions), so the multi-line contiguity gate must still keep them (#216).
+    // deletions), so the multi-line contiguity gate must still keep them.
     var diff =
         """
         ### src/New.java (modified, +2 -0)

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -312,7 +312,7 @@ class FollowUpAnalyzerTest {
 
   @Test
   void dropRepliedDuplicatesShouldKeepDistinctNearbyFindingOfTheSameSeverity() {
-    // Regression (#214): severity must not be part of finding identity. A different defect a couple
+    // Regression: severity must not be part of finding identity. A different defect a couple
     // of lines from a replied prior finding of the same severity must still post — not be dropped
     // as
     // a re-raise just because the severities match.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -372,7 +372,7 @@ class ReviewOrchestratorTest {
           .thenThrow(new RuntimeException("GitHub API error"));
 
       // Swallowing the failure into an empty list would yield an empty diff and a false APPROVE on
-      // unreviewed code (#211); it must propagate so review() takes the failure path.
+      // unreviewed code; it must propagate so review() takes the failure path.
       assertThrows(
           RuntimeException.class, () -> orchestrator.fetchPrFiles("auth", "owner", "repo", 42));
     }
@@ -1358,7 +1358,7 @@ class ReviewOrchestratorTest {
                 anyInt(),
                 argThat(req -> "APPROVE".equals(req.event())));
         // ...so the post-result failure must NOT post a "could not be completed — retry" notice,
-        // flip the session to failed, or broadcast a failure over the posted result (#220).
+        // flip the session to failed, or broadcast a failure over the posted result.
         verify(commentClient, never())
             .createComment(
                 anyString(),
@@ -1428,7 +1428,7 @@ class ReviewOrchestratorTest {
                 false));
 
         // listReviews is fetched exactly once for the whole run — dismissal reuses that list
-        // (#74)...
+        // ...
         verify(reviewClient, times(1))
             .listReviews(anyString(), anyString(), anyString(), anyString(), anyInt());
         // ...and the bot's stale pending review is still dismissed from the reused list.
@@ -2399,7 +2399,7 @@ class ReviewOrchestratorTest {
       // The finding's file is not in the diff, so no inline comment anchors (posted == 0). On a
       // first review the findings are in the summary comment, so the review body points there — but
       // a
-      // review event is still posted so the findings never vanish behind a bare check (#215).
+      // review event is still posted so the findings never vanish behind a bare check.
       var finding = new Finding(RiskLevel.MEDIUM, "missing.java", 10, "Bug", "desc", null, null);
       var result = resultWithFinding(finding, ReviewState.COMMENT); // isFirstReview = true
 
@@ -2428,7 +2428,7 @@ class ReviewOrchestratorTest {
 
     @Test
     void shouldListFindingsInReviewBodyWhenNoneAnchorInlineOnFollowUp() {
-      // Regression (#215): on a follow-up review (which posts no summary comment) findings whose
+      // Regression: on a follow-up review (which posts no summary comment) findings whose
       // lines fall outside the diff must still be listed in the review body, not show only as a red
       // check run.
       var finding =
@@ -3818,7 +3818,7 @@ class ReviewOrchestratorTest {
     void shouldHoldApprovalWhenAStatusStateIsUnrecognized() {
       // A commit status whose state is neither success/pending/failure/error (here a malformed
       // value; null behaves identically) is not a confirmed pass — it must surface as a pending
-      // offending check so it holds the approval rather than clearing the gate (#217).
+      // offending check so it holds the approval rather than clearing the gate.
       var passRun =
           new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
               1L, "build", "completed", "success", null);


### PR DESCRIPTION
## What type of PR is this?

- [x] 🧹 Chore / cleanup

## Description

Trims the "narrating" comments that accumulated during the recent review-path fixes — per-step / code-restating lines and issue-referencing rationale blocks (mostly in `review()` and `buildResult`), plus collapsing the `GitHubReviewClient` pagination constant comments to one line each (the full rationale already lives in those methods' javadoc).

**Kept** (per the agreed line): javadoc, constant-group labels (`// Check run status constants`, …), and genuinely non-obvious WHY comments — the deterministic backstop, CI "absent → gate on all checks (null)" semantics, `isFirstVisibleReview` vs `hasContext`, the #211 fetch-propagation gotcha, the #217 classification rule, the severity-merge rule, the case-sensitive test-file match, etc.

The removable narration was concentrated in `ReviewOrchestrator` and `GitHubReviewClient`; the rest of the review package's comments are legitimate complex-logic/javadoc and were left untouched.

## Related Issues

Follow-up cleanup from the v0.2.x review-path work (no issue).

## How Has This Been Tested?

- [x] Comment-only change — no logic touched.
- [x] Full suite: **1238 passing**; spotbugs + spotless clean (JDK 25).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests (n/a — comment-only)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (n/a)
- [x] My changes generate no new warnings or errors
