### PR TITLE
refactor(review): remove test-only constructors, overloads, and pass-throughs (F13)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
@@ -237,14 +237,6 @@ public class ReviewContextLoader {
     return prClient.getPullRequestFiles(auth, ACCEPT, owner, repo, prNumber);
   }
 
-  String buildDiffString(List<GitHubPullRequestClient.FileDiff> files) {
-    return diffFormatter.buildDiffString(files);
-  }
-
-  String buildBaseComparison(String auth, String owner, String repo, String base, String head) {
-    return buildBaseComparisonWithStats(auth, owner, repo, base, head).text();
-  }
-
   ReviewDiffFormatter.FormattedDiff buildBaseComparisonWithStats(
       String auth, String owner, String repo, String base, String head) {
     if (base == null || head == null || base.length() < 7 || head.length() < 7) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -75,60 +75,6 @@ public record ReviewResult(
         false);
   }
 
-  /** Convenience constructor for results with no omitted files (a complete diff). */
-  public ReviewResult(
-      List<Finding> findings,
-      int criticalCount,
-      int highCount,
-      int mediumCount,
-      int lowCount,
-      RiskLevel highestRisk,
-      ReviewState reviewState,
-      boolean isFirstReview,
-      String summaryMarkdown,
-      List<PreviousFindingStatus> previousStatuses,
-      List<CiCheck> offendingCiChecks) {
-    this(
-        findings,
-        criticalCount,
-        highCount,
-        mediumCount,
-        lowCount,
-        highestRisk,
-        reviewState,
-        isFirstReview,
-        summaryMarkdown,
-        previousStatuses,
-        offendingCiChecks,
-        0);
-  }
-
-  public ReviewResult(
-      List<Finding> findings,
-      int criticalCount,
-      int highCount,
-      int mediumCount,
-      int lowCount,
-      RiskLevel highestRisk,
-      ReviewState reviewState,
-      boolean isFirstReview,
-      String summaryMarkdown,
-      List<PreviousFindingStatus> previousStatuses) {
-    this(
-        findings,
-        criticalCount,
-        highCount,
-        mediumCount,
-        lowCount,
-        highestRisk,
-        reviewState,
-        isFirstReview,
-        summaryMarkdown,
-        previousStatuses,
-        List.of(),
-        0);
-  }
-
   public boolean hasIssues() {
     return !findings.isEmpty();
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -269,29 +269,4 @@ public class VerdictBuilder {
     }
     return new FindingTally(findings, critical, high, medium, low, highest);
   }
