### PR TITLE
fix(webhook): /summary gates on the live summary comment, not persistence state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to ThrillhouseBot.
 
+## [Unreleased]
+
+### Fixed
+
+- **`/summary` regenerates a deleted summary comment**: the command gated on persistence state ("a review ever completed for this PR") rather than the live PR, so once the summary comment was deleted it could never be regenerated — and `/summary` logged that a summary "already exists" when none was present. It now checks the PR for the bot's own summary comment and, when it is missing, re-posts it (even on a PR that already carries a formal review, where the first-review gate alone would suppress it); it still no-ops when the summary is present. The log line and README wording no longer claim a summary exists when it doesn't (#297)
+
 ## [0.3.0] — 2026-06-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ mention form, e.g. `@Thrillhousebot review`.
 |---|---|---|
 | `/help` | List the available commands | anyone |
 | `/review` | Run (or re-run) a full review of the PR | write |
-| `/summary` | Post the PR summary, but only if one has not been generated yet (otherwise no-op) | write |
+| `/summary` | Post the PR summary if it isn't already on the PR — regenerates it if the comment was deleted, otherwise no-op | write |
 | `/describe` | Suggest an improved PR title and description generated from the diff, as a comment to copy in (never overwrites the PR) | write |
 | `/changelog` | Draft a CHANGELOG entry for the PR from the diff (Added/Changed/Fixed/Security…), as a comment to copy into `CHANGELOG.md` (never commits) | write |
 | `/add-docs` | Generate docstrings/inline docs for the symbols changed in the PR, posted as committable suggestions (or a note with the drafted docs when a multi-line declaration can't be pinned to a single diff hunk) | write |

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionPersistence.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionPersistence.java
@@ -78,21 +78,6 @@ public class ReviewSessionPersistence {
         .toList();
   }
 
-  /**
-   * Whether any completed review exists for the PR. The first completed review posts the PR summary
-   * comment, so this doubles as "has a summary already been generated" for the {@code /summary}
-   * command gate.
-   */
-  @Transactional
-  public boolean hasCompletedReview(String repository, int prNumber) {
-    return this.repository.count(
-            "repository = ?1 and prNumber = ?2 and status = ?3",
-            repository,
-            prNumber,
-            ReviewSession.STATUS_COMPLETED)
-        > 0;
-  }
-
   /** Loads a managed session by ID and applies updates — safe after the entity becomes detached. */
   @Transactional
   public void update(long sessionId, Consumer<ReviewSession> mutator) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
@@ -218,7 +218,8 @@ public class ReviewContextLoader {
         req.defaultBranch(),
         req.installationId(),
         req.isManualTrigger(),
-        pr.base() != null ? pr.base().ref() : "");
+        pr.base() != null ? pr.base().ref() : "",
+        req.forceSummary());
   }
 
   /** Stack context is best-effort enrichment — its failure must never fail the review. */
@@ -272,7 +273,7 @@ public class ReviewContextLoader {
    * a first round held back only by pending CI). Best-effort: on a fetch failure it returns {@code
    * false}, falling back to the review-based signal rather than blocking the summary.
    */
