### PR TITLE
fix(review): confine a multi-line suggestion range to one hunk

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -40,12 +40,14 @@ public final class DiffLineResolver {
   private final Map<String, List<String>> rightSideTextByFile;
   private final Map<String, List<Integer>> rightSideTextLineNumbersByFile;
   private final Map<String, Map<Integer, String>> rightSideLineTextByFile;
+  private final Map<String, TreeSet<Integer>> rightSideHunkStartsByFile;
 
   public DiffLineResolver(Map<String, String> patchesByFile) {
     this.rightSideLinesByFile = new HashMap<>();
     this.rightSideTextByFile = new HashMap<>();
     this.rightSideTextLineNumbersByFile = new HashMap<>();
     this.rightSideLineTextByFile = new HashMap<>();
+    this.rightSideHunkStartsByFile = new HashMap<>();
     patchesByFile.forEach(
         (file, patch) -> {
           RightSide rightSide = parseRightSide(patch);
@@ -53,6 +55,7 @@ public final class DiffLineResolver {
           rightSideTextByFile.put(file, rightSide.text());
           rightSideTextLineNumbersByFile.put(file, rightSide.textLineNumbers());
           rightSideLineTextByFile.put(file, rightSide.lineText());
+          rightSideHunkStartsByFile.put(file, rightSide.hunkStarts());
         });
   }
 
@@ -320,14 +323,16 @@ public final class DiffLineResolver {
     int startLine = lineNumbers.get(matchOffset);
     int endLine = lineNumbers.get(matchOffset + anchorLines.size() - 1);
     // The match is contiguous in the trimmed-text list, but blank-line dropping lets it straddle a
-    // hunk boundary (last line of one hunk, first line of the next). Such a span covers line
-    // numbers
-    // that are not on the diff's right side, so GitHub rejects the range (422). Accept it only when
-    // every line in [startLine, endLine] is a real right-side line — always true within a single
-    // hunk, false across a boundary — otherwise fall back to a single-line comment.
-    TreeSet<Integer> fileLines = rightSideLinesByFile.get(key);
-    if (fileLines == null
-        || fileLines.subSet(startLine, true, endLine, true).size() != endLine - startLine + 1) {
+    // hunk boundary (last line of one hunk, first line of the next). A multi-line GitHub suggestion
+    // must stay within a single hunk — start_line and line in different hunks is rejected (422),
+    // even when the two hunks are numerically adjacent and the span has no missing line number.
+    // Fall
+    // back to a single-line comment when any hunk begins inside (startLine, endLine]. The key came
+    // from the parallel right-side-text map, populated in the same pass, so its hunk-starts entry
+    // is
+    // always present.
+    TreeSet<Integer> hunkStarts = rightSideHunkStartsByFile.get(key);
+    if (!hunkStarts.subSet(startLine, false, endLine, true).isEmpty()) {
       return Optional.empty();
     }
     return Optional.of(new LineRange(startLine, endLine));
@@ -368,13 +373,15 @@ public final class DiffLineResolver {
    * test the anchor as a contiguous run; blank lines are dropped from both sides so a blank line
    * inside a block never breaks an otherwise-adjacent match. {@code textLineNumbers} runs parallel
    * to {@code text}, carrying the right-side line number of each retained line so a matched anchor
-   * run can be mapped back to a concrete line range (#71).
+   * run can be mapped back to a concrete line range (#71). {@code hunkStarts} holds each hunk's
+   * 1-based right-side start line, so a resolved range can be confined to a single hunk.
    */
   private record RightSide(
       TreeSet<Integer> lines,
       List<String> text,
       List<Integer> textLineNumbers,
-      Map<Integer, String> lineText) {}
+      Map<Integer, String> lineText,
+      TreeSet<Integer> hunkStarts) {}
 
   /**
    * Walks a unified-diff patch once, collecting the right-side line numbers and the trimmed text of
@@ -391,8 +398,9 @@ public final class DiffLineResolver {
     var text = new ArrayList<String>();
     var textLineNumbers = new ArrayList<Integer>();
     var lineText = new HashMap<Integer, String>();
+    var hunkStarts = new TreeSet<Integer>();
     if (patch == null || patch.isBlank()) {
-      return new RightSide(lines, text, textLineNumbers, lineText);
+      return new RightSide(lines, text, textLineNumbers, lineText, hunkStarts);
     }
 
     var newLine = 0;
@@ -401,6 +409,7 @@ public final class DiffLineResolver {
       OptionalInt hunkStart = hunkStart(rawLine);
       if (hunkStart.isPresent()) {
         newLine = hunkStart.getAsInt();
+        hunkStarts.add(newLine);
         inHunk = true;
         continue;
       }
@@ -409,7 +418,7 @@ public final class DiffLineResolver {
         newLine++;
       }
     }
-    return new RightSide(lines, text, textLineNumbers, lineText);
+    return new RightSide(lines, text, textLineNumbers, lineText, hunkStarts);
   }
 
   /** The 1-based right-side start line of a hunk header, or empty if the line is not one. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolverTest.java
@@ -773,6 +773,33 @@ class DiffLineResolverTest {
   }
 
   @Test
+  void resolveSuggestionRangeShouldReturnEmptyAcrossNumericallyAdjacentHunks() {
+    // Two hunks with consecutive right-side line numbers: hunk 1 ends at 11, hunk 2 starts at 12.
+    // Every line in 11..12 is a real right-side line, so a line-membership check would accept the
+    // span — but GitHub rejects a suggestion whose start_line and line are in different hunks
+    // (422),
+    // even with no gap. The range must stay in one hunk, so this falls back to a single-line
+    // comment.
+    var patch =
+        """
+        @@ -10,2 +10,2 @@
+         keep10()
+        +shared_a()
+        @@ -12,2 +12,2 @@
+        +shared_b()
+         keep13()
+        """;
+    var resolver = new DiffLineResolver(Map.of("A.java", patch));
+
+    assertTrue(resolver.resolveSuggestionRange("A.java", "shared_a()\nshared_b()").isEmpty());
+    // A genuine within-hunk run still resolves.
+    var range = resolver.resolveSuggestionRange("A.java", "keep10()\nshared_a()");
+    assertTrue(range.isPresent());
+    assertEquals(10, range.get().startLine());
+    assertEquals(11, range.get().endLine());
+  }
+
+  @Test
   void resolveSuggestionRangeShouldReturnEmptyForSingleLineOrBlankAnchor() {
     var resolver = new DiffLineResolver(Map.of("main.py", PATCH));
 


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`DiffLineResolver.resolveSuggestionRange` could return a
`start_line`/`line` pair that spans **two hunks**. Because blank-line
dropping flattens the trimmed-text list across hunks, an anchor match
can straddle a hunk boundary; the prior guard only checked that every
line in the span was a real right-side line. That's true when the two
hunks are **numerically adjacent** (consecutive right-side line numbers,
no gap), so the range was accepted — but GitHub requires a multi-line
suggestion's `start_line` and `line` to be in the **same hunk** and
rejects it with **422** otherwise, forcing a wasted API round-trip
before the existing single-line fallback.

**Fix:** track each hunk's 1-based right-side start line in the diff
parser (`RightSide.hunkStarts`), and in `resolveSuggestionRange` fall
back to a single-line comment when **any hunk begins inside `(startLine,
endLine]`**. This:

- catches the numerically-adjacent case the old line-membership check
missed, and
- **subsumes** the old guard — a hunk boundary inside the range is
exactly what produced the boundary-with-a-gap straddle too — so the
doomed 422 call is avoided entirely.

## Related Issues

N/A — LOW "adjacent-hunk → 422 → graceful fallback" edge found during
the `release/v0.3.0` regression review. Relates to multi-line
suggestions (#71).

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

New
`resolveSuggestionRangeShouldReturnEmptyAcrossNumericallyAdjacentHunks`
— two hunks at lines 10-11 and 12-13; the cross-boundary anchor now
falls back, while a genuine within-hunk run still resolves. Existing
gap-straddle, blank-line-span, ambiguity, and path-variant range tests
stay green. Full suite green locally (1353 tests), spotbugs + spotless
clean, SonarCloud 0 new issues, codecov/patch 100%.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

The single-line fallback already existed (the caller catches the 422);
this avoids the wasted GitHub round-trip by detecting the cross-hunk
range locally.