-
-  ReviewResult buildResult(
-      ReviewResponse aiResponse,
-      boolean isFirstReview,
-      DiffStats diffStats,
-      List<Finding> unresolvedPrevious,
-      List<ReviewResult.CiCheck> offendingCiChecks) {
-    return buildResult(
-        aiResponse,
-        isFirstReview,
-        diffStats,
-        List.of(),
-        unresolvedPrevious,
-        offendingCiChecks,
-        false,
-        List.of());
-  }
-
-  ReviewResult buildResult(
-      ReviewResponse aiResponse,
-      boolean isFirstReview,
-      DiffStats diffStats,
-      List<Finding> unresolvedPrevious) {
-    return buildResult(aiResponse, isFirstReview, diffStats, unresolvedPrevious, List.of());
-  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -41,7 +41,8 @@ class PrSummaryGeneratorTest {
 
     var fromConfig = new PrSummaryGenerator(config);
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary =
         fromConfig.generate(
@@ -59,7 +60,18 @@ class PrSummaryGeneratorTest {
 
     var result =
         new ReviewResult(
-            findings, 0, 1, 1, 0, RiskLevel.HIGH, ReviewState.REQUEST_CHANGES, true, "", List.of());
+            findings,
+            0,
+            1,
+            1,
+            0,
+            RiskLevel.HIGH,
+            ReviewState.REQUEST_CHANGES,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
 
     var summary = generator.generate(3, 120, 45, List.of(), null, result);
 
@@ -85,7 +97,8 @@ class PrSummaryGeneratorTest {
             "Adds a user update endpoint with validation.",
             List.of("Description claims tests were added, but no test files changed", "  "));
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
 
@@ -105,7 +118,8 @@ class PrSummaryGeneratorTest {
     // Only blank gaps must not render a section header with zero bullets
     var blankGapsSummary = new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", null, List.of(" ", ""));
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     for (var summary :
         List.of(
@@ -121,7 +135,8 @@ class PrSummaryGeneratorTest {
   @Test
   void shouldNotRenderSignedZeroLineCounts() {
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(3, 169, 0, List.of(), null, result);
 
@@ -135,7 +150,8 @@ class PrSummaryGeneratorTest {
   void shouldNotIncludeDashboardLink() {
     // The dashboard deep-link lives on the check run (details_url), not in the PR comment
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     assertFalse(generator.generate(1, 0, 0, List.of(), null, result).contains("View in dashboard"));
   }
@@ -143,7 +159,8 @@ class PrSummaryGeneratorTest {
   @Test
   void shouldGenerateSummaryWithZeroFindings() {
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
@@ -154,7 +171,8 @@ class PrSummaryGeneratorTest {
   @Test
   void cleanReviewCelebratesInsideTheSummary() {
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
@@ -166,7 +184,8 @@ class PrSummaryGeneratorTest {
   void unresolvedStatusCasingDoesNotEnableCelebration() {
     var statuses = List.of(new ReviewResult.PreviousFindingStatus(1, "UNRESOLVED", "still"));
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses);
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses, List.of(), 0);
 
     assertFalse(
         generator.generate(1, 10, 2, List.of(), null, result).contains("coming up Thrillhouse"));
@@ -176,7 +195,8 @@ class PrSummaryGeneratorTest {
   void cleanReviewWithUnresolvedPreviousFindingsDoesNotCelebrate() {
     var statuses = List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "Still there"));
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses);
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses, List.of(), 0);
 
     var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
@@ -188,7 +208,18 @@ class PrSummaryGeneratorTest {
     var findings = List.of(new Finding(RiskLevel.LOW, "src/A.java", 1, "Nit", "d", null, null));
     var result =
         new ReviewResult(
-            findings, 0, 0, 0, 1, RiskLevel.LOW, ReviewState.COMMENT, true, "", List.of());
+            findings,
+            0,
+            0,
+            0,
+            1,
+            RiskLevel.LOW,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
 
     var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
@@ -204,7 +235,8 @@ class PrSummaryGeneratorTest {
             new ReviewResult.PreviousFindingStatus(2, "unresolved", "Still broken"));
 
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses);
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses, List.of(), 0);
 
     var summary = generator.generate(1, 0, 0, List.of(), null, result);
 
@@ -224,7 +256,8 @@ class PrSummaryGeneratorTest {
             new ReviewResult.PreviousFindingStatus(3, "Justified", "Intentional"));
 
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses);
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses, List.of(), 0);
 
     var summary = generator.generate(1, 0, 0, List.of(), null, result);
 
@@ -255,7 +288,9 @@ class PrSummaryGeneratorTest {
             ReviewState.REQUEST_CHANGES,
             true,
             "",
-            List.of());
+            List.of(),
+            List.of(),
+            0);
 
     var summary = generator.generate(6, 0, 0, List.of(), null, result);
 
@@ -276,7 +311,7 @@ class PrSummaryGeneratorTest {
             new ReviewResult.CiCheck("test", "status", "pending", "pending"));
     var result =
         new ReviewResult(
-            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), checks);
+            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), checks, 0);
 
     var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
@@ -296,7 +331,18 @@ class PrSummaryGeneratorTest {
     var checks = List.of(new ReviewResult.CiCheck("lint", "status", "failing", "failure"));
     var result =
         new ReviewResult(
-            findings, 0, 0, 0, 1, RiskLevel.LOW, ReviewState.COMMENT, true, "", List.of(), checks);
+            findings,
+            0,
+            0,
+            0,
+            1,
+            RiskLevel.LOW,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            checks,
+            0);
 
     var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
@@ -314,7 +360,7 @@ class PrSummaryGeneratorTest {
         List.of(new ReviewResult.CiCheck("build | strict", "check-run", "failing", "failure"));
     var result =
         new ReviewResult(
-            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), checks);
+            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), checks, 0);
 
     var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
@@ -327,7 +373,7 @@ class PrSummaryGeneratorTest {
     var checks = List.of(new ReviewResult.CiCheck(null, "missing", "pending", null));
     var result =
         new ReviewResult(
-            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), checks);
+            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), checks, 0);
 
     var summary = generator.generate(1, 10, 2, List.of(), null, result);
 
@@ -347,7 +393,8 @@ class PrSummaryGeneratorTest {
             new ReviewResponse.FileSummary("src/A.java", "Adds null guard to parse()"),
             new ReviewResponse.FileSummary("src/B.java", "New cache wrapper"));
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(2, 10, 1, changedFiles, aiSummary, result);
 
@@ -363,7 +410,8 @@ class PrSummaryGeneratorTest {
     // AI summarized a different file; the changed file still appears, with "-" for its summary.
     var aiSummary = summaryWithFiles(new ReviewResponse.FileSummary("src/Other.java", "unrelated"));
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(1, 1, 0, changedFiles, aiSummary, result);
 
@@ -373,7 +421,8 @@ class PrSummaryGeneratorTest {
   @Test
   void shouldOmitChangedFilesSectionWhenNoFiles() {
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(0, 0, 0, List.of(), summaryWithFiles(), result);
 
@@ -388,7 +437,8 @@ class PrSummaryGeneratorTest {
       changedFiles.add(new PrSummaryGenerator.ChangedFile("src/F" + i + ".java", "modified"));
     }
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(total, 0, 0, changedFiles, null, result);
 
@@ -405,7 +455,8 @@ class PrSummaryGeneratorTest {
     var aiSummary =
         summaryWithFiles(new ReviewResponse.FileSummary("src/a|b.java", "handles a | b case"));
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(1, 1, 0, changedFiles, aiSummary, result);
 
@@ -419,7 +470,8 @@ class PrSummaryGeneratorTest {
     var aiSummary =
         summaryWithFiles(new ReviewResponse.FileSummary("src/A.java", "first line\nsecond line"));
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(1, 1, 0, changedFiles, aiSummary, result);
 
@@ -444,7 +496,8 @@ class PrSummaryGeneratorTest {
             new PrSummaryGenerator.ChangedFile("i", "copied"),
             new PrSummaryGenerator.ChangedFile("j", "CHANGED"));
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(10, 0, 0, changedFiles, null, result);
 
@@ -463,7 +516,8 @@ class PrSummaryGeneratorTest {
   @Test
   void shouldOmitChangedFilesSectionWhenChangedFilesNull() {
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(0, 0, 0, null, null, result);
 
@@ -487,7 +541,8 @@ class PrSummaryGeneratorTest {
             new ReviewResponse.FileSummary("src/A.java", "second ignored"),
             new ReviewResponse.FileSummary("src/B.java", "b note"));
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(2, 1, 0, changedFiles, aiSummary, result);
 
@@ -505,7 +560,8 @@ class PrSummaryGeneratorTest {
   void shouldRenderWalkthroughDiagramAsCollapsibleMermaidBlock() {
     var aiSummary = summaryWithDiagram("flowchart TD\n  A[Start] --> B[End]");
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
 
@@ -550,7 +606,8 @@ class PrSummaryGeneratorTest {
     var disabled = new PrSummaryGenerator(false);
     var aiSummary = summaryWithDiagram("flowchart TD\n  A[Start] --> B[End]");
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = disabled.generate(1, 5, 0, List.of(), aiSummary, result);
 
@@ -561,7 +618,8 @@ class PrSummaryGeneratorTest {
   @Test
   void shouldOmitDiagramSectionWhenBlankOrNull() {
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     for (var aiSummary : List.of(summaryWithDiagram(null), summaryWithDiagram("   "))) {
       var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
@@ -575,7 +633,8 @@ class PrSummaryGeneratorTest {
     // A model that ignores the "no fences" rule and wraps the source must not escape our block.
     var aiSummary = summaryWithDiagram("```mermaid\nflowchart TD\n  A --> B\n```");
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
 
@@ -590,7 +649,8 @@ class PrSummaryGeneratorTest {
     // Prose that is not a Mermaid diagram would render as a broken block, so it is dropped.
     var aiSummary = summaryWithDiagram("This change refactors the parser and adds a cache.");
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
 
@@ -602,7 +662,8 @@ class PrSummaryGeneratorTest {
     var huge = "flowchart TD\n" + "  A --> B\n".repeat(PrSummaryGenerator.MAX_DIAGRAM_CHARS);
     var aiSummary = summaryWithDiagram(huge);
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
 
@@ -615,7 +676,8 @@ class PrSummaryGeneratorTest {
     // the tag leaves an empty string, which must be dropped rather than rendered.
     var aiSummary = summaryWithDiagram("```mermaid```");
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
@@ -49,6 +49,7 @@ class ReviewContextLoaderTest {
   @Mock private ReviewSessionPersistence sessionPersistence;
 
   private ReviewContextLoader loader;
+  private final ReviewDiffFormatter diffFormatter = new ReviewDiffFormatter(List.of(), 5000);
 
   @BeforeEach
   void setUp() {
@@ -60,7 +61,7 @@ class ReviewContextLoaderTest {
             commentClient,
             instructionsResolver,
             projectStackResolver,
-            new ReviewDiffFormatter(List.of(), 5000),
+            diffFormatter,
             labeler,
             followUpAnalyzer,
             sessionPersistence,
@@ -72,13 +73,13 @@ class ReviewContextLoaderTest {
 
     @Test
     void shouldReturnNoChangesForNullList() {
-      var result = loader.buildDiffString(null);
+      var result = diffFormatter.buildDiffString(null);
       assertEquals("(no changes detected)", result);
     }
 
     @Test
     void shouldReturnNoChangesForEmptyList() {
-      var result = loader.buildDiffString(Collections.emptyList());
+      var result = diffFormatter.buildDiffString(Collections.emptyList());
       assertEquals("(no changes detected)", result);
     }
 
@@ -94,7 +95,7 @@ class ReviewContextLoaderTest {
                   8,
                   "@@ -1,3 +1,5 @@\n unchanged\n+added line\n+another line"));
 
-      var result = loader.buildDiffString(files);
+      var result = diffFormatter.buildDiffString(files);
 
       assertTrue(result.contains("## Overview: 1 files (+5 -3)"));
       assertTrue(result.contains("### src/main/Foo.java (modified, +5 -3)"));
@@ -108,7 +109,7 @@ class ReviewContextLoaderTest {
           List.of(
               new GitHubPullRequestClient.FileDiff("binary-file.png", "modified", 0, 0, 0, null));
 
-      var result = loader.buildDiffString(files);
+      var result = diffFormatter.buildDiffString(files);
 
       assertTrue(result.contains("binary-file.png (modified, +0 -0)"));
       assertFalse(result.contains("```diff"));
@@ -122,7 +123,7 @@ class ReviewContextLoaderTest {
               new GitHubPullRequestClient.FileDiff("b.java", "added", 25, 0, 25, "@@ patch b"),
               new GitHubPullRequestClient.FileDiff("c.java", "modified", 3, 5, 8, null));
 
-      var result = loader.buildDiffString(files);
+      var result = diffFormatter.buildDiffString(files);
 
       assertTrue(result.contains("## Overview: 3 files (+38 -7)"));
       assertTrue(result.contains("a.java"));
@@ -136,7 +137,7 @@ class ReviewContextLoaderTest {
           List.of(
               new GitHubPullRequestClient.FileDiff("renamed-only.txt", "renamed", 0, 0, 0, null));
 
-      var result = loader.buildDiffString(files);
+      var result = diffFormatter.buildDiffString(files);
 
       assertTrue(result.contains("## Overview: 1 files (+0 -0)"));
       assertTrue(result.contains("renamed-only.txt (renamed, +0 -0)"));
@@ -148,31 +149,35 @@ class ReviewContextLoaderTest {
 
     @Test
     void shouldReturnSafeMessageForNullBase() {
-      var result = loader.buildBaseComparison("auth", "owner", "repo", null, "abcdefgh");
+      var result =
+          loader.buildBaseComparisonWithStats("auth", "owner", "repo", null, "abcdefgh").text();
       assertEquals("(regression comparison unavailable — refs too short)", result);
     }
 
     @Test
     void shouldReturnSafeMessageForNullHead() {
-      var result = loader.buildBaseComparison("auth", "owner", "repo", "abcdefgh", null);
+      var result =
+          loader.buildBaseComparisonWithStats("auth", "owner", "repo", "abcdefgh", null).text();
       assertEquals("(regression comparison unavailable — refs too short)", result);
     }
 
     @Test
     void shouldReturnSafeMessageForShortBaseSha() {
-      var result = loader.buildBaseComparison("auth", "owner", "repo", "abc", "abcdefgh");
+      var result =
+          loader.buildBaseComparisonWithStats("auth", "owner", "repo", "abc", "abcdefgh").text();
       assertEquals("(regression comparison unavailable — refs too short)", result);
     }
 
     @Test
     void shouldReturnSafeMessageForShortHeadSha() {
-      var result = loader.buildBaseComparison("auth", "owner", "repo", "abcdefgh", "def");
+      var result =
+          loader.buildBaseComparisonWithStats("auth", "owner", "repo", "abcdefgh", "def").text();
       assertEquals("(regression comparison unavailable — refs too short)", result);
     }
 
     @Test
     void shouldReturnSafeMessageWhenBothNull() {
-      var result = loader.buildBaseComparison("auth", "owner", "repo", null, null);
+      var result = loader.buildBaseComparisonWithStats("auth", "owner", "repo", null, null).text();
       assertEquals("(regression comparison unavailable — refs too short)", result);
     }
 
@@ -183,7 +188,10 @@ class ReviewContextLoaderTest {
               any(), any(), eq("owner"), eq("repo"), eq("abcdefgh"), eq("hijklmn")))
           .thenReturn(emptyComparison);
 
-      var result = loader.buildBaseComparison("Bearer tok", "owner", "repo", "abcdefgh", "hijklmn");
+      var result =
+          loader
+              .buildBaseComparisonWithStats("Bearer tok", "owner", "repo", "abcdefgh", "hijklmn")
+              .text();
 
       assertEquals("(no changes between abcdefg and hijklmn)", result);
     }
@@ -195,7 +203,10 @@ class ReviewContextLoaderTest {
               any(), any(), eq("owner"), eq("repo"), eq("abcdefgh"), eq("hijklmn")))
           .thenReturn(nullFilesComparison);
 
-      var result = loader.buildBaseComparison("Bearer tok", "owner", "repo", "abcdefgh", "hijklmn");
+      var result =
+          loader
+              .buildBaseComparisonWithStats("Bearer tok", "owner", "repo", "abcdefgh", "hijklmn")
+              .text();
 
       assertEquals("(no changes between abcdefg and hijklmn)", result);
     }
@@ -212,7 +223,10 @@ class ReviewContextLoaderTest {
               any(), any(), eq("owner"), eq("repo"), eq("abcdefgh"), eq("hijklmn")))
           .thenReturn(comparison);
 
-      var result = loader.buildBaseComparison("Bearer tok", "owner", "repo", "abcdefgh", "hijklmn");
+      var result =
+          loader
+              .buildBaseComparisonWithStats("Bearer tok", "owner", "repo", "abcdefgh", "hijklmn")
+              .text();
 
       assertTrue(result.contains("## Changes between base and head"));
       assertTrue(result.contains("abcdefg..hijklmn: 2"));
@@ -234,7 +248,10 @@ class ReviewContextLoaderTest {
               any(), any(), eq("owner"), eq("repo"), eq("abcdefgh"), eq("hijklmn")))
           .thenReturn(comparison);
 
-      var result = loader.buildBaseComparison("Bearer tok", "owner", "repo", "abcdefgh", "hijklmn");
+      var result =
+          loader
+              .buildBaseComparisonWithStats("Bearer tok", "owner", "repo", "abcdefgh", "hijklmn")
+              .text();
 
       assertTrue(result.contains("src/Text.java"));
       assertFalse(result.contains("binary.bin"));
@@ -246,7 +263,10 @@ class ReviewContextLoaderTest {
               any(), any(), eq("owner"), eq("repo"), eq("abcdefgh"), eq("hijklmn")))
           .thenThrow(new RuntimeException("API down"));
 
-      var result = loader.buildBaseComparison("Bearer tok", "owner", "repo", "abcdefgh", "hijklmn");
+      var result =
+          loader
+              .buildBaseComparisonWithStats("Bearer tok", "owner", "repo", "abcdefgh", "hijklmn")
+              .text();
 
       assertEquals("(regression comparison unavailable)", result);
     }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -243,7 +243,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, true, new VerdictBuilder.DiffStats(0, 0, 0), List.of());
+              aiResponse,
+              true,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertNotNull(result);
       assertTrue(result.findings().isEmpty());
@@ -260,7 +267,14 @@ class ReviewOrchestratorTest {
       // A clean review that would APPROVE, but 7 files were omitted by the line budget.
       var result =
           verdictBuilder.buildResult(
-              aiResponse, true, new VerdictBuilder.DiffStats(120, 4000, 4000, 7), List.of());
+              aiResponse,
+              true,
+              new VerdictBuilder.DiffStats(120, 4000, 4000, 7),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       // The verdict is held back from APPROVE — a partial review must not gate-approve the PR...
       assertEquals(ReviewState.COMMENT, result.reviewState());
@@ -277,7 +291,14 @@ class ReviewOrchestratorTest {
       // COMMENT, but a follow-up posts no summary comment to carry the truncation banner (#245).
       var result =
           verdictBuilder.buildResult(
-              aiResponse, false, new VerdictBuilder.DiffStats(120, 4000, 4000, 7), List.of());
+              aiResponse,
+              false,
+              new VerdictBuilder.DiffStats(120, 4000, 4000, 7),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
       assertEquals(ReviewState.COMMENT, result.reviewState());
 
       reviewPublisher.postReview("auth", "owner", "repo", 5, "sha", result, resolverFor());
@@ -362,7 +383,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, false, new VerdictBuilder.DiffStats(0, 0, 0), List.of());
+              aiResponse,
+              false,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertNotNull(result);
       assertTrue(result.findings().isEmpty());
@@ -389,7 +417,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, true, new VerdictBuilder.DiffStats(0, 0, 0), List.of());
+              aiResponse,
+              true,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertEquals(1, result.criticalCount());
       assertEquals(RiskLevel.CRITICAL, result.highestRisk());
@@ -414,7 +449,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, true, new VerdictBuilder.DiffStats(0, 0, 0), List.of());
+              aiResponse,
+              true,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertEquals(1, result.totalFindings());
       assertEquals(1, result.criticalCount());
@@ -441,7 +483,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, true, new VerdictBuilder.DiffStats(0, 0, 0), List.of());
+              aiResponse,
+              true,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertEquals(1, result.highCount());
       assertEquals(RiskLevel.HIGH, result.highestRisk());
@@ -466,7 +515,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, false, new VerdictBuilder.DiffStats(0, 0, 0), List.of());
+              aiResponse,
+              false,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertEquals(1, result.mediumCount());
       assertEquals(RiskLevel.MEDIUM, result.highestRisk());
@@ -491,7 +547,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, true, new VerdictBuilder.DiffStats(0, 0, 0), List.of());
+              aiResponse,
+              true,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertEquals(1, result.lowCount());
       assertEquals(RiskLevel.LOW, result.highestRisk());
@@ -513,7 +576,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, true, new VerdictBuilder.DiffStats(0, 0, 0), List.of());
+              aiResponse,
+              true,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertEquals(4, result.totalFindings());
       assertEquals(1, result.criticalCount());
@@ -548,7 +618,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, false, new VerdictBuilder.DiffStats(0, 0, 0), List.of());
+              aiResponse,
+              false,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertEquals(2, result.previousStatuses().size());
       verify(followUpAnalyzer).toStatuses(aiStatuses);
@@ -569,7 +646,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, true, new VerdictBuilder.DiffStats(4, 120, 45), List.of());
+              aiResponse,
+              true,
+              new VerdictBuilder.DiffStats(4, 120, 45),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertTrue(result.summaryMarkdown().contains("Test summary content"));
       verify(summaryGenerator).generate(eq(4), eq(120), eq(45), any(), any(), any());
@@ -583,7 +667,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, true, new VerdictBuilder.DiffStats(0, 0, 0), List.of());
+              aiResponse,
+              true,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertEquals("Clean summary with celebration", result.summaryMarkdown());
       verify(summaryGenerator).generate(eq(0), eq(0), eq(0), any(), any(), any());
@@ -607,7 +698,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, true, new VerdictBuilder.DiffStats(0, 0, 0), List.of());
+              aiResponse,
+              true,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertEquals(1, result.lowCount());
       assertEquals(RiskLevel.LOW, result.highestRisk());
@@ -621,7 +719,8 @@ class ReviewOrchestratorTest {
     @Test
     void checkSummaryForResultShouldUseZeroIssuesMessageWhenClean() {
       var result =
-          new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+          new ReviewResult(
+              List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
       String summary = VerdictBuilder.checkSummaryForResult(result);
 
@@ -642,7 +741,9 @@ class ReviewOrchestratorTest {
               ReviewState.REQUEST_CHANGES,
               true,
               "",
-              List.of());
+              List.of(),
+              List.of(),
+              0);
 
       String summary = VerdictBuilder.checkSummaryForResult(result);
 
@@ -652,7 +753,8 @@ class ReviewOrchestratorTest {
     @Test
     void checkTitleForResultShouldAppendCheckmarkWhenClean() {
       var result =
-          new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+          new ReviewResult(
+              List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
       String title = VerdictBuilder.checkTitleForResult(result);
 
@@ -703,7 +805,7 @@ class ReviewOrchestratorTest {
       var offending = List.of(new ReviewResult.CiCheck("build", "check-run", "failing", "failure"));
       var result =
           new ReviewResult(
-              List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), offending);
+              List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), offending, 0);
 
       assertFalse(VerdictBuilder.checkTitleForResult(result).contains("✅"));
       String summary = VerdictBuilder.checkSummaryForResult(result);
@@ -2235,7 +2337,18 @@ class ReviewOrchestratorTest {
     void shouldReturnSuccessConclusionForApprovedReview() {
       var result =
           new ReviewResult(
-              List.of(), 0, 0, 0, 0, RiskLevel.LOW, ReviewState.APPROVE, true, "", List.of());
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              RiskLevel.LOW,
+              ReviewState.APPROVE,
+              true,
+              "",
+              List.of(),
+              List.of(),
+              0);
 
       String conclusion = VerdictBuilder.conclusionForResult(result);
 
@@ -2255,7 +2368,9 @@ class ReviewOrchestratorTest {
               ReviewState.REQUEST_CHANGES,
               true,
               "",
-              List.of());
+              List.of(),
+              List.of(),
+              0);
 
       assertEquals("failure", VerdictBuilder.conclusionForResult(result));
     }
@@ -2264,7 +2379,18 @@ class ReviewOrchestratorTest {
     void shouldReturnNeutralConclusionForCommentReview() {
       var result =
           new ReviewResult(
-              List.of(), 0, 0, 1, 0, RiskLevel.MEDIUM, ReviewState.COMMENT, true, "", List.of());
+              List.of(),
+              0,
+              0,
+              1,
+              0,
+              RiskLevel.MEDIUM,
+              ReviewState.COMMENT,
+              true,
+              "",
+              List.of(),
+              List.of(),
+              0);
 
       assertEquals("neutral", VerdictBuilder.conclusionForResult(result));
     }
@@ -2284,7 +2410,9 @@ class ReviewOrchestratorTest {
           state,
           true,
           "",
-          List.of());
+          List.of(),
+          List.of(),
+          0);
     }
 
     @Test
@@ -2398,7 +2526,9 @@ class ReviewOrchestratorTest {
               ReviewState.COMMENT,
               true,
               "",
-              List.of());
+              List.of(),
+              List.of(),
+              0);
       var resolver =
           new DiffLineResolver(
               Map.of(
@@ -2466,7 +2596,9 @@ class ReviewOrchestratorTest {
               ReviewState.REQUEST_CHANGES,
               false, // follow-up: no summary comment is posted
               "",
-              List.of());
+              List.of(),
+              List.of(),
+              0);
 
       reviewPublisher.postReview(
           "Bearer tok",
@@ -2494,7 +2626,8 @@ class ReviewOrchestratorTest {
     @Test
     void shouldApproveCleanPrFromPostReview() {
       var result =
-          new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+          new ReviewResult(
+              List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
       reviewPublisher.postReview("Bearer tok", "owner", "repo", 7, "sha", result, resolverFor());
 
@@ -2516,7 +2649,8 @@ class ReviewOrchestratorTest {
     void shouldApproveCleanFollowUpWithCelebrationBody() {
       // Follow-up reviews post no summary, so the celebration stays in the approval body
       var result =
-          new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, false, "", List.of());
+          new ReviewResult(
+              List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, false, "", List.of(), List.of(), 0);
 
       reviewPublisher.postReview("Bearer tok", "owner", "repo", 7, "sha", result, resolverFor());
 
@@ -2843,7 +2977,9 @@ class ReviewOrchestratorTest {
               ReviewState.REQUEST_CHANGES,
               true,
               "",
-              List.of());
+              List.of(),
+              List.of(),
+              0);
 
       orchestrator.applyReviewResult(session, result);
 
@@ -2870,7 +3006,8 @@ class ReviewOrchestratorTest {
       var session = new ReviewSession();
       session.id = 8L;
       var result =
-          new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+          new ReviewResult(
+              List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
       orchestrator.applyReviewResult(session, result);
 
@@ -3045,7 +3182,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, false, new VerdictBuilder.DiffStats(0, 0, 0), unresolvedPrevious);
+              aiResponse,
+              false,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              unresolvedPrevious,
+              List.of(),
+              false,
+              List.of());
 
       assertEquals(ReviewState.COMMENT, result.reviewState());
       assertFalse(VerdictBuilder.checkTitleForResult(result).contains("✅"));
@@ -3064,7 +3208,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, false, new VerdictBuilder.DiffStats(0, 0, 0), unresolvedPrevious);
+              aiResponse,
+              false,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              unresolvedPrevious,
+              List.of(),
+              false,
+              List.of());
 
       assertEquals(ReviewState.REQUEST_CHANGES, result.reviewState());
     }
@@ -3077,7 +3228,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, false, new VerdictBuilder.DiffStats(0, 0, 0), List.of());
+              aiResponse,
+              false,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertEquals(ReviewState.COMMENT, result.reviewState());
     }
@@ -3092,7 +3250,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, false, new VerdictBuilder.DiffStats(0, 0, 0), List.of());
+              aiResponse,
+              false,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
 
       assertEquals(ReviewState.APPROVE, result.reviewState());
       assertTrue(VerdictBuilder.checkTitleForResult(result).contains("✅"));
@@ -3112,7 +3277,9 @@ class ReviewOrchestratorTest {
               ReviewState.COMMENT,
               false,
               "",
-              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still")));
+              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still")),
+              List.of(),
+              0);
 
       reviewPublisher.postReview("auth", "owner", "repo", 5, "sha", result, resolverFor());
 
@@ -3136,7 +3303,9 @@ class ReviewOrchestratorTest {
               ReviewState.REQUEST_CHANGES,
               false,
               "",
-              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still")));
+              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still")),
+              List.of(),
+              0);
 
       reviewPublisher.postReview("auth", "owner", "repo", 5, "sha", result, resolverFor());
 
@@ -3162,7 +3331,8 @@ class ReviewOrchestratorTest {
               true,
               "",
               List.of(),
-              List.of(new ReviewResult.CiCheck("build", "check-run", "pending", null)));
+              List.of(new ReviewResult.CiCheck("build", "check-run", "pending", null)),
+              0);
 
       reviewPublisher.postReview("auth", "owner", "repo", 5, "sha", result, resolverFor());
 
@@ -3185,7 +3355,8 @@ class ReviewOrchestratorTest {
               false,
               "",
               List.of(),
-              List.of(new ReviewResult.CiCheck("build", "check-run", "pending", null)));
+              List.of(new ReviewResult.CiCheck("build", "check-run", "pending", null)),
+              0);
 
       reviewPublisher.postReview("auth", "owner", "repo", 5, "sha", result, resolverFor());
 
@@ -4005,7 +4176,14 @@ class ReviewOrchestratorTest {
 
       var result =
           verdictBuilder.buildResult(
-              aiResponse, false, new VerdictBuilder.DiffStats(0, 0, 0), List.of(), offending);
+              aiResponse,
+              false,
+              new VerdictBuilder.DiffStats(0, 0, 0),
+              List.of(),
+              List.of(),
+              offending,
+              false,
+              List.of());
 
       assertEquals(ReviewState.COMMENT, result.reviewState());
     }
@@ -4028,7 +4206,8 @@ class ReviewOrchestratorTest {
               false,
               "",
               List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "")),
