### PR TITLE
fix(review): PR summary "Changes Overview" counts diverge from GitHub's file/line totals (#298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to ThrillhouseBot.
 
+## [Unreleased]
+
+### Fixed
+
+- **PR summary "Changes Overview" no longer undercounts files/lines**: the overview reported the file and line totals summed over the bot's *reviewable* file list — the ignore-glob-filtered subset — so a PR with any ignore-globbed file (e.g. a lockfile) showed fewer files and lines than GitHub's own totals, and the changed-files walkthrough's "…and N more file(s)" rollup was short by the same amount. The overview and the rollup now report GitHub's authoritative `changed_files` / `additions` / `deletions` for the PR (fetched from the pulls endpoint), while the walkthrough table still lists only the reviewable files. Truncation gating and disclosure are unchanged, and if the PR totals can't be fetched the summary falls back to the previous diff-derived counts (#298)
+
 ## [0.3.0] — 2026-06-30
 
 ### Added

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubPullRequestClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubPullRequestClient.java
@@ -95,7 +95,25 @@ public interface GitHubPullRequestClient {
       @PathParam("path") String path,
       @QueryParam("ref") String ref);
 
-  record PullRequestDetails(String title, String body, Ref head, Ref base) {}
+  record PullRequestDetails(
+      String title,
+      String body,
+      Ref head,
+      Ref base,
+      // GitHub's authoritative PR-level totals (the same fields `gh pr view` reads). Populated from
+      // the pulls endpoint and preferred over the ignore-glob-filtered diff counts for the
+      // summary's
+      // "Changes Overview", which otherwise undercounts whenever a changed file is ignore-globbed.
+      @JsonProperty("changed_files") int changedFiles,
+      int additions,
+      int deletions) {
+    // The fields the review path historically read (title/body/refs). Retained so call sites and
+    // fixtures that don't model the file/line totals keep compiling; production always deserializes
+    // the full object via the canonical constructor, so these totals are only 0 in such fixtures.
+    public PullRequestDetails(String title, String body, Ref head, Ref base) {
+      this(title, body, head, base, 0, 0, 0);
+    }
+  }
 
   record Ref(String sha, String ref) {
     public Ref(String sha) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -85,6 +85,14 @@ public class PrSummaryGenerator {
           "journey",
           "gantt");
 
+  /**
+   * Renders the summary comment. {@code filesChanged}/{@code additions}/{@code deletions} are
+   * GitHub's authoritative PR-level totals (or the diff-derived fallback), so the "Changes
+   * Overview" reflects the whole PR even when files are dropped by the ignore-glob. {@code
+   * changedFiles} is the reviewable (non-ignored) file list rendered as the walkthrough table; its
+   * rollup "…and N more" note is derived from {@code filesChanged} so it, too, matches the
+   * authoritative total.
+   */
   public String generate(
       int filesChanged,
       int additions,
@@ -104,7 +112,7 @@ public class PrSummaryGenerator {
     sb.append("- **Lines added:** ").append(signed('+', additions)).append("\n");
     sb.append("- **Lines removed:** ").append(signed('-', deletions)).append("\n\n");
 
-    appendChangedFiles(sb, changedFiles, aiSummary);
+    appendChangedFiles(sb, filesChanged, changedFiles, aiSummary);
 
     sb.append("### Risk Assessment\n");
     sb.append("| Risk | Count |\n");
@@ -251,10 +259,18 @@ public class PrSummaryGenerator {
    * Renders the file-by-file walkthrough as a table of (file, change type, one-line summary). The
    * change type comes from the diff (authoritative); the summary is the model's per-file note,
    * matched by path. Files without a model summary still appear, so the table always mirrors the
-   * actual change set. Bounded to {@link #MAX_FILE_ROWS} rows to respect the comment-size budget.
+   * reviewable change set. Bounded to {@link #MAX_FILE_ROWS} rows to respect the comment-size
+   * budget.
+   *
+   * <p>The trailing "…and N more file(s)" rollup is measured against {@code totalFilesChanged}
+   * (GitHub's authoritative total), not the reviewable-row count, so it also accounts for files the
+   * ignore-glob dropped from the table — matching the "Changes Overview" total above it (#298).
    */
   private static void appendChangedFiles(
-      StringBuilder sb, List<ChangedFile> changedFiles, ReviewResponse.Summary aiSummary) {
+      StringBuilder sb,
+      int totalFilesChanged,
+      List<ChangedFile> changedFiles,
+      ReviewResponse.Summary aiSummary) {
     if (changedFiles == null || changedFiles.isEmpty()) {
       return;
     }
@@ -273,7 +289,8 @@ public class PrSummaryGenerator {
           .append(summary.isBlank() ? "-" : escapeTableCell(summary.strip()))
           .append(" |\n");
     }
-    int overflow = changedFiles.size() - MAX_FILE_ROWS;
+    int rowsShown = Math.min(changedFiles.size(), MAX_FILE_ROWS);
+    int overflow = totalFilesChanged - rowsShown;
     if (overflow > 0) {
       sb.append("\n_…and ").append(overflow).append(" more file(s)._\n");
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
@@ -77,6 +77,14 @@ public class ReviewContextLoader {
     this.botIdentity = botIdentity;
   }
 
+  /**
+   * GitHub's authoritative PR-level file/line totals, read from the pulls endpoint. Preferred over
+   * the ignore-glob-filtered diff counts for the summary's "Changes Overview"; {@code null} when
+   * the totals could not be fetched, in which case the summary falls back to the diff-derived
+   * counts.
+   */
+  public record PrTotals(int filesChanged, int additions, int deletions) {}
+
   /** Everything the review pipeline reads before the model call, loaded once up front. */
   public record ReviewContext(
       List<GitHubPullRequestClient.FileDiff> files,
@@ -94,7 +102,8 @@ public class ReviewContextLoader {
       List<GitHubLabelClient.Label> repoLabels,
       String projectStack,
       List<GitHubPullRequestClient.FileDiff> reviewableFiles,
-      DiffLineResolver lineResolver) {
+      DiffLineResolver lineResolver,
+      PrTotals prTotals) {
     public ReviewContext {
       files = List.copyOf(files);
       priorReviews = List.copyOf(priorReviews);
@@ -114,6 +123,10 @@ public class ReviewContextLoader {
   ReviewContext load(
       String auth, ReviewOrchestrator.ReviewRequest req, ReviewSession session, String repository) {
     var files = fetchPrFiles(auth, req.owner(), req.repo(), req.prNumber());
+    // GitHub's authoritative PR-level totals for the summary's "Changes Overview". Fetched
+    // best-effort: a failure leaves prTotals null and the summary falls back to the diff-derived
+    // counts (#298).
+    var prTotals = fetchPrTotals(auth, req.owner(), req.repo(), req.prNumber());
     // The ignore-glob filter runs once here; the already-filtered list feeds the diff render (so
     // formatFileSection does not re-glob each file) and the line resolver alike, instead of either
     // re-walking it.
@@ -194,7 +207,8 @@ public class ReviewContextLoader {
         repoLabels,
         resolveProjectStack(req),
         reviewableFiles,
-        lineResolver);
+        lineResolver,
+        prTotals);
   }
 
   /**
@@ -239,6 +253,24 @@ public class ReviewContextLoader {
     // produces a false APPROVE + green check on code that was never read. A genuinely empty
     // PR returns an empty list with no exception and still takes the normal path.
     return prClient.getPullRequestFiles(auth, ACCEPT, owner, repo, prNumber);
+  }
+
+  /**
+   * GitHub's authoritative PR-level file/line totals ({@code changed_files}/{@code
+   * additions}/{@code deletions} on the pulls endpoint), or {@code null} when they can't be read.
+   * The summary reports these rather than the ignore-glob-filtered diff counts, which undercount
+   * whenever a changed file is dropped by the ignore-glob (#298). Best-effort: a fetch failure
+   * returns {@code null} so the summary falls back to the diff-derived counts rather than failing
+   * the review.
+   */
+  PrTotals fetchPrTotals(String auth, String owner, String repo, int prNumber) {
+    try {
+      var pr = prClient.getPullRequest(auth, ACCEPT, owner, repo, prNumber);
+      return new PrTotals(pr.changedFiles(), pr.additions(), pr.deletions());
+    } catch (RuntimeException e) {
+      Log.warn("Failed to fetch PR totals; summary will fall back to diff-derived counts", e);
+      return null;
+    }
   }
 
   ReviewDiffFormatter.FormattedDiff buildBaseComparisonWithStats(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -57,7 +57,13 @@ public class VerdictBuilder {
       ReviewContextLoader.ReviewContext ctx,
       ReviewResponse aiResponse,
       CiStatusEvaluator.CiEvaluation ciEvaluation) {
-    var diffStats = DiffStats.fromFiles(ctx.reviewableFiles(), ctx.omittedFiles());
+    // The "Changes Overview" reports GitHub's authoritative PR-level totals when available; the
+    // diff-derived counts (summed over the ignore-glob-filtered reviewable files) undercount
+    // whenever a changed file is dropped by the ignore-glob (#298). The reviewed-diff omitted-file
+    // count is preserved either way, so truncation gating and disclosure are unaffected.
+    var diffStats =
+        DiffStats.fromFiles(ctx.reviewableFiles(), ctx.omittedFiles())
+            .withAuthoritativeTotals(ctx.prTotals());
     var changedFiles = toChangedFiles(ctx.reviewableFiles());
     var unresolvedPrevious =
         followUpAnalyzer.unresolvedFindings(
@@ -160,6 +166,21 @@ public class VerdictBuilder {
     /** True when the line budget dropped whole files, so the model never saw part of the change. */
     boolean truncated() {
       return omittedFiles > 0;
+    }
+
+    /**
+     * Replaces the file/line counts with GitHub's authoritative PR-level totals, keeping the
+     * reviewed diff's omitted-file count. Returns {@code this} unchanged when {@code totals} is
+     * {@code null} (totals couldn't be fetched), so the summary falls back to the diff-derived
+     * counts. Only the overview counts change; {@link #truncated()} and {@link #omittedFiles()} —
+     * which gate approval and drive the truncation disclosure — still reflect the reviewed diff.
+     */
+    DiffStats withAuthoritativeTotals(ReviewContextLoader.PrTotals totals) {
+      if (totals == null) {
+        return this;
+      }
+      return new DiffStats(
+          totals.filesChanged(), totals.additions(), totals.deletions(), omittedFiles);
     }
 
     static DiffStats fromFiles(List<GitHubPullRequestClient.FileDiff> files, int omittedFiles) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubPullRequestClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubPullRequestClientTest.java
@@ -24,7 +24,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient.FileDiff;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient.PullRequestDetails;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
@@ -100,5 +102,20 @@ class GitHubPullRequestClientTest {
     when(client.getPullRequestFilesPage("auth", "json", "o", "r", 7, 100, 1)).thenReturn(null);
 
     assertEquals(0, client.getPullRequestFiles("auth", "json", "o", "r", 7).size());
+  }
+
+  @Test
+  void deserializesAuthoritativePrTotalsFromTheGitHubSnakeCaseFields() throws Exception {
+    // GitHub's pulls payload uses changed_files (snake_case); the @JsonProperty mapping must hold
+    // so
+    // the summary's "Changes Overview" reads the authoritative totals rather than 0 (#298).
+    var json =
+        "{\"title\":\"T\",\"body\":\"B\",\"changed_files\":27,\"additions\":975,\"deletions\":196}";
+
+    var pr = new ObjectMapper().readValue(json, PullRequestDetails.class);
+
+    assertEquals(27, pr.changedFiles());
+    assertEquals(975, pr.additions());
+    assertEquals(196, pr.deletions());
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -482,6 +482,34 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
+  void changesOverviewUsesAuthoritativeTotalsWhenReviewableCountsDiverge() {
+    // #298: the "Changes Overview" and the walkthrough rollup report GitHub's authoritative PR
+    // totals passed in, not the ignore-glob-filtered reviewable-file counts. Mirrors MongOCOM#46:
+    // GitHub reports 27 files / +975 / -196, but only 26 files are reviewable (one dropped by the
+    // ignore-glob), so counts derived from the reviewable list alone would undercount.
+    var reviewable = new java.util.ArrayList<PrSummaryGenerator.ChangedFile>();
+    for (int i = 0; i < 26; i++) {
+      reviewable.add(new PrSummaryGenerator.ChangedFile("src/F" + i + ".java", "modified"));
+    }
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
+
+    var summary = generator.generate(27, 975, 196, reviewable, null, result);
+
+    // Overview reflects GitHub's authoritative totals, not the 26 reviewable files.
+    assertTrue(summary.contains("**Files changed:** 27"), summary);
+    assertTrue(summary.contains("**Lines added:** +975"), summary);
+    assertTrue(summary.contains("**Lines removed:** -196"), summary);
+    // The walkthrough still caps at MAX_FILE_ROWS rows (row 19 present, row 20 rolled up)...
+    assertTrue(summary.contains("`src/F19.java`"));
+    assertFalse(summary.contains("`src/F20.java`"));
+    // ...and the rollup counts against the authoritative total (27 - 20 = 7), not the reviewable
+    // list (26 - 20 = 6), so it matches the "Changes Overview" file total above it.
+    assertTrue(summary.contains("…and 7 more file(s)."), summary);
+  }
+
+  @Test
   void shouldEscapePipesInChangedFilesTable() {
     var changedFiles = List.of(new PrSummaryGenerator.ChangedFile("src/a|b.java", "modified"));
     var aiSummary =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
@@ -407,6 +407,40 @@ class ReviewContextLoaderTest {
   }
 
   @Nested
+  class FetchPrTotals {
+
+    @Test
+    void returnsGitHubAuthoritativeTotalsFromThePullRequest() {
+      // The summary's "Changes Overview" reports these, not the ignore-glob-filtered diff counts.
+      when(prClient.getPullRequest(anyString(), anyString(), eq("owner"), eq("repo"), eq(46)))
+          .thenReturn(
+              new GitHubPullRequestClient.PullRequestDetails(
+                  "add API",
+                  "body",
+                  new GitHubPullRequestClient.Ref("headsha"),
+                  new GitHubPullRequestClient.Ref("basesha"),
+                  27,
+                  975,
+                  196));
+
+      var totals = loader.fetchPrTotals("Bearer tok", "owner", "repo", 46);
+
+      assertNotNull(totals);
+      assertEquals(27, totals.filesChanged());
+      assertEquals(975, totals.additions());
+      assertEquals(196, totals.deletions());
+    }
+
+    @Test
+    void returnsNullWhenTheFetchThrowsSoTheSummaryFallsBackToDiffCounts() {
+      when(prClient.getPullRequest(anyString(), anyString(), eq("owner"), eq("repo"), eq(46)))
+          .thenThrow(new RuntimeException("PR fetch failed"));
+
+      assertNull(loader.fetchPrTotals("Bearer tok", "owner", "repo", 46));
+    }
+  }
+
+  @Nested
   class FetchPullRequestComments {
 
     @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -282,6 +282,30 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void diffStatsWithAuthoritativeTotalsOverridesCountsButKeepsOmittedFileCount() {
+      // #298: the "Changes Overview" uses GitHub's authoritative totals, but the reviewed-diff
+      // omitted-file count (which gates approval and drives truncation disclosure) is preserved.
+      var reviewed = new VerdictBuilder.DiffStats(26, 958, 186, 3);
+
+      var authoritative =
+          reviewed.withAuthoritativeTotals(new ReviewContextLoader.PrTotals(27, 975, 196));
+
+      assertEquals(27, authoritative.filesChanged());
+      assertEquals(975, authoritative.additions());
+      assertEquals(196, authoritative.deletions());
+      assertEquals(3, authoritative.omittedFiles());
+      assertTrue(authoritative.truncated());
+    }
+
+    @Test
+    void diffStatsWithNullAuthoritativeTotalsFallsBackToDiffDerivedCounts() {
+      // When the PR-level totals can't be fetched, the reviewed-diff counts are used unchanged.
+      var reviewed = new VerdictBuilder.DiffStats(26, 958, 186, 0);
+
+      assertSame(reviewed, reviewed.withAuthoritativeTotals(null));
+    }
+
+    @Test
     void truncatedCleanSummaryBodyDoesNotCelebrateEndToEnd() {
       // Regression (#1): buildResult handed omittedFiles=0 to the summary generator, so the body's
       // truncated() branch was dead and emitted the all-clear celebration directly under the


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The first-review PR summary's **Changes Overview** reported file/line
counts summed over the bot's *reviewable* file list — the
ignore-glob-filtered subset — rather than GitHub's authoritative PR
totals. So any PR with an ignore-globbed file (e.g. a lockfile) showed
fewer files/lines than GitHub's own numbers, and the changed-files
walkthrough's "…and N more file(s)" rollup was short by the same amount.

**Fix:**

- `GitHubPullRequestClient.PullRequestDetails` now carries
`changed_files` / `additions` / `deletions` (the same fields `gh pr
view` reads), via `@JsonProperty("changed_files")`. A 4-arg convenience
constructor keeps existing call sites/fixtures compiling.
- `ReviewContextLoader` fetches these best-effort in `load()`
(`fetchPrTotals`) and carries them on `ReviewContext` as a new
`PrTotals` record.
- `VerdictBuilder.build()` applies
`DiffStats.withAuthoritativeTotals(ctx.prTotals())` — it overrides the
overview counts but **preserves the reviewed-diff omitted-file count**,
so truncation gating (#234) and disclosure are unchanged.
- `PrSummaryGenerator` derives the walkthrough's "…and N more file(s)"
rollup from the authoritative total (`total − min(reviewableRows,
MAX_FILE_ROWS)`), while the table still lists only reviewable files.
- If the PR totals can't be fetched, the summary falls back to the
previous diff-derived counts rather than failing.

Only the review path gains one extra `getPullRequest` read; on-demand
commands are untouched.

## Related Issues

Fixes #298

Related: #39 (walkthrough origin — its rollup count now moves to
authoritative totals too), #234 (truncation disclosure — preserved). Not
#239 (per-model tokenizer, unrelated).

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

-
`PrSummaryGeneratorTest.changesOverviewUsesAuthoritativeTotalsWhenReviewableCountsDiverge`
— MongOCOM#46 shape (27 files / +975 / −196, 26 reviewable): overview
reads 27 / +975 / −196, table caps at 20 rows, rollup reads "…and 7 more
file(s)".
- `ReviewContextLoaderTest.FetchPrTotals` — authoritative totals from
the pulls endpoint; `null` fallback when the fetch throws.
-
`GitHubPullRequestClientTest.deserializesAuthoritativePrTotalsFromTheGitHubSnakeCaseFields`
— locks the `changed_files` snake_case mapping.
- `ReviewOrchestratorTest.BuildResult` — `withAuthoritativeTotals`
override-keeps-omitted and null-fallback.
- Manual: verified this PR's own bot summary renders 9 files / +205 / −8
(no ignore-globbed files here, so old and new counts agree — confirms
the non-diverging case is unchanged).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (CHANGELOG
`[Unreleased]`)
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Local verification (`JAVA_HOME=jdk-25`):

```
./mvnw verify        → Tests run: 1409, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
                       JaCoCo: All coverage checks have been met.
./mvnw spotbugs:check spotless:check → clean (exit 0)
Patch coverage (JaCoCo vs merge-base origin/main): 20/20 changed lines covered → 100.0%
```

CI on the PR: `test`, `format`, `codecov/patch` (100%), `SonarCloud`
(Quality Gate passed, 0 new issues, 100% coverage on new code),
`CodeQL`, `Analyze`, `trivy`, `frontend` — all green.

## Additional Notes

Acceptance criteria (all met): overview equals GitHub's totals;
MongOCOM#46 shape → 27 / +975 / −196 + "…and 7 more file(s)";
non-diverging PR unchanged; ignore-globbed files still excluded from the
table; truncated PR shows full totals with the truncation banner +
rollup disclosing the omission; fallback on fetch failure; divergence
test added.