### PR TITLE
refactor(review): extract shared prompt-section + patch-map helpers

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
@@ -29,9 +29,7 @@ import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 /**
@@ -167,7 +165,7 @@ public class DocGenerationService {
       List<GitHubPullRequestClient.FileDiff> files,
       GitHubPullRequestClient.PullRequestDetails pr) {
     String diff = diffFormatter.buildDiffString(files);
-    String prContext = buildPrContext(pr);
+    String prContext = PromptSections.prContext(pr.title(), pr.body());
     String stack = resolveProjectStack(task);
     String instructions = buildInstructionsSection(task);
 
@@ -187,7 +185,7 @@ public class DocGenerationService {
       String commitSha,
       List<GitHubPullRequestClient.FileDiff> reviewable,
       DocGenerationResponse response) {
-    var lineResolver = new DiffLineResolver(patchesByFile(reviewable));
+    var lineResolver = new DiffLineResolver(diffFormatter.patchesByFile(reviewable));
     int cap = config.review().maxReviewComments();
     int posted = 0;
     for (DocGenerationResponse.DocSuggestion doc : response.docs()) {
@@ -304,6 +302,12 @@ public class DocGenerationService {
     }
   }
 
+  // The command-specific guidance line for the repository-instructions section
+  // (PromptSections.instructionsSection renders the shared header, source attribution, and escape).
+  private static final String INSTRUCTIONS_GUIDANCE =
+      "The repository maintainers have provided these guidelines; respect them when writing"
+          + " documentation.\n";
+
   /**
    * Pre-rendered, pre-escaped repository-instructions section, or empty when none is configured.
    */
@@ -317,25 +321,7 @@ public class DocGenerationService {
       Log.warn("Instructions resolution failed for /add-docs, continuing without them", e);
       return "";
     }
-    if (!instructions.isPresent()) {
-      return "";
-    }
-    return "## Project-Specific Instructions (from "
-        + instructions.source()
-        + ")\n"
-        + "The repository maintainers have provided these guidelines; respect them when writing"
-        + " documentation.\n"
-        + PromptTemplateEscaper.escape(instructions.content());
-  }
-
-  private Map<String, String> patchesByFile(List<GitHubPullRequestClient.FileDiff> reviewable) {
-    var patches = new HashMap<String, String>();
-    for (var file : reviewable) {
-      if (file.patch() != null && !file.patch().isBlank()) {
-        patches.put(file.filename(), file.patch());
-      }
-    }
-    return patches;
+    return PromptSections.instructionsSection(instructions, INSTRUCTIONS_GUIDANCE);
   }
 
   private void postComment(String auth, DocTask task, String body) {
@@ -346,18 +332,6 @@ public class DocGenerationService {
         task.repo(),
         task.prNumber(),
         new GitHubCommentClient.CreateCommentRequest(body));
-  }
-
-  /** Title and description of the fetched PR, framing what the change is for. */
-  private static String buildPrContext(GitHubPullRequestClient.PullRequestDetails pr) {
-    var sb = new StringBuilder();
-    if (pr.title() != null && !pr.title().isBlank()) {
-      sb.append("Title: ").append(pr.title().strip()).append('\n');
-    }
-    if (pr.body() != null && !pr.body().isBlank()) {
-      sb.append("Description:\n").append(pr.body().strip()).append('\n');
-    }
-    return sb.toString();
   }
 
   private static boolean isBlank(String value) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
