### PR TITLE
fix(deps): bump jackson to 2.22.0 to clear GHSA-5jmj-h7xm-6q6v (CVE-2026-54515)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <quarkus-langchain4j.version>1.11.2</quarkus-langchain4j.version>
         <opentelemetry.version>1.62.0</opentelemetry.version>
         <opentelemetry.alpha.version>1.62.0-alpha</opentelemetry.alpha.version>
+        <jackson-bom.version>2.22.0</jackson-bom.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
         <!-- Default for @{argLine} in surefire; overwritten by the JaCoCo agent when active -->
@@ -73,6 +74,20 @@
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom-alpha</artifactId>
                 <version>${opentelemetry.alpha.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!--
+                CVE override for jackson-databind GHSA-5jmj-h7xm-6q6v / CVE-2026-54515
+                (@JsonIgnoreProperties deserialization bypass). quarkus-bom 3.36.3 manages 2.21.4
+                (vulnerable); the 2.21.x fix (2.21.5) is not yet on Maven Central, so bump to
+                2.22.0 — the next published release OSV reports clean. Declared before the
+                quarkus-bom import so this BOM wins. Remove once the platform ships a fixed jackson.
+            -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔒 Security / dependency fix

## Description

OpenSSF Scorecard's **Vulnerabilities** check (OSV) flagged **GHSA-5jmj-h7xm-6q6v** / **CVE-2026-54515** — a case-insensitive deserialization bypass in `jackson-databind` that can circumvent per-property `@JsonIgnoreProperties` exclusions ("mass-assignment-style writes" from untrusted JSON).

`quarkus-bom` 3.36.3 brings **jackson-databind 2.21.4**, which is in the vulnerable range `2.19.0–2.21.4`. The 2.21.x fix (`2.21.5`) is **not yet on Maven Central**, so this overrides **`jackson-bom` to 2.22.0** — the next published release — declared *before* the `quarkus-bom` import so it wins (same pattern as the existing opentelemetry CVE override).

Verified against the OSV API:
- `jackson-databind:2.21.4` → **GHSA-5jmj-h7xm-6q6v** (flagged)
- `jackson-databind:2.22.0` → **clean**

## Related Issues

Clears the OpenSSF Scorecard Vulnerabilities finding (no tracking issue).

## How Has This Been Tested?

- [x] `dependency:list` confirms `jackson-databind`/`jackson-core` resolve to **2.22.0**
- [x] Full suite: **1238 passing**; spotbugs + spotless clean (JDK 25)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] Tests (n/a — dependency override)
- [x] New and existing unit tests pass locally
- [ ] Documentation (CHANGELOG handled in release PR #233)
- [x] My changes generate no new warnings or errors

## Additional Notes

⚠️ **Native build:** this is a jackson **minor** bump (2.21→2.22) in a GraalVML-native app. JVM tests pass; Quarkus's jackson extension registers serialization at build time, so native should be unaffected, but PR CI's `native-build` is skipped — the native image is validated on the release/main pipeline. Happy to run a local native build first if you'd prefer certainty before merge.
