### PR TITLE
fix(review): disclose a truncated first review in the body, not only the best-effort summary (Sonnet final review)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -170,8 +170,8 @@ public interface GitHubReviewClient {
 
   /**
    * A pull request review comment. When {@code startLine} is set, the comment spans the inclusive
-   * range {@code start_line}..{@code line} so a GitHub suggestion replaces every line in it (#71);
-   * a single-line comment leaves both range fields null and they are omitted from the payload.
+   * range {@code start_line}..{@code line} so a GitHub suggestion replaces every line in it; a
+   * single-line comment leaves both range fields null and they are omitted from the payload.
    */
   @JsonInclude(JsonInclude.Include.NON_NULL)
   record CreatePullRequestCommentRequest(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluator.java
@@ -35,8 +35,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 /**
  * Resolves a PR's required status-check contexts and evaluates which CI checks on a commit are
  * offending (pending, failing, or missing) — the deterministic, read-only input the review verdict
- * uses to hold approval back until required CI is green. Extracted from {@code ReviewOrchestrator}
- * as the self-contained CI-status subsystem.
+ * uses to hold approval back until required CI is green.
  */
 @ApplicationScoped
 public class CiStatusEvaluator {
@@ -160,7 +159,7 @@ public class CiStatusEvaluator {
    * The outcome of evaluating a commit's CI: the <em>offending</em> checks (pending, failing, or
    * missing) and whether a CI source could not be read at all. Both hold the APPROVE decision back,
    * but they are distinct concepts — unreadable is not a check — so the verdict and the rendered
-   * summary can treat them separately (#253/#6).
+   * summary can treat them separately.
    */
   record CiEvaluation(List<ReviewResult.CiCheck> offendingChecks, boolean unreadable) {}
 
@@ -195,13 +194,13 @@ public class CiStatusEvaluator {
 
     addMissingRequiredChecks(requiredContexts, seen, offending);
 
-    // Fail closed for the APPROVE decision (#253/#5): if either CI source could not be read (an
+    // Fail closed for the APPROVE decision: if either CI source could not be read (an
     // exception or a null body — GitHub returns an empty list, never null, past the last page) we
-    // cannot confirm CI is green, so the verdict must not approve over CI we never saw (#217). This
+    // cannot confirm CI is green, so the verdict must not approve over CI we never saw. This
     // holds in BOTH gate modes: gate-specific is not automatically safe, because
-    // addMissingRequired-
-    // Checks only catches required contexts that did not report — a source going unread can still
-    // hide a required check's true state. Reported as a first-class signal, not a synthetic check.
+    // addMissingRequiredChecks only catches required contexts that did not report — a source going
+    // unread can still hide a required check's true state. Reported as a first-class signal, not a
+    // synthetic check.
     boolean unreadable = !checkRunsReadable || !statusReadable;
     return new CiEvaluation(offending, unreadable);
   }
@@ -326,8 +325,8 @@ public class CiStatusEvaluator {
       return CI_FAILING;
     }
     // "pending", null, or any unrecognized state is not a confirmed pass: classify it as pending so
-    // an indeterminate required check holds the approval rather than being mistaken for success
-    // . Only an explicit "success" clears the gate.
+    // an indeterminate required check holds the approval rather than being mistaken for success.
+    // Only an explicit "success" clears the gate.
     return CI_PENDING;
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -283,7 +283,7 @@ public final class DiffLineResolver {
   /**
    * Resolves the right-side line range a finding's {@code suggestion_old} (the verbatim code it
    * replaces) occupies in the diff, so a multi-line replacement can be posted as a multi-line
-   * GitHub suggestion that overwrites the whole range rather than a single anchor line (#71).
+   * GitHub suggestion that overwrites the whole range rather than a single anchor line.
    *
    * <p>The anchor's trimmed, non-blank lines must appear as a contiguous, in-order run of
    * right-side lines (the same matching {@link #isFindingPresent} uses); the range spans the first
@@ -373,8 +373,8 @@ public final class DiffLineResolver {
    * test the anchor as a contiguous run; blank lines are dropped from both sides so a blank line
    * inside a block never breaks an otherwise-adjacent match. {@code textLineNumbers} runs parallel
    * to {@code text}, carrying the right-side line number of each retained line so a matched anchor
-   * run can be mapped back to a concrete line range (#71). {@code hunkStarts} holds each hunk's
-   * 1-based right-side start line, so a resolved range can be confined to a single hunk.
+   * run can be mapped back to a concrete line range. {@code hunkStarts} holds each hunk's 1-based
+   * right-side start line, so a resolved range can be confined to a single hunk.
    */
   private record RightSide(
       TreeSet<Integer> lines,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
@@ -274,7 +274,7 @@ public class DocGenerationService {
     // whole span, not just doc.line() — otherwise the commit replaces only the first line and
     // leaves
     // the rest in place, corrupting the file. Resolve the range from the verbatim old code's
-    // position in the diff (#71), which also anchors it independently of doc.line().
+    // position in the diff, which also anchors it independently of doc.line().
     var range =
         multiLine
             ? lineResolver.resolveSuggestionRange(doc.file(), doc.suggestionOld())

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -32,8 +32,8 @@ import java.util.List;
 /**
  * The post-AI finding chain: validate quotes, dedupe, verify against the diff, drop already-replied
  * duplicates, backfill missing content anchors, and persist the response. Extracted from {@code
- * ReviewOrchestrator} (#250); the ordering is preserved verbatim — quote validation runs before
- * dedupe so a merged finding cannot inherit a phantom quote while a verbatim sibling is discarded.
+ * ReviewOrchestrator}; the ordering is preserved verbatim — quote validation runs before dedupe so
+ * a merged finding cannot inherit a phantom quote while a verbatim sibling is discarded.
  */
 @ApplicationScoped
 public class FindingPipeline {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -203,7 +203,7 @@ public class PrSummaryGenerator {
       sb.append("\n");
     }
     // Unreadable CI is a distinct hold from an offending check: render it as its own note rather
-    // than as a counterfeit row in the required-checks table (#253/#6).
+    // than as a counterfeit row in the required-checks table.
     if (result.ciUnreadable()) {
       sb.append("### ⚠️ CI Status Unavailable\n");
       sb.append(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
@@ -34,8 +34,8 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
  * Loads everything a review reads from GitHub and persistence before the AI is called — the diff,
  * base comparison, prior reviews/comments, persisted prior findings, repository instructions,
  * existing labels, and project stack — and computes the first-visible / has-context signals.
- * Extracted from {@code ReviewOrchestrator} (#250) as the read side of the pipeline; every fetch
- * fails soft exactly as before, except the PR-files fetch whose failure must reach the caller.
+ * Extracted from {@code ReviewOrchestrator} as the read side of the pipeline; every fetch fails
+ * soft exactly as before, except the PR-files fetch whose failure must reach the caller.
  */
 @ApplicationScoped
 public class ReviewContextLoader {
@@ -121,7 +121,7 @@ public class ReviewContextLoader {
     var diffResult = diffFormatter.buildDiffStringWithStats(files, reviewableFiles);
     var baseComparisonResult =
         buildBaseComparisonWithStats(auth, req.owner(), req.repo(), req.baseSha(), req.commitSha());
-    // Only the PR diff's omitted files gate the verdict (#234): the base↔head comparison is
+    // Only the PR diff's omitted files gate the verdict: the base↔head comparison is
     // supplementary regression context, so trimming it must not hold APPROVE or claim a partial
     // review when the PR diff itself was reviewed in full.
     var omittedFiles = diffResult.omittedFiles();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -237,11 +237,11 @@ public class ReviewOrchestrator {
       reviewPublisher.postReview(
           auth, req.owner(), req.repo(), req.prNumber(), req.commitSha(), result, lineResolver);
 
-      // The review and its comments are on the PR now (#254). Everything past this point is
+      // The review and its comments are on the PR now. Everything past this point is
       // best-effort and independent: each step runs in isolation so one failure can't abort the
       // rest. In particular a failure in an earlier step must not skip the session completion and
       // broadcast, which would otherwise leave the session stuck IN_PROGRESS in the dashboard even
-      // though the review was posted (#253/#254 follow-up).
+      // though the review was posted.
       resultSurfaced = true;
       final var doneReq = req;
       final var concludedCheckRunId = checkRunId;
@@ -308,8 +308,8 @@ public class ReviewOrchestrator {
   /**
    * Resolves the CI evaluation for a request: the required-context lookup unioned across rulesets
    * and classic protection, then the per-check evaluation on the head commit. Runs off the review
-   * executor concurrently with the blocking AI call (#10) — it depends only on the commit and base
-   * branch carried on the request, not the model response.
+   * executor concurrently with the blocking AI call — it depends only on the commit and base branch
+   * carried on the request, not the model response.
    */
   private CiStatusEvaluator.CiEvaluation resolveCiEvaluation(String auth, ReviewRequest req) {
     List<String> requiredContexts =

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssembler.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssembler.java
@@ -25,8 +25,8 @@ import jakarta.inject.Inject;
  * Turns a loaded {@link ReviewContextLoader.ReviewContext} into the {@link
  * AiReviewService.PromptInputs} the model is called with — fencing the diff, escaping the prose
  * slots, and assembling the trailing guidance (labels + diagram request + repository instructions)
- * into the single {@code repoInstructions} slot. Extracted from {@code ReviewOrchestrator} (#250)
- * as the pure prompt-shaping transform.
+ * into the single {@code repoInstructions} slot. Extracted from {@code ReviewOrchestrator} as the
+ * pure prompt-shaping transform.
  */
 @ApplicationScoped
 public class ReviewPromptAssembler {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -32,9 +32,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 /**
  * Posts a review's outcome to GitHub — inline finding comments, the review verdict (or no-issues
  * body), dismissal of the bot's stale pending review, and resolution of addressed finding threads.
- * Extracted from {@code ReviewOrchestrator} (#250) as the write side of the pipeline; the #215
- * fallback (surface findings in the review body when no inline comment anchors) and #74 (reuse the
- * already-fetched reviews for dismissal) behaviours move verbatim.
+ * The write side of the pipeline.
  */
 @ApplicationScoped
 public class ReviewPublisher {
@@ -253,8 +251,7 @@ public class ReviewPublisher {
     // A COMMENT held back only by pending/failed CI (no findings, nothing unresolved) merely
     // restates the summary comment the first review already posts, so emitting it too would
     // duplicate that message. Skip it on the first review and let the summary stand alone — EXCEPT
-    // when the hold is (also) a truncated diff: the summary comment is posted best-effort (#282),
-    // so
+    // when the hold is (also) a truncated diff: the summary comment is posted best-effort, so
     // a transient failure would leave the partial review disclosed nowhere on the PR (CI holds stay
     // visible via the red checks themselves; truncation has no other PR surface). Post the body for
     // a truncated review so the partial-review notice is never lost.
@@ -317,8 +314,8 @@ public class ReviewPublisher {
           .append(ReviewResult.unresolvedPreviousMessage(unresolved));
     }
     // Disclose the partial review here whenever the diff was truncated — on follow-ups (which post
-    // no summary) and on first reviews too: the first-review summary banner is posted best-effort
-    // (#282), so relying on it alone would lose the only PR-visible notice if that post fails. The
+    // no summary) and on first reviews too: the first-review summary banner is posted best-effort,
+    // so relying on it alone would lose the only PR-visible notice if that post fails. The
     // summary may repeat it; a duplicated notice is the acceptable cost of never dropping it.
     if (result.truncated()) {
       if (!sb.isEmpty()) {
@@ -389,7 +386,7 @@ public class ReviewPublisher {
     }
 
     // A suggestion whose old code spans several lines is posted as a multi-line comment so the
-    // GitHub suggestion overwrites the whole range, not just the anchor line (#71). The range is
+    // GitHub suggestion overwrites the whole range, not just the anchor line. The range is
     // resolved from the verbatim old code's position in the diff; a blank/single-line/unresolvable
     // anchor leaves it empty and the comment stays single-line.
     var range =
@@ -398,14 +395,12 @@ public class ReviewPublisher {
             : Optional.<DiffLineResolver.LineRange>empty();
 
     // A multi-line suggestion must overwrite its whole range. When that range can't be resolved
-    // (the
-    // old code doesn't match the diff verbatim, is ambiguous, or straddles a hunk), attaching the
-    // suggestion would post it against a single line — applying it then overwrites only the anchor
-    // line and leaves the rest of the quoted block in place (the same #71 multi-line corruption).
-    // In
-    // that case post the finding without the suggestion: the problem is still reported, just not as
-    // a
-    // one-click fix.
+    // (the old code doesn't match the diff verbatim, is ambiguous, or straddles a hunk), attaching
+    // the suggestion would post it against a single line — applying it then overwrites only the
+    // anchor line and leaves the rest of the quoted block in place (the same multi-line
+    // corruption).
+    // In that case post the finding without the suggestion: the problem is still reported, just not
+    // as a one-click fix.
     // hasSuggestion() already guarantees a non-blank suggestionOld, so the newline check is safe.
     var multiLineSuggestion =
         finding.hasSuggestion() && finding.suggestionOld().strip().contains("\n");

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -252,13 +252,19 @@ public class ReviewPublisher {
     }
     // A COMMENT held back only by pending/failed CI (no findings, nothing unresolved) merely
     // restates the summary comment the first review already posts, so emitting it too would
-    // duplicate that message. Skip it on the first review and let the summary stand alone.
+    // duplicate that message. Skip it on the first review and let the summary stand alone — EXCEPT
+    // when the hold is (also) a truncated diff: the summary comment is posted best-effort (#282),
+    // so
+    // a transient failure would leave the partial review disclosed nowhere on the PR (CI holds stay
+    // visible via the red checks themselves; truncation has no other PR surface). Post the body for
+    // a truncated review so the partial-review notice is never lost.
     // Unresolved previous findings are excluded — their COMMENT carries distinct "reply on the
     // thread" guidance the summary lacks, so it still posts. Follow-ups post no summary, so the
     // COMMENT is their only signal; REQUEST_CHANGES always posts; the merge gate is the check run.
     if (result.reviewState() == ReviewState.COMMENT
         && result.isFirstReview()
-        && result.unresolvedPreviousCount() == 0) {
+        && result.unresolvedPreviousCount() == 0
+        && !result.truncated()) {
       return;
     }
     // No new findings, but previous ones are still unresolved or CI checks are pending/failed —
@@ -310,10 +316,11 @@ public class ReviewPublisher {
       sb.append(ciHeld ? "\nAdditionally, " : "")
           .append(ReviewResult.unresolvedPreviousMessage(unresolved));
     }
-    // The first-review summary comment carries the truncation banner; a follow-up posts no summary,
-    // so disclose the partial review here instead — otherwise a truncation-only hold would surface
-    // no reason at all (and used to misreport "0 previous finding(s) remain unresolved").
-    if (result.truncated() && !result.isFirstReview()) {
+    // Disclose the partial review here whenever the diff was truncated — on follow-ups (which post
+    // no summary) and on first reviews too: the first-review summary banner is posted best-effort
+    // (#282), so relying on it alone would lose the only PR-visible notice if that post fails. The
+    // summary may repeat it; a duplicated notice is the acceptable cost of never dropping it.
+    if (result.truncated()) {
       if (!sb.isEmpty()) {
         sb.append("\n\n");
       }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -25,10 +25,9 @@ import java.util.List;
 
 /**
  * Builds the {@link ReviewResult} verdict from the model response and the review's gating inputs,
- * and derives the check-run conclusion/title/summary. Extracted from {@code ReviewOrchestrator}
- * (#250) as the decision core: the APPROVE-gating guards move here <em>verbatim</em> — a review
- * approves only when there are no outstanding new findings AND no unresolved previous findings
- * (#118/#130/#143 backstop), no offending CI checks (#217), and the diff was not truncated (#234).
+ * and derives the check-run conclusion/title/summary. The decision core: a review approves only
+ * when there are no outstanding new findings AND no unresolved previous findings (backstop), no
+ * offending CI checks, and the diff was not truncated.
  */
 @ApplicationScoped
 public class VerdictBuilder {
@@ -91,7 +90,7 @@ public class VerdictBuilder {
   static String checkTitleForResult(ReviewResult result) {
     // Derive the ✅ from the single verdict gate, not a parallel predicate: reviewState() is APPROVE
     // only when nothing holds the review back — no findings, no unresolved previous findings, no
-    // offending CI, AND the diff was not truncated (#234). Re-deriving the "all clear" condition by
+    // offending CI, AND the diff was not truncated. Re-deriving the "all clear" condition by
     // hand here used to omit the truncation guard, so a truncated-but-clean PR showed ✅ over a
     // neutral (held) conclusion.
     if (result.reviewState() == ReviewState.APPROVE) {
@@ -111,7 +110,7 @@ public class VerdictBuilder {
           result.lowCount());
     }
     // No new findings — surface CI gating first, since it also holds approval back. When the diff
-    // was also truncated, append that so a partial review is disclosed on this surface too (#234).
+    // was also truncated, append that so a partial review is disclosed on this surface too.
     var truncationSuffix =
         result.truncated()
             ? String.format(
@@ -121,8 +120,7 @@ public class VerdictBuilder {
             : "";
     // An offending check and an unreadable CI source are independent hold reasons that can both
     // apply at once; disclose the unreadable one alongside the offending message rather than
-    // letting
-    // the offending branch suppress it, matching the PR review comment
+    // letting the offending branch suppress it, matching the PR review comment
     // (ReviewPublisher.noIssuesBody).
     var unreadableSuffix =
         result.ciUnreadable()
@@ -141,7 +139,7 @@ public class VerdictBuilder {
           + " can be confirmed."
           + truncationSuffix;
     }
-    // A truncated diff holds approval at neutral (#234); the summary must say so rather than fall
+    // A truncated diff holds approval at neutral; the summary must say so rather than fall
     // through to the all-clear celebration, which would caption a held check run as "no issues".
     if (result.truncated()) {
       return String.format(
@@ -219,7 +217,7 @@ public class VerdictBuilder {
     }
 
     // CI holds approval back when a required check is offending OR a CI source could not be read at
-    // all — an unread source means we cannot confirm CI is green, so we fail closed (#253/#5).
+    // all — an unread source means we cannot confirm CI is green, so we fail closed.
     if (state == ReviewState.APPROVE && (!offendingCiChecks.isEmpty() || ciUnreadable)) {
       state = ReviewState.COMMENT;
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChangelogAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChangelogAssistant.java
@@ -31,7 +31,7 @@ public interface ChangelogAssistant {
   // @UserMessage MUST be on the method, not a parameter: on a parameter quarkus-langchain4j sends
   // only that parameter's raw value as the user message and never renders this template, silently
   // dropping prNumber, currentTitle, currentDescription and repoInstructions (see
-  // AiServicePromptRenderingTest and the #186 regression).
+  // AiServicePromptRenderingTest).
   @SystemMessage(ChangelogAssistantPrompts.SYSTEM)
   @UserMessage(PrSuggestionPrompts.USER)
   String draft(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGenerator.java
@@ -31,8 +31,7 @@ public interface DocGenerator {
 
   // @UserMessage MUST be on the method, not a parameter: on a parameter quarkus-langchain4j sends
   // only that parameter's raw value as the user message and never renders this template, silently
-  // dropping prContext, projectStack and repoInstructions (see AiServicePromptRenderingTest and the
-  // #186 regression).
+  // dropping prContext, projectStack and repoInstructions (see AiServicePromptRenderingTest).
   @SystemMessage(DocGeneratorPrompts.SYSTEM)
   @UserMessage(DocGeneratorPrompts.USER)
   String generate(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrDescribeAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrDescribeAssistant.java
@@ -30,8 +30,7 @@ public interface PrDescribeAssistant {
   // @UserMessage MUST be on the method, not a parameter: on a parameter quarkus-langchain4j sends
   // only that parameter's raw value as the user message and never renders this template, silently
   // dropping currentTitle, currentDescription and repoInstructions (see
-  // AiServicePromptRenderingTest
-  // and the #186 regression).
+  // AiServicePromptRenderingTest).
   @SystemMessage(PrDescribeAssistantPrompts.SYSTEM)
   @UserMessage(PrSuggestionPrompts.USER)
   String describe(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
@@ -395,8 +395,6 @@ public class CommentCommandService {
    */
   private List<Long> botRootCommentIds(String auth, CommandContext ctx) {
     var ids = new ArrayList<Long>();
-    // The client walks every page, so a PR with many comments does not leave later-page bot threads
-    // unresolved.
     for (var c :
         reviewClient.listPullRequestComments(
             auth, ACCEPT, ctx.owner(), ctx.repo(), ctx.prNumber())) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -373,10 +373,11 @@ class ReviewOrchestratorTest {
     }
 
     @Test
-    void truncatedFirstReviewBodyOmitsBannerSinceSummaryCarriesIt() {
-      // On a FIRST review the summary comment carries the truncation banner, so the review body
-      // must
-      // not repeat it — even when the body is posted for unresolved previous findings.
+    void truncatedFirstReviewBodyNowDisclosesPartialReview() {
+      // Even on a FIRST review the body must disclose the truncation. The summary comment that used
+      // to carry the banner is posted best-effort (#282), so relying on it alone could lose the
+      // only
+      // PR-visible notice if that post fails — a duplicated notice is the acceptable cost.
       var result =
           new ReviewResult(
               List.of(),
@@ -399,7 +400,32 @@ class ReviewOrchestratorTest {
           .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
       var body = captor.getValue().body();
       assertTrue(body.contains("1 previous finding(s) remain unresolved"), body);
-      assertFalse(body.contains("partial review"), body);
+      assertTrue(body.contains("partial review"), body);
+      assertTrue(body.contains("7 file"), body);
+    }
+
+    @Test
+    void truncationOnlyHeldFirstReviewStillPostsThePartialReviewBody() {
+      // Regression (Sonnet final review): a clean-but-truncated FIRST review (no findings, no CI
+      // hold, nothing unresolved) is demoted to COMMENT, but postNoIssuesReview used to
+      // early-return
+      // and rely on the best-effort summary comment for the truncation banner. If that summary post
+      // failed, the partial review was disclosed nowhere on the PR comment surface. It must now
+      // post
+      // a review body carrying the truncation notice.
+      var result =
+          new ReviewResult(
+              List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), List.of(), 4);
+
+      reviewPublisher.postReview("auth", "owner", "repo", 5, "sha", result, resolverFor());
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      var body = captor.getValue().body();
+      assertTrue(body.contains("partial review"), body);
+      assertTrue(body.contains("4 file"), body);
+      assertEquals("COMMENT", captor.getValue().event());
     }
 
     @Test


### PR DESCRIPTION
- [x] 🐛 Bug fix

The single HIGH finding from the **Sonnet 5** final pre-tag review
(independent second-model pass over the whole v0.2.1→tip delta — opus
had swept it twice and missed this). It's a sibling of the #285 #1 fix:
same "best-effort summary failure loses disclosure" class, but in the
**no-findings** path.

**A truncated-but-clean first review could disclose the partial review
nowhere on the PR.** When a large PR truncates the diff (`omittedFiles >
0`) with no findings, green/readable CI, and nothing unresolved,
`VerdictBuilder` demotes APPROVE → COMMENT *solely* for truncation, and
the truncation banner lives only in `summaryMarkdown`.
`postNoIssuesReview` then early-returns ("let the summary stand alone")
for a first-review COMMENT with no unresolved findings — but since #282
the summary comment is posted **best-effort** (a transient
`createComment` 5xx/rate-limit is swallowed). If it fails, nothing is
posted: the partial review is surfaced only on the secondary check-run
caption, so a maintainer can merge believing the PR was fully reviewed.

**Fix:**
- `postNoIssuesReview` keeps posting the body for a **truncated** first
review (`&& !result.truncated()` added to the skip). CI-only holds still
skip — the failing checks are themselves visible on the PR; truncation
has no other PR surface.
- `noIssuesBody` discloses truncation whenever truncated (drops the
`!isFirstReview` guard), so the body carries it independently of the
best-effort summary. When the summary *does* post, a duplicated notice
is the acceptable cost of never dropping it.

N/A — Sonnet final-review finding. Relates to #282, #234.

- [x] Unit tests

-
`ReviewOrchestratorTest.truncationOnlyHeldFirstReviewStillPostsThePartialReviewBody`
— the exact bug scenario: truncated-only-held first review now posts a
COMMENT body with the partial-review notice.
- `truncatedFirstReviewBodyNowDisclosesPartialReview` (rewritten from
the test that asserted the old "omit on first review" behavior).
- Existing follow-up truncation tests unchanged.
- Full suite green: 1396 tests, SpotBugs 0, Spotless clean, patch fully
covered (merge-base).

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (no CHANGELOG —
v0.3.0-introduced)
- [x] My changes generate no new warnings or errors

Last finding before tagging. After this merges, the Sonnet pass is
clean; JVM (1396 tests) + native build are green; pom is at
0.3.0-SNAPSHOT — `v0.3.0` is ready to tag.