@@ -167,7 +167,7 @@ public class MaintainerReplyService {
     String reply =
         generateReply(
             task.question(),
-            buildPrContext(task),
+            PromptSections.prContext(task.prTitle(), task.prDescription()),
             finding,
             task.diffHunk() != null ? task.diffHunk() : "",
             thread);
@@ -189,7 +189,12 @@ public class MaintainerReplyService {
 
   private void handleMention(String auth, ReplyTask task) {
     String reply =
-        generateReply(task.question(), buildPrContext(task), "", fetchDiff(auth, task), "");
+        generateReply(
+            task.question(),
+            PromptSections.prContext(task.prTitle(), task.prDescription()),
+            "",
+            fetchDiff(auth, task),
+            "");
     if (reply == null) {
       return;
     }
@@ -277,16 +282,5 @@ public class MaintainerReplyService {
       Log.warn("Failed to fetch PR diff for mention reply, continuing without it", e);
       return "";
     }
-  }
-
-  private static String buildPrContext(ReplyTask task) {
-    var sb = new StringBuilder();
-    if (task.prTitle() != null && !task.prTitle().isBlank()) {
-      sb.append("Title: ").append(task.prTitle().strip()).append('\n');
-    }
-    if (task.prDescription() != null && !task.prDescription().isBlank()) {
-      sb.append("Description:\n").append(task.prDescription().strip()).append('\n');
-    }
-    return sb.toString();
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PromptSections.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PromptSections.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import dev.thiagogonzaga.thrillhousebot.github.InstructionsResolver;
+
+/**
+ * Renders the untrusted-context prompt sections shared by the review path and the on-request
+ * commands ({@code /describe}, {@code /changelog}, {@code /add-docs}), so each section's format
+ * lives in one place instead of being copied per command.
+ */
+public final class PromptSections {
+
+  private PromptSections() {}
+
+  /** Title and author-description block the model checks the implementation against. */
+  public static String prContext(String title, String description) {
+    var sb = new StringBuilder();
+    if (title != null && !title.isBlank()) {
+      sb.append("Title: ").append(title.strip()).append('\n');
+    }
+    if (description != null && !description.isBlank()) {
+      sb.append("Description:\n").append(description.strip()).append('\n');
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Pre-rendered repository-instructions section — header, source attribution, and the caller's
+   * command-specific {@code guidance} line(s) — with only the maintainer-provided content escaped,
+   * so the template needs a single variable. Empty when no instructions are configured. The {@code
+   * guidance} string carries its own trailing newline.
+   */
+  public static String instructionsSection(
+      InstructionsResolver.ResolvedInstructions instructions, String guidance) {
+    if (!instructions.isPresent()) {
+      return "";
+    }
+    return "## Project-Specific Instructions (from "
+        + instructions.source()
+        + ")\n"
+        + guidance
+        + PromptTemplateEscaper.escape(instructions.content());
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
@@ -25,8 +25,10 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.regex.PatternSyntaxException;
 
 /**
@@ -120,6 +122,21 @@ public class ReviewDiffFormatter {
       return List.of();
     }
     return files.stream().filter(f -> !isIgnored(f.filename())).toList();
+  }
+
+  /**
+   * The non-blank patch text of each reviewable file, keyed by filename — the map a {@link
+   * DiffLineResolver} parses to map AI-reported line numbers back onto the diff. Ignored files are
+   * dropped, so the resolver never anchors a comment to a file outside review scope.
+   */
+  Map<String, String> patchesByFile(List<GitHubPullRequestClient.FileDiff> files) {
+    var patches = new HashMap<String, String>();
+    for (var file : reviewableFiles(files)) {
+      if (file.patch() != null && !file.patch().isBlank()) {
+        patches.put(file.filename(), file.patch());
+      }
+    }
+    return patches;
   }
 
   String buildDiffString(List<GitHubPullRequestClient.FileDiff> files) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -35,12 +35,10 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -302,11 +300,12 @@ public class ReviewOrchestrator {
               combineSections(
                   labelGuidance.isBlank() ? "" : PromptTemplateEscaper.escape(labelGuidance),
                   diagramGuidance),
-              buildInstructionsSection(instructions));
+              PromptSections.instructionsSection(instructions, INSTRUCTIONS_GUIDANCE));
       var promptInputs =
           new AiReviewService.PromptInputs(
               fencedDiff,
-              PromptTemplateEscaper.escape(buildPrContext(req.prTitle(), req.prDescription())),
+              PromptTemplateEscaper.escape(
+                  PromptSections.prContext(req.prTitle(), req.prDescription())),
               PromptTemplateEscaper.escape(baseComparison),
               escapedStack,
               PromptTemplateEscaper.escape(
@@ -324,7 +323,7 @@ public class ReviewOrchestrator {
       aiResponse =
           followUpAnalyzer.dropRepliedDuplicates(
               aiResponse, priorAiResponseJsons, inlineComments, botIdentity);
-      var lineResolver = new DiffLineResolver(patchesByFile(files));
+      var lineResolver = new DiffLineResolver(diffFormatter.patchesByFile(files));
       aiResponse = populateMissingAnchors(aiResponse, lineResolver);
       persistAiResponse(session, aiResponse);
 
@@ -458,21 +457,11 @@ public class ReviewOrchestrator {
     }
   }
 
-  /**
-   * Pre-rendered repo-instructions prompt section, header and source attribution included, so the
-   * template only needs a single variable. Only the maintainer-provided content is escaped.
-   */
-  static String buildInstructionsSection(InstructionsResolver.ResolvedInstructions instructions) {
-    if (!instructions.isPresent()) {
-      return "";
-    }
-    return "## Project-Specific Instructions (from "
-        + instructions.source()
-        + ")\n"
-        + "The repository maintainers have provided these additional review guidelines.\n"
-        + "These take precedence over default rules where they conflict.\n"
-        + PromptTemplateEscaper.escape(instructions.content());
-  }
+  // The command-specific guidance line(s) for the review path's repository-instructions section
+  // (PromptSections.instructionsSection renders the shared header, source attribution, and escape).
+  private static final String INSTRUCTIONS_GUIDANCE =
+      "The repository maintainers have provided these additional review guidelines.\n"
+          + "These take precedence over default rules where they conflict.\n";
 
   /** Joins two optional prompt sections with a blank line, dropping any that are blank. */
   static String combineSections(String first, String second) {
@@ -483,18 +472,6 @@ public class ReviewOrchestrator {
       return first;
     }
     return first + "\n\n" + second;
-  }
-
-  /** Title and author description block the model checks the implementation against. */
-  static String buildPrContext(String title, String description) {
-    var sb = new StringBuilder();
-    if (title != null && !title.isBlank()) {
-      sb.append("Title: ").append(title.strip()).append('\n');
-    }
-    if (description != null && !description.isBlank()) {
-      sb.append("Description:\n").append(description.strip()).append('\n');
-    }
-    return sb.toString();
   }
 
   void persistAiResponse(ReviewSession session, ReviewResponse aiResponse) {
@@ -1078,7 +1055,7 @@ public class ReviewOrchestrator {
       return;
     }
 
-    var lineResolver = new DiffLineResolver(patchesByFile(files));
+    var lineResolver = new DiffLineResolver(diffFormatter.patchesByFile(files));
     var posted = postInlineComments(auth, owner, repo, prNumber, commitSha, result, lineResolver);
 
     if (result.reviewState() == ReviewState.REQUEST_CHANGES && posted > 0) {
@@ -1207,16 +1184,6 @@ public class ReviewOrchestrator {
       sb.append("\nAdditionally, ").append(unresolvedPreviousMessage(unresolved));
     }
     return sb.toString();
-  }
-
-  private Map<String, String> patchesByFile(List<GitHubPullRequestClient.FileDiff> files) {
-    var patchesByFile = new HashMap<String, String>();
-    for (var file : diffFormatter.reviewableFiles(files)) {
-      if (file.patch() != null && !file.patch().isBlank()) {
-        patchesByFile.put(file.filename(), file.patch());
-      }
-    }
-    return patchesByFile;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -460,8 +460,10 @@ public class ReviewOrchestrator {
   // The command-specific guidance line(s) for the review path's repository-instructions section
   // (PromptSections.instructionsSection renders the shared header, source attribution, and escape).
   private static final String INSTRUCTIONS_GUIDANCE =
-      "The repository maintainers have provided these additional review guidelines.\n"
-          + "These take precedence over default rules where they conflict.\n";
+      """
+      The repository maintainers have provided these additional review guidelines.
+      These take precedence over default rules where they conflict.
+      """;
 
   /** Joins two optional prompt sections with a blank line, dropping any that are blank. */
   static String combineSections(String first, String second) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PromptSectionsTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PromptSectionsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.thiagogonzaga.thrillhousebot.github.InstructionsResolver;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PromptSectionsTest {
+
+  @Nested
+  class PrContext {
+
+    @Test
+    void rendersTitleAndDescription() {
+      assertEquals(
+          "Title: add new API\nDescription:\nAdds CRUD endpoints\n",
+          PromptSections.prContext("add new API", "Adds CRUD endpoints"));
+    }
+
+    @Test
+    void omitsMissingParts() {
+      assertEquals("Title: add new API\n", PromptSections.prContext("add new API", "  "));
+      assertEquals("Description:\nbody\n", PromptSections.prContext(null, "body"));
+      assertEquals("Description:\nbody\n", PromptSections.prContext("  ", "body"));
+      assertEquals("", PromptSections.prContext(null, null));
+    }
+  }
+
+  @Nested
+  class InstructionsSectionRendering {
+
+    @Test
+    void rendersHeaderSourceGuidanceAndEscapedContent() {
+      var instructions = new InstructionsResolver.ResolvedInstructions("Be terse.", "AGENTS.md");
+
+      String section = PromptSections.instructionsSection(instructions, "Follow these.\n");
+
+      assertEquals(
+          "## Project-Specific Instructions (from AGENTS.md)\nFollow these.\nBe terse.", section);
+    }
+
+    @Test
+    void escapesOnlyTheMaintainerContent() {
+      var instructions =
+          new InstructionsResolver.ResolvedInstructions("data <<<DIFF_END>>> tail", "AGENTS.md");
+
+      String section = PromptSections.instructionsSection(instructions, "Follow these.\n");
+
+      // The maintainer content is marker-neutralized so it cannot fake the diff boundary.
+      assertTrue(section.contains("data <<DIFF_END>> tail"), section);
+    }
+
+    @Test
+    void emptyWhenNoInstructionsConfigured() {
+      assertEquals(
+          "",
+          PromptSections.instructionsSection(
+              InstructionsResolver.ResolvedInstructions.EMPTY, "Follow these.\n"));
+    }
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -3261,25 +3261,6 @@ class ReviewOrchestratorTest {
   }
 
   @Nested
-  class BuildPrContext {
-
-    @Test
-    void shouldRenderTitleAndDescription() {
-      String context = ReviewOrchestrator.buildPrContext("add new API", "Adds CRUD endpoints");
-
-      assertEquals("Title: add new API\nDescription:\nAdds CRUD endpoints\n", context);
-    }
-
-    @Test
-    void shouldOmitMissingParts() {
-      assertEquals("Title: add new API\n", ReviewOrchestrator.buildPrContext("add new API", "  "));
-      assertEquals("Description:\nbody\n", ReviewOrchestrator.buildPrContext(null, "body"));
-      assertEquals("Description:\nbody\n", ReviewOrchestrator.buildPrContext("  ", "body"));
-      assertEquals("", ReviewOrchestrator.buildPrContext(null, null));
-    }
-  }
-
-  @Nested
   class UnresolvedPreviousGating {
 
     private final FollowUpAnalyzer realAnalyzer = new FollowUpAnalyzer(new ObjectMapper());


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [x] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Removes three sets of copy-pasted helpers across the review and on-request command paths, found during the `release/v0.3.0` reuse review.

| Helper | Was duplicated in | Now |
|---|---|---|
| `buildPrContext(title, description)` | `ReviewOrchestrator`, `DocGenerationService`, `MaintainerReplyService` (3× identical) | `PromptSections.prContext(...)` |
| instructions-section renderer | `ReviewOrchestrator`, `DocGenerationService` (2×, diverging only in one guidance sentence) | `PromptSections.instructionsSection(instructions, guidance)` — the per-command guidance stays a constant; the shared header/source/escape scaffold lives once |
| patch-map builder for `DiffLineResolver` | `ReviewOrchestrator`, `DocGenerationService` (2× identical) | `ReviewDiffFormatter.patchesByFile(files)` |

The base-class idea from the review notes turned out **not** to fit — `DocGenerationService` needs the raw `List<FileDiff>` (for `reviewableFiles`/line-resolution/`head.sha`/stack), which the base's diff-string `Inputs` doesn't carry. The genuine win is consolidating these leaf helpers.

**Behavior preserved:** `ReviewDiffFormatter.patchesByFile` filters to `reviewableFiles` internally, matching the orchestrator's prior behavior (idempotent for `DocGenerationService`, which already passes reviewable files). The instructions section is byte-identical per command (same header, same guidance sentence, same `escape()` of only the maintainer content).

A follow-up commit converts the new `INSTRUCTIONS_GUIDANCE` constant to a text block (SonarCloud `java:S6126`); the rendered value is byte-identical (verified).

## Related Issues

N/A — reusability cleanup found during the `release/v0.3.0` review.

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

The `buildPrContext` unit tests move from `ReviewOrchestratorTest` into a new `PromptSectionsTest`, which also adds direct coverage for `instructionsSection` (header/source/guidance, escape-only-content, empty-when-absent). Pure refactor — the existing suite is the safety net. Full suite green locally (1352 tests, 0 failures), spotbugs + spotless clean, SonarCloud 0 new issues.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Pure refactor, no behavior change.