### PR TITLE
perf+fix(review): single glob pass + surface over-cap findings + best-effort summary comment (#2,#7,#9; #8 accepted)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
@@ -130,7 +130,7 @@ public class DocGenerationService {
         return;
       }
 
-      var response = generateOrReportFailure(auth, task, files, pr);
+      var response = generateOrReportFailure(auth, task, files, reviewable, pr);
       if (response == null) {
         return;
       }
@@ -154,9 +154,10 @@ public class DocGenerationService {
       String auth,
       DocTask task,
       List<GitHubPullRequestClient.FileDiff> files,
+      List<GitHubPullRequestClient.FileDiff> reviewable,
       GitHubPullRequestClient.PullRequestDetails pr) {
     try {
-      return generate(task, files, pr);
+      return generate(task, files, reviewable, pr);
     } catch (RuntimeException e) {
       Log.warnf(
           e, "Doc generation failed for %s/%s #%d", task.owner(), task.repo(), task.prNumber());
@@ -168,8 +169,10 @@ public class DocGenerationService {
   private DocGenerationResponse generate(
       DocTask task,
       List<GitHubPullRequestClient.FileDiff> files,
+      List<GitHubPullRequestClient.FileDiff> reviewable,
       GitHubPullRequestClient.PullRequestDetails pr) {
-    String diff = diffFormatter.buildDiffString(files);
+    // Reuse the caller's already-filtered reviewable list rather than re-walking the ignore glob.
+    String diff = diffFormatter.buildDiffStringWithStats(files, reviewable).text();
     String prContext = PromptSections.prContext(pr.title(), pr.body());
     String stack =
         SoftLoaders.projectStack(
@@ -191,11 +194,7 @@ public class DocGenerationService {
   }
 
   /** How many /add-docs comments landed, split into committable suggestions and plain notes. */
-  record DocPostOutcome(int suggestions, int notes) {
-    int total() {
-      return suggestions + notes;
-    }
-  }
+  record DocPostOutcome(int suggestions, int notes) {}
 
   private enum DocPostResult {
     SUGGESTION,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -219,7 +219,19 @@ public class ReviewOrchestrator {
       String conclusion = VerdictBuilder.conclusionForResult(result);
       String checkTitle = VerdictBuilder.checkTitleForResult(result);
       String checkSummary = VerdictBuilder.checkSummaryForResult(result);
-      reviewPublisher.publishSummary(auth, req.owner(), req.repo(), req.prNumber(), result);
+      // The summary comment is first-review enrichment, not the review itself: a transient failure
+      // posting it must not abort before postReview and surface a hard FAILED check for a review
+      // that would otherwise post. Keep it best-effort; the review below is the critical step.
+      try {
+        reviewPublisher.publishSummary(auth, req.owner(), req.repo(), req.prNumber(), result);
+      } catch (RuntimeException e) {
+        Log.warnf(
+            e,
+            "Failed to post the PR summary comment for %s/%s #%d — continuing to post the review",
+            req.owner(),
+            req.repo(),
+            req.prNumber());
+      }
       reviewPublisher.dismissPendingBotReviews(
           auth, req.owner(), req.repo(), req.prNumber(), priorReviews);
       reviewPublisher.postReview(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -352,11 +352,15 @@ public class ReviewPublisher {
     var posted = 0;
     var unanchored = new ArrayList<Finding>();
     var maxComments = config.review().maxReviewComments();
-    for (var i = 0; i < result.findings().size() && posted < maxComments; i++) {
+    for (var i = 0; i < result.findings().size(); i++) {
       // The 1-based index doubles as the finding's id in the persisted response and the
       // hidden comment marker, keeping thread matching deterministic on follow-up reviews
       var finding = result.findings().get(i);
-      if (postFindingComment(target, finding, i + 1, lineResolver)) {
+      // The cap limits inline comments, not findings: once it's reached, remaining findings (and
+      // any
+      // that couldn't anchor) are returned as unanchored so the caller still reports them in the
+      // review body — capped on noise, but never silently dropped.
+      if (posted < maxComments && postFindingComment(target, finding, i + 1, lineResolver)) {
         posted++;
       } else {
         unanchored.add(finding);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
@@ -245,6 +245,51 @@ class DocGenerationServiceTest {
   }
 
   @Test
+  void aNoteThatGitHubRejectsIsNotCounted() {
+    // The note fallback can itself be rejected by GitHub; it must not be counted, leaving the
+    // could-not-place summary rather than claiming a note was drafted.
+    prWithFiles(fooWithPatch());
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenReturn(
+            """
+            {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
+            "suggestion_old":"public int bar(int x) {\\n  return x * 99;",
+            "suggestion_new":"/** d */\\npublic int bar(int x) {\\n  return x * 99;"}]}
+            """);
+    doThrow(new RuntimeException("422 Unprocessable Entity"))
+        .when(reviewClient)
+        .createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
+
+    service.handle(task());
+
+    assertEquals(DocGenerationService.COULD_NOT_PLACE, postedSummary());
+  }
+
+  @Test
+  void summaryReportsBothCommittableSuggestionsAndNotes() {
+    // One symbol anchors as a committable suggestion; another (multi-line, can't anchor) posts a
+    // note. The summary must mention both kinds, not just "committable suggestions".
+    prWithFiles(fooWithPatch());
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenReturn(
+            """
+            {"docs":[
+              {"file":"src/Foo.java","line":1,"symbol":"bar",
+               "suggestion_old":"public int bar(int x) {",
+               "suggestion_new":"/** a */\\npublic int bar(int x) {"},
+              {"file":"src/Foo.java","line":4,"symbol":"baz",
+               "suggestion_old":"public int baz(int y) {\\n  return y + 99;",
+               "suggestion_new":"/** b */\\npublic int baz(int y) {\\n  return y + 99;"}]}
+            """);
+
+    service.handle(task());
+
+    var summary = postedSummary();
+    assertTrue(summary.contains("committable documentation suggestion"), summary);
+    assertTrue(summary.contains("add manually"), summary);
+  }
+
+  @Test
   void capsAtMaxReviewComments() {
     when(reviewConfig.maxReviewComments()).thenReturn(1);
     prWithFiles(fooWithPatch());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -1248,6 +1248,69 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void summaryCommentFailureDoesNotAbortTheReview() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getPrTitle()).thenReturn("Test PR");
+        when(session.getCommitSha()).thenReturn("abcdefgh");
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        when(authClient.getAuthHeader(123L)).thenReturn("Bearer test");
+        when(checkRunClient.createCheckRun(
+                anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(new GitHubCheckRunClient.CheckRunResponse(1L, "http://check"));
+        when(prClient.getPullRequestFiles(
+                anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of());
+        when(checkRunClient.getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(new GitHubCheckRunClient.RequiredStatusChecks(List.of(), List.of()));
+        when(prClient.compareCommits(
+                anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
+        when(reviewClient.listReviews(anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of());
+        when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
+            .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
+        when(aiReviewService.review(any(ReviewSession.class), any()))
+            .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+        // A first review with a non-blank summary, so publishSummary tries to post the comment...
+        when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any(), any()))
+            .thenReturn("## PR summary");
+        // ...and that comment post fails transiently.
+        doThrow(new RuntimeException("comment 500"))
+            .when(commentClient)
+            .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+
+        orchestrator.review(
+            new ReviewOrchestrator.ReviewRequest(
+                "owner",
+                "repo",
+                42,
+                "abcdefgh",
+                "Test PR",
+                "",
+                "base1234567",
+                "main",
+                123L,
+                false));
+
+        // The summary comment is enrichment: its failure must not abort the review before it is
+        // posted. The review still lands and the session completes — no hard FAILED check.
+        verify(reviewClient)
+            .createReview(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+        verify(session).setStatus(ReviewSession.STATUS_COMPLETED);
+        verify(session, never()).setStatus(ReviewSession.STATUS_FAILED);
+      }
+    }
+
+    @Test
     void postReviewFailureMarksReviewFailedInsteadOfLeavingAConcludedCheckRun() {
       try (var mockedStatic = mockStatic(ReviewSession.class)) {
         var session = mock(ReviewSession.class);
@@ -2654,15 +2717,18 @@ class ReviewOrchestratorTest {
                   "src/B.java", fileDiffWithLine("src/B.java", 20).patch()));
       when(suggestionFormatter.formatReviewComment(any(), eq(true))).thenReturn("body");
 
-      var posted =
-          reviewPublisher
-              .postInlineComments("Bearer tok", "owner", "repo", 7, "sha", result, resolver)
-              .posted();
+      var inline =
+          reviewPublisher.postInlineComments(
+              "Bearer tok", "owner", "repo", 7, "sha", result, resolver);
 
-      assertEquals(1, posted);
+      assertEquals(1, inline.posted());
       verify(reviewClient, times(1))
           .createPullRequestComment(
               anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+      // The over-cap finding is not posted inline, but it's returned as unanchored so the review
+      // body still reports it — capped on inline noise, never silently dropped.
+      assertEquals(1, inline.unanchored().size());
+      assertEquals("Two", inline.unanchored().get(0).title());
     }
 
     @Test


### PR DESCRIPTION
- [x] 🐛 Bug fix
- [x] ⚡ Performance

Perf + resilience follow-ons from the second ultra code-review of
`release/v0.3.0`. **PR 3 of 4** (A and B already merged into release).
Off `release/v0.3.0`.

**#2 — `/add-docs` walked the ignore-glob filter twice.** `handle()`
computes the reviewable list once, but `generate()` then called
`buildDiffString(files)`, which re-ran `reviewableFiles(files)`
internally. The precomputed list is now threaded through to the existing
reuse overload (`buildDiffStringWithStats(files, reviewable)`) — one
glob walk per run, matching the F8 single-pass the review path already
does.

**#7 — over-cap findings were silently dropped.** `postInlineComments`'s
loop condition exited as soon as `posted` hit `maxReviewComments`, so
findings past the cap were neither posted inline nor returned as
unanchored — and both review-body fallbacks draw only from the
unanchored list, so an over-cap finding whose line was outside the diff
vanished. The loop now visits every finding and gates only the *inline
post* on the cap; the rest are returned as unanchored so the review body
still reports them. (Only bites when an operator lowers the cap below
the finding count; default is 50.)

**#9 — a transient summary-comment failure failed the whole review.**
Since #254, `resultSurfaced` is set only after `postReview`, so a
failure posting the first-review summary comment (enrichment) aborted
into `handleReviewFailure` — a hard FAILED check + "retry" notice — even
though the review itself hadn't been posted yet and would have
succeeded. The summary comment is now best-effort; the review is the
critical step.

**#8 — orphaned CI future (intentionally not fixed).** When the AI call
throws, the concurrent CI-resolution future is left running. This is
**consciously accepted**: `CompletableFuture.cancel()` from
`supplyAsync` cannot interrupt the in-flight GitHub call (interrupts
aren't used), and the review executor is an unbounded
virtual-thread-per-task pool, so the wasted I/O is bounded and harmless.
Adding a `cancel()` would be cosmetic (zero runtime effect), so it's
documented here rather than cargo-culted.

N/A — surfaced by the second v0.3.0 ultra code-review. Relates to #56,

- [x] Unit tests

- `ReviewOrchestratorTest`: `shouldRespectMaxReviewCommentsLimit` now
also asserts the over-cap finding is returned as unanchored (#7);
`summaryCommentFailureDoesNotAbortTheReview` (#9).
- `DocGenerationServiceTest`:
`summaryReportsBothCommittableSuggestionsAndNotes`,
`aNoteThatGitHubRejectsIsNotCounted`.
- Full suite green: 1393 tests, SpotBugs 0, Spotless clean, patch fully
covered (merge-base).

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (no CHANGELOG — all
v0.3.0-era paths)
- [x] My changes generate no new warnings or errors

**PR 3 of 4.** All fixes are within v0.3.0-introduced paths (`/add-docs`
they net out under the changelog policy — no CHANGELOG lines. Stacked on