### PR TITLE
docs(review): document the possessive-quantifier trim + broaden NONE-sentinel test coverage

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGenerator.java
@@ -109,6 +109,10 @@ public class ChangelogEntryGenerator extends AbstractPrSuggestionGenerator {
    * markdown emphasis/quote markers and trailing punctuation (e.g. {@code **NONE**}, {@code
    * NONE.}), so a decorated decline is never posted as a literal changelog entry. Only the entire
    * reply collapsing to {@code NONE} counts; a real entry that merely mentions the word does not.
+   *
+   * <p>The trailing trim uses a possessive quantifier ({@code ++}) so a mismatch fails at the first
+   * non-matching character instead of backtracking one character at a time back to the anchor —
+   * same match result, no backtrack-and-fail scan.
    */
   private static boolean isNoneVerdict(String entry) {
     String core = entry.replaceAll("^[\\s`*_>#-]+", "").replaceAll("[\\s`*_.!]++$", "");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGeneratorTest.java
@@ -109,7 +109,20 @@ class ChangelogEntryGeneratorTest {
   // markers and trailing punctuation) or returned a blank answer — post nothing rather than noise.
   // One parameterized test covers each "nothing usable".
   @ParameterizedTest
-  @ValueSource(strings = {"NONE", " none ", "**NONE**", "`NONE`", "NONE.", "> NONE", "   "})
+  @ValueSource(
+      strings = {
+        "NONE",
+        " none ",
+        "**NONE**",
+        "`NONE`",
+        "NONE.",
+        "> NONE",
+        "   ",
+        "_NONE_",
+        "#NONE!",
+        "\tNONE\t",
+        "\nNONE\n"
+      })
   void returnsNullWhenAssistantProducesNothingUsable(String draft) {
     diffReturns("## Overview\ndiff");
     when(prClient.getPullRequest(eq(AUTH), any(), eq("owner"), eq("repo"), eq(7)))


### PR DESCRIPTION
## What type of PR is this?

- [x] 📝 Documentation
- [x] ✅ Test

## Description

Correction to my own earlier description (caught by ThrillhouseBot's review and by @devops-thiago): this PR does **not** revert anything that's actually in `release/v0.3.0`.

What happened: while working PR #291, I drafted a hand-rolled, regex-free rewrite of `ChangelogEntryGenerator.isNoneVerdict` to try to satisfy a SonarCloud finding (`S8786`) — but that rewrite only ever existed as an uncommitted local edit. I reverted it back to the original regex (with its existing possessive quantifier) before committing, so the commit that actually got squash-merged into `release/v0.3.0` already had the simple, correct, fully-covered version. There was never a coverage regression on the merged branch to fix.

This PR is just the leftover, genuinely additive part of that detour:
- A Javadoc paragraph explaining *why* the trailing trim uses a possessive quantifier (`++`) — no functional change, the regex itself is identical to what's already on `release/v0.3.0`.
- A broader `@ValueSource` for the `NONE`-sentinel parameterized test (adds underscore, `!`, tab, and newline decoration/whitespace combinations), for extra coverage margin on a method that was already fully covered.

SonarCloud's `S8786` finding on this line (possessive quantifiers don't seem to register with this very-new rule) remains open and unresolved by this PR — that's a separate, likely-false-positive issue best dismissed manually in the SonarCloud UI, not something this PR touches.

## Related Issues

Follow-up to #291. No CHANGELOG entry — docs/test only, no behavior change.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- `./mvnw clean test jacoco:report` — 1102/1102 tests pass
- `./mvnw spotless:check` / `spotbugs:check` — both clean