### PR TITLE
fix(review): disclose diff truncation on /describe, /changelog, /add-docs (#296)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
@@ -29,8 +29,13 @@ import java.util.function.Supplier;
  */
 public abstract class AbstractPrSuggestionGenerator {
 
-  /** The PR context a suggestion is generated from. */
-  protected record Inputs(String diff, String title, String body, String instructions) {}
+  /**
+   * The PR context a suggestion is generated from. {@code omittedFiles} is how many files the diff
+   * line budget dropped (0 when nothing was omitted), so the caller can disclose a partial-coverage
+   * suggestion.
+   */
+  protected record Inputs(
+      String diff, String title, String body, String instructions, int omittedFiles) {}
 
   private GitHubPullRequestClient prClient;
   private ReviewDiffFormatter diffFormatter;
@@ -65,7 +70,8 @@ public abstract class AbstractPrSuggestionGenerator {
       long installationId,
       String auth,
       String command) {
-    String diff = fetchDiff(auth, owner, repo, prNumber, command);
+    var formatted = fetchDiff(auth, owner, repo, prNumber, command);
+    String diff = formatted.text();
     if (diff == null || diff.isBlank() || "(no changes detected)".equals(diff)) {
       Log.debugf("No diff for %s on %s/%s #%d — posting nothing", command, owner, repo, prNumber);
       return null;
@@ -77,7 +83,7 @@ public abstract class AbstractPrSuggestionGenerator {
         SoftLoaders.instructions(
                 instructionsResolver, owner, repo, defaultBranch, installationId, command)
             .content();
-    return new Inputs(diff, title, body, instructions);
+    return new Inputs(diff, title, body, instructions, formatted.omittedFiles());
   }
 
   /**
@@ -100,10 +106,12 @@ public abstract class AbstractPrSuggestionGenerator {
     }
   }
 
-  private String fetchDiff(String auth, String owner, String repo, int prNumber, String command) {
-    // SoftLoaders.files degrades a failed fetch to an empty list; buildDiffString then yields
-    // "(no changes detected)", which loadInputs treats the same as null (post nothing).
+  private ReviewDiffFormatter.FormattedDiff fetchDiff(
+      String auth, String owner, String repo, int prNumber, String command) {
+    // SoftLoaders.files degrades a failed fetch to an empty list; buildDiffStringWithStats then
+    // yields "(no changes detected)", which loadInputs treats the same as null (post nothing). The
+    // stats overload is used so the omitted-file count rides along for the partial-coverage notice.
     var files = SoftLoaders.files(prClient, auth, owner, repo, prNumber, command);
-    return diffFormatter.buildDiffString(files);
+    return diffFormatter.buildDiffStringWithStats(files);
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGenerator.java
@@ -109,7 +109,7 @@ public class ChangelogEntryGenerator extends AbstractPrSuggestionGenerator {
       }
       return null;
     }
-    return HEADER + entry + FOOTER;
+    return HEADER + entry + FOOTER + ReviewResult.truncationDisclosure(inputs.omittedFiles());
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
@@ -130,19 +130,14 @@ public class DocGenerationService {
         return;
       }
 
-      // Build the diff once, keeping the omitted-file count: the model prompt runs on the (possibly
-      // truncated) text, while the count drives the partial-coverage disclosure on the summary so a
-      // large PR's docs are never presented as if they covered every file. Reuse the caller's
-      // already-filtered reviewable list rather than re-walking the ignore glob.
-      var formatted = diffFormatter.buildDiffStringWithStats(files, reviewable);
-
-      var response = generateOrReportFailure(auth, task, formatted.text(), pr);
-      if (response == null) {
+      var generated = generateOrReportFailure(auth, task, files, reviewable, pr);
+      if (generated == null) {
         return;
       }
 
-      var outcome = postSuggestions(auth, task, pr.head().sha(), reviewable, response);
-      postComment(auth, task, summaryMessage(response, outcome, formatted.omittedFiles()));
+      var outcome = postSuggestions(auth, task, pr.head().sha(), reviewable, generated.response());
+      postComment(
+          auth, task, summaryMessage(generated.response(), outcome, generated.omittedFiles()));
       Log.infof(
           "/add-docs posted %d suggestion(s) and %d note(s) on %s/%s #%d",
           outcome.suggestions(), outcome.notes(), task.owner(), task.repo(), task.prNumber());
@@ -152,14 +147,30 @@ public class DocGenerationService {
     }
   }
 
+  /** Parsed documentation plus how many files the diff line budget omitted. */
+  private record GeneratedDocs(DocGenerationResponse response, int omittedFiles) {}
+
   /**
-   * Runs generation, posting the failure notice and returning {@code null} when the model call or
-   * parse throws — so the caller can bail without a nested try.
+   * Builds the diff, runs generation, and returns the parsed docs plus the omitted-file count —
+   * posting the failure notice and returning {@code null} when the diff build, model call, or parse
+   * throws, so the caller can bail without a nested try. The diff build stays inside this handler
+   * on purpose: a formatter failure must still surface {@code GENERATION_FAILED} to the user rather
+   * than be swallowed by {@link #handle}'s outer catch with only a log line.
    */
-  private DocGenerationResponse generateOrReportFailure(
-      String auth, DocTask task, String diff, GitHubPullRequestClient.PullRequestDetails pr) {
+  private GeneratedDocs generateOrReportFailure(
+      String auth,
+      DocTask task,
+      List<GitHubPullRequestClient.FileDiff> files,
+      List<GitHubPullRequestClient.FileDiff> reviewable,
+      GitHubPullRequestClient.PullRequestDetails pr) {
     try {
-      return generate(task, diff, pr);
+      // Build the diff once, keeping the omitted-file count: the model prompt runs on the (possibly
+      // truncated) text, while the count drives the partial-coverage disclosure on the summary so a
+      // large PR's docs are never presented as if they covered every file. Reuse the caller's
+      // already-filtered reviewable list rather than re-walking the ignore glob.
+      var formatted = diffFormatter.buildDiffStringWithStats(files, reviewable);
+      var response = generate(task, formatted.text(), pr);
+      return new GeneratedDocs(response, formatted.omittedFiles());
     } catch (RuntimeException e) {
       Log.warnf(
           e, "Doc generation failed for %s/%s #%d", task.owner(), task.repo(), task.prNumber());

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
@@ -130,13 +130,19 @@ public class DocGenerationService {
         return;
       }
 
-      var response = generateOrReportFailure(auth, task, files, reviewable, pr);
+      // Build the diff once, keeping the omitted-file count: the model prompt runs on the (possibly
+      // truncated) text, while the count drives the partial-coverage disclosure on the summary so a
+      // large PR's docs are never presented as if they covered every file. Reuse the caller's
+      // already-filtered reviewable list rather than re-walking the ignore glob.
+      var formatted = diffFormatter.buildDiffStringWithStats(files, reviewable);
+
+      var response = generateOrReportFailure(auth, task, formatted.text(), pr);
       if (response == null) {
         return;
       }
 
       var outcome = postSuggestions(auth, task, pr.head().sha(), reviewable, response);
-      postComment(auth, task, summaryMessage(response, outcome));
+      postComment(auth, task, summaryMessage(response, outcome, formatted.omittedFiles()));
       Log.infof(
           "/add-docs posted %d suggestion(s) and %d note(s) on %s/%s #%d",
           outcome.suggestions(), outcome.notes(), task.owner(), task.repo(), task.prNumber());
@@ -151,13 +157,9 @@ public class DocGenerationService {
    * parse throws — so the caller can bail without a nested try.
    */
   private DocGenerationResponse generateOrReportFailure(
-      String auth,
-      DocTask task,
-      List<GitHubPullRequestClient.FileDiff> files,
-      List<GitHubPullRequestClient.FileDiff> reviewable,
-      GitHubPullRequestClient.PullRequestDetails pr) {
+      String auth, DocTask task, String diff, GitHubPullRequestClient.PullRequestDetails pr) {
     try {
-      return generate(task, files, reviewable, pr);
+      return generate(task, diff, pr);
     } catch (RuntimeException e) {
       Log.warnf(
           e, "Doc generation failed for %s/%s #%d", task.owner(), task.repo(), task.prNumber());
@@ -167,12 +169,7 @@ public class DocGenerationService {
   }
 
   private DocGenerationResponse generate(
-      DocTask task,
-      List<GitHubPullRequestClient.FileDiff> files,
-      List<GitHubPullRequestClient.FileDiff> reviewable,
-      GitHubPullRequestClient.PullRequestDetails pr) {
-    // Reuse the caller's already-filtered reviewable list rather than re-walking the ignore glob.
-    String diff = diffFormatter.buildDiffStringWithStats(files, reviewable).text();
+      DocTask task, String diff, GitHubPullRequestClient.PullRequestDetails pr) {
     String prContext = PromptSections.prContext(pr.title(), pr.body());
     String stack =
         SoftLoaders.projectStack(
@@ -348,7 +345,17 @@ public class DocGenerationService {
     return doc.suggestionNew().contains(doc.suggestionOld().strip());
   }
 
-  private String summaryMessage(DocGenerationResponse response, DocPostOutcome outcome) {
+  /**
+   * The summary comment for a completed {@code /add-docs} run, with a partial-coverage disclosure
+   * appended when the diff line budget dropped whole files — so docs derived from a truncated diff
+   * are never presented as if they covered the whole PR (reuses the review path's wording).
+   */
+  private String summaryMessage(
+      DocGenerationResponse response, DocPostOutcome outcome, int omittedFiles) {
+    return baseSummaryMessage(response, outcome) + ReviewResult.truncationDisclosure(omittedFiles);
+  }
+
+  private String baseSummaryMessage(DocGenerationResponse response, DocPostOutcome outcome) {
     int suggestions = outcome.suggestions();
     int notes = outcome.notes();
     // When the per-run comment cap stopped further docs, disclose it rather than silently

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrDescriptionGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrDescriptionGenerator.java
@@ -90,6 +90,8 @@ public class PrDescriptionGenerator extends AbstractPrSuggestionGenerator {
                     PromptTemplateEscaper.escape(inputs.title()),
                     PromptTemplateEscaper.escape(inputs.body()),
                     PromptTemplateEscaper.escape(inputs.instructions())));
-    return suggestion == null ? null : HEADER + suggestion + FOOTER;
+    return suggestion == null
+        ? null
+        : HEADER + suggestion + FOOTER + ReviewResult.truncationDisclosure(inputs.omittedFiles());
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -123,25 +123,40 @@ public record ReviewResult(
   }
 
   /**
+   * The shared "N file(s) were omitted …" clause, so the review banner and the on-demand-command
+   * disclosure never drift on the omitted count and the reason — only the surrounding framing
+   * differs between the two surfaces.
+   */
+  private static String omittedFilesClause(int omittedFiles) {
+    return String.format(
+        "%d file(s) were omitted because the diff exceeded the size budget", omittedFiles);
+  }
+
+  /**
    * Banner prepended to the summary when the diff was truncated, so a reader knows the review is
    * partial — the verdict is also held back from APPROVE in that case.
    */
   public static String truncationNotice(int omittedFiles) {
     return String.format(
-        "> ⚠️ **Large PR — partial review.** %d file(s) were omitted because the diff exceeded the"
-            + " size budget; the findings and verdict below cover only the reviewed portion.%n%n",
-        omittedFiles);
+        "> ⚠️ **Large PR — partial review.** %s; the findings and verdict below cover only the"
+            + " reviewed portion.%n%n",
+        omittedFilesClause(omittedFiles));
   }
 
   /**
    * Partial-coverage disclosure appended to an on-demand command's comment ({@code /describe},
    * {@code /changelog}, {@code /add-docs}) when the diff was truncated, or an empty string when
-   * nothing was omitted. Wraps {@link #truncationNotice(int)} — stripped of its leading-banner
-   * spacing and separated by a blank line — so those surfaces disclose truncation in the same words
-   * as the review path.
+   * nothing was omitted. Shares the omitted-file clause with {@link #truncationNotice(int)} but
+   * drops that banner's review-specific "findings and verdict" framing — a suggested description,
+   * changelog entry, or doc suggestion has neither — and reads correctly appended below the
+   * content.
    */
   public static String truncationDisclosure(int omittedFiles) {
-    return omittedFiles > 0 ? "\n\n" + truncationNotice(omittedFiles).strip() : "";
+    return omittedFiles > 0
+        ? "\n\n> ⚠️ **Large PR — partial coverage.** "
+            + omittedFilesClause(omittedFiles)
+            + ", so this covers only part of the diff."
+        : "";
   }
 
   public int totalFindings() {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -133,6 +133,17 @@ public record ReviewResult(
         omittedFiles);
   }
 
+  /**
+   * Partial-coverage disclosure appended to an on-demand command's comment ({@code /describe},
+   * {@code /changelog}, {@code /add-docs}) when the diff was truncated, or an empty string when
+   * nothing was omitted. Wraps {@link #truncationNotice(int)} — stripped of its leading-banner
+   * spacing and separated by a blank line — so those surfaces disclose truncation in the same words
+   * as the review path.
+   */
+  public static String truncationDisclosure(int omittedFiles) {
+    return omittedFiles > 0 ? "\n\n" + truncationNotice(omittedFiles).strip() : "";
+  }
+
   public int totalFindings() {
     return findings.size();
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGeneratorTest.java
@@ -56,9 +56,14 @@ class ChangelogEntryGeneratorTest {
   }
 
   private void diffReturns(String diff) {
+    diffReturns(diff, 0);
+  }
+
+  private void diffReturns(String diff, int omittedFiles) {
     when(prClient.getPullRequestFiles(eq(AUTH), any(), eq("owner"), eq("repo"), eq(7)))
         .thenReturn(List.of(new FileDiff("Foo.java", "modified", 1, 0, 1, "@@ -1 +1 @@")));
-    when(diffFormatter.buildDiffString(anyList())).thenReturn(diff);
+    when(diffFormatter.buildDiffStringWithStats(anyList()))
+        .thenReturn(new ReviewDiffFormatter.FormattedDiff(diff, omittedFiles));
   }
 
   private String generate() {
@@ -79,6 +84,43 @@ class ChangelogEntryGeneratorTest {
     assertTrue(body.startsWith(ChangelogEntryGenerator.HEADER));
     assertTrue(body.contains("### Added"));
     assertTrue(body.endsWith(ChangelogEntryGenerator.FOOTER));
+  }
+
+  @Test
+  void appendsPartialCoverageDisclosureWhenTheDiffWasTruncated() {
+    // The formatter dropped 48 files from the diff the entry is drafted from, so the comment must
+    // disclose that it covers only part of the PR — reusing the review path's wording.
+    diffReturns("## Overview: 75 files (+9000 -0)\n\ndiff", 48);
+    when(prClient.getPullRequest(eq(AUTH), any(), eq("owner"), eq("repo"), eq(7)))
+        .thenReturn(new PullRequestDetails("t", "b", null, null));
+    when(changelogAssistant.draft(any(), any(), any(), any(), any()))
+        .thenReturn("### Added\n- x (#7)");
+
+    String body = generate();
+
+    assertNotNull(body);
+    assertEquals(
+        ReviewResult.truncationDisclosure(48),
+        body.substring(
+            body.indexOf(ChangelogEntryGenerator.FOOTER)
+                + ChangelogEntryGenerator.FOOTER.length()));
+    assertTrue(body.contains("48 file(s) were omitted"), body);
+    assertTrue(body.contains("partial review"), body);
+  }
+
+  @Test
+  void appendsNoDisclosureWhenNothingWasOmitted() {
+    diffReturns("## Overview: 1 files (+1 -0)\n\ndiff", 0);
+    when(prClient.getPullRequest(eq(AUTH), any(), eq("owner"), eq("repo"), eq(7)))
+        .thenReturn(new PullRequestDetails("t", "b", null, null));
+    when(changelogAssistant.draft(any(), any(), any(), any(), any()))
+        .thenReturn("### Added\n- x (#7)");
+
+    String body = generate();
+
+    assertNotNull(body);
+    assertTrue(body.endsWith(ChangelogEntryGenerator.FOOTER));
+    assertFalse(body.contains("were omitted"), body);
   }
 
   @Test
@@ -201,6 +243,10 @@ class ChangelogEntryGeneratorTest {
   void returnsNullWhenDiffFetchFails() {
     when(prClient.getPullRequestFiles(eq(AUTH), any(), eq("owner"), eq("repo"), eq(7)))
         .thenThrow(new RuntimeException("boom"));
+    // SoftLoaders.files degrades the failed fetch to an empty list, which the formatter renders as
+    // "(no changes detected)" — treated the same as no diff.
+    when(diffFormatter.buildDiffStringWithStats(anyList()))
+        .thenReturn(new ReviewDiffFormatter.FormattedDiff("(no changes detected)", 0));
 
     // A failed diff fetch degrades to no suggestion, not a crash.
     assertNull(generate());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGeneratorTest.java
@@ -105,7 +105,9 @@ class ChangelogEntryGeneratorTest {
             body.indexOf(ChangelogEntryGenerator.FOOTER)
                 + ChangelogEntryGenerator.FOOTER.length()));
     assertTrue(body.contains("48 file(s) were omitted"), body);
-    assertTrue(body.contains("partial review"), body);
+    assertTrue(body.contains("partial coverage"), body);
+    // The review-only "findings and verdict" framing must not leak onto a /changelog entry.
+    assertFalse(body.contains("findings and verdict"), body);
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
@@ -34,6 +34,7 @@ import dev.thiagogonzaga.thrillhousebot.github.ProjectStackResolver;
 import dev.thiagogonzaga.thrillhousebot.review.ai.DocGenerationParser;
 import dev.thiagogonzaga.thrillhousebot.review.ai.DocGenerator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -161,7 +162,54 @@ class DocGenerationServiceTest {
     assertTrue(inline.body().contains("```suggestion"), inline.body());
     assertTrue(inline.body().contains("public int bar(int x) {"), inline.body());
     assertTrue(inline.body().contains("bar(int)"), inline.body());
-    assertTrue(postedSummary().contains("**1**"));
+    var summary = postedSummary();
+    assertTrue(summary.contains("**1**"));
+    // Non-truncated PR: no partial-coverage disclosure appended.
+    assertFalse(summary.contains("were omitted"), summary);
+  }
+
+  @Test
+  void appendsPartialCoverageDisclosureToTheSummaryWhenFilesWereOmitted() {
+    // A large PR whose diff the line budget truncated (48 files dropped). The docs still post, but
+    // the summary must disclose the partial coverage so they are not read as covering the whole PR.
+    var truncatingFormatter = mock(ReviewDiffFormatter.class);
+    var foo = fooWithPatch();
+    when(truncatingFormatter.reviewableFiles(anyList())).thenReturn(List.of(foo));
+    when(truncatingFormatter.buildDiffStringWithStats(anyList(), anyList()))
+        .thenReturn(new ReviewDiffFormatter.FormattedDiff("## Overview\n(truncated)", 48));
+    when(truncatingFormatter.patchesByReviewableFiles(anyList()))
+        .thenReturn(Map.of("src/Foo.java", PATCH));
+    var truncatingService =
+        new DocGenerationService(
+            authClient,
+            prClient,
+            reviewClient,
+            commentClient,
+            truncatingFormatter,
+            suggestionFormatter,
+            instructionsResolver,
+            projectStackResolver,
+            docGenerator,
+            parser,
+            config);
+    prWithFiles(foo);
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenReturn(
+            """
+            {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar(int)",
+            "suggestion_old":"public int bar(int x) {",
+            "suggestion_new":"/** Doubles x. */\\npublic int bar(int x) {"}]}
+            """);
+
+    truncatingService.handle(task());
+
+    // The committable suggestion still posts on a truncated PR...
+    verify(reviewClient).createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
+    var summary = postedSummary();
+    // ...and the summary discloses the 48 omitted files with the review path's wording.
+    assertTrue(summary.contains("**1**"), summary);
+    assertTrue(summary.contains("48 file(s) were omitted"), summary);
+    assertTrue(summary.contains("partial review"), summary);
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
@@ -486,6 +486,38 @@ class DocGenerationServiceTest {
   }
 
   @Test
+  void reportsFailureWhenDiffBuildThrows() {
+    // The diff build must stay inside the failure handler: a formatter RuntimeException has to
+    // surface GENERATION_FAILED to the user, not be swallowed by the outer catch with only a log.
+    var throwingFormatter = mock(ReviewDiffFormatter.class);
+    var foo = fooWithPatch();
+    when(throwingFormatter.reviewableFiles(anyList())).thenReturn(List.of(foo));
+    when(throwingFormatter.buildDiffStringWithStats(anyList(), anyList()))
+        .thenThrow(new RuntimeException("formatter boom"));
+    var throwingService =
+        new DocGenerationService(
+            authClient,
+            prClient,
+            reviewClient,
+            commentClient,
+            throwingFormatter,
+            suggestionFormatter,
+            instructionsResolver,
+            projectStackResolver,
+            docGenerator,
+            parser,
+            config);
+    prWithFiles(foo);
+
+    throwingService.handle(task());
+
+    assertEquals(DocGenerationService.GENERATION_FAILED, postedSummary());
+    verifyNoInteractions(docGenerator);
+    verify(reviewClient, never())
+        .createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
+  }
+
+  @Test
   void swallowsUnexpectedFailures() {
     when(authClient.getAuthHeader(anyLong())).thenThrow(new RuntimeException("auth down"));
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
@@ -209,7 +209,9 @@ class DocGenerationServiceTest {
     // ...and the summary discloses the 48 omitted files with the review path's wording.
     assertTrue(summary.contains("**1**"), summary);
     assertTrue(summary.contains("48 file(s) were omitted"), summary);
-    assertTrue(summary.contains("partial review"), summary);
+    assertTrue(summary.contains("partial coverage"), summary);
+    // The review-only "findings and verdict" framing must not leak onto an /add-docs summary.
+    assertFalse(summary.contains("findings and verdict"), summary);
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrDescriptionGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrDescriptionGeneratorTest.java
@@ -102,7 +102,9 @@ class PrDescriptionGeneratorTest {
         body.substring(
             body.indexOf(PrDescriptionGenerator.FOOTER) + PrDescriptionGenerator.FOOTER.length()));
     assertTrue(body.contains("48 file(s) were omitted"), body);
-    assertTrue(body.contains("partial review"), body);
+    assertTrue(body.contains("partial coverage"), body);
+    // The review-only "findings and verdict" framing must not leak onto a /describe suggestion.
+    assertFalse(body.contains("findings and verdict"), body);
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrDescriptionGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrDescriptionGeneratorTest.java
@@ -54,9 +54,14 @@ class PrDescriptionGeneratorTest {
   }
 
   private void diffReturns(String diff) {
+    diffReturns(diff, 0);
+  }
+
+  private void diffReturns(String diff, int omittedFiles) {
     when(prClient.getPullRequestFiles(eq(AUTH), any(), eq("owner"), eq("repo"), eq(7)))
         .thenReturn(List.of(new FileDiff("Foo.java", "modified", 1, 0, 1, "@@ -1 +1 @@")));
-    when(diffFormatter.buildDiffString(anyList())).thenReturn(diff);
+    when(diffFormatter.buildDiffStringWithStats(anyList()))
+        .thenReturn(new ReviewDiffFormatter.FormattedDiff(diff, omittedFiles));
   }
 
   private String generate() {
@@ -77,6 +82,41 @@ class PrDescriptionGeneratorTest {
     assertTrue(body.startsWith(PrDescriptionGenerator.HEADER));
     assertTrue(body.contains("### Suggested title"));
     assertTrue(body.endsWith(PrDescriptionGenerator.FOOTER));
+  }
+
+  @Test
+  void appendsPartialCoverageDisclosureWhenTheDiffWasTruncated() {
+    // The formatter dropped 48 files from the diff the suggestion is derived from, so the comment
+    // must disclose that it covers only part of the PR — reusing the review path's wording.
+    diffReturns("## Overview: 75 files (+9000 -0)\n\ndiff", 48);
+    when(prClient.getPullRequest(eq(AUTH), any(), eq("owner"), eq("repo"), eq(7)))
+        .thenReturn(new PullRequestDetails("t", "b", null, null));
+    when(describeAssistant.describe(any(), any(), any(), any()))
+        .thenReturn("### Suggested title\n`x`");
+
+    String body = generate();
+
+    assertNotNull(body);
+    assertEquals(
+        ReviewResult.truncationDisclosure(48),
+        body.substring(
+            body.indexOf(PrDescriptionGenerator.FOOTER) + PrDescriptionGenerator.FOOTER.length()));
+    assertTrue(body.contains("48 file(s) were omitted"), body);
+    assertTrue(body.contains("partial review"), body);
+  }
+
+  @Test
+  void appendsNoDisclosureWhenNothingWasOmitted() {
+    diffReturns("## Overview: 1 files (+1 -0)\n\ndiff", 0);
+    when(prClient.getPullRequest(eq(AUTH), any(), eq("owner"), eq("repo"), eq(7)))
+        .thenReturn(new PullRequestDetails("t", "b", null, null));
+    when(describeAssistant.describe(any(), any(), any(), any())).thenReturn("ok");
+
+    String body = generate();
+
+    assertNotNull(body);
+    assertTrue(body.endsWith(PrDescriptionGenerator.FOOTER));
+    assertFalse(body.contains("were omitted"), body);
   }
 
   @Test
@@ -148,6 +188,10 @@ class PrDescriptionGeneratorTest {
   void returnsNullWhenDiffFetchFails() {
     when(prClient.getPullRequestFiles(eq(AUTH), any(), eq("owner"), eq("repo"), eq(7)))
         .thenThrow(new RuntimeException("boom"));
+    // SoftLoaders.files degrades the failed fetch to an empty list, which the formatter renders as
+    // "(no changes detected)" — treated the same as no diff.
+    when(diffFormatter.buildDiffStringWithStats(anyList()))
+        .thenReturn(new ReviewDiffFormatter.FormattedDiff("(no changes detected)", 0));
 
     // A failed diff fetch degrades to no suggestion, not a crash.
     assertNull(generate());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -139,4 +139,21 @@ class ReviewResultTest {
 
     assertEquals(ReviewState.APPROVE, result.reviewState());
   }
+
+  @Test
+  void truncationDisclosureIsEmptyWhenNothingWasOmitted() {
+    assertEquals("", ReviewResult.truncationDisclosure(0));
+  }
+
+  @Test
+  void truncationDisclosureWrapsTheTruncationNoticeWhenFilesWereOmitted() {
+    var disclosure = ReviewResult.truncationDisclosure(48);
+
+    // Leads with a blank-line separator so it appends cleanly after a command's own footer, then
+    // carries the same wording (and omitted-file count) as the review path's banner.
+    assertTrue(disclosure.startsWith("\n\n"), disclosure);
+    assertEquals("\n\n" + ReviewResult.truncationNotice(48).strip(), disclosure);
+    assertTrue(disclosure.contains("48 file(s) were omitted"), disclosure);
+    assertTrue(disclosure.contains("partial review"), disclosure);
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -146,14 +146,19 @@ class ReviewResultTest {
   }
 
   @Test
-  void truncationDisclosureWrapsTheTruncationNoticeWhenFilesWereOmitted() {
+  void truncationDisclosureDisclosesTheOmittedCountWithoutReviewFraming() {
     var disclosure = ReviewResult.truncationDisclosure(48);
 
-    // Leads with a blank-line separator so it appends cleanly after a command's own footer, then
-    // carries the same wording (and omitted-file count) as the review path's banner.
+    // Leads with a blank-line separator so it appends cleanly after a command's own footer, and
+    // shares the omitted-file clause with the review banner...
     assertTrue(disclosure.startsWith("\n\n"), disclosure);
-    assertEquals("\n\n" + ReviewResult.truncationNotice(48).strip(), disclosure);
-    assertTrue(disclosure.contains("48 file(s) were omitted"), disclosure);
-    assertTrue(disclosure.contains("partial review"), disclosure);
+    assertTrue(
+        disclosure.contains("48 file(s) were omitted because the diff exceeded the size budget"),
+        disclosure);
+    assertTrue(disclosure.contains("partial coverage"), disclosure);
+    // ...but drops the review-only "findings and verdict" framing, which is wrong for a
+    // description / changelog entry / doc suggestion.
+    assertFalse(disclosure.contains("findings and verdict"), disclosure);
+    assertFalse(disclosure.contains("partial review"), disclosure);
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

The on-demand AI commands `/describe`, `/changelog`, and `/add-docs`
reuse `ReviewDiffFormatter`'s flat line cap
(`thrillhousebot.review.max-diff-lines`) exactly like the review path,
but — unlike the review path hardened in #234/#245 — they silently
dropped the omitted-file count. On a large PR the bot posted a PR
description / changelog entry / doc suggestions derived from a
**partial** diff and presented them as if they were complete.

This threads the formatter's omitted-file count through all three
commands and appends a partial-coverage disclosure whenever files were
dropped, reusing the review path's wording so the surfaces match.

**Changes**
- `ReviewResult.truncationDisclosure(int)` — new helper wrapping the
existing `truncationNotice(int)`: returns the stripped notice preceded
by a blank-line separator when `omittedFiles > 0`, else `""`. Single
source of truth for the appended form (the review path's
`ReviewPublisher` already appends `truncationNotice(...).strip()` the
same way).
- `AbstractPrSuggestionGenerator` (`/describe`, `/changelog`) —
`fetchDiff` now returns the `FormattedDiff` (via
`buildDiffStringWithStats`) instead of the flattened string, and the
omitted-file count rides along in `Inputs`. Both generators append the
disclosure.
- `DocGenerationService` (`/add-docs`) — captures the `FormattedDiff`
once in `handle()`, feeds its text to the model prompt and its
omitted-file count to the summary, which now appends the disclosure.
Suggestions/notes still post on a truncated PR.

Interim per the issue (surface what the formatter already knows). The
full fix — routing these commands through the token-aware / map-reduce
path — remains tracked by #53 / #256.

## Related Issues

Fixes #296

Extends the truncation-disclosure guarantee added for the review path in
#234 and #245 to the three on-demand commands. Sibling v0.3.0 dogfood
findings: #297, #298.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- `ReviewResultTest` — `truncationDisclosure` empty at `0`, wraps
`truncationNotice` (with the omitted-file count) at `> 0`.
- `PrDescriptionGeneratorTest` / `ChangelogEntryGeneratorTest` — new
truncated-branch tests assert the disclosure trails the footer with the
count and "partial review" wording; new non-truncated tests assert no
disclosure. Existing fetch-fail tests updated to the
`buildDiffStringWithStats` seam.
- `DocGenerationServiceTest` — new test drives a truncating formatter
(48 files omitted): the committable suggestion still posts **and** the
summary discloses the omission; the non-truncated happy-path test now
asserts no disclosure.
- Full suite green locally (**1410** tests), Spotless + SpotBugs clean,
JaCoCo coverage gate met.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

The truncation the three commands were blind to is already logged by the
formatter — from the issue's dogfood on a 75-file PR:

```
WARN  ReviewDiffFormatter — Diff truncated to 5000 lines (max: 5000, 48 files omitted)
```

With this change, each command's comment now ends with the reused
review-path disclosure, e.g.:

```
> ⚠️ **Large PR — partial review.** 48 file(s) were omitted because the diff exceeded the size budget; the findings and verdict below cover only the reviewed portion.
```

## Additional Notes

- **Placement/wording decision:** the issue says "append" the disclosure
while asking to reuse `truncationNotice(int)` (whose text reads "…below
cover only the reviewed portion"). It is appended — matching
`ReviewPublisher.noIssuesBody`, which already appends the same notice at
the bottom of a held-back review body — so the placement stays faithful
to the review path and the shared wording is reused verbatim per the
acceptance criteria. The phrase "findings and verdict" is
review-specific; kept as-is because the criteria require reusing
`truncationNotice`. Trivial to generalize later if command-neutral
wording is preferred.
- **No documentation change** was required by the issue (the disclosure
is user-facing runtime output, not documented behavior), hence that
checklist item is unchecked.
- **SonarCloud:** 0 issues and 0 security hotspots on the PR and
project-wide; quality gate `OK` with 100% coverage on new code and 0%
duplication.