### PR TITLE
fix(review): disclose truncation on follow-up reviews (#245)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -976,7 +976,8 @@ public class ReviewOrchestrator {
         isFirstReview,
         summaryMarkdown,
         previousStatuses,
-        offendingCiChecks);
+        offendingCiChecks,
+        diffStats.omittedFiles());
   }
 
   /** Findings parsed from the model response, with per-severity counts and the highest risk. */
@@ -1168,22 +1169,37 @@ public class ReviewOrchestrator {
   }
 
   /**
-   * Body for a no-new-findings COMMENT review: failing/pending CI checks and/or unresolved items.
+   * Body for a no-new-findings COMMENT review: failing/pending CI checks, unresolved previous
+   * findings, and/or a truncated diff — whichever held the verdict back from APPROVE. The
+   * unresolved message is emitted only when there actually are unresolved findings (never a bogus
+   * "0 … unresolved"), and truncation is disclosed here on follow-up reviews, which post no summary
+   * comment to carry the first-review banner.
    */
   private String noIssuesBody(ReviewResult result) {
     long unresolved = unresolvedPreviousCount(result);
-    if (result.offendingCiChecks().isEmpty()) {
-      return unresolvedPreviousMessage(unresolved);
-    }
     var sb = new StringBuilder();
-    sb.append(
-        "ThrillhouseBot found no issues in this PR, but some checks are still pending or failed:\n");
-    for (var check : result.offendingCiChecks()) {
-      String status = check.isFailing() ? "failed" : CI_PENDING;
-      sb.append("- Check **").append(check.name()).append("** is ").append(status).append("\n");
+    if (!result.offendingCiChecks().isEmpty()) {
+      sb.append(
+          "ThrillhouseBot found no issues in this PR, but some checks are still pending or"
+              + " failed:\n");
+      for (var check : result.offendingCiChecks()) {
+        String status = check.isFailing() ? "failed" : CI_PENDING;
+        sb.append("- Check **").append(check.name()).append("** is ").append(status).append("\n");
+      }
+      if (unresolved > 0) {
+        sb.append("\nAdditionally, ").append(unresolvedPreviousMessage(unresolved));
+      }
+    } else if (unresolved > 0) {
+      sb.append(unresolvedPreviousMessage(unresolved));
     }
-    if (unresolved > 0) {
-      sb.append("\nAdditionally, ").append(unresolvedPreviousMessage(unresolved));
+    // The first-review summary comment carries the truncation banner; a follow-up posts no summary,
+    // so disclose the partial review here instead — otherwise a truncation-only hold would surface
+    // no reason at all (and used to misreport "0 previous finding(s) remain unresolved").
+    if (result.truncated() && !result.isFirstReview()) {
+      if (sb.length() > 0) {
+        sb.append("\n\n");
+      }
+      sb.append(truncationNotice(result.omittedFiles()).strip());
     }
     return sb.toString();
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -1196,7 +1196,7 @@ public class ReviewOrchestrator {
     // so disclose the partial review here instead — otherwise a truncation-only hold would surface
     // no reason at all (and used to misreport "0 previous finding(s) remain unresolved").
     if (result.truncated() && !result.isFirstReview()) {
-      if (sb.length() > 0) {
+      if (!sb.isEmpty()) {
         sb.append("\n\n");
       }
       sb.append(truncationNotice(result.omittedFiles()).strip());

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -31,7 +31,8 @@ public record ReviewResult(
     boolean isFirstReview,
     String summaryMarkdown,
     List<PreviousFindingStatus> previousStatuses,
-    List<CiCheck> offendingCiChecks) {
+    List<CiCheck> offendingCiChecks,
+    int omittedFiles) {
   public ReviewResult {
     findings = List.copyOf(findings);
     previousStatuses = List.copyOf(previousStatuses);
@@ -41,6 +42,34 @@ public record ReviewResult(
     if (reviewState == null) {
       reviewState = ReviewState.fromHighestRisk(highestRisk);
     }
+  }
+
+  /** Convenience constructor for results with no omitted files (a complete diff). */
+  public ReviewResult(
+      List<Finding> findings,
+      int criticalCount,
+      int highCount,
+      int mediumCount,
+      int lowCount,
+      RiskLevel highestRisk,
+      ReviewState reviewState,
+      boolean isFirstReview,
+      String summaryMarkdown,
+      List<PreviousFindingStatus> previousStatuses,
+      List<CiCheck> offendingCiChecks) {
+    this(
+        findings,
+        criticalCount,
+        highCount,
+        mediumCount,
+        lowCount,
+        highestRisk,
+        reviewState,
+        isFirstReview,
+        summaryMarkdown,
+        previousStatuses,
+        offendingCiChecks,
+        0);
   }
 
   public ReviewResult(
@@ -65,11 +94,17 @@ public record ReviewResult(
         isFirstReview,
         summaryMarkdown,
         previousStatuses,
-        List.of());
+        List.of(),
+        0);
   }
 
   public boolean hasIssues() {
     return !findings.isEmpty();
+  }
+
+  /** True when the line budget dropped whole files, so this review covers only part of the diff. */
+  public boolean truncated() {
+    return omittedFiles > 0;
   }
 
   public int totalFindings() {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -490,6 +490,33 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void truncatedFollowUpReviewBodyDisclosesPartialAndOmitsZeroUnresolved() {
+      var aiResponse = new ReviewResponse(List.of(), List.of(), null);
+      // A follow-up (not first review) clean review with 7 files omitted by the line budget: held
+      // to
+      // COMMENT, but a follow-up posts no summary comment to carry the truncation banner (#245).
+      var result =
+          orchestrator.buildResult(
+              aiResponse, false, new ReviewOrchestrator.DiffStats(120, 4000, 4000, 7), List.of());
+      assertEquals(ReviewState.COMMENT, result.reviewState());
+
+      orchestrator.postReview("auth", "owner", "repo", 5, "sha", result, List.of());
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      var body = captor.getValue().body();
+      // The follow-up review body itself now discloses the partial review and the omitted count...
+      assertTrue(body.contains("partial review"), body);
+      assertTrue(body.contains("7 file"), body);
+      // ...and never the bogus "0 previous finding(s) remain unresolved" the truncation hold used
+      // to
+      // emit when there were no unresolved findings.
+      assertFalse(body.contains("remain unresolved"), body);
+      assertEquals("COMMENT", captor.getValue().event());
+    }
+
+    @Test
     void shouldHandleNullFindingsInAiResponse() {
       var aiResponse = new ReviewResponse(null, null, null);
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -517,6 +517,66 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void truncatedFollowUpBodyAppendsTruncationAfterUnresolved() {
+      // A follow-up held to COMMENT by BOTH unresolved previous findings and a truncated diff: the
+      // body carries the unresolved message and then the partial-review banner.
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.COMMENT,
+              false,
+              "",
+              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "")),
+              List.of(),
+              7);
+
+      orchestrator.postReview("auth", "owner", "repo", 5, "sha", result, List.of());
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      var body = captor.getValue().body();
+      assertTrue(body.contains("1 previous finding(s) remain unresolved"), body);
+      assertTrue(body.contains("partial review"), body);
+      assertTrue(body.contains("7 file"), body);
+    }
+
+    @Test
+    void truncatedFirstReviewBodyOmitsBannerSinceSummaryCarriesIt() {
+      // On a FIRST review the summary comment carries the truncation banner, so the review body
+      // must
+      // not repeat it — even when the body is posted for unresolved previous findings.
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.COMMENT,
+              true,
+              "",
+              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "")),
+              List.of(),
+              7);
+
+      orchestrator.postReview("auth", "owner", "repo", 5, "sha", result, List.of());
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      var body = captor.getValue().body();
+      assertTrue(body.contains("1 previous finding(s) remain unresolved"), body);
+      assertFalse(body.contains("partial review"), body);
+    }
+
+    @Test
     void shouldHandleNullFindingsInAiResponse() {
       var aiResponse = new ReviewResponse(null, null, null);
 


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Follow-up to #234. The *gating* half works — a truncated review is held
to `COMMENT` instead of `APPROVE` — but the *disclosure* half never
reached the reader on a **follow-up** review:

- The "⚠️ Large PR — partial review, N files omitted" banner is
prepended only to `summaryMarkdown`, which is posted just as the
**first-review** summary comment. A follow-up posts no summary, so
truncation was never surfaced.
- Worse, the held-back `COMMENT` body then read *"…but **0** previous
finding(s) remain unresolved — fix them…"* — citing findings that don't
exist, because the real reason for the hold was truncation, not
unresolved findings.

Fix:

- `ReviewResult` now carries `omittedFiles` (with a `truncated()`
helper); `buildResult` threads `diffStats.omittedFiles()` into the
returned result. Existing 10-/11-arg constructors are kept as 0-default
convenience overloads, so no other call site changes.
- `noIssuesBody` emits the unresolved-findings message **only when there
actually are unresolved findings** (never a bogus "0 … unresolved"), and
on a **follow-up** appends the partial-review banner with the
omitted-file count. First reviews keep disclosing via the summary
banner, so nothing is duplicated.

## Related Issues

Fixes #245.

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

New `truncatedFollowUpReviewBodyDisclosesPartialAndOmitsZeroUnresolved`:
a follow-up clean review with 7 files omitted is held to `COMMENT`; the
posted review body states it is partial and names the omitted count, and
asserts it does **not** contain "remain unresolved". Existing CI-body
and unresolved-message tests stay green. Full suite green locally (1354
tests), spotbugs + spotless clean.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Observed in dogfooding: a re-review of a large PR (~120 files, diff
truncated) correctly went `APPROVED → COMMENTED`, but the review body
cited non-existent unresolved findings and never mentioned the omission.
This PR makes that follow-up body state the partial review and omitted
count instead.

## Additional Notes

The first-review disclosure path (summary banner) is unchanged; this
only adds the follow-up review-body disclosure and removes the bogus
zero-unresolved message.