### PR TITLE
fix(review): label cap-skipped findings separately from unanchored ones

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -172,7 +172,7 @@ public class ReviewPublisher {
           repo,
           prNumber,
           new GitHubReviewClient.CreateReviewRequest(
-              commitSha, unanchoredFindingsBody(inline.unanchored()), event, List.of()));
+              commitSha, String.join("\n\n", skippedFindingsBodyParts(inline)), event, List.of()));
       return;
     }
 
@@ -187,9 +187,7 @@ public class ReviewPublisher {
     // comment also names it. The summary's Key Findings is a brief table of contents (risk, title,
     // location — no description), so this body is the only place an un-anchored finding's detail is
     // surfaced; repeating the title here is the acceptable cost of never dropping the problem.
-    if (!inline.unanchored().isEmpty()) {
-      bodyParts.add(unanchoredFindingsBody(inline.unanchored()));
-    }
+    bodyParts.addAll(skippedFindingsBodyParts(inline));
     if (!bodyParts.isEmpty()) {
       createReviewWithFallback(
           auth,
@@ -206,11 +204,39 @@ public class ReviewPublisher {
    * lines fell outside the current diff). It keeps the findings visible on a follow-up review,
    * which posts no summary comment — without it the findings would surface only as a red check run.
    */
+  /** Review-body sections for findings not posted inline — un-anchored and/or cap-skipped. */
+  private static List<String> skippedFindingsBodyParts(InlineCommentResult inline) {
+    var parts = new ArrayList<String>();
+    if (!inline.unanchored().isEmpty()) {
+      parts.add(unanchoredFindingsBody(inline.unanchored()));
+    }
+    if (!inline.capSkipped().isEmpty()) {
+      parts.add(capSkippedFindingsBody(inline.capSkipped()));
+    }
+    return parts;
+  }
+
   private static String unanchoredFindingsBody(List<Finding> findings) {
     var sb = new StringBuilder();
     sb.append("ThrillhouseBot found ")
         .append(findings.size())
         .append(" issue(s) that could not be anchored to the current diff:\n\n");
+    appendFindingList(sb, findings);
+    return sb.toString();
+  }
+
+  private static String capSkippedFindingsBody(List<Finding> findings) {
+    var sb = new StringBuilder();
+    sb.append("ThrillhouseBot found ")
+        .append(findings.size())
+        .append(
+            " issue(s) not posted inline because the per-run comment cap was reached — re-run"
+                + " `/review` or raise the comment cap:\n\n");
+    appendFindingList(sb, findings);
+    return sb.toString();
+  }
+
+  private static void appendFindingList(StringBuilder sb, List<Finding> findings) {
     for (Finding f : findings) {
       sb.append("- **")
           .append(f.risk().name())
@@ -228,7 +254,6 @@ public class ReviewPublisher {
       }
       sb.append("\n");
     }
-    return sb.toString();
   }
 
   /**
@@ -326,8 +351,11 @@ public class ReviewPublisher {
     return sb.toString();
   }
 
-  /** How many findings anchored as inline comments, and the ones that could not be. */
-  record InlineCommentResult(int posted, List<Finding> unanchored) {}
+  /**
+   * How many findings anchored as inline comments, the ones that could not be anchored, and the
+   * ones skipped because {@code maxReviewComments} was reached (never tried for anchoring).
+   */
+  record InlineCommentResult(int posted, List<Finding> unanchored, List<Finding> capSkipped) {}
 
   /**
    * Posts each finding as its own pull request review comment on the diff. Individual comments
@@ -346,22 +374,27 @@ public class ReviewPublisher {
     var target = new CommentTarget(auth, owner, repo, prNumber, commitSha);
     var posted = 0;
     var unanchored = new ArrayList<Finding>();
+    var capSkipped = new ArrayList<Finding>();
     var maxComments = config.review().maxReviewComments();
     for (var i = 0; i < result.findings().size(); i++) {
       // The 1-based index doubles as the finding's id in the persisted response and the
       // hidden comment marker, keeping thread matching deterministic on follow-up reviews
       var finding = result.findings().get(i);
-      // The cap limits inline comments, not findings: once it's reached, remaining findings (and
-      // any
-      // that couldn't anchor) are returned as unanchored so the caller still reports them in the
-      // review body — capped on noise, but never silently dropped.
-      if (posted < maxComments && postFindingComment(target, finding, i + 1, lineResolver)) {
+      // The cap limits inline comments, not findings: once it's reached, remaining findings are
+      // returned as capSkipped (never tried for anchoring) so the caller reports them with the
+      // right
+      // reason — capped on noise, but never silently dropped or mislabeled as un-anchorable.
+      if (posted >= maxComments) {
+        capSkipped.add(finding);
+        continue;
+      }
+      if (postFindingComment(target, finding, i + 1, lineResolver)) {
         posted++;
       } else {
         unanchored.add(finding);
       }
     }
-    return new InlineCommentResult(posted, List.copyOf(unanchored));
+    return new InlineCommentResult(posted, List.copyOf(unanchored), List.copyOf(capSkipped));
   }
 
   /** PR coordinates shared by every inline comment of one review. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2780,10 +2780,56 @@ class ReviewOrchestratorTest {
       verify(reviewClient, times(1))
           .createPullRequestComment(
               anyString(), anyString(), anyString(), anyString(), anyInt(), any());
-      // The over-cap finding is not posted inline, but it's returned as unanchored so the review
-      // body still reports it — capped on inline noise, never silently dropped.
-      assertEquals(1, inline.unanchored().size());
-      assertEquals("Two", inline.unanchored().get(0).title());
+      // The over-cap finding is not posted inline, but it's returned as capSkipped so the review
+      // body still reports it with the right reason — capped on inline noise, never silently
+      // dropped
+      // or mislabeled as un-anchorable.
+      assertTrue(inline.unanchored().isEmpty());
+      assertEquals(1, inline.capSkipped().size());
+      assertEquals("Two", inline.capSkipped().get(0).title());
+    }
+
+    @Test
+    void shouldDiscloseCapSkippedFindingsInReviewBodyWithCapReasonNotAnchoringReason() {
+      when(reviewConfig.maxReviewComments()).thenReturn(1);
+      var first = new Finding(RiskLevel.MEDIUM, "src/A.java", 10, "One", "desc one", null, null);
+      var second = new Finding(RiskLevel.HIGH, "src/B.java", 20, "Two", "desc two", null, null);
+      var result =
+          new ReviewResult(
+              List.of(first, second),
+              0,
+              0,
+              2,
+              0,
+              RiskLevel.HIGH,
+              ReviewState.REQUEST_CHANGES,
+              false,
+              "",
+              List.of(),
+              List.of(),
+              0);
+      var resolver =
+          new DiffLineResolver(
+              Map.of(
+                  "src/A.java", fileDiffWithLine("src/A.java", 10).patch(),
+                  "src/B.java", fileDiffWithLine("src/B.java", 20).patch()));
+      when(suggestionFormatter.formatReviewComment(any(), eq(true), anyInt())).thenReturn("body");
+
+      reviewPublisher.postReview("Bearer tok", "owner", "repo", 7, "sha", result, resolver);
+
+      verify(reviewClient)
+          .createReview(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(
+                  req ->
+                      req.body().contains("comment cap was reached")
+                          && req.body().contains("Two")
+                          && req.body().contains("desc two")
+                          && !req.body().contains("could not be anchored")));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

When some findings anchor inline but others are skipped because `maxReviewComments` was reached, the review body still reported those cap-skipped findings as "could not be anchored to the current diff." They were never tried for anchoring, so the message was misleading and could send maintainers toward the wrong fix (force-push / line mapping) instead of raising the comment cap or re-running `/review`.

This PR splits `InlineCommentResult` into `unanchored` (line outside the diff or GitHub rejected the comment) and `capSkipped` (never attempted because the per-run cap was reached), and uses distinct review-body wording for each case. This closes the #12 item deferred from the v0.3.0 release-gate PR (#285).

## Related Issues

N/A — follow-up to the v0.3.0 release-readiness review (#285, deferred item #12).

## How Has This Been Tested?

- [x] Unit tests

- `ReviewOrchestratorTest$PostInlineComments.shouldRespectMaxReviewCommentsLimit` — over-cap finding is returned as `capSkipped`, not `unanchored`.
- `ReviewOrchestratorTest$PostInlineComments.shouldDiscloseCapSkippedFindingsInReviewBodyWithCapReasonNotAnchoringReason` — review body mentions the comment cap, not anchoring failure.
- Existing unanchored-finding review-body tests still pass.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (no CHANGELOG — v0.3.0-era review path)
- [x] My changes generate no new warnings or errors

## Additional Notes

No CHANGELOG entry — this is a wording/labeling fix within v0.3.0-introduced review paths, same rationale as #285.