-              offending);
+              offending,
+              0);
 
       reviewPublisher.postReview("auth", "owner", "repo", 5, "sha", result, resolverFor());
 
@@ -4148,7 +4327,18 @@ class ReviewOrchestratorTest {
     void shouldCoverCiCheckMethods() {
       var nullChecksResult =
           new ReviewResult(
-              List.of(), 0, 0, 0, 0, RiskLevel.LOW, ReviewState.APPROVE, true, "", List.of(), null);
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              RiskLevel.LOW,
+              ReviewState.APPROVE,
+              true,
+              "",
+              List.of(),
+              null,
+              0);
       assertTrue(nullChecksResult.offendingCiChecks().isEmpty());
       var failing = new ReviewResult.CiCheck("build", "check-run", "failing", "failure");
       var pending = new ReviewResult.CiCheck("lint", "status", "pending", "pending");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -29,7 +29,18 @@ class ReviewResultTest {
 
     var result =
         new ReviewResult(
-            findings, 0, 0, 0, 1, RiskLevel.LOW, ReviewState.COMMENT, true, "", List.of());
+            findings,
+            0,
+            0,
+            0,
+            1,
+            RiskLevel.LOW,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
 
     assertTrue(result.hasIssues());
   }
@@ -37,7 +48,8 @@ class ReviewResultTest {
   @Test
   void hasIssuesShouldReturnFalseWhenFindingsEmpty() {
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     assertFalse(result.hasIssues());
   }
@@ -61,7 +73,9 @@ class ReviewResultTest {
             ReviewState.REQUEST_CHANGES,
             false,
             "",
-            List.of());
+            List.of(),
+            List.of(),
+            0);
 
     assertEquals(3, result.totalFindings());
   }
