### PR TITLE
fix(release): bump UBI9 micro base to 9.8, ignore unfixable libacl/libattr CVEs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,8 @@
-# libcap in quay.io/quarkus/ubi9-quarkus-micro-image@2.0-2026-06-07 (el9_7).
-# Fixed in 2.48-10.el9_8.1; micro base has no package manager to apply the update.
-# The :*-distroless image variant scans clean. Remove when the Quarkus UBI base refreshes.
-CVE-2026-4878
+# libacl / libattr in quay.io/quarkus/ubi9-quarkus-micro-image@2.0-2026-06-28 (el9, RHEL 9.8).
+# Symlink-traversal privilege escalation (CVE-2026-54369 / CVE-2026-54371). RHEL has shipped no
+# fixed package for el9 yet — Trivy reports "no fix" on every micro base tag, including the latest;
+# the micro base has no package manager to apply an update, and the :*-distroless image variant
+# scans clean. Remove when RHEL ships fixed libacl/libattr.
+# (The earlier libcap CVE-2026-4878 is dropped: the 9.8 base above no longer ships it.)
+CVE-2026-54369
+CVE-2026-54371

--- a/src/main/docker/Dockerfile.multistage
+++ b/src/main/docker/Dockerfile.multistage
@@ -20,7 +20,7 @@ COPY src /code/src
 RUN ./mvnw package -Pnative -DskipTests
 
 ## Stage 2: Minimal runtime image (includes embedded frontend from Stage 1)
-FROM quay.io/quarkus/ubi9-quarkus-micro-image@sha256:242ca7ff99bef00bec6edbdbeee8407c481c12f2b96c9e17f271ae6f99131db5
+FROM quay.io/quarkus/ubi9-quarkus-micro-image@sha256:7d40f354792f52079213107a50b88a3381da34058b77672925307d9ca377da2e
 WORKDIR /work/
 COPY --from=build /code/target/*-runner /work/application
 RUN chmod 775 /work /work/application \

--- a/src/main/docker/Dockerfile.runtime
+++ b/src/main/docker/Dockerfile.runtime
@@ -2,7 +2,7 @@
 # Expects target/<TARGETARCH>/*-runner from a buildx multi-arch build.
 # Hardened variant: Dockerfile.runtime-distroless. Local dev: Dockerfile.multistage.
 
-FROM quay.io/quarkus/ubi9-quarkus-micro-image@sha256:242ca7ff99bef00bec6edbdbeee8407c481c12f2b96c9e17f271ae6f99131db5
+FROM quay.io/quarkus/ubi9-quarkus-micro-image@sha256:7d40f354792f52079213107a50b88a3381da34058b77672925307d9ca377da2e
 
 ARG TARGETARCH
 WORKDIR /work/


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔒 Security
- [x] 📦 Dependency update

## Description

Unblocks the **v0.3.0** release, which the image security gate correctly halted. Trivy found two new **HIGH** CVEs in the Quarkus UBI9 **micro** base image:

- **CVE-2026-54369** — `libacl` 2.3.1-4.el9 (acl: symlink-traversal privilege escalation)
- **CVE-2026-54371** — `libattr` 2.5.1-3.el9 (attr: symlink-traversal privilege escalation via getfattr)

**A base bump cannot fix these** — RHEL has published no patched `libacl`/`libattr` for el9 yet; Trivy reports `(no fix)` on *every* micro base tag, including the newest. So this PR takes every available improvement and suppresses only the genuinely unfixable:

- **Bumps the micro base** to `2.0-2026-06-28` (RHEL 9.8) in `Dockerfile.runtime` and `Dockerfile.multistage`. The newer base **drops the previously-ignored libcap CVE-2026-4878**, so that `.trivyignore` line is removed.
- **Replaces** the stale libcap entry in `.trivyignore` with the two unfixable libacl/libattr CVEs, documented: micro base has no package manager to patch, RHEL has no fix, and the `:*-distroless` variant scans clean. Marked to remove when RHEL ships a fix.

## Related Issues

Unblocks the v0.3.0 release (relates to release pipeline / #181). No separate issue.

## How Has This Been Tested?

- [x] Manual testing

Verified locally with **Trivy 0.71.2** (same version CI uses):
- New 9.8 base: only these two HIGH CVEs, both `(no fix)`; libcap CVE-2026-4878 **absent**.
- Gate simulation (`--severity CRITICAL,HIGH --exit-code 1`) honoring the updated `.trivyignore`: **exit 0** (passes).
- `:*-distroless` base: **0 CRITICAL/HIGH** (the clean alternative image still publishes).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

- Suppression is limited to CVEs with **no available fix in any base**; the base was bumped to take all fixes that *do* exist (including retiring the libcap ignore). The hardened `:0.3.0-distroless` image scans clean for anyone requiring zero findings.
- After merge, the `v0.3.0` tag is moved to this commit and the release re-run (nothing was published on the first attempt — the gate blocked it).
