### PR TITLE
feat(review): recalibrate severity so config/IaC findings aren't suppressed (#238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to ThrillhouseBot.
 ### Changed
 
 - **Multi-line suggestions**: when a finding's fix replaces several consecutive lines, the bot now posts a multi-line review comment (`start_line`..`line`) so the GitHub suggestion replaces the whole range in one click, instead of anchoring to a single line and mis-applying the rest. The range is derived from the flagged code's position in the diff and falls back to a single-line comment when it can't be resolved (#71)
+- **Config/IaC findings no longer suppressed**: the reviewer was high-precision but had weak recall on declarative diffs (Kubernetes/Helm manifests, Terraform, CI workflow YAML, Dockerfiles) — it would *consider* issues like over-broad RBAC, missing container hardening, token automounting, or a schema-invalid manifest and then drop them, because the SECURITY dimension named only application-code threats and severity was anchored on "will fail at runtime". The review prompt now names infra/config security classes, adds a config/IaC correctness dimension, and recalibrates severity so a change that fails schema/lint/CI validation — or that weakens a safety property the PR itself claims to add — is a defensible finding. Precision is preserved by the verifier (it still rejects config claims that rest on cluster/provider state not in the diff), not by blanket suppression (#238)
 
 ## [0.2.1] — 2026-06-24
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
@@ -38,7 +38,12 @@ public final class FindingVerifierPrompts {
               contracts, query dialects, lifecycle rules, routing and rendering semantics) that
               the provided diff and project
               stack do not support — especially claims that idiomatic-looking code "will fail
-              at runtime".
+              at runtime". This does NOT cover a config/IaC finding whose breakage is visible in
+              the diff text itself — an invalid or schema-violating manifest field, an over-broad
+              RBAC/IAM rule, a privileged or unhardened container, an automounted service-account
+              token: that is demonstrable here, so confirm or reject it against the manifest rather
+              than rejecting it as unverifiable remembered behavior. Still reject a config claim
+              that genuinely rests on cluster, provider, or registry state not shown in the diff.
             - suggestion_new is functionally equivalent to suggestion_old (an alias,
               reformatting, or a documented shorthand of the same call) — a fix that changes
               nothing disproves the finding.
@@ -84,8 +89,12 @@ public final class FindingVerifierPrompts {
               repeat.
 
             Severity calibration: "critical" and "high" risk require breakage demonstrable from
-            the provided diff and context. Unverifiable framework-behavior claims are at most
-            "medium" risk with "low" confidence. Claims about the contents or behavior of
+            the provided diff and context. A config/IaC defect whose breakage is visible in the
+            manifest text in the diff — a field that fails schema validation, an over-broad RBAC
+            rule, a privileged container, a change that weakens the safety property the PR claims
+            to add — IS demonstrable here and may be "high"; do not auto-downgrade it as remembered
+            framework behavior. Unverifiable framework-behavior claims are at most "medium" risk
+            with "low" confidence. Claims about the contents or behavior of
             artifacts not shown in the diff (base images, registries, installed packages,
             remote services) are not demonstrable here: downgrade any such finding above
             "medium". An "undefined / unset / missing symbol" claim is demonstrable only when

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -25,7 +25,16 @@ public final class PrReviewPrompts {
 
             Review dimensions:
             1. FUNCTIONAL CORRECTNESS: Does the code do what it claims? Edge cases covered? Null checks? Off-by-one errors?
-            2. SECURITY: SQL injection, XSS, path traversal, auth bypass, hardcoded secrets, unsafe deserialization, race conditions.
+            2. SECURITY: application-code threats — SQL injection, XSS, path traversal, auth bypass,
+               hardcoded secrets, unsafe deserialization, race conditions — and, equally,
+               infrastructure and configuration threats in declarative files (Kubernetes/Helm
+               manifests, Terraform, CI workflow YAML, Dockerfiles): over-broad RBAC/IAM that
+               violates least privilege, missing container hardening or privilege escalation
+               (privileged, runAsRoot, no securityContext, hostPath/hostNetwork), secret and token
+               exposure (including service-account token automounting), unintended public exposure,
+               and unpinned supply-chain references. A config or hardening weakness visible in the
+               diff is as much a finding as a code vulnerability — do not pass over it because it is
+               declarative rather than executable.
             3. REGRESSIONS: Does this change break or remove existing behavior? Compare with base commit context.
             4. COMMENT CONSISTENCY: Comments that contradict code. Outdated comments. Missing comments where logic is complex.
                Excessive/obvious comments (e.g., "i++ // increment i"). TODO/FIXME without resolution.
@@ -46,6 +55,19 @@ public final class PrReviewPrompts {
                that one page suffices or the call intentionally caps the result. Scale severity by
                what is dropped: a lost review thread, finding, or changed file that alters a decision
                is medium or higher; a cosmetic list is low.
+            7. CONFIG / IaC CORRECTNESS: When the diff adds or changes a declarative file — a
+               Kubernetes/Helm manifest, a Terraform file, a CI workflow YAML, a Dockerfile, or
+               similar — check it for defects demonstrable from the text in the diff: a manifest that
+               will not pass schema validation (a missing required field, a mistyped value, an
+               invalid apiVersion/kind pairing), a Helm/template expression that renders to invalid
+               output, a workflow that will not parse, or a value that contradicts a constraint
+               stated elsewhere in the same file. These fail at apply/validation/CI time, not at
+               "runtime", so judge them on whether the breakage is visible here — not on whether they
+               map to a code exception. Scale severity by impact: a change that will fail
+               schema/lint/CI validation, or that breaks the safety property the PR itself claims to
+               add, is high; a cosmetic or stylistic config nitpick is low. Not a finding when a
+               comment or adjacent value justifies the choice, or when correctness depends on
+               cluster/provider state not shown in the diff — phrase that as a verification request.
 
             For each finding, provide:
             - risk: "critical" | "high" | "medium" | "low"
@@ -63,13 +85,19 @@ public final class PrReviewPrompts {
               provided here (e.g. a null dereference on a path visible in the diff, injected
               user input reaching a query, a committed secret).
             - "high": a likely bug with a concrete failure scenario you can trace through the
-              diff.
+              diff — including a declarative change that will fail schema/lint/CI validation, or
+              that removes or weakens a safety property the PR itself claims to provide (a PR that
+              says it hardens RBAC but widens it, that adds a securityContext but leaves a container
+              privileged). "Will fail at runtime" is not the only path to this level; "will fail at
+              apply/validation time, shown in the diff" counts equally.
             - "medium": a real correctness or maintainability concern. Performance findings need
               evidence of scale in the diff (unbounded data, hot paths) — a one-time task over a
               handful of rows is not a finding.
             - "low": rarely worth reporting — prefer omitting it unless the project instructions
-              ask for that level of detail. Documentation-vs-code phrasing nitpicks with no
-              correctness impact are not findings.
+              ask for that level of detail. Cosmetic phrasing nitpicks (documentation-vs-code
+              wording, stylistic config formatting) with no correctness or security impact are not
+              findings — but a genuine config defect, least-privilege violation, or hardening gap is
+              a real finding, not a nitpick, and belongs at its impact-based severity above.
 
             Confidence calibration:
             - confidence "high" means another reviewer could confirm the issue using only the
@@ -106,7 +134,13 @@ public final class PrReviewPrompts {
               enclosing method's entry to the crash line. If an earlier statement makes that line
               unreachable for that input — an early return/continue/throw, or a guard on a value
               derived from the flagged one — the line cannot crash and the finding is invalid.
-            - A claim that two places are inconsistent ("X does this but Y does not") must quote
+            - A claim that a declarative/config change fails at apply, validation, or CI time
+              (schema validation, template render, YAML/HCL parse) is defended differently from a
+              runtime crash: name the offending field, expression, or value in the diff and the
+              specific rule it breaks — the required field it omits, the type it mismatches, the
+              schema or constraint it violates. Such a finding needs no runtime input trace; but if
+              the rule it cites cannot be confirmed from the diff and provided context, it is a
+              confidence "medium"/"low" finding phrased as a verification request, not "high".
               both places verbatim from the provided material and confirm they belong to the
               same enclosing unit (the same function, block, or scope). When the two places are
               in different units, first verify the units are genuinely equivalent; when the

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the config/IaC severity-recalibration guidance added for #238 so a future prompt edit cannot
+ * silently revert it and re-introduce the suppression. The reviewer was high-precision but
+ * suppressed declarative/config/IaC findings (RBAC, container hardening, schema-invalid manifests)
+ * because the SECURITY dimension named only application-code threats and severity was anchored on
+ * "will fail at runtime". These assertions are intentionally coarse — they check the recalibration
+ * intent survives, not exact wording; an intentional rewording should update the matching anchor.
+ *
+ * <p>The automated LLM eval that checks the model actually <em>acts</em> on this guidance is
+ * tracked separately (#113); this is the cheap deterministic guard.
+ */
+class PrReviewPromptsContentTest {
+
+  private static void assertContains(String haystack, String needle, String why) {
+    assertTrue(haystack.contains(needle), why + " — missing marker: \"" + needle + "\"");
+  }
+
+  @Test
+  void generatorPromptBroadensSecurityToInfraAndConfig() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys, "least privilege", "SECURITY must name over-broad RBAC/IAM (least privilege)");
+    assertContains(
+        sys, "securityContext", "SECURITY must name container hardening (securityContext)");
+    assertContains(
+        sys, "automounting", "SECURITY must name service-account token automounting exposure");
+  }
+
+  @Test
+  void generatorPromptHasConfigIacCorrectnessDimension() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys, "CONFIG / IaC CORRECTNESS", "the config/IaC correctness review dimension must exist");
+    assertContains(
+        sys,
+        "schema validation",
+        "config/IaC dimension must cover manifests that fail schema validation");
+  }
+
+  @Test
+  void generatorPromptRecalibratesSeverityBeyondRuntime() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "schema/lint/CI validation",
+        "severity must let an apply/validation-time failure reach high, not only runtime crashes");
+    assertContains(
+        sys,
+        "not a nitpick",
+        "the low-severity exclusion must carve out genuine config/hardening findings");
+    assertContains(
+        sys,
+        "apply, validation, or CI time",
+        "the runtime-failure self-check must offer a config-aware defence path");
+  }
+
+  @Test
+  void verifierPromptDoesNotResuppressDemonstrableConfigFindings() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "config/IaC finding whose breakage is visible",
+        "verifier must not reject demonstrable config findings as remembered framework behavior");
+    assertContains(
+        sys,
+        "config/IaC defect whose breakage is visible",
+        "verifier severity calibration must let demonstrable config defects stand at high");
+  }
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature
- [x] 🔒 Security