-  boolean botSummaryCommentExists(String auth, String owner, String repo, int prNumber) {
+  public boolean botSummaryCommentExists(String auth, String owner, String repo, int prNumber) {
     for (var comment : fetchIssueComments(auth, owner, repo, prNumber)) {
       var user = comment.user();
       var body = comment.body();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -80,6 +80,10 @@ public class ReviewOrchestrator {
    * @param isManualTrigger {@code true} when triggered by a /review command
    * @param baseRef PR base/target branch name, used to resolve required CI checks without an extra
    *     PR fetch; may be empty until {@link ReviewContextLoader#resolveMissingPrDetails} fills it
+   * @param forceSummary {@code true} when the PR summary comment must be (re)posted even on a
+   *     follow-up review — set by {@code /summary} to regenerate a summary that was deleted from
+   *     the PR. Off by every other path, which posts the summary only on the first user-visible
+   *     review
    */
   public record ReviewRequest(
       String owner,
@@ -92,12 +96,46 @@ public class ReviewOrchestrator {
       String defaultBranch,
       long installationId,
       boolean isManualTrigger,
-      String baseRef) {
+      String baseRef,
+      boolean forceSummary) {
+
+    /**
+     * Back-compat convenience for callers that carry the base ref but never force the summary — the
+     * automatic {@code pull_request} path and tests. Defaults {@code forceSummary} to {@code
+     * false}.
+     */
+    public ReviewRequest(
+        String owner,
+        String repo,
+        int prNumber,
+        String commitSha,
+        String prTitle,
+        String prDescription,
+        String baseSha,
+        String defaultBranch,
+        long installationId,
+        boolean isManualTrigger,
+        String baseRef) {
+      this(
+          owner,
+          repo,
+          prNumber,
+          commitSha,
+          prTitle,
+          prDescription,
+          baseSha,
+          defaultBranch,
+          installationId,
+          isManualTrigger,
+          baseRef,
+          false);
+    }
 
     /**
      * Back-compat convenience for callers that don't yet carry the base ref — the manual /review
      * entry points (filled in later by {@link ReviewContextLoader#resolveMissingPrDetails}) and
-     * tests. Defaults {@code baseRef} to empty, so the CI resolver gates on all checks until known.
+     * tests. Defaults {@code baseRef} to empty and {@code forceSummary} to {@code false}, so the CI
+     * resolver gates on all checks until known.
      */
     public ReviewRequest(
         String owner,
@@ -301,7 +339,8 @@ public class ReviewOrchestrator {
    */
   private void publishSummaryBestEffort(String auth, ReviewRequest req, ReviewResult result) {
     try {
-      reviewPublisher.publishSummary(auth, req.owner(), req.repo(), req.prNumber(), result);
+      reviewPublisher.publishSummary(
+          auth, req.owner(), req.repo(), req.prNumber(), result, req.forceSummary());
     } catch (RuntimeException e) {
       Log.warnf(
           e,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -75,10 +75,17 @@ public class ReviewPublisher {
   /**
    * Posts the PR summary comment, but only on the first user-visible review (and only when there is
    * a summary to post). Follow-up reviews carry their signal in the review itself, not a new
-   * comment.
+   * comment — unless {@code forceSummary} is set, which the {@code /summary} command uses to
+   * regenerate a summary that was deleted from the PR even though a review already ran.
    */
-  void publishSummary(String auth, String owner, String repo, int prNumber, ReviewResult result) {
-    if (result.isFirstReview() && !result.summaryMarkdown().isBlank()) {
+  void publishSummary(
+      String auth,
+      String owner,
+      String repo,
+      int prNumber,
+      ReviewResult result,
+      boolean forceSummary) {
+    if ((result.isFirstReview() || forceSummary) && !result.summaryMarkdown().isBlank()) {
       commentClient.createComment(
           auth,
           ACCEPT,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
@@ -17,7 +17,6 @@ package dev.thiagogonzaga.thrillhousebot.webhook;
 
 import dev.thiagogonzaga.thrillhousebot.config.ReviewExecutor;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
-import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSessionPersistence;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
@@ -25,6 +24,7 @@ import dev.thiagogonzaga.thrillhousebot.github.ReviewThreadService;
 import dev.thiagogonzaga.thrillhousebot.review.ChangelogEntryGenerator;
 import dev.thiagogonzaga.thrillhousebot.review.DocGenerationService;
 import dev.thiagogonzaga.thrillhousebot.review.PrDescriptionGenerator;
+import dev.thiagogonzaga.thrillhousebot.review.ReviewContextLoader;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestrator;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -60,7 +60,7 @@ public class CommentCommandService {
       | Command | What it does |
       |---------|--------------|
       | `/review` | Run a fresh review of this PR |
-      | `/summary` | Post the PR summary if one has not been generated yet |
+      | `/summary` | Post the PR summary if it isn't already on the PR (regenerates a deleted one) |
       | `/describe` | Suggest an improved PR title and description from the diff |
       | `/changelog` | Draft a CHANGELOG entry for this PR from the diff |
       | `/add-docs` | Suggest docstrings for the symbols changed in this PR |
@@ -78,7 +78,7 @@ public class CommentCommandService {
   private final GitHubReviewClient reviewClient;
   private final ReviewThreadService reviewThreadService;
   private final ReviewDispatcher reviewDispatcher;
-  private final ReviewSessionPersistence sessionPersistence;
+  private final ReviewContextLoader contextLoader;
   private final PrPauseService prPauseService;
   private final ManualReviewAuthorizer authorizer;
   private final TriggerDetector triggerDetector;
@@ -95,7 +95,7 @@ public class CommentCommandService {
       @RestClient GitHubReviewClient reviewClient,
       ReviewThreadService reviewThreadService,
       ReviewDispatcher reviewDispatcher,
-      ReviewSessionPersistence sessionPersistence,
+      ReviewContextLoader contextLoader,
       PrPauseService prPauseService,
       ManualReviewAuthorizer authorizer,
       TriggerDetector triggerDetector,
@@ -109,7 +109,7 @@ public class CommentCommandService {
     this.reviewClient = reviewClient;
     this.reviewThreadService = reviewThreadService;
     this.reviewDispatcher = reviewDispatcher;
-    this.sessionPersistence = sessionPersistence;
+    this.contextLoader = contextLoader;
     this.prPauseService = prPauseService;
     this.authorizer = authorizer;
     this.triggerDetector = triggerDetector;
@@ -183,10 +183,13 @@ public class CommentCommandService {
       postComment(auth, ctx, PAUSED_NOTICE);
       return;
     }
-    if (sessionPersistence.hasCompletedReview(repository(ctx), ctx.prNumber())) {
-      // A summary was already generated on the first review; the command is a no-op by design.
+    // Gate on the live PR, not persistence: a review that once completed does not mean the summary
+    // comment is still there — it may have been deleted. No-op only when the comment is actually
+    // present; otherwise dispatch a review that (re)posts it via forceSummary, even on a PR that
+    // already carries a formal bot review, where the first-review gate alone would suppress it.
+    if (contextLoader.botSummaryCommentExists(auth, ctx.owner(), ctx.repo(), ctx.prNumber())) {
       log.info(
-          "Ignoring /summary — a summary already exists on {}/{} #{}",
+          "Ignoring /summary — a summary comment is already present on {}/{} #{}",
           ctx.owner(),
           ctx.repo(),
           num(ctx));
@@ -209,6 +212,8 @@ public class CommentCommandService {
             "",
             ctx.defaultBranch(),
             ctx.installationId(),
+            true,
+            "",
             true));
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionPersistenceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionPersistenceTest.java
@@ -124,24 +124,6 @@ class ReviewSessionPersistenceTest extends ReviewSessionTestSupport {
     assertTrue(persistence.findAllPriorAiResponseJsons("owner/repo", 3, current.id).isEmpty());
   }
 
-  @Test
-  void shouldReportCompletedReviewExists() throws Exception {
-    persistSessionWith("owner/repo", 3, ReviewSession.STATUS_COMPLETED, "{\"v\":1}");
-
-    assertTrue(persistence.hasCompletedReview("owner/repo", 3));
-  }
-
-  @Test
-  void shouldNotReportCompletedReviewForOtherStatusesOrPrs() throws Exception {
-    persistSessionWith("owner/repo", 3, ReviewSession.STATUS_IN_PROGRESS, null);
-    persistSessionWith("owner/repo", 3, ReviewSession.STATUS_FAILED, null);
-    persistSessionWith("owner/repo", 4, ReviewSession.STATUS_COMPLETED, "{\"v\":1}");
-
-    // No completed review for PR #3, and the completed one on PR #4 must not leak across.
-    assertFalse(persistence.hasCompletedReview("owner/repo", 3));
-    assertFalse(persistence.hasCompletedReview("other/repo", 4));
-  }
-
   private ReviewSession persistSession() throws Exception {
     tx.begin();
     ReviewSession session = ReviewSession.create("owner/repo", 3, "PR", "abc");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2102,6 +2102,82 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void shouldRepostSummaryWhenForceSummarySetEvenThoughReviewExists() {
+      // The /summary regeneration path: a formal bot review already exists (so the first-review
+      // gate is off), yet the summary comment was deleted. forceSummary must re-post it anyway.
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = mock(ReviewSession.class);
+        session.id = 1L;
+        when(session.getRepository()).thenReturn("owner/repo");
+        when(session.getPrNumber()).thenReturn(42);
+        when(session.getPrTitle()).thenReturn("Test PR");
+        when(session.getCommitSha()).thenReturn("abcdefgh");
+        when(session.getTimestamp()).thenReturn(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+
+        when(authClient.getAuthHeader(123L)).thenReturn("Bearer test");
+        when(checkRunClient.createCheckRun(
+                anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(new GitHubCheckRunClient.CheckRunResponse(1L, "http://check"));
+        doNothing()
+            .when(checkRunClient)
+            .updateCheckRun(anyString(), anyString(), anyString(), anyString(), anyLong(), any());
+        when(prClient.getPullRequestFiles(
+                anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of());
+        when(checkRunClient.getRequiredStatusChecks(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(new GitHubCheckRunClient.RequiredStatusChecks(List.of(), List.of()));
+        when(prClient.compareCommits(
+                anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(new GitHubPullRequestClient.CompareResponse(0, List.of()));
+        // A prior bot review is present, so isFirstVisibleReview is false and the ordinary
+        // first-review gate would suppress the summary.
+        when(reviewClient.listReviews(anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(
+                List.of(
+                    new GitHubReviewClient.ReviewResponse(
+                        1L,
+                        "",
+                        "APPROVED",
+                        "abc12345",
+                        new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]"))));
+        when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
+            .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
+        when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any(), any()))
+            .thenReturn(PrSummaryGenerator.SUMMARY_HEADING);
+        when(aiReviewService.review(any(ReviewSession.class), any()))
+            .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+        orchestrator.review(
+            new ReviewOrchestrator.ReviewRequest(
+                "owner",
+                "repo",
+                42,
+                "abcdefgh",
+                "(manual summary)",
+                "",
+                "base1234567",
+                "main",
+                123L,
+                true,
+                "main",
+                true));
+
+        // The summary issue-comment IS re-posted despite the existing review, because forceSummary
+        // is set — this is the deleted-summary regeneration the /summary command relies on.
+        var body = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+        verify(commentClient)
+            .createComment(
+                anyString(), anyString(), anyString(), anyString(), anyInt(), body.capture());
+        assertTrue(body.getValue().body().startsWith(PrSummaryGenerator.SUMMARY_HEADING));
+        verify(session).setStatus(ReviewSession.STATUS_COMPLETED);
+      }
+    }
+
+    @Test
     void shouldSkipSummaryWhenABotSummaryCommentAlreadyExistsButNoReviewDoes() {
       // Regression for the duplicate-summary bug: a first round held back only by pending CI posts
       // the summary issue-comment but leaves no review. On the next round no bot review

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
-import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSessionPersistence;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
@@ -30,6 +29,7 @@ import dev.thiagogonzaga.thrillhousebot.github.ReviewThreadService;
 import dev.thiagogonzaga.thrillhousebot.review.ChangelogEntryGenerator;
 import dev.thiagogonzaga.thrillhousebot.review.DocGenerationService;
 import dev.thiagogonzaga.thrillhousebot.review.PrDescriptionGenerator;
+import dev.thiagogonzaga.thrillhousebot.review.ReviewContextLoader;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestrator;
 import java.util.List;
@@ -49,7 +49,7 @@ class CommentCommandServiceTest {
   @Mock private GitHubReviewClient reviewClient;
   @Mock private ReviewThreadService reviewThreadService;
   @Mock private ReviewDispatcher reviewDispatcher;
-  @Mock private ReviewSessionPersistence sessionPersistence;
+  @Mock private ReviewContextLoader contextLoader;
   @Mock private PrPauseService prPauseService;
   @Mock private ManualReviewAuthorizer authorizer;
   @Mock private PrDescriptionGenerator descriptionGenerator;
@@ -82,7 +82,7 @@ class CommentCommandServiceTest {
             reviewClient,
             reviewThreadService,
             reviewDispatcher,
-            sessionPersistence,
+            contextLoader,
             prPauseService,
             authorizer,
             new TriggerDetector(),
@@ -118,25 +118,39 @@ class CommentCommandServiceTest {
   }
 
   @Test
-  void summaryDispatchesReviewWhenNoSummaryExists() {
+  void summaryDispatchesForcedReviewWhenNoLiveSummaryComment() {
     authorize(true);
     when(prPauseService.isPaused("owner", "repo", 7)).thenReturn(false);
-    when(sessionPersistence.hasCompletedReview("owner/repo", 7)).thenReturn(false);
+    // No summary comment currently on the PR (never generated, or deleted) — the command must run.
+    when(contextLoader.botSummaryCommentExists("token", "owner", "repo", 7)).thenReturn(false);
 
     service.handle(ctx(CommentCommand.SUMMARY));
 
+    // Dispatched with forceSummary=true (last arg) so the summary is (re)posted even if a formal
+    // bot review already exists, where the first-review gate alone would suppress it.
     verify(reviewDispatcher)
         .dispatch(
             new ReviewOrchestrator.ReviewRequest(
-                "owner", "repo", 7, "", "(manual summary)", "", "", "main", 12345L, true));
+                "owner",
+                "repo",
+                7,
+                "",
+                "(manual summary)",
+                "",
+                "",
+                "main",
+                12345L,
+                true,
+                "",
+                true));
     verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
   }
 
   @Test
-  void summaryIsNoOpWhenSummaryAlreadyExists() {
+  void summaryIsNoOpWhenSummaryCommentIsLiveOnPr() {
     authorize(true);
     when(prPauseService.isPaused("owner", "repo", 7)).thenReturn(false);
-    when(sessionPersistence.hasCompletedReview("owner/repo", 7)).thenReturn(true);
+    when(contextLoader.botSummaryCommentExists("token", "owner", "repo", 7)).thenReturn(true);
 
     service.handle(ctx(CommentCommand.SUMMARY));
 
@@ -153,7 +167,7 @@ class CommentCommandServiceTest {
 
     assertEquals(CommentCommandService.PAUSED_NOTICE, postedBody());
     verify(reviewDispatcher, never()).dispatch(any());
-    verify(sessionPersistence, never()).hasCompletedReview(any(), anyInt());
+    verify(contextLoader, never()).botSummaryCommentExists(any(), any(), any(), anyInt());
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`/summary` decided to no-op based on **persistence state** —
`hasCompletedReview` counts `ReviewSession` rows in `STATUS_COMPLETED`,
i.e. "a review ever completed for this PR" — rather than whether the
bot's summary comment is **currently on the PR**. Consequences:

- A deleted summary comment could never be regenerated via `/summary`
(only a full `/review`, and even that only in the no-formal-review
case).
- The bot logged `Ignoring /summary — a summary already exists …` when
**no** summary comment was present (dogfooded on ThrillhouseBot#256).

This is the same *persistence-state-vs-actual-PR-state* class already
fixed for the `/review` path in #134, which introduced
`ReviewContextLoader.botSummaryCommentExists()` (a live scan of the PR's
issue comments for the `## 🤖 ThrillhouseBot PR Summary` marker,
pagination- / bot-identity- / truncation-banner-aware). `/summary`
simply never migrated to it.

### Changes

- **Gate `/summary` on the live comment**, not persistence:
`CommentCommandService.handleSummary` now calls
`contextLoader.botSummaryCommentExists(...)` (made `public`) and only
no-ops when the comment is actually present. The log line no longer
asserts a comment exists.
- **`forceSummary` flag on `ReviewRequest`** →
`publishSummaryBestEffort` → `ReviewPublisher.publishSummary`
(`isFirstReview || forceSummary`). This is the essential part: without
it, re-dispatching a review on a PR that already carries a formal bot
review would spend AI budget yet still suppress the summary
(`isFirstVisibleReview` is false). `/summary` sets it so a deleted
summary genuinely regenerates. `summaryMarkdown` is always generated, so
the content is available on any review.
- **Propagated through `ReviewContextLoader.resolveMissingPrDetails`**,
which reconstructs the request when `commitSha` is blank — exactly the
`/summary` path — otherwise the flag would be dropped.
- **Removed dead code**: `ReviewSessionPersistence.hasCompletedReview`
(its only caller was the old gate; its javadoc described the now-removed
`/summary` proxy).
- **Docs**: README `/summary` row, in-app `/help` table, and a CHANGELOG
`[Unreleased]` entry aligned with the shipped behavior.

Behavior preserved: normal case (`/summary` with the comment present)
still no-ops; unauthorized and paused-PR paths unchanged.

## Related Issues

Fixes #297

Related context: #134 (same bug class, `/review` path), #32
(slash-command origin), #296 / #298 (sibling v0.3.0 dogfood findings).

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

Full local verification on **JDK 25**:

| Check | Result |
|---|---|
| Test suite (`mvn clean test`) | **1402 passed**, 0 failures/errors |
| SpotBugs (`spotbugs:check`) | **0 bugs** |
| Spotless (`spotless:check`) | clean |
| Patch coverage (JaCoCo vs merge-base) | **100% (9/9 trackable lines)**
|

New / updated tests:
- `CommentCommandServiceTest`: `/summary` dispatches with
`forceSummary=true` when no live comment; no-ops when the comment is
present; skips the check when paused.
-
`ReviewOrchestratorTest.shouldRepostSummaryWhenForceSummarySetEvenThoughReviewExists`:
proves `forceSummary` re-posts the summary **even when a formal bot
review already exists** (the deleted-summary regeneration path).
- `ReviewSessionPersistenceTest`: dropped the tests for the removed
`hasCompletedReview`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A — backend logic change with no UI surface. Behavior is covered by
the automated tests and verification table above; the fixed log line
reads `Ignoring /summary — a summary comment is already present on
{owner}/{repo} #{n}` (was `… a summary already exists …`).

## Additional Notes

`/summary` continues to run a full review under the hood (unchanged
behavior); this PR does not alter its cost profile. No breaking changes
— the two back-compat `ReviewRequest` constructors default
`forceSummary` to `false`, so every other call site is unaffected.