### PR TITLE
fix(review): truncated clean review no longer celebrates in the summary comment (#1)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -236,7 +236,10 @@ public class VerdictBuilder {
                 "",
                 previousStatuses,
                 offendingCiChecks,
-                0,
+                // Carry the real omitted-file count so the summary body's truncated() branch fires
+                // and reports a partial review instead of the all-clear celebration; passing 0 here
+                // made that branch dead and let the celebration contradict the truncation banner.
+                diffStats.omittedFiles(),
                 ciUnreadable));
     if (diffStats.truncated()) {
       summaryMarkdown = ReviewResult.truncationNotice(diffStats.omittedFiles()) + summaryMarkdown;

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -284,6 +284,31 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void truncatedCleanSummaryBodyDoesNotCelebrateEndToEnd() {
+      // Regression (#1): buildResult handed omittedFiles=0 to the summary generator, so the body's
+      // truncated() branch was dead and emitted the all-clear celebration directly under the
+      // partial-review banner. Exercise the REAL generator end-to-end (the mocked one returns "")
+      // and assert the body no longer contradicts the banner.
+      var realVerdict = new VerdictBuilder(new PrSummaryGenerator(false), followUpAnalyzer, BOT_ID);
+      var aiResponse = new ReviewResponse(List.of(), List.of(), null);
+
+      var result =
+          realVerdict.buildResult(
+              aiResponse,
+              true,
+              new VerdictBuilder.DiffStats(120, 4000, 4000, 7),
+              List.of(),
+              List.of(),
+              List.of(),
+              false,
+              List.of());
+
+      var summary = result.summaryMarkdown();
+      assertFalse(summary.contains("Everything's coming up Thrillhouse"), summary);
+      assertTrue(summary.contains("partial review"), summary);
+    }
+
+    @Test
     void truncatedFollowUpReviewBodyDisclosesPartialAndOmitsZeroUnresolved() {
       var aiResponse = new ReviewResponse(List.of(), List.of(), null);
       // A follow-up (not first review) clean review with 7 files omitted by the line budget: held


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Highest-severity finding from the second ultra code-review of
`release/v0.3.0`. **PR 1 of 4** (stacked: B/C/D follow). Off
`release/v0.3.0`.

**#1 — a truncated clean review still celebrated in the summary
comment.** `VerdictBuilder.buildResult` constructs an inner
`ReviewResult` purely to feed `PrSummaryGenerator.generate()`, and it
hardcoded `omittedFiles=0`. So inside the summary body
`result.truncated()` was **always false** — the `truncated()` branch
added in #279 (and the CI+truncation combined branch) was **dead in
production**. A clean-but-truncated review rendered the "Everything's
coming up Thrillhouse! No issues found in this PR." celebration directly
beneath the prepended *"partial review"* banner: a self-contradiction
that overstated confidence in what was only a partial review.

The verdict gate (`diffStats.truncated()` at the APPROVE check) and the
check-run caption (`checkSummaryForResult`, which reads the final
result) were already correct — this was a summary-comment text bug only,
not a merge-gate bypass.

**Fix:** pass `diffStats.omittedFiles()` into the inner `ReviewResult`.
The CHANGELOG `[0.3.0]` already states "both now report a partial review
(#234)"; this makes that true for the summary comment.

**Why #279's test missed it:** `PrSummaryGeneratorTest` exercises
`generate()` directly with `omittedFiles=2` (branch works in isolation),
and `ReviewOrchestratorTest` mocks the summary generator to `""` —
neither ran the real generator through `buildResult`. Added that
end-to-end test.

## Related Issues

N/A — surfaced by the second v0.3.0 ultra code-review. Relates to #234,
#279.

## How Has This Been Tested?

- [x] Unit tests

-
`ReviewOrchestratorTest.truncatedCleanSummaryBodyDoesNotCelebrateEndToEnd`
— real `PrSummaryGenerator` through `buildResult`; asserts the body does
not celebrate and says "partial review".
- Full suite green: 1386 tests, SpotBugs 0, Spotless clean, patch fully
covered (merge-base).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (no change —
CHANGELOG already states the behavior)
- [x] My changes generate no new warnings or errors

## Additional Notes

**PR 1 of 4** of the second-review fixes. Stacked: B (#278/#279
follow-ons) builds on this, then C (perf/resilience), then D (cleanup).