## Description

The reviewer is high-precision but has weak **recall on declarative /
config / IaC diffs** (Kubernetes & Helm manifests, Terraform, CI
workflow YAML, Dockerfiles). The cause is the **prompt, not the
language**: the SECURITY dimension named only application-code threats
and severity was anchored on `"will fail at runtime"`, so the model
*considered* config/hardening issues (over-broad RBAC, missing
`securityContext`, token automounting, a schema-invalid manifest) and
then **suppressed** them for not mapping to a runtime code bug — posting
`APPROVE` 0/0/0/0 on an infra PR an independent reviewer found ~two
dozen issues in.

Following the established dual-prompt **claim-class** pattern (#97 /
#107 / #109):

- **`PrReviewPrompts` (generator)** — broadens SECURITY to name
infra/config classes (least privilege / RBAC, container hardening, token
& secret exposure, public exposure, unpinned supply-chain refs); adds
**dimension 7 — CONFIG / IaC CORRECTNESS** (manifest validity, template
render, schema/lint/CI validation), parallel in tone to the existing
PAGINATION dimension; **recalibrates severity** so a change that will
fail apply/validation/CI — or that weakens a safety property the PR
itself claims to add — is defensible at `high`, not only runtime
crashes; adds a config-aware branch to the runtime-failure self-check;
and carves genuine config/hardening findings out of the `low`/nitpick
exclusion.
- **`FindingVerifierPrompts` (verifier)** — a config/IaC finding
**demonstrable from the manifest text in the diff** is *not* "remembered
framework behavior" and must not be auto-rejected/auto-capped as one; it
may stand at `high`. Precision is preserved: config claims resting on
cluster/provider/registry state **not** in the diff are still rejected.

Precision is held by the verifier and the existing self-checks, **not**
by blanket suppression.

## Related Issues

Fixes #238. Removes the calibration that suppresses the findings #60
(deterministic secret/IaC scanning) is meant to *detect*; the automated
eval/regression corpus is tracked in #113; the config-doc-completeness
claim-class is #109.

## How Has This Been Tested?

- [x] Unit tests

New `PrReviewPromptsContentTest` pins the recalibration guidance
(SECURITY infra classes, the CONFIG/IaC dimension, the schema/validation
severity path, the verifier carve-out) so a future prompt edit can't
silently revert it. Full suite green (**1360**), SpotBugs + Spotless
clean. `AiServicePromptRenderingTest` still passes — the prompt-content
changes don't break `@V` rendering.

> ⚠️ **Remaining verification (behavioral AC):** the issue asks for
confirmation by re-running captured infra-PR cases. That requires a live
dogfood — running the deployed bot against a real K8s/Helm PR
(over-broad RBAC + a schema-invalid manifest) and confirming it now
surfaces them instead of `APPROVE` 0/0/0/0, with the verifier confirming
(not rejecting) them. The automated eval that pins this behaviorally is
#113.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (CHANGELOG)
- [x] My changes generate no new warnings or errors