### PR TITLE
fix(review): quote Mermaid node labels so the control-flow diagram renders

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -291,7 +291,12 @@ public final class PrReviewPrompts {
             reorders interactions between components, or introduces a new multi-step path),
             populate summary.walkthrough_diagram with a single Mermaid diagram of the AFFECTED
             control flow:
-            - Use a `flowchart TD` or a `sequenceDiagram` — nothing else.
+            - Use a `flowchart TD` or a `sequenceDiagram` — nothing else. Prefer simple rectangle
+              and rhombus nodes; avoid exotic shapes.
+            - ALWAYS wrap node label text in double quotes, whatever the shape — `A["call foo()"]`,
+              `B{"ready?"}`, `C(["Fetch & merge"])`. GitHub's Mermaid parser rejects unquoted
+              parentheses, ampersands, colons, slashes and the like inside a label and then fails to
+              render the whole diagram; write a literal double quote as `#quot;`.
             - Keep it small: at most ~12 nodes / participants, modelling only the changed path,
               not the whole system.
             - Emit ONLY the raw Mermaid source: no ``` fences, no prose, no Markdown around it.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -103,4 +103,19 @@ class PrReviewPromptsContentTest {
         "both places verbatim from the provided material",
         "the guard's body must stay attached to its header, not dangle as a fragment");
   }
+
+  @Test
+  void diagramRequestRequiresQuotedNodeLabels() {
+    // GitHub's Mermaid parser rejects unquoted (), &, : etc. inside a node label and fails to
+    // render
+    // the whole diagram. Quoting at generation time is the guard (server-side rewriting can't
+    // disambiguate Mermaid's shape grammar safely), so pin the instruction and its escape.
+    String req = PrReviewPrompts.DIAGRAM_REQUEST;
+    assertContains(
+        req,
+        "wrap node label text in double quotes",
+        "the diagram prompt must require quoted node labels so GitHub can render them");
+    assertContains(
+        req, "#quot;", "the diagram prompt must give the escape for a literal double quote");
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The opt-in Mermaid control-flow diagram (#181) failed to render on GitHub. GitHub's Mermaid parser rejects **unquoted special characters** — `(`, `)`, `&`, `:`, `/` — inside node labels, so a diagram with a label like `A[Call foo()]` or `E{Existing client?}` renders as:

```
Unable to render rich display
Parse error on line 2: ...ateCollectionManager()] --> B[createBase
Expecting 'SQE', 'PS', ... got 'PS'
```

The whole diagram is dropped. Found while dogfooding a review.

**Fix (prompt-only):** `PrReviewPrompts.DIAGRAM_REQUEST` now instructs the model to wrap every node label in double quotes for **any** shape (`A["call foo()"]`, `B{"ready?"}`, `C(["Fetch & merge"])`), escaping a literal quote as `#quot;`. Quoting happens at generation time, where the model knows each node's shape.

### Why not a server-side safety net?

I first added a defensive server-side quoter (rewrite `[...]`/`{...}` labels before posting). **Two rounds of adversarial review — verified against the real Mermaid 11.16.0 parser — proved a regex cannot rewrite Mermaid labels safely:**

1. It corrupted **cylinder `[(…)]`, parallelogram `[/…/]`, and trapezoid `[/…\]`** nodes into rectangles (even clean ones), and a trailing `\` produced `["…\"]` — *creating* the very parse error we're fixing.
2. After guarding those, it *still* injected quotes into **`-- … -->` edge-label text** (`A -- opt{x:y} --> B` → `opt{"x:y"}`, which the parser rejects), because a regex can't distinguish a node definition from edge-label text without parsing the grammar.

A defensive layer that corrupts valid diagrams is worse than none, so it was dropped. The correct layer is the prompt.

## Related Issues

Relates to #181 (the diagram feature this fixes before v0.3.0 ships). Surfaced via dogfooding; no separate tracked issue.

## How Has This Been Tested?

- [x] Unit tests

`PrReviewPromptsContentTest.diagramRequestRequiresQuotedNodeLabels` pins the quoting instruction and the `#quot;` escape so a future prompt edit can't silently drop it. Full suite green (**1403 tests**); Spotless + SpotBugs clean. The corrected (quoted) Mermaid renders on GitHub; the original does not.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

- No CHANGELOG entry: this fixes a bug in an unreleased v0.3.0 feature (#181) before it ships, so the existing "Added" entry stands.
- The abandoned server-side approach and the adversarial-review evidence (shape corruption + edge-label corruption) are summarized above so reviewers understand why the fix is intentionally prompt-only.
