### PR TITLE
fix(security): document/suppress non-applicable jackson GHSA-5jmj-h7xm-6q6v (no 2.x fix)

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,22 @@
+# OSV-Scanner / OpenSSF Scorecard vulnerability suppressions.
+# Each entry documents an advisory that has no actionable fix for our dependency line
+# AND does not affect this project. Re-evaluate these periodically.
+
+[[IgnoredVulns]]
+id = "GHSA-5jmj-h7xm-6q6v" # CVE-2026-54515
+reason = """
+jackson-databind case-insensitive bypass of per-property @JsonIgnoreProperties filtering.
+
+Not applicable, and no fix exists for the Jackson line Quarkus uses:
+- The only fix is tools.jackson.core:jackson-databind 3.1.4 (Jackson 3.x, new namespace).
+  Quarkus 3.37 resolves com.fasterxml.jackson.core:jackson-databind (Jackson 2.x), whose
+  entire range -- including our resolved 2.22.0 -- is affected with no 2.x fix available.
+- The vulnerable behaviour is a per-property @JsonIgnoreProperties({"name"}) name-based
+  filter defeated via case-insensitive matching. This codebase uses ONLY
+  @JsonIgnoreProperties(ignoreUnknown = true) (drop unknown fields for forward
+  compatibility), never a named-property blocklist, and no polymorphic/default typing --
+  so there is no protected property for the bypass to defeat.
+
+Verified with a CycloneDX SBOM generated from Maven's own resolution scanned against OSV.
+Revisit when Quarkus adopts Jackson 3.x or a fixed 2.x release ships.
+"""

--- a/pom.xml
+++ b/pom.xml
@@ -78,11 +78,16 @@
                 <scope>import</scope>
             </dependency>
             <!--
-                CVE override for jackson-databind GHSA-5jmj-h7xm-6q6v / CVE-2026-54515
-                (@JsonIgnoreProperties deserialization bypass). quarkus-bom 3.36.3 manages 2.21.4
-                (vulnerable); the 2.21.x fix (2.21.5) is not yet on Maven Central, so bump to
-                2.22.0 — the next published release OSV reports clean. Declared before the
-                quarkus-bom import so this BOM wins. Remove once the platform ships a fixed jackson.
+                Pin the Jackson family to the latest 2.x (2.22.0) over the quarkus-bom-managed
+                version; declared before the quarkus-bom import so this BOM wins.
+                NOTE on GHSA-5jmj-h7xm-6q6v / CVE-2026-54515 (@JsonIgnoreProperties case-insensitive
+                deserialization bypass): the advisory affects the ENTIRE Jackson 2.x line with no
+                2.x fix — the only fix is tools.jackson.core:jackson-databind 3.1.4 (Jackson 3.x),
+                which Quarkus does not use — so 2.22.0 does NOT clear it. It does not affect this
+                codebase (all @JsonIgnoreProperties usage is ignoreUnknown=true, never a per-property
+                name blocklist, and there is no polymorphic/default typing), so it is documented and
+                suppressed in osv-scanner.toml. Revisit the pin and the suppression when the
+                platform adopts Jackson 3.x or a fixed 2.x release ships.
             -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔒 Security

## Description

OpenSSF Scorecard's Vulnerabilities check flags **GHSA-5jmj-h7xm-6q6v** (CVE-2026-54515) — a jackson-databind *case-insensitive bypass of per-property `@JsonIgnoreProperties` filtering*. This PR investigates it properly and addresses it.

### Findings (verified against OSV via a Maven-generated CycloneDX SBOM, not a pom re-parse)

- **It's a real match, not a resolution false-positive.** Our resolved `jackson-databind 2.22.0` is explicitly in the advisory's affected set.
- **There is no fix for our Jackson line.** The only fix is `tools.jackson.core:jackson-databind 3.1.4` — Jackson **3.x** (new `tools.jackson` namespace). Quarkus 3.37 uses Jackson **2.x** (`com.fasterxml.jackson.core`), whose entire range — including 2.22.0 — is affected with **no 2.x fix**. So the earlier 2.22.0 bump can't clear it; the 0.2.1 CHANGELOG's "cleared by 2.22.0" is stale (the advisory was revised to include 2.x).
- **It does not affect this codebase.** The bug defeats per-property `@JsonIgnoreProperties({"name"})` *name-based* filters via case-insensitive matching. Every usage here is `@JsonIgnoreProperties(ignoreUnknown = true)` (drop unknown fields for forward-compat), never a name blocklist, and there is **no polymorphic/default typing** — so there is no protected property for the bypass to defeat. (Severity note: the advisory is CVSS **5.3 Medium**; Scorecard's "9" is its check sub-score out of 10, not a CVSS-9.)

### Change

Per Scorecard's own remediation guidance ("if the vulnerability does not affect your project… create an `osv-scanner.toml`"):

- **Add `osv-scanner.toml`** at the repo root (next to `pom.xml`) ignoring the advisory with a full documented reason.
- **Correct the now-inaccurate pom comment** on the jackson-bom override (it claimed 2.22.0 "reports clean").

## Related Issues

Addresses the OpenSSF Scorecard Vulnerabilities finding for GHSA-5jmj-h7xm-6q6v. Supersedes the understanding recorded in the 0.2.1 CHANGELOG entry.

## How Has This Been Tested?

- [x] Manual testing

- Generated a CycloneDX SBOM from Maven's own resolution and scanned it with osv-scanner (same DB as Scorecard): **without** the config → 1 finding (exit 1); **with** `--config osv-scanner.toml` → *"filtered out… No issues found"* (exit 0).
- Confirmed the resolved tree is Jackson 2.22.0 across the family; confirmed all 17 `@JsonIgnoreProperties` are `ignoreUnknown = true` and there is no `@JsonTypeInfo`/default typing.
- `spotless:check` passes.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

- The `jackson-bom` 2.22.0 override is **kept** (it's still the latest Jackson 2.x — best available), only its comment is corrected. It no longer clears this advisory (nothing in 2.x does).
- **Revisit** the suppression when Quarkus adopts Jackson 3.x or a fixed 2.x release ships — noted in both the toml and the pom comment.
