### PR TITLE
refactor(review): dedup assistant-call skeleton + clarify bot-token substring (#13,#15; #12/#14/#16 deferred)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
@@ -18,6 +18,7 @@ package dev.thiagogonzaga.thrillhousebot.review;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
 import dev.thiagogonzaga.thrillhousebot.github.InstructionsResolver;
 import io.quarkus.logging.Log;
+import java.util.function.Supplier;
 
 /**
  * Shared loading for the on-request "suggestion from the diff" commands ({@code /describe}, {@code
@@ -77,6 +78,26 @@ public abstract class AbstractPrSuggestionGenerator {
                 instructionsResolver, owner, repo, defaultBranch, installationId, command)
             .content();
     return new Inputs(diff, title, body, instructions);
+  }
+
+  /**
+   * Runs an assistant call with the shared fail-soft contract: an empty/blank reply, or any {@link
+   * RuntimeException}, degrades to {@code null} (post nothing); a usable reply is returned
+   * stripped. {@code command} labels the operation in logs (e.g. {@code "/describe"}). Subclasses
+   * supply the actual call (and apply any command-specific post-filtering to the result).
+   */
+  protected String callAssistant(String command, Supplier<String> assistantCall) {
+    try {
+      String suggestion = assistantCall.get();
+      if (suggestion == null || suggestion.isBlank()) {
+        Log.debugf("%s assistant produced an empty suggestion — posting nothing", command);
+        return null;
+      }
+      return suggestion.strip();
+    } catch (RuntimeException e) {
+      Log.warnf(e, "%s assistant call failed — posting nothing", command);
+      return null;
+    }
   }
 
   private String fetchDiff(String auth, String owner, String repo, int prNumber, String command) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGenerator.java
@@ -85,37 +85,23 @@ public class ChangelogEntryGenerator extends AbstractPrSuggestionGenerator {
     if (inputs == null) {
       return null;
     }
-    String entry = callAssistant(inputs, prNumber);
-    return entry == null ? null : HEADER + entry + FOOTER;
-  }
-
-  /**
-   * Calls the assistant with already-loaded inputs, fencing the diff and escaping the rest for
-   * templating. Null on failure.
-   */
-  private String callAssistant(Inputs inputs, int prNumber) {
-    try {
-      String entry =
-          changelogAssistant.draft(
-              PromptTemplateEscaper.fence(inputs.diff()),
-              String.valueOf(prNumber),
-              PromptTemplateEscaper.escape(inputs.title()),
-              PromptTemplateEscaper.escape(inputs.body()),
-              PromptTemplateEscaper.escape(inputs.instructions()));
-      if (entry == null || entry.isBlank()) {
-        Log.debug("Changelog assistant produced an empty entry — posting nothing");
-        return null;
-      }
-      entry = entry.strip();
-      if (isNoneVerdict(entry)) {
+    String entry =
+        callAssistant(
+            COMMAND,
+            () ->
+                changelogAssistant.draft(
+                    PromptTemplateEscaper.fence(inputs.diff()),
+                    String.valueOf(prNumber),
+                    PromptTemplateEscaper.escape(inputs.title()),
+                    PromptTemplateEscaper.escape(inputs.body()),
+                    PromptTemplateEscaper.escape(inputs.instructions())));
+    if (entry == null || isNoneVerdict(entry)) {
+      if (entry != null) {
         Log.debug("Changelog assistant judged the change not changelog-worthy — posting nothing");
-        return null;
       }
-      return entry;
-    } catch (RuntimeException e) {
-      Log.warn("Changelog assistant call failed — posting nothing", e);
       return null;
     }
+    return HEADER + entry + FOOTER;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluator.java
@@ -340,6 +340,9 @@ public class CiStatusEvaluator {
     return app != null && (containsBotToken(app.slug()) || containsBotToken(app.name()));
   }
 
+  // Deliberately a substring test, not BotIdentity.matches (exact login set): a check's app slug or
+  // name lacks the "[bot]" suffix that BotIdentity strips, so an exact match would never recognise
+  // the bot's own check. This is why identity matching is not reused here.
   private boolean containsBotToken(String value) {
     if (value == null) {
       return false;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrDescriptionGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrDescriptionGenerator.java
@@ -18,7 +18,6 @@ package dev.thiagogonzaga.thrillhousebot.review;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
 import dev.thiagogonzaga.thrillhousebot.github.InstructionsResolver;
 import dev.thiagogonzaga.thrillhousebot.review.ai.PrDescribeAssistant;
-import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
@@ -77,30 +76,15 @@ public class PrDescriptionGenerator extends AbstractPrSuggestionGenerator {
     if (inputs == null) {
       return null;
     }
-    String suggestion = callAssistant(inputs);
+    String suggestion =
+        callAssistant(
+            COMMAND,
+            () ->
+                describeAssistant.describe(
+                    PromptTemplateEscaper.fence(inputs.diff()),
+                    PromptTemplateEscaper.escape(inputs.title()),
+                    PromptTemplateEscaper.escape(inputs.body()),
+                    PromptTemplateEscaper.escape(inputs.instructions())));
     return suggestion == null ? null : HEADER + suggestion + FOOTER;
-  }
-
-  /**
-   * Calls the assistant with already-loaded inputs, fencing the diff and escaping the rest for
-   * templating. Null on failure.
-   */
-  private String callAssistant(Inputs inputs) {
-    try {
-      String suggestion =
-          describeAssistant.describe(
-              PromptTemplateEscaper.fence(inputs.diff()),
-              PromptTemplateEscaper.escape(inputs.title()),
-              PromptTemplateEscaper.escape(inputs.body()),
-              PromptTemplateEscaper.escape(inputs.instructions()));
-      if (suggestion == null || suggestion.isBlank()) {
-        Log.debug("Describe assistant produced an empty suggestion — posting nothing");
-        return null;
-      }
-      return suggestion.strip();
-    } catch (RuntimeException e) {
-      Log.warn("Describe assistant call failed — posting nothing", e);
-      return null;
-    }
   }
 }


### PR DESCRIPTION
- [x] ♻️ Refactor

Cleanup batch from the second ultra code-review of `release/v0.3.0`.
**PR 4 of 4.** Off `release/v0.3.0`; file-disjoint from #282 (PR C). No
behaviour change.

**#13 — duplicated assistant-call skeleton.**
`PrDescriptionGenerator.callAssistant` and
`ChangelogEntryGenerator.callAssistant` were copy-paste variants of the
same `try → empty/blank → strip → catch(RuntimeException) → null`
fail-soft skeleton. Extracted it into
`AbstractPrSuggestionGenerator.callAssistant(command, Supplier<String>)`
— the parent that already factors `loadInputs` — so each subclass keeps
only its own assistant call (and `/changelog` keeps its `NONE`
post-filter). Removes the drift risk the duplication carried.

**#15 — clarify the intentional bot-token substring.**
`CiStatusEvaluator.containsBotToken` is a lowercased substring test
rather than `BotIdentity.matches` (exact login set), which the review
flagged as a reuse/consistency concern. It's deliberate: a check's app
slug/name lacks the `[bot]` suffix `BotIdentity` strips, so exact
matching would never recognise the bot's own check. Added a comment so
it isn't re-flagged or "fixed" into a regression.

- **#12 — `ReviewResponse.Summary` telescoping constructors.**
Test-only, but unlike the untested pass-throughs F13 (#277) removed,
these are documented, forward to the canonical constructor with explicit
defaults, **and** have dedicated defaulting tests in
`ReviewResponseTest`. Removing them churns 17 call sites across 7 files
(and deletes those defaulting tests) for marginal benefit.
- **#14 — `MaintainerReplyService.fetchDiff`.** Can't fold onto
`SoftLoaders.files` without erasing its deliberate `""`-on-failure
degrade (the mention path wants empty context; `SoftLoaders` would yield
`"(no changes detected)"`) — a behaviour change on a non-bug the
reviewer explicitly called out.
- **#16 — `DiffLineResolver` variant lookups.** Unifying the four copies
needs parameterizing three distinct ambiguity policies
(`presentInFileOrVariant` is intentionally first-match; the others
return a null/empty sentinel), a behaviour-drift risk; the code already
documents the mirror.

Happy to take any of the three deferrals if you'd prefer them done —
flagging the tradeoffs rather than silently churning.

N/A — surfaced by the second v0.3.0 ultra code-review.

- [x] Unit tests

- Existing `PrDescriptionGeneratorTest` / `ChangelogEntryGeneratorTest`
/ `CiStatusEvaluatorTest` cover the refactored paths unchanged.
- Full suite green: 1390 tests, SpotBugs 0, Spotless clean, patch fully
covered (merge-base).

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (no CHANGELOG —
refactor only)
- [x] My changes generate no new warnings or errors

**PR 4 of 4** of the second-review fixes. Pure refactor + a clarifying
comment; the three deferrals are documented above with rationale.