@@ -69,7 +83,8 @@ class ReviewResultTest {
   @Test
   void totalFindingsShouldReturnZeroForEmptyList() {
     var result =
-        new ReviewResult(List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of());
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
     assertEquals(0, result.totalFindings());
   }
@@ -92,7 +107,9 @@ class ReviewResultTest {
             ReviewState.COMMENT,
             true,
             "",
-            mutableStatuses);
+            mutableStatuses,
+            List.of(),
+            0);
 
     // Mutate the original lists — the record's lists should be unaffected
     mutableFindings.add(new Finding(RiskLevel.HIGH, "g", 2, "x", "y", null, null));
@@ -108,14 +125,17 @@ class ReviewResultTest {
   void compactConstructorShouldDeriveNullReviewStateFromHighestRisk() {
     var findings = List.of(new Finding(RiskLevel.HIGH, "f", 1, "t", "d", null, null));
 
-    var result = new ReviewResult(findings, 0, 1, 0, 0, RiskLevel.HIGH, null, true, "", List.of());
+    var result =
+        new ReviewResult(
+            findings, 0, 1, 0, 0, RiskLevel.HIGH, null, true, "", List.of(), List.of(), 0);
 
     assertEquals(ReviewState.REQUEST_CHANGES, result.reviewState());
   }
 
   @Test
   void compactConstructorShouldDeriveApproveWhenStateAndRiskAreNull() {
-    var result = new ReviewResult(List.of(), 0, 0, 0, 0, null, null, true, "", List.of());
+    var result =
+        new ReviewResult(List.of(), 0, 0, 0, 0, null, null, true, "", List.of(), List.of(), 0);
 
     assertEquals(ReviewState.APPROVE, result.reviewState());
   }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor

## Description

Final v0.3.0 final-review item (F13): remove test-only convenience
constructors / overloads / pass-throughs that no production code
reaches, so the API surface is smaller and tests exercise only
production-reachable shapes. **PR 4 of 4** (the diff/doc PR #276 is
merged; based on release/v0.3.0). Pure cleanup — no behavior change
(test count unchanged).

Removed (each verified to have no `src/main` caller):
- **`ReviewResult`** 10-arg and 11-arg convenience constructors —
production uses the 12-arg and canonical 13-arg forms. The ~60 test
sites are padded to the 12-arg form.
- **`VerdictBuilder.buildResult`** 4-arg and 5-arg overloads —
production reaches the builder through `build(...)`; the overloads only
let tests bypass the real input derivation (diff-stat / backstop). The
19 test sites move to the canonical 8-arg `buildResult`.
- **`ReviewContextLoader.buildDiffString` / `buildBaseComparison`** thin
pass-throughs — `load()` uses the `*WithStats` methods and the formatter
directly. The loader tests now call `diffFormatter.buildDiffString(...)`
and `loader.buildBaseComparisonWithStats(...).text()`.

## Related Issues

N/A — v0.3.0 final-review remaining item (#13). Relates to #250.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- All migrated test sites compile against the canonical signatures and
pass unchanged; removing the overloads is what proves they had no
production reach.
- Full suite green: 1374 tests, SpotBugs 0, Spotless clean. No
production behavior changed, so no CHANGELOG entry.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (N/A — no behavior
change)
- [x] My changes generate no new warnings or errors

## Additional Notes

**PR 4 of 4** — the last of the v0.3.0 final-review cleanup, based on
release/v0.3.0 (the diff/doc PR #276 is merged). With this merged, all
six requested remaining items (#7, #8, #10, #13, #14, #15) plus the
audit-found regressions are closed.