### PR TITLE
fix(review): restore the orphaned cross-location-consistency bullet in the review system prompt

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -141,6 +141,7 @@ public final class PrReviewPrompts {
               schema or constraint it violates. Such a finding needs no runtime input trace; but if
               the rule it cites cannot be confirmed from the diff and provided context, it is a
               confidence "medium"/"low" finding phrased as a verification request, not "high".
+            - A claim that two places are inconsistent ("X does this but Y does not") must quote
               both places verbatim from the provided material and confirm they belong to the
               same enclosing unit (the same function, block, or scope). When the two places are
               in different units, first verify the units are genuinely equivalent; when the

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -87,4 +87,20 @@ class PrReviewPromptsContentTest {
         "config/IaC defect whose breakage is visible",
         "verifier severity calibration must let demonstrable config defects stand at high");
   }
+
+  @Test
+  void generatorPromptKeepsTheCrossLocationConsistencyGuard() {
+    String sys = PrReviewPrompts.SYSTEM;
+    // Regression: adding the config/IaC bullet once overwrote this bullet's opening line, orphaning
+    // its body and dropping the guard that forces the model to verify both sides of an "X does this
+    // but Y does not" claim before flagging it. Both header and body must remain, as one bullet.
+    assertContains(
+        sys,
+        "A claim that two places are inconsistent",
+        "the cross-location-inconsistency guard must remain a complete, headed bullet");
+    assertContains(
+        sys,
+        "both places verbatim from the provided material",
+        "the guard's body must stay attached to its header, not dangle as a fragment");
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The one HIGH finding from the **final Sonnet attestation pass** over the
full v0.2.1→tip delta — caught after four prior review passes (opus ×3 +
Sonnet ×1) had missed it, because it's buried in a long prompt text
block.

**The review system prompt had an orphaned, headerless bullet.** When
the config/IaC apply-time-defence bullet was added to
`PrReviewPrompts.SYSTEM` during v0.3.0, it was merged in by
**overwriting the opening line** of the pre-existing *"A claim that two
places are inconsistent ("X does this but Y does not")"* self-check
bullet, leaving its body stranded. Two consequences on the prompt sent
to the model **on every review**:

1. **Malformed prompt** — the config bullet ends "...not 'high'." and is
immediately followed by a subjectless fragment: "both places verbatim
from the provided material and confirm they belong to the same enclosing
unit…".
2. **Dropped guard** — the rule that forces the model to quote and
verify *both* sides of a cross-location "X does this but Y does not"
claim before raising it is gone (grep for "two places are inconsistent"
→ zero matches), re-opening that false-positive class on the generating
pass. (The parallel `FindingVerifierPrompts` post-hoc rejection stayed
intact, so the verifier still catches some, but the generator no longer
avoids making the claim.)

**Fix:** restore the bullet's header line so both the config/IaC bullet
and the cross-location-consistency bullet are complete, separate
instructions (matches the v0.2.1 wording).

## Related Issues

N/A — final Sonnet attestation finding before tagging v0.3.0.

## How Has This Been Tested?

- [x] Unit tests

-
`PrReviewPromptsContentTest.generatorPromptKeepsTheCrossLocationConsistencyGuard`
— pins both the bullet header and its body so a future prompt edit can't
orphan it again.
- Full suite green: 1397 tests, SpotBugs 0, Spotless clean, patch fully
covered.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (no CHANGELOG —
v0.3.0-introduced, unreleased)
- [x] My changes generate no new warnings or errors

## Additional Notes

The pass's only other finding (low/cleanup) is a `github.*` wildcard
import in `ReviewOrchestrator` — pure cleanup, deferred to 0.3.1 with
the rest. After this merges the Sonnet pass is clean and `v0.3.0` is
ready to tag.