### PR TITLE
fix(review): paginate listIssueLabels in PrLabeler.currentLabelKeys (#304)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrLabeler.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrLabeler.java
@@ -293,8 +293,10 @@ public class PrLabeler {
    * Lower-cased names of every label currently on the PR, used to keep additive re-reviews from
    * exceeding max-labels. GitHub paginates issue labels at {@value #LABELS_PER_PAGE} per page, so
    * we walk pages up to {@link #MAX_LABEL_PAGES} — a label beyond page one still counts against the
-   * per-PR budget. Best-effort: if the lookup fails we return an empty set, which simply falls back
-   * to applying the reconciled suggestions for this review.
+   * per-PR budget. Best-effort: on a fetch failure we keep the pages we already read rather than
+   * discarding them — dropping page-one labels when a later page fails would under-count the
+   * current set and let {@link #applyLabels} over-apply past max-labels. If even the first page
+   * fails the set is empty, which falls back to applying this review's reconciled suggestions.
    */
   private Set<String> currentLabelKeys(LabelRequest request) {
     var keys = new HashSet<String>();
@@ -322,16 +324,16 @@ public class PrLabeler {
           }
         }
       }
-      return keys;
     } catch (RuntimeException e) {
       Log.debugf(
           e,
-          "Could not read current labels for %s/%s #%d; applying suggestions without a cap check",
+          "Could not read all current labels for %s/%s #%d; capping against the %d already read",
           request.owner(),
           request.repo(),
-          request.prNumber());
-      return Set.of();
+          request.prNumber(),
+          keys.size());
     }
+    return keys;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrLabeler.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrLabeler.java
@@ -290,29 +290,36 @@ public class PrLabeler {
   }
 
   /**
-   * Lower-cased names of the labels currently on the PR, used to keep additive re-reviews from
-   * exceeding max-labels. Best-effort: if the lookup fails we return an empty set, which simply
-   * falls back to applying the reconciled suggestions for this review.
+   * Lower-cased names of every label currently on the PR, used to keep additive re-reviews from
+   * exceeding max-labels. GitHub paginates issue labels at {@value #LABELS_PER_PAGE} per page, so
+   * we walk pages up to {@link #MAX_LABEL_PAGES} — a label beyond page one still counts against the
+   * per-PR budget. Best-effort: if the lookup fails we return an empty set, which simply falls back
+   * to applying the reconciled suggestions for this review.
    */
   private Set<String> currentLabelKeys(LabelRequest request) {
+    var keys = new HashSet<String>();
     try {
-      var labels =
-          labelClient.listIssueLabels(
-              request.auth(),
-              ACCEPT,
-              request.owner(),
-              request.repo(),
-              request.prNumber(),
-              LABELS_PER_PAGE,
-              1);
-      if (labels == null) {
-        return Set.of();
-      }
-      var keys = new HashSet<String>();
-      for (var label : labels) {
-        var name = label.name();
-        if (name != null && !name.isBlank()) {
-          keys.add(name.strip().toLowerCase(Locale.ROOT));
+      List<GitHubLabelClient.Label> page = null;
+      for (int p = 1;
+          p <= MAX_LABEL_PAGES && (page == null || page.size() == LABELS_PER_PAGE);
+          p++) {
+        page =
+            labelClient.listIssueLabels(
+                request.auth(),
+                ACCEPT,
+                request.owner(),
+                request.repo(),
+                request.prNumber(),
+                LABELS_PER_PAGE,
+                p);
+        if (page == null) {
+          break;
+        }
+        for (var label : page) {
+          var name = label.name();
+          if (name != null && !name.isBlank()) {
+            keys.add(name.strip().toLowerCase(Locale.ROOT));
+          }
         }
       }
       return keys;

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrLabelerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrLabelerTest.java
@@ -373,6 +373,56 @@ class PrLabelerTest {
               anyString(), anyString(), anyString(), anyString(), anyInt(), captor.capture());
       assertEquals(List.of("bug"), captor.getValue().labels());
     }
+
+    @Test
+    void shouldTreatLabelsBeyondTheFirstPageAsAlreadyApplied() {
+      // max is set well above the label count so the budget stays positive — this isolates the
+      // pagination check: the suggestion is skipped only because it is recognised as already on the
+      // PR (page 2), not because the cap was hit. Page one must be full (100) or the walk stops
+      // before requesting page two, so the only label the PR could exceed one page with lives
+      // there.
+      when(labelsConfig.maxLabels()).thenReturn(200);
+      var fullFirstPage = new java.util.ArrayList<GitHubLabelClient.Label>();
+      for (int i = 0; i < 100; i++) {
+        fullFirstPage.add(label("page1-" + i));
+      }
+      when(labelClient.listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), eq(1)))
+          .thenReturn(fullFirstPage);
+      when(labelClient.listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), eq(2)))
+          .thenReturn(List.of(label("page2-only")));
+
+      labeler.applyOrSuggest(request(false, List.of("page2-only"), List.of(label("page2-only"))));
+
+      // A single-page fetch would miss "page2-only" and re-add it; walking to page 2 sees it as
+      // already present, so nothing new is applied.
+      verify(labelClient, never())
+          .addLabels(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+      // Both pages were walked to build the current-label set.
+      verify(labelClient, times(2))
+          .listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt());
+    }
+
+    @Test
+    void shouldStopWalkingCurrentLabelsAtThePageCap() {
+      // Every page of PR labels comes back full, so only the MAX_LABEL_PAGES guard can end the
+      // walk.
+      var fullPage = new java.util.ArrayList<GitHubLabelClient.Label>();
+      for (int i = 0; i < 100; i++) {
+        fullPage.add(label("label-" + i));
+      }
+      when(labelClient.listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+          .thenReturn(fullPage);
+
+      labeler.applyOrSuggest(request(false, List.of("bug"), List.of(label("bug"))));
+
+      verify(labelClient, times(PrLabeler.MAX_LABEL_PAGES))
+          .listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt());
+    }
   }
 
   @Nested

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrLabelerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrLabelerTest.java
@@ -423,6 +423,29 @@ class PrLabelerTest {
           .listIssueLabels(
               anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt());
     }
+
+    @Test
+    void shouldKeepEarlierPageLabelsWhenALaterPageFails() {
+      when(labelsConfig.maxLabels()).thenReturn(3);
+      // Page 1 already fills the budget; a transient failure fetching page 2 must not discard the
+      // page-1 labels, or the current count would collapse to zero and re-open the budget — adding
+      // labels to a PR that already sits well past max. The pages read so far still apply the cap.
+      var fullFirstPage = new java.util.ArrayList<GitHubLabelClient.Label>();
+      for (int i = 0; i < 100; i++) {
+        fullFirstPage.add(label("page1-" + i));
+      }
+      when(labelClient.listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), eq(1)))
+          .thenReturn(fullFirstPage);
+      when(labelClient.listIssueLabels(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), eq(2)))
+          .thenThrow(new RuntimeException("rate limited"));
+
+      labeler.applyOrSuggest(request(false, List.of("docs"), List.of(label("docs"))));
+
+      verify(labelClient, never())
+          .addLabels(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+    }
   }
 
   @Nested


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] ✅ Test

## Description

`PrLabeler.currentLabelKeys` fetched PR labels with `listIssueLabels(..., page=1)` only. GitHub paginates issue/PR labels at 100 per page, so on a PR carrying more than one page of labels the reconciler saw an **incomplete current set**. That let it undercount the per-PR label budget (`max - current.size()`) and re-apply labels that already live beyond page 1 — pushing a PR past `max-labels` over successive re-reviews.

This is the bot's own instance of the single-page-fetch pattern that the v0.2.0 review dimension now flags in *reviewed* code (#166); the bot even flagged it on itself in PR #198 (`discussion_r3447622565`).

**Fix:** `currentLabelKeys` now walks every page up to `MAX_LABEL_PAGES`, mirroring the existing `fetchExistingLabels` page-walk in the same class. Best-effort semantics are unchanged — any fetch failure still returns an empty set and falls back to applying this review's reconciled suggestions. Label-application semantics are otherwise untouched.

## Related Issues

Fixes #304

## How Has This Been Tested?

`./mvnw clean test jacoco:report` — **1405 tests, 0 failures**. `spotless:check` and `spotbugs:check` pass. Added two `PrLabelerTest` cases:
- `shouldTreatLabelsBeyondTheFirstPageAsAlreadyApplied` — a full page 1 (100) plus one label on page 2; with a positive budget the page-2 label is recognised as already present and nothing new is applied, and both pages are walked. (This fails on the old single-page code.)
- `shouldStopWalkingCurrentLabelsAtThePageCap` — every page full, so the walk stops at `MAX_LABEL_PAGES`.

JaCoCo: `currentLabelKeys` is 100% line and branch (14/14) covered. SonarCloud: Quality Gate passed, 100% coverage on new code, 0 new issues.

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A — internal pagination fix with no user-visible surface.

## Additional Notes

Acceptance criteria from #304:
- [x] `currentLabelKeys` aggregates labels from every page returned by the client.
- [x] Test proves a label present only on page 2 is treated as already applied.
- [x] `mvn test` passes.
