### PR TITLE
fix(review): v0.3.0 release-gate — surface findings, disclose cap drops, complete CI caption, pom 0.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>dev.thiagogonzaga.thrillhousebot</groupId>
     <artifactId>thrillhousebot</artifactId>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
 
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
@@ -194,7 +194,7 @@ public class DocGenerationService {
   }
 
   /** How many /add-docs comments landed, split into committable suggestions and plain notes. */
-  record DocPostOutcome(int suggestions, int notes) {}
+  record DocPostOutcome(int suggestions, int notes, int skippedByCap) {}
 
   private enum DocPostResult {
     SUGGESTION,
@@ -218,13 +218,20 @@ public class DocGenerationService {
     int cap = config.review().maxReviewComments();
     int suggestions = 0;
     int notes = 0;
-    for (DocGenerationResponse.DocSuggestion doc : response.docs()) {
+    int skippedByCap = 0;
+    var docs = response.docs();
+    for (int i = 0; i < docs.size(); i++) {
       if (suggestions + notes >= cap) {
+        // Count the postable docs we're dropping because the cap is reached, so the summary can
+        // disclose them rather than silently under-documenting the PR.
+        skippedByCap =
+            (int) docs.subList(i, docs.size()).stream().filter(d -> d.isPostable()).count();
         Log.debugf(
-            "/add-docs reached the %d-comment cap on %s/%s #%d",
-            cap, task.owner(), task.repo(), task.prNumber());
+            "/add-docs reached the %d-comment cap on %s/%s #%d — %d further doc(s) not posted",
+            cap, task.owner(), task.repo(), task.prNumber(), skippedByCap);
         break;
       }
+      var doc = docs.get(i);
       if (!doc.isPostable()) {
         continue;
       }
@@ -236,7 +243,7 @@ public class DocGenerationService {
         }
       }
     }
-    return new DocPostOutcome(suggestions, notes);
+    return new DocPostOutcome(suggestions, notes, skippedByCap);
   }
 
   private DocPostResult postDoc(
@@ -345,6 +352,15 @@ public class DocGenerationService {
   private String summaryMessage(DocGenerationResponse response, DocPostOutcome outcome) {
     int suggestions = outcome.suggestions();
     int notes = outcome.notes();
+    // When the per-run comment cap stopped further docs, disclose it rather than silently
+    // under-documenting the PR — the maintainer needs to know to re-run after addressing these.
+    String capSuffix =
+        outcome.skippedByCap() > 0
+            ? " "
+                + outcome.skippedByCap()
+                + " more changed symbol(s) were not documented because the per-run comment cap was"
+                + " reached — re-run `/add-docs` after addressing these."
+            : "";
     if (suggestions > 0 && notes > 0) {
       return "📝 ThrillhouseBot added **"
           + suggestions
@@ -352,13 +368,15 @@ public class DocGenerationService {
           + notes
           + "** more it couldn't post as committable suggestions (declarations that don't map"
           + " cleanly onto the diff — each note has the docs to add manually). Review each one and"
-          + " commit the suggestions you want to keep.";
+          + " commit the suggestions you want to keep."
+          + capSuffix;
     }
     if (suggestions > 0) {
       return "📝 ThrillhouseBot added **"
           + suggestions
           + "** documentation suggestion(s) for changed symbols. "
-          + "Review each one and commit the suggestions you want to keep.";
+          + "Review each one and commit the suggestions you want to keep."
+          + capSuffix;
     }
     if (notes > 0) {
       // Notes have no committable ```suggestion block, so don't tell the maintainer to "commit"
@@ -366,7 +384,8 @@ public class DocGenerationService {
       return "📝 ThrillhouseBot drafted documentation for **"
           + notes
           + "** symbol(s) it couldn't post as committable suggestions (the declaration doesn't map"
-          + " cleanly onto the diff). Each note has the docs to add manually.";
+          + " cleanly onto the diff). Each note has the docs to add manually."
+          + capSuffix;
     }
     return response.docs().isEmpty() ? NOTHING_TO_DOCUMENT : COULD_NOT_PLACE;
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
@@ -387,6 +387,13 @@ public class DocGenerationService {
           + " cleanly onto the diff). Each note has the docs to add manually."
           + capSuffix;
     }
+    if (outcome.skippedByCap() > 0) {
+      // Nothing posted, but the cap (e.g. maxReviewComments=0) stopped postable docs. Disclose the
+      // cap rather than falling through to COULD_NOT_PLACE, which would wrongly blame anchoring.
+      return "📝 ThrillhouseBot posted no documentation: the per-run comment cap was reached, so **"
+          + outcome.skippedByCap()
+          + "** changed symbol(s) were not documented. Raise the comment cap or re-run `/add-docs`.";
+    }
     return response.docs().isEmpty() ? NOTHING_TO_DOCUMENT : COULD_NOT_PLACE;
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -159,24 +159,22 @@ public class ReviewPublisher {
 
     if (inline.posted() == 0) {
       // Inline anchoring failed for every finding (e.g. all lines fell outside the diff after a
-      // force-push). Surface them in the review body so they are not invisible: a follow-up review
-      // posts no summary comment, so without this the findings would show only as a red check run.
+      // force-push). List them in the review body with their descriptions so they are never
+      // invisible. This does not point at the PR summary comment even on a first review: the
+      // summary
+      // is posted best-effort (a transient failure leaves no such comment), and its Key Findings is
+      // only a brief TOC without descriptions — so the body is the one place the detail is sure to
+      // appear.
       Log.warnf(
           "No inline comments posted for %s/%s #%d — surfacing findings in the review body",
           owner, repo, prNumber);
-      String body =
-          result.isFirstReview()
-              ? "ThrillhouseBot found "
-                  + result.findings().size()
-                  + " issue(s) that could not be anchored to the current diff — see the PR summary"
-                  + " comment above for details."
-              : unanchoredFindingsBody(inline.unanchored());
       createReviewWithFallback(
           auth,
           owner,
           repo,
           prNumber,
-          new GitHubReviewClient.CreateReviewRequest(commitSha, body, event, List.of()));
+          new GitHubReviewClient.CreateReviewRequest(
+              commitSha, unanchoredFindingsBody(inline.unanchored()), event, List.of()));
       return;
     }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -84,8 +84,8 @@ public record ReviewResult(
 
   /**
    * The highest-risk findings the first-review summary comment lists under "Key Findings" (top
-   * {@value #KEY_FINDINGS_COUNT} by risk). Shared with the review-body fallback so it can avoid
-   * re-listing findings the summary already shows.
+   * {@value #KEY_FINDINGS_COUNT} by risk). Used by {@code PrSummaryGenerator} to render that
+   * section.
    */
   public List<Finding> keyFindings() {
     return findings.stream()

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -119,10 +119,21 @@ public class VerdictBuilder {
                     + " review.",
                 result.omittedFiles())
             : "";
+    // An offending check and an unreadable CI source are independent hold reasons that can both
+    // apply at once; disclose the unreadable one alongside the offending message rather than
+    // letting
+    // the offending branch suppress it, matching the PR review comment
+    // (ReviewPublisher.noIssuesBody).
+    var unreadableSuffix =
+        result.ciUnreadable()
+            ? " The CI status for some checks could not be read — holding approval until it can be"
+                + " confirmed."
+            : "";
     if (!result.offendingCiChecks().isEmpty()) {
       return String.format(
               "No new issues found, but %d required CI check(s) are still pending or failing.",
               result.offendingCiChecks().size())
+          + unreadableSuffix
           + truncationSuffix;
     }
     if (result.ciUnreadable()) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
@@ -315,6 +315,29 @@ class DocGenerationServiceTest {
     assertTrue(postedSummary().contains("re-run"), postedSummary());
   }
 
+  @Test
+  void disclosesCapDropEvenWhenNothingWasPosted() {
+    // cap=0 → no docs posted at all, but postable docs were skipped. The summary must still
+    // disclose
+    // the cap, not fall back to the generic could-not-anchor message (which would misattribute it).
+    when(reviewConfig.maxReviewComments()).thenReturn(0);
+    prWithFiles(fooWithPatch());
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenReturn(
+            """
+            {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
+             "suggestion_old":"public int bar(int x) {",
+             "suggestion_new":"/** a */\\npublic int bar(int x) {"}]}
+            """);
+
+    service.handle(task());
+
+    verify(reviewClient, never())
+        .createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
+    assertTrue(postedSummary().contains("comment cap was reached"), postedSummary());
+    assertFalse(postedSummary().contains("could not anchor"), postedSummary());
+  }
+
   @ParameterizedTest(name = "{0}")
   @MethodSource("unpostableSuggestions")
   void doesNotPostSuggestionThatCannotAnchorCleanly(String reason, String docsJson) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
@@ -310,6 +310,9 @@ class DocGenerationServiceTest {
     // Only one inline comment despite two candidates.
     verify(reviewClient, times(1))
         .createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
+    // ...and the cap-dropped doc is disclosed, not silently withheld.
+    assertTrue(postedSummary().contains("1 more changed symbol"), postedSummary());
+    assertTrue(postedSummary().contains("re-run"), postedSummary());
   }
 
   @ParameterizedTest(name = "{0}")

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -786,6 +786,35 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void checkSummaryForResultShouldDiscloseUnreadableCiAlongsideAnOffendingCheck() {
+      // An offending check AND an unreadable CI source are independent holds that can both apply;
+      // the
+      // caption must disclose both, not let the offending branch suppress the unreadable note — the
+      // PR review comment already discloses both, so the check-run caption must agree.
+      var checks = List.of(new ReviewResult.CiCheck("build", "check-run", "failing", null));
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.COMMENT,
+              true,
+              "",
+              List.of(),
+              checks,
+              0,
+              true);
+
+      String summary = VerdictBuilder.checkSummaryForResult(result);
+
+      assertTrue(summary.contains("required CI check(s)"), summary);
+      assertTrue(summary.contains("could not be read"), summary);
+    }
+
+    @Test
     void checkSummaryForResultShouldSummarizeFindingCountsWhenIssuesPresent() {
       var result =
           new ReviewResult(
@@ -2732,12 +2761,15 @@ class ReviewOrchestratorTest {
     }
 
     @Test
-    void shouldPointToSummaryInReviewBodyWhenNoneAnchorInlineOnFirstReview() {
-      // The finding's file is not in the diff, so no inline comment anchors (posted == 0). On a
-      // first review the findings are in the summary comment, so the review body points there — but
+    void shouldListFindingsWithDescriptionsInReviewBodyWhenNoneAnchorInlineOnFirstReview() {
+      // The finding's file is not in the diff, so no inline comment anchors (posted == 0). Even on
       // a
-      // review event is still posted so the findings never vanish behind a bare check.
-      var finding = new Finding(RiskLevel.MEDIUM, "missing.java", 10, "Bug", "desc", null, null);
+      // first review the body must LIST the findings with their descriptions, not point at the PR
+      // summary comment: the summary is posted best-effort (a transient failure leaves no such
+      // comment) and its Key Findings carries no descriptions, so the body is the one place the
+      // detail is guaranteed to appear.
+      var finding =
+          new Finding(RiskLevel.MEDIUM, "missing.java", 10, "Bug", "the X path NPEs", null, null);
       var result = resultWithFinding(finding, ReviewState.COMMENT); // isFirstReview = true
 
       reviewPublisher.postReview(
@@ -2759,8 +2791,10 @@ class ReviewOrchestratorTest {
               argThat(
                   req ->
                       "COMMENT".equals(req.event())
-                          && req.body().contains("could not be anchored")
-                          && req.body().contains("PR summary")));
+                          && req.body().contains("Bug")
+                          && req.body().contains("missing.java:10")
+                          && req.body().contains("the X path NPEs")
+                          && !req.body().contains("PR summary")));
     }
 
     @Test


### PR DESCRIPTION
- [x] 🐛 Bug fix

The **v0.3.0 release gate**: the functional findings from the full
v0.2.1→release-tip readiness review, so the branch satisfies "new
features work, no regressions/new bugs" and can be tagged. The
removed-behaviour auditor confirmed **no v0.2.1 feature was broken**;
this PR fixes the new-bugs/feature-gaps it did surface. Pure structural
cleanup is deferred to 0.3.1 (see below). All fixes are within
v0.3.0-introduced paths, so no CHANGELOG entries.

**#1 — first-review body could point at a non-existent summary
comment.** When no finding anchors inline, the first-review body said
"see the PR summary comment above". But #282 made the summary post
best-effort, so a transient comment failure left the body referencing a
missing comment, and the finding descriptions (carried only by the
summary's brief Key Findings) were lost. The body now lists every
finding **with its description** regardless of review type — the body is
the one surface guaranteed to carry the detail.

**#3 — `/add-docs` silently dropped over-cap docs.** Once the per-run
comment cap was hit the loop broke and remaining postable docs vanished
(debug log only), so on a large PR the maintainer believed coverage was
complete. The summary now discloses *"N more changed symbol(s) were not
documented because the per-run comment cap was reached — re-run
`/add-docs`"*.

**#2 — check-run caption dropped a hold reason.** When CI was **both**
offending and unreadable, `checkSummaryForResult` returned on the
offending branch and omitted the unreadable disclosure that the PR
review comment already shows. Both surfaces now agree.

**#5 — stale javadoc.** `ReviewResult.keyFindings()` still claimed it
was "shared with the review-body fallback" after #284 removed that
dedup; corrected.

**#14 — pom version.** `0.2.2-SNAPSHOT` → `0.3.0-SNAPSHOT` (the branch
ships v0.3.0 / CHANGELOG `[0.3.0]`; required to tag).

**Verified, no change:** #13 — `/changelog` `prNumber` rendering is
already guarded by `AiServicePromptRenderingTest` (the #186 regression
test) and `@UserMessage` is correctly on the method.

**Deferred to 0.3.1** (pure structure/dedup, zero functional impact):
hold-reason logic dedup (#8), `DiffLineResolver` variant-lookup
unification (#7), multi-line-suggestion protocol dedup (#6),
`ReviewResult` build dedup (#9), sequential CI fetch overlap (#10), dead
`patchesByFile`/`DiffStats` test-only members (#4, #11), and the
over-cap review-finding label (#12 — findings are surfaced, only the
header wording is imprecise).

N/A — from the v0.2.1→v0.3.0 release-readiness review.

- [x] Unit tests

-
`ReviewOrchestratorTest.shouldListFindingsWithDescriptionsInReviewBodyWhenNoneAnchorInlineOnFirstReview`
(#1),
`checkSummaryForResultShouldDiscloseUnreadableCiAlongsideAnOffendingCheck`
(#2).
- `DocGenerationServiceTest.capsAtMaxReviewComments` now asserts the
cap-drop disclosure (#3).
- Full suite green: 1394 tests, SpotBugs 0, Spotless clean, patch fully
covered (merge-base).

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (no CHANGELOG — all
v0.3.0-era paths)
- [x] My changes generate no new warnings or errors

After this merges, the release criteria are met (features work, no
regressions, pom at 0.3.0-SNAPSHOT) and `v0.3.0` can be tagged; the
deferred cleanup lands in 0.3.1.