### PR TITLE
fix(review): include nested review-thread replies in MaintainerReply context (#303)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
@@ -280,13 +280,12 @@ public class MaintainerReplyService {
         continue;
       }
       threadIds.add(c.id());
-      // The triggering comment anchors this reply (and any descendants), but is shown only as the
-      // question — never repeated in the rendered thread.
-      if (c.id() == triggeringCommentId) {
-        continue;
+      // Render every thread comment except the triggering one: it anchors this reply (and any
+      // descendants) but is shown only as the question, never repeated in the rendered thread.
+      if (c.id() != triggeringCommentId) {
+        String author = c.user() != null ? c.user().login() : "unknown";
+        sb.append("- @").append(author).append(": ").append(c.body()).append("\n");
       }
-      String author = c.user() != null ? c.user().login() : "unknown";
-      sb.append("- @").append(author).append(": ").append(c.body()).append("\n");
     }
     return sb.toString();
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
@@ -26,6 +26,7 @@ import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
+import java.util.HashSet;
 import java.util.List;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -253,18 +254,35 @@ public class MaintainerReplyService {
 
   /**
    * Replies already on this thread, oldest first, excluding the message that triggered the reply.
+   *
+   * <p>Collects the whole thread by walking the reply chain, not just comments that point straight
+   * at the root. GitHub review threads are usually flat — every reply's {@code in_reply_to_id} is
+   * the root comment — but a reply to a reply points at its immediate parent, so a filter keyed
+   * only on the root drops those nested replies (a maintainer clarifying or disputing mid-thread)
+   * from the context handed to the assistant. Following the chain is correct under both models: a
+   * flat thread yields exactly the direct replies, a nested one additionally yields the deeper
+   * ones.
+   *
+   * <p>Relies on the chronological (oldest-first) order the comment list arrives in — a reply is
+   * always created after its parent — so a single forward pass sees each parent before its replies.
    */
   private static String renderThread(
       List<GitHubReviewClient.PullRequestComment> comments,
       long rootCommentId,
       long triggeringCommentId) {
+    var threadIds = new HashSet<Long>();
+    threadIds.add(rootCommentId);
     var sb = new StringBuilder();
     for (var c : comments) {
-      // Keep only the other replies on this thread: skip non-replies, replies to a different root,
-      // and the message that triggered this reply.
-      if (c.inReplyToId() == null
-          || c.inReplyToId() != rootCommentId
-          || c.id() == triggeringCommentId) {
+      // A comment joins the thread when it replies, directly or transitively, to something already
+      // in it; record its id so its own nested replies are picked up on a later iteration.
+      if (c.inReplyToId() == null || !threadIds.contains(c.inReplyToId())) {
+        continue;
+      }
+      threadIds.add(c.id());
+      // The triggering comment anchors this reply (and any descendants), but is shown only as the
+      // question — never repeated in the rendered thread.
+      if (c.id() == triggeringCommentId) {
         continue;
       }
       String author = c.user() != null ? c.user().login() : "unknown";

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
@@ -176,6 +176,40 @@ class MaintainerReplyServiceTest {
   }
 
   @Test
+  void nestedReplyToAReplyIsIncludedInThreadContext() {
+    authorize();
+    // Three-level thread: bot finding (root 99) → maintainer reply (500) → reply-to-reply (700),
+    // with the triggering comment (1000) nested one deeper still. On GitHub a reply-to-reply
+    // carries in_reply_to_id of its immediate parent, not the root, so the chain must be walked for
+    // the nested reply to reach the assistant and for the deeply nested trigger to be recognized.
+    when(reviewClient.listPullRequestComments(
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+        .thenReturn(
+            List.of(
+                comment(99L, null, BOT, "**CRITICAL — possible NPE** on user lookup"),
+                comment(500L, 99L, "maintainer", "are you sure?"),
+                comment(700L, 500L, BOT, "yes — foo is unchecked here"),
+                comment(1000L, 700L, "octocat", "Why is this flagged?")));
+    when(replyAssistant.reply(any(), any(), any(), any(), any()))
+        .thenReturn("Because foo can be null.");
+
+    service.handle(reviewThreadTask(false));
+
+    var thread = ArgumentCaptor.forClass(String.class);
+    verify(replyAssistant).reply(any(), any(), any(), any(), thread.capture());
+    assertTrue(thread.getValue().contains("are you sure?"), "direct reply is in the thread");
+    assertTrue(
+        thread.getValue().contains("foo is unchecked here"),
+        "nested reply-to-reply is in the thread");
+    assertFalse(
+        thread.getValue().contains("Why is this flagged?"),
+        "triggering comment excluded even when deeply nested");
+    verify(reviewClient)
+        .replyToReviewComment(
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), eq(99L), any());
+  }
+
+  @Test
   void replyOnHumanThreadWithoutMentionPostsNothing() {
     authorize();
     when(reviewClient.listPullRequestComments(


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`MaintainerReplyService.renderThread` built the conversational context for maintainer replies by keeping only comments whose `in_reply_to_id` equalled the thread **root** comment id. On GitHub, a reply to a reply carries `in_reply_to_id` of its **immediate parent**, not the root, so any deeper nested reply in the same review thread was omitted from the `thread` argument passed to `ReplyAssistant` — dropping maintainer clarifications or disputes that happened mid-thread and producing answers that ignore relevant prior discussion.

The fix walks the reply chain instead: starting from the root, a comment joins the thread whenever it replies (directly or transitively) to something already in it, and its own id is recorded so its nested replies are picked up too. A single forward pass suffices because the comment list arrives oldest-first (a reply is always created after its parent).

This is correct under both threading models: a flat thread yields exactly the direct replies (unchanged behavior), a nested one additionally yields the deeper replies. The triggering comment is still excluded from the rendered thread (anchoring its descendants but shown only as the question), and ordering stays oldest-first.

**Scope note:** `FollowUpAnalyzer.appendReplies` / `hasHumanReply` share the same `rootId.equals(inReplyToId)` pattern for a different feature (follow-up review rounds). Left untouched to keep this fix focused on #303; can be tracked separately if the nested-reply model is confirmed to affect it.

## Related Issues

Fixes #303

## How Has This Been Tested?

- [x] Unit tests

- New test `nestedReplyToAReplyIsIncludedInThreadContext`: a three-level thread (root bot finding → maintainer reply → reply-to-reply) with the triggering comment nested one deeper. Asserts the reply-to-reply reaches the assistant's `thread` argument and the triggering comment stays excluded even when deeply nested.
- Existing direct-reply coverage (`replyOnBotThreadPostsAnswerWithFindingAndPriorRepliesAsContext`, `threadRenderingSkipsOtherThreadsAndHandlesAnonymousReplies`, etc.) still passes.
- Full local suite: **1101 tests, 0 failures**. `spotbugs:check` + `spotless:check` clean. Every executable line of `renderThread` fully covered per JaCoCo.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Minimal diff: one method body + its Javadoc in `MaintainerReplyService`, one new unit test, and a `java.util.HashSet` import. No production behavior changes for flat threads.