### PR TITLE
fix(review): resolve SonarCloud findings and close codecov patch gap

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
@@ -109,9 +109,10 @@ public interface GitHubCheckRunClient {
 
   /**
    * All check runs for {@code ref}, paging through {@link #getCheckRuns} (full page → fetch the
-   * next, short page → stop) and bounded by {@link #CI_MAX_PAGES}. Returns {@code null} if a page
-   * response body is {@code null} — the "could not read" signal callers need to distinguish from
-   * "no checks" (GitHub returns an empty list, never null, past the last page).
+   * next, short page → stop) and bounded by {@link #CI_MAX_PAGES}. Throws if a page response body
+   * is {@code null} — the "could not read" signal callers need to distinguish from "no checks"
+   * (GitHub returns an empty list, never null, past the last page) — so the caller's existing
+   * exception handling reports it as unreadable.
    */
   default List<CheckRunsResponse.CheckRun> getAllCheckRuns(
       String auth, String accept, String owner, String repo, String ref) {
@@ -119,7 +120,7 @@ public interface GitHubCheckRunClient {
     for (int page = 1; page <= CI_MAX_PAGES; page++) {
       var resp = getCheckRuns(auth, accept, owner, repo, ref, CI_PER_PAGE, page);
       if (resp == null) {
-        return null;
+        throw new IllegalStateException("Null check runs response for " + ref + " page " + page);
       }
       var batch = resp.checkRuns();
       all.addAll(batch);
@@ -132,7 +133,7 @@ public interface GitHubCheckRunClient {
 
   /**
    * All commit-status details for {@code ref}, paging through {@link #getCombinedStatus} the same
-   * way as {@link #getAllCheckRuns} and with the same {@code null}-means-unreadable contract.
+   * way as {@link #getAllCheckRuns} and with the same null-body-throws-unreadable contract.
    */
   default List<CombinedStatus.StatusDetail> getAllCombinedStatus(
       String auth, String accept, String owner, String repo, String ref) {
@@ -140,7 +141,8 @@ public interface GitHubCheckRunClient {
     for (int page = 1; page <= CI_MAX_PAGES; page++) {
       var resp = getCombinedStatus(auth, accept, owner, repo, ref, CI_PER_PAGE, page);
       if (resp == null) {
-        return null;
+        throw new IllegalStateException(
+            "Null combined status response for " + ref + " page " + page);
       }
       var batch = resp.statuses();
       all.addAll(batch);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGenerator.java
@@ -111,7 +111,7 @@ public class ChangelogEntryGenerator extends AbstractPrSuggestionGenerator {
    * reply collapsing to {@code NONE} counts; a real entry that merely mentions the word does not.
    */
   private static boolean isNoneVerdict(String entry) {
-    String core = entry.replaceAll("^[\\s`*_>#-]+", "").replaceAll("[\\s`*_.!]+$", "");
+    String core = entry.replaceAll("^[\\s`*_>#-]+", "").replaceAll("[\\s`*_.!]++$", "");
     return NONE.equalsIgnoreCase(core);
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluator.java
@@ -180,16 +180,17 @@ public class CiStatusEvaluator {
     // and the Commit Status API is not listed twice.
     var offendingNames = new HashSet<String>();
 
+    var tracker = new OffendingTracker(requiredContexts, seen, offendingNames, offending);
     var checkRunsReadable =
         collectReadable(
             () -> checkRunClient.getAllCheckRuns(auth, ACCEPT, owner, repo, commitSha),
-            run -> addOffendingCheckRun(run, requiredContexts, seen, offendingNames, offending),
+            run -> addOffendingCheckRun(run, tracker),
             "check runs for commit " + commitSha);
 
     var statusReadable =
         collectReadable(
             () -> checkRunClient.getAllCombinedStatus(auth, ACCEPT, owner, repo, commitSha),
-            status -> addOffendingStatus(status, requiredContexts, seen, offendingNames, offending),
+            status -> addOffendingStatus(status, tracker),
             "combined status for commit " + commitSha);
 
     addMissingRequiredChecks(requiredContexts, seen, offending);
@@ -207,18 +208,14 @@ public class CiStatusEvaluator {
 
   /**
    * Applies {@code consume} to every row from {@code fetchAll} (the client's paging helper) and
-   * reports whether the fetch was actually readable. Returns {@code false} when the call threw or
-   * came back {@code null} — the client's "could not read" signal — so the caller can tell "no
-   * checks" from "could not read" (GitHub returns an empty list, never null, when there are none).
+   * reports whether the fetch was actually readable. Returns {@code false} when the call throws —
+   * including the client's null-body-means-unreadable signal — so the caller can tell "no checks"
+   * from "could not read" (GitHub returns an empty list, never null, when there are none).
    */
   private <T> boolean collectReadable(
       Supplier<List<T>> fetchAll, Consumer<T> consume, String what) {
     try {
-      var all = fetchAll.get();
-      if (all == null) {
-        return false;
-      }
-      all.forEach(consume);
+      fetchAll.get().forEach(consume);
       return true;
     } catch (Exception e) {
       Log.warnf(e, "Failed to fetch %s", what);
@@ -226,40 +223,38 @@ public class CiStatusEvaluator {
     }
   }
 
-  private void addOffendingCheckRun(
-      GitHubCheckRunClient.CheckRunsResponse.CheckRun run,
+  /**
+   * Mutable state threaded through one {@link #evaluateCiChecks} call as both CI sources are
+   * walked: the required contexts to gate against, the contexts seen in any state (so the
+   * missing-check pass does not re-flag them), the names already recorded as offending (deduped
+   * across the Check Runs and Commit Status APIs), and the offending list itself.
+   */
+  private record OffendingTracker(
       List<String> requiredContexts,
       Set<String> seen,
       Set<String> offendingNames,
-      List<ReviewResult.CiCheck> offending) {
+      List<ReviewResult.CiCheck> offending) {}
+
+  private void addOffendingCheckRun(
+      GitHubCheckRunClient.CheckRunsResponse.CheckRun run, OffendingTracker tracker) {
     addOffending(
         run.name(),
         isThrillhouseBotCheck(run.name(), run.app()),
         classifyCheckRun(run.status(), run.conclusion()),
         "check-run",
         run.conclusion(),
-        requiredContexts,
-        seen,
-        offendingNames,
-        offending);
+        tracker);
   }
 
   private void addOffendingStatus(
-      GitHubCheckRunClient.CombinedStatus.StatusDetail status,
-      List<String> requiredContexts,
-      Set<String> seen,
-      Set<String> offendingNames,
-      List<ReviewResult.CiCheck> offending) {
+      GitHubCheckRunClient.CombinedStatus.StatusDetail status, OffendingTracker tracker) {
     addOffending(
         status.context(),
         isThrillhouseBotCheck(status.context(), null),
         classifyStatus(status.state()),
         "status",
         status.state(),
-        requiredContexts,
-        seen,
-        offendingNames,
-        offending);
+        tracker);
   }
 
   /**
@@ -274,16 +269,13 @@ public class CiStatusEvaluator {
       String ciStatus,
       String type,
       String rawConclusion,
-      List<String> requiredContexts,
-      Set<String> seen,
-      Set<String> offendingNames,
-      List<ReviewResult.CiCheck> offending) {
-    if (isBotCheck || isNotRequired(name, requiredContexts)) {
+      OffendingTracker tracker) {
+    if (isBotCheck || isNotRequired(name, tracker.requiredContexts())) {
       return;
     }
-    seen.add(name);
-    if (!CI_SUCCESS.equals(ciStatus) && offendingNames.add(name)) {
-      offending.add(new ReviewResult.CiCheck(name, type, ciStatus, rawConclusion));
+    tracker.seen().add(name);
+    if (!CI_SUCCESS.equals(ciStatus) && tracker.offendingNames().add(name)) {
+      tracker.offending().add(new ReviewResult.CiCheck(name, type, ciStatus, rawConclusion));
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
@@ -48,6 +48,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 public class DocGenerationService {
 
   private static final String ACCEPT = "application/vnd.github+json";
+  private static final String COMMAND = "/add-docs";
 
   static final String NO_PR_DETAILS =
       "📝 ThrillhouseBot could not load this pull request to generate documentation. "
@@ -115,15 +116,14 @@ public class DocGenerationService {
       var auth = authClient.getAuthHeader(task.installationId());
       var pr =
           SoftLoaders.pullRequest(
-              prClient, auth, task.owner(), task.repo(), task.prNumber(), "/add-docs");
+              prClient, auth, task.owner(), task.repo(), task.prNumber(), COMMAND);
       if (pr == null || pr.head() == null || isBlank(pr.head().sha())) {
         postComment(auth, task, NO_PR_DETAILS);
         return;
       }
 
       var files =
-          SoftLoaders.files(
-              prClient, auth, task.owner(), task.repo(), task.prNumber(), "/add-docs");
+          SoftLoaders.files(prClient, auth, task.owner(), task.repo(), task.prNumber(), COMMAND);
       var reviewable = diffFormatter.reviewableFiles(files);
       if (reviewable.isEmpty()) {
         postComment(auth, task, NO_FILES);
@@ -181,7 +181,7 @@ public class DocGenerationService {
             task.repo(),
             task.defaultBranch(),
             task.installationId(),
-            "/add-docs");
+            COMMAND);
     String instructions = buildInstructionsSection(task);
 
     String raw =
@@ -232,14 +232,13 @@ public class DocGenerationService {
         break;
       }
       var doc = docs.get(i);
-      if (!doc.isPostable()) {
-        continue;
-      }
-      switch (postDoc(auth, task, commitSha, doc, lineResolver)) {
-        case SUGGESTION -> suggestions++;
-        case NOTE -> notes++;
-        case SKIPPED -> {
-          // Not posted — nothing to count.
+      if (doc.isPostable()) {
+        switch (postDoc(auth, task, commitSha, doc, lineResolver)) {
+          case SUGGESTION -> suggestions++;
+          case NOTE -> notes++;
+          case SKIPPED -> {
+            // Not posted — nothing to count.
+          }
         }
       }
     }
@@ -414,7 +413,7 @@ public class DocGenerationService {
             task.repo(),
             task.defaultBranch(),
             task.installationId(),
-            "/add-docs");
+            COMMAND);
     return PromptSections.instructionsSection(instructions, INSTRUCTIONS_GUIDANCE);
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrDescriptionGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrDescriptionGenerator.java
@@ -41,8 +41,13 @@ public class PrDescriptionGenerator extends AbstractPrSuggestionGenerator {
   static final String HEADER = "## 🤖 ThrillhouseBot — suggested title & description\n\n";
 
   static final String FOOTER =
-      "\n\n---\n*Suggestion only — your PR was not modified. Copy whatever is useful into the "
-          + "title and description. Re-run with `/describe`.*\n";
+      """
+
+
+      ---
+      *Suggestion only — your PR was not modified. Copy whatever is useful into the title and \
+      description. Re-run with `/describe`.*
+      """;
 
   private final PrDescribeAssistant describeAssistant;
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -207,8 +207,11 @@ public class PrSummaryGenerator {
     if (result.ciUnreadable()) {
       sb.append("### ⚠️ CI Status Unavailable\n");
       sb.append(
-          "The CI status could not be read from GitHub, so approval is held until it can be"
-              + " confirmed.\n\n");
+          """
+          The CI status could not be read from GitHub, so approval is held until it can be \
+          confirmed.
+
+          """);
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -212,9 +212,7 @@ public class ReviewOrchestrator {
 
       CiStatusEvaluator.CiEvaluation ciEvaluation = ciFuture.join();
 
-      var result =
-          verdictBuilder.build(
-              ctx, aiResponse, ciEvaluation.offendingChecks(), ciEvaluation.unreadable());
+      var result = verdictBuilder.build(ctx, aiResponse, ciEvaluation);
 
       String conclusion = VerdictBuilder.conclusionForResult(result);
       String checkTitle = VerdictBuilder.checkTitleForResult(result);
@@ -222,16 +220,7 @@ public class ReviewOrchestrator {
       // The summary comment is first-review enrichment, not the review itself: a transient failure
       // posting it must not abort before postReview and surface a hard FAILED check for a review
       // that would otherwise post. Keep it best-effort; the review below is the critical step.
-      try {
-        reviewPublisher.publishSummary(auth, req.owner(), req.repo(), req.prNumber(), result);
-      } catch (RuntimeException e) {
-        Log.warnf(
-            e,
-            "Failed to post the PR summary comment for %s/%s #%d — continuing to post the review",
-            req.owner(),
-            req.repo(),
-            req.prNumber());
-      }
+      publishSummaryBestEffort(auth, req, result);
       reviewPublisher.dismissPendingBotReviews(
           auth, req.owner(), req.repo(), req.prNumber(), priorReviews);
       reviewPublisher.postReview(
@@ -302,6 +291,24 @@ public class ReviewOrchestrator {
       } else {
         handleReviewFailure(auth, req, session, checkRunId, e);
       }
+    }
+  }
+
+  /**
+   * Posts the PR summary comment, swallowing any failure: it is first-review enrichment, not the
+   * review itself, so a transient failure here must not abort before {@code postReview} and surface
+   * a hard FAILED check for a review that would otherwise post.
+   */
+  private void publishSummaryBestEffort(String auth, ReviewRequest req, ReviewResult result) {
+    try {
+      reviewPublisher.publishSummary(auth, req.owner(), req.repo(), req.prNumber(), result);
+    } catch (RuntimeException e) {
+      Log.warnf(
+          e,
+          "Failed to post the PR summary comment for %s/%s #%d — continuing to post the review",
+          req.owner(),
+          req.repo(),
+          req.prNumber());
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -199,11 +199,6 @@ public class ReviewPublisher {
     }
   }
 
-  /**
-   * A review-body list of findings, used when none could be anchored as inline comments (their
-   * lines fell outside the current diff). It keeps the findings visible on a follow-up review,
-   * which posts no summary comment — without it the findings would surface only as a red check run.
-   */
   /** Review-body sections for findings not posted inline — un-anchored and/or cap-skipped. */
   private static List<String> skippedFindingsBodyParts(InlineCommentResult inline) {
     var parts = new ArrayList<String>();
@@ -230,8 +225,11 @@ public class ReviewPublisher {
     sb.append("ThrillhouseBot found ")
         .append(findings.size())
         .append(
-            " issue(s) not posted inline because the per-run comment cap was reached — re-run"
-                + " `/review` or raise the comment cap:\n\n");
+            """
+             issue(s) not posted inline because the per-run comment cap was reached — re-run \
+            `/review` or raise the comment cap:
+
+            """);
     appendFindingList(sb, findings);
     return sb.toString();
   }
@@ -535,7 +533,9 @@ public class ReviewPublisher {
     try {
       reviewClient.createReview(auth, ACCEPT, owner, repo, prNumber, req);
     } catch (RuntimeException e) {
-      if (req.comments() == null || req.comments().isEmpty()) {
+      // CreateReviewRequest's compact constructor normalizes a null comments list to List.of(), so
+      // only the isEmpty() check is ever reachable here.
+      if (req.comments().isEmpty()) {
         throw new ReviewPostException(
             "GitHub review rejected for " + owner + "/" + repo + " #" + prNumber, e);
       }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatter.java
@@ -22,6 +22,8 @@ import java.util.Locale;
 @ApplicationScoped
 public class SuggestionFormatter {
 
+  private static final String CODE_FENCE_CLOSE = "\n```\n";
+
   /**
    * Wraps suggestion_old and suggestion_new in a GitHub suggestion block.
    *
@@ -30,7 +32,7 @@ public class SuggestionFormatter {
    */
   public String formatSuggestionBlock(String suggestionOld, String suggestionNew) {
     if (suggestionOld == null || suggestionNew == null) return "";
-    return "\n```suggestion\n" + suggestionNew.stripTrailing() + "\n```\n";
+    return "\n```suggestion\n" + suggestionNew.stripTrailing() + CODE_FENCE_CLOSE;
   }
 
   /**
@@ -70,9 +72,9 @@ public class SuggestionFormatter {
     }
     sb.append("**\n");
     sb.append("This symbol is missing documentation. Suggested:\n");
-    sb.append("\n```\n")
+    sb.append(CODE_FENCE_CLOSE)
         .append(suggestionNew == null ? "" : suggestionNew.stripTrailing())
-        .append("\n```\n");
+        .append(CODE_FENCE_CLOSE);
     return sb.toString();
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -56,8 +56,7 @@ public class VerdictBuilder {
   ReviewResult build(
       ReviewContextLoader.ReviewContext ctx,
       ReviewResponse aiResponse,
-      List<ReviewResult.CiCheck> offendingCiChecks,
-      boolean ciUnreadable) {
+      CiStatusEvaluator.CiEvaluation ciEvaluation) {
     var diffStats = DiffStats.fromFiles(ctx.reviewableFiles(), ctx.omittedFiles());
     var changedFiles = toChangedFiles(ctx.reviewableFiles());
     var unresolvedPrevious =
@@ -78,8 +77,7 @@ public class VerdictBuilder {
         diffStats,
         changedFiles,
         unresolvedPrevious,
-        offendingCiChecks,
-        ciUnreadable,
+        ciEvaluation,
         backstopUnresolved);
   }
 
@@ -191,9 +189,10 @@ public class VerdictBuilder {
       DiffStats diffStats,
       List<PrSummaryGenerator.ChangedFile> changedFiles,
       List<Finding> unresolvedPrevious,
-      List<ReviewResult.CiCheck> offendingCiChecks,
-      boolean ciUnreadable,
+      CiStatusEvaluator.CiEvaluation ciEvaluation,
       List<ReviewResult.PreviousFindingStatus> backstopUnresolved) {
+    var offendingCiChecks = ciEvaluation.offendingChecks();
+    var ciUnreadable = ciEvaluation.unreadable();
     var tally = tallyFindings(aiResponse);
 
     // The review may only approve when nothing is outstanding: new findings AND previous

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/BotIdentityProducerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/BotIdentityProducerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class BotIdentityProducerTest {
+
+  @Test
+  void shouldProduceIdentityFromConfiguredBotLogins() {
+    var config = mock(ThrillhouseConfig.class);
+    var github = mock(ThrillhouseConfig.GitHubConfig.class);
+    when(config.github()).thenReturn(github);
+    when(github.botLogins()).thenReturn(List.of("my-app[bot]"));
+
+    var identity = new BotIdentityProducer().botIdentity(config);
+
+    assertEquals(BotIdentity.from(List.of("my-app[bot]")), identity);
+  }
+
+  @Test
+  void shouldFallBackToDefaultLoginsWhenNoneConfigured() {
+    var config = mock(ThrillhouseConfig.class);
+    var github = mock(ThrillhouseConfig.GitHubConfig.class);
+    when(config.github()).thenReturn(github);
+    when(github.botLogins()).thenReturn(List.of());
+
+    var identity = new BotIdentityProducer().botIdentity(config);
+
+    assertEquals(BotIdentity.from(BotIdentity.DEFAULT_LOGINS), identity);
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -248,8 +248,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertNotNull(result);
@@ -272,8 +271,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(120, 4000, 4000, 7),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       // The verdict is held back from APPROVE — a partial review must not gate-approve the PR...
@@ -299,8 +297,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(120, 4000, 4000, 7),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       var summary = result.summaryMarkdown();
@@ -321,8 +318,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(120, 4000, 4000, 7),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
       assertEquals(ReviewState.COMMENT, result.reviewState());
 
@@ -439,8 +435,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertNotNull(result);
@@ -473,8 +468,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertEquals(1, result.criticalCount());
@@ -505,8 +499,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertEquals(1, result.totalFindings());
@@ -539,8 +532,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertEquals(1, result.highCount());
@@ -571,8 +563,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertEquals(1, result.mediumCount());
@@ -603,8 +594,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertEquals(1, result.lowCount());
@@ -632,8 +622,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertEquals(4, result.totalFindings());
@@ -674,8 +663,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertEquals(2, result.previousStatuses().size());
@@ -702,8 +690,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(4, 120, 45),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertTrue(result.summaryMarkdown().contains("Test summary content"));
@@ -723,8 +710,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertEquals("Clean summary with celebration", result.summaryMarkdown());
@@ -754,8 +740,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertEquals(1, result.lowCount());
@@ -813,10 +798,9 @@ class ReviewOrchestratorTest {
 
     @Test
     void checkSummaryForResultShouldDiscloseUnreadableCiAlongsideAnOffendingCheck() {
-      // An offending check AND an unreadable CI source are independent holds that can both apply;
-      // the
-      // caption must disclose both, not let the offending branch suppress the unreadable note — the
-      // PR review comment already discloses both, so the check-run caption must agree.
+      // An offending check and an unreadable CI source are independent holds that can both apply.
+      // The caption must disclose both, not let the offending branch suppress the unreadable note
+      // — the PR review comment already discloses both, so the check-run caption must agree.
       var checks = List.of(new ReviewResult.CiCheck("build", "check-run", "failing", null));
       var result =
           new ReviewResult(
@@ -897,8 +881,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(1, 1, 0),
               List.of(),
               List.of(),
-              List.of(),
-              true, // ciUnreadable
+              new CiStatusEvaluator.CiEvaluation(List.of(), true),
               List.of());
 
       assertEquals(ReviewState.COMMENT, result.reviewState());
@@ -3654,8 +3637,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               unresolvedPrevious,
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertEquals(ReviewState.COMMENT, result.reviewState());
@@ -3680,8 +3662,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               unresolvedPrevious,
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertEquals(ReviewState.REQUEST_CHANGES, result.reviewState());
@@ -3700,8 +3681,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertEquals(ReviewState.COMMENT, result.reviewState());
@@ -3722,8 +3702,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              List.of(),
-              false,
+              new CiStatusEvaluator.CiEvaluation(List.of(), false),
               List.of());
 
       assertEquals(ReviewState.APPROVE, result.reviewState());
@@ -3854,8 +3833,7 @@ class ReviewOrchestratorTest {
           new VerdictBuilder.DiffStats(0, 0, 0),
           List.of(), // changedFiles
           List.of(),
-          List.of(),
-          false, // ciUnreadable
+          new CiStatusEvaluator.CiEvaluation(List.of(), false),
           backstop);
     }
 
@@ -4691,8 +4669,7 @@ class ReviewOrchestratorTest {
               new VerdictBuilder.DiffStats(0, 0, 0),
               List.of(),
               List.of(),
-              offending,
-              false,
+              new CiStatusEvaluator.CiEvaluation(offending, false),
               List.of());
 
       assertEquals(ReviewState.COMMENT, result.reviewState());


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

PR #290 (the v0.3.0 release branch) has 14 unresolved SonarCloud code-smell issues (no bugs/vulnerabilities/hotspots — the quality gate is green because they fall outside the new-code metrics) and a `codecov/patch` check that passes on margin (99.76%, 3 uncovered lines) rather than cleanly. This closes both out.

### Sonar (14 issues)

| File | Rule | Fix |
|---|---|---|
| `GitHubCheckRunClient` | S1168 (null collection) | `getAllCheckRuns`/`getAllCombinedStatus` throw on an unreadable page instead of returning `null`, preserving the unreadable-vs-empty contract `CiStatusEvaluator` depends on |
| `ChangelogEntryGenerator` | S8786 (regex perf) | Possessive quantifier on the trailing-trim regex — same match, no backtrack-and-fail scan |
| `CiStatusEvaluator` | S107 (9 params) | Bundled the 4 CI-evaluation accumulator params into an `OffendingTracker` record — `addOffending` drops to 6 params |
| `DocGenerationService` | S1192 + S135 | Extracted the `"/add-docs"` literal into a constant; dropped the loop's redundant `continue` so only the cap `break` remains |
| `PrDescriptionGenerator`, `PrSummaryGenerator`, `ReviewPublisher` | S6126 (text block) | Converted string concatenations to text blocks — verified byte-for-byte identical to the originals before/after |
| `ReviewOrchestrator` | S1141 (nested try) | Extracted the `publishSummary` try/catch into `publishSummaryBestEffort` |
| `ReviewPublisher` | S8491 (dangling Javadoc) | Removed a stale orphaned Javadoc block left over from #289 |
| `SuggestionFormatter` | S1192 (dup literal) | Extracted the duplicated `` "\n```\n" `` fence into a constant |
| `VerdictBuilder` | S107 (8 params) | Merged `offendingCiChecks`/`ciUnreadable` into the existing `CiStatusEvaluator.CiEvaluation` record across `build()`/`buildResult()` — drops to 7 params (rippled through ~24 call sites in `ReviewOrchestratorTest`) |
| `ReviewOrchestratorTest` | S125 (commented-out code) | False positive — reworded a prose comment Sonar's heuristic misread as dead code; it was never actual code |

### Codecov (3 uncovered lines → 100%)

- `ReviewPublisher.createReviewWithFallback`: dropped the unreachable `req.comments() == null` check — `CreateReviewRequest`'s compact constructor already normalizes `null` to `List.of()`, so only `isEmpty()` was ever reachable. This was the partial-branch gap.
- Added `BotIdentityProducerTest` — the CDI producer had no direct unit test (mirrors the existing `ReviewExecutorProducerTest`/`HttpClientProducerTest` pattern).

No behavior change intended anywhere in this PR.

## Related Issues

N/A — internal code-quality/test-coverage cleanup ahead of the v0.3.0 release, no CHANGELOG entry (no observable change in bot behavior).

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- `./mvnw clean test jacoco:report` — 1098/1098 tests pass
- `./mvnw spotless:check` — clean
- `./mvnw spotbugs:check` — clean
- Reproduced `codecov/patch` locally (merge-base diff + fresh JaCoCo, partials counted as missing): before this PR, 99.76% (1253 hits / 2 misses / 1 partial, matching Codecov's API exactly); after, **100%** (0 uncovered)
- Each text-block conversion verified with a throwaway `jshell`/`java` snippet asserting `oldLiteral.equals(newTextBlock)` before landing