### PR TITLE
fix(review): restore un-anchored finding's description on first review + correct /add-docs note docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ mention form, e.g. `@Thrillhousebot review`.
 | `/summary` | Post the PR summary, but only if one has not been generated yet (otherwise no-op) | write |
 | `/describe` | Suggest an improved PR title and description generated from the diff, as a comment to copy in (never overwrites the PR) | write |
 | `/changelog` | Draft a CHANGELOG entry for the PR from the diff (Added/Changed/Fixed/Security…), as a comment to copy into `CHANGELOG.md` (never commits) | write |
-| `/add-docs` | Generate docstrings/inline docs for the symbols changed in the PR, posted as committable suggestions (or a note with the drafted docs when a declaration can't be anchored) | write |
+| `/add-docs` | Generate docstrings/inline docs for the symbols changed in the PR, posted as committable suggestions (or a note with the drafted docs when a multi-line declaration can't be pinned to a single diff hunk) | write |
 | `/resolve` | Resolve ThrillhouseBot's outstanding finding threads on the PR | write |
 | `/pause` | Silence the bot on the PR | write |
 | `/resume` | Re-enable the bot on a paused PR | write |
@@ -93,9 +93,9 @@ ignores `/review`, `/summary`, `/describe`, `/changelog`, and `/add-docs`, and d
 the public symbols changed in the PR, honoring the repository instructions and each file's
 language. Each suggestion is a committable `suggestion` block placed on the symbol's
 declaration (spanning the whole signature when it wraps), so it only inserts docs without
-rewriting code. When a declaration can't be anchored cleanly to the diff, the bot still posts
-a note with the drafted docs to add manually rather than dropping it. It spends AI budget per
-run; operators can turn it off with `REVIEW_ADD_DOCS_ENABLED=false`.
+rewriting code. When a multi-line declaration can't be pinned to a single diff hunk, the bot
+posts a note with the drafted docs to add manually instead of a committable suggestion. It
+spends AI budget per run; operators can turn it off with `REVIEW_ADD_DOCS_ENABLED=false`.
 
 ## Quick start
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -25,7 +25,6 @@ import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -188,18 +187,12 @@ public class ReviewPublisher {
     if (result.reviewState() == ReviewState.REQUEST_CHANGES) {
       bodyParts.add("ThrillhouseBot requested changes — see inline comments on the diff.");
     }
-    // On a first review the summary comment already lists the top findings, so drop those from the
-    // body to avoid reporting a finding twice — but keep any un-anchored finding the summary
-    // doesn't
-    // cover, so nothing is silently dropped. A follow-up posts no summary, so list them all.
-    var unanchoredToReport = inline.unanchored();
-    if (result.isFirstReview()) {
-      var summarized = new HashSet<>(result.keyFindings());
-      unanchoredToReport =
-          unanchoredToReport.stream().filter(f -> !summarized.contains(f)).toList();
-    }
-    if (!unanchoredToReport.isEmpty()) {
-      bodyParts.add(unanchoredFindingsBody(unanchoredToReport));
+    // List every un-anchored finding with its description, even on a first review where the summary
+    // comment also names it. The summary's Key Findings is a brief table of contents (risk, title,
+    // location — no description), so this body is the only place an un-anchored finding's detail is
+    // surfaced; repeating the title here is the acceptable cost of never dropping the problem.
+    if (!inline.unanchored().isEmpty()) {
+      bodyParts.add(unanchoredFindingsBody(inline.unanchored()));
     }
     if (!bodyParts.isEmpty()) {
       createReviewWithFallback(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2877,13 +2877,23 @@ class ReviewOrchestratorTest {
     }
 
     @Test
-    void firstReviewDoesNotRepeatAnUnanchoredFindingTheSummaryAlreadyLists() {
-      // On a first review the summary comment lists the top findings, so an un-anchored one among
-      // them must NOT also be listed in the review body (it would appear twice).
+    void firstReviewStillReportsAnUnanchoredTopFindingWithItsDescriptionInTheBody() {
+      // Even on a first review where the summary comment names a top finding, an un-anchored one
+      // must
+      // still be reported in the review body WITH its description: the summary's Key Findings is a
+      // brief TOC (no description), so the body is the only place the detail is surfaced. Repeating
+      // the title is the acceptable cost of never dropping the problem.
       var anchored =
           new Finding(RiskLevel.HIGH, "src/Main.java", 10, "Anchored bug", "a", null, null);
       var floating =
-          new Finding(RiskLevel.CRITICAL, "missing.java", 99, "Floating bug", "f", null, null);
+          new Finding(
+              RiskLevel.CRITICAL,
+              "missing.java",
+              99,
+              "Floating bug",
+              "Null deref when the account is deleted.",
+              null,
+              null);
       var result =
           new ReviewResult(
               List.of(anchored, floating),
@@ -2893,7 +2903,8 @@ class ReviewOrchestratorTest {
               0,
               RiskLevel.CRITICAL,
               ReviewState.REQUEST_CHANGES,
-              true, // first review: summary comment carries the Key Findings
+              true, // first review: summary comment carries the Key Findings (brief, no
+              // description)
               "",
               List.of(),
               List.of(),
@@ -2918,7 +2929,8 @@ class ReviewOrchestratorTest {
               argThat(
                   req ->
                       req.body().contains("requested changes")
-                          && !req.body().contains("Floating bug")));
+                          && req.body().contains("Floating bug")
+                          && req.body().contains("Null deref when the account is deleted.")));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 📝 Documentation

## Description

A regression-focused ultra re-review of the four merged second-review
PRs (#280–#283) found **two issues — both introduced by those PRs**. No
deleted behaviour, no new crashes; every other fix verified complete.
This PR remediates them.

**Regression — an un-anchored finding's description was dropped on a
first review.** The first-review dedup added in #281 (#3) filtered an
un-anchored finding out of the review body when it was among the
summary's Key Findings. But that Key Findings list is a brief table of
contents — risk + title + `file:line`, **no description** — and
`unanchoredFindingsBody` (which renders the description) is the *only*
place an un-anchored finding's detail is surfaced. So a top-5 finding
that anchored nowhere inline lost its description entirely: named in the
summary, but its actionable detail appeared nowhere. That directly
contradicts the "surface the problem, never drop it" principle the whole
second review was built on — the #3 fix traded harmless title
duplication for dropping part of the problem.

Fix: list every un-anchored finding in the body again (with its
description). The summary repeating the title is the acceptable cost;
the body is the detail.

**Doc accuracy — the `/add-docs` note fallback was overstated.** The
README said a note is posted "when a declaration can't be anchored
cleanly to the diff … rather than dropping it." In fact `postDoc` posts
a note only for a **multi-line** declaration whose verbatim span can't
be pinned to a single hunk; single-line near-misses (and declarations
whose file isn't in the diff) are deliberately dropped (#6 — a snapped
single-line anchor would rewrite the wrong line). Tightened both the
command table and the prose to match the code.

## Related Issues

N/A — surfaced by the regression re-review of #280–#283. Relates to
#281, #6.

## How Has This Been Tested?

- [x] Unit tests

-
`ReviewOrchestratorTest.firstReviewStillReportsAnUnanchoredTopFindingWithItsDescriptionInTheBody`
(rewritten from the test that codified the dropping behaviour) — asserts
a top-5 un-anchored finding's description appears in the body on a first
review.
- `firstReviewStillListsAnUnanchoredFindingBeyondTheSummaryTopFive` and
`shouldSurfaceAnUnanchoredFindingInBodyEvenWhenOthersAnchorInline` still
pass unchanged.
- Full suite green: 1393 tests, SpotBugs 0, Spotless clean, patch fully
covered (merge-base).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (README)
- [x] My changes generate no new warnings or errors

## Additional Notes

Both regressions were introduced within the v0.3.0 cycle (#281), so they
net out under the changelog policy — no CHANGELOG entry. The regression
review otherwise confirmed the 16 second-review fixes are complete and
correct, with no accidentally-deleted behaviour.