### PR TITLE
fix(review): clarify CI hold copy when required contexts are unknown (#302)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluator.java
@@ -157,11 +157,26 @@ public class CiStatusEvaluator {
 
   /**
    * The outcome of evaluating a commit's CI: the <em>offending</em> checks (pending, failing, or
-   * missing) and whether a CI source could not be read at all. Both hold the APPROVE decision back,
-   * but they are distinct concepts — unreadable is not a check — so the verdict and the rendered
-   * summary can treat them separately.
+   * missing), whether a CI source could not be read at all, and whether the required-context set
+   * was actually resolved. The first two both hold the APPROVE decision back but are distinct
+   * concepts — unreadable is not a check — so the verdict and the rendered summary can treat them
+   * separately. {@code requiredContextsKnown} is false in fail-closed gate-all mode (the required
+   * set could not be resolved, so every check is gated): the rendered copy then drops the word
+   * "required", which would misdescribe checks branch protection never named (#302).
    */
-  record CiEvaluation(List<ReviewResult.CiCheck> offendingChecks, boolean unreadable) {}
+  record CiEvaluation(
+      List<ReviewResult.CiCheck> offendingChecks,
+      boolean unreadable,
+      boolean requiredContextsKnown) {
+
+    /**
+     * Convenience for callers/tests that predate the required-context flag: assumes the required
+     * set was resolved, so rendered copy keeps the accurate "required" wording.
+     */
+    CiEvaluation(List<ReviewResult.CiCheck> offendingChecks, boolean unreadable) {
+      this(offendingChecks, unreadable, true);
+    }
+  }
 
   /**
    * Evaluates the CI checks on {@code commitSha}: the <em>offending</em> ones — pending, failing,
@@ -203,7 +218,12 @@ public class CiStatusEvaluator {
     // unread can still hide a required check's true state. Reported as a first-class signal, not a
     // synthetic check.
     boolean unreadable = !checkRunsReadable || !statusReadable;
-    return new CiEvaluation(offending, unreadable);
+    // requiredContexts == null means the required set could not be resolved and we are gating on
+    // every check; the rendered copy then uses neutral "CI check(s)" wording rather than calling
+    // checks "required" when branch protection never named them (#302). A resolved list (even
+    // empty)
+    // keeps the accurate "required" wording.
+    return new CiEvaluation(offending, unreadable, requiredContexts != null);
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -165,13 +165,21 @@ public class PrSummaryGenerator {
       }
       sb.append("\n");
     } else if (hasNoUnresolvedPrevious(result)) {
+      // Drop "required" in fail-closed gate-all mode: CI holds approval because the required set
+      // was
+      // unknown (gating all checks), not because branch protection named these checks (#302).
+      String ciPhrase = result.requiredContextsKnown() ? "required CI" : "CI";
       if (result.ciHoldsApproval() && result.truncated()) {
         // Both holds apply — report both so a truncated review isn't masked by the CI message.
         sb.append(
-            "No new issues found in the reviewed portion of this PR, but it cannot be approved: required CI is not confirmed green, and the diff was too large to review in full (a partial review).\n\n");
+                "No new issues found in the reviewed portion of this PR, but it cannot be approved: ")
+            .append(ciPhrase)
+            .append(
+                " is not confirmed green, and the diff was too large to review in full (a partial review).\n\n");
       } else if (result.ciHoldsApproval()) {
-        sb.append(
-            "No new issues found in this PR, but the review cannot be approved until required CI is confirmed green.\n\n");
+        sb.append("No new issues found in this PR, but the review cannot be approved until ")
+            .append(ciPhrase)
+            .append(" is confirmed green.\n\n");
       } else if (result.truncated()) {
         sb.append(
             "No new issues found in the reviewed portion of this PR — but the diff was too large to review in full, so this is a partial review.\n\n");
@@ -183,8 +191,15 @@ public class PrSummaryGenerator {
 
   private static void appendCiChecks(StringBuilder sb, ReviewResult result) {
     if (!result.offendingCiChecks().isEmpty()) {
-      sb.append("### ⚠️ Required CI Checks Status\n");
-      sb.append("Some required checks are still pending or have failed:\n\n");
+      // Drop "Required"/"required" in fail-closed gate-all mode: these checks are gated because the
+      // required set was unknown, not because branch protection named them required (#302).
+      if (result.requiredContextsKnown()) {
+        sb.append("### ⚠️ Required CI Checks Status\n");
+        sb.append("Some required checks are still pending or have failed:\n\n");
+      } else {
+        sb.append("### ⚠️ CI Checks Status\n");
+        sb.append("Some checks are still pending or have failed:\n\n");
+      }
       sb.append("| Check | Type | Status | Detail |\n");
       sb.append("|-------|------|--------|--------|\n");
       for (var check : result.offendingCiChecks()) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -165,27 +165,47 @@ public class PrSummaryGenerator {
       }
       sb.append("\n");
     } else if (hasNoUnresolvedPrevious(result)) {
-      // Drop "required" in fail-closed gate-all mode: CI holds approval because the required set
-      // was
-      // unknown (gating all checks), not because branch protection named these checks (#302).
-      String ciPhrase = result.requiredContextsKnown() ? "required CI" : "CI";
-      if (result.ciHoldsApproval() && result.truncated()) {
-        // Both holds apply — report both so a truncated review isn't masked by the CI message.
-        sb.append(
-                "No new issues found in the reviewed portion of this PR, but it cannot be approved: ")
-            .append(ciPhrase)
-            .append(
-                " is not confirmed green, and the diff was too large to review in full (a partial review).\n\n");
-      } else if (result.ciHoldsApproval()) {
-        sb.append("No new issues found in this PR, but the review cannot be approved until ")
-            .append(ciPhrase)
-            .append(" is confirmed green.\n\n");
+      if (result.ciHoldsApproval()) {
+        appendCiHold(sb, result);
       } else if (result.truncated()) {
         sb.append(
             "No new issues found in the reviewed portion of this PR — but the diff was too large to review in full, so this is a partial review.\n\n");
       } else {
         sb.append(ZERO_ISSUES_MESSAGE).append("\n\n");
       }
+    }
+  }
+
+  /**
+   * Renders the celebration-replacement line when CI holds approval (optionally alongside a
+   * truncated diff). The two CI holds read differently: an offending check is pending/failing, so
+   * it is phrased as CI "not confirmed green" — with neutral "CI"/"required CI" wording per whether
+   * the required set was resolved (#302). An unreadable source is NOT a not-green result — it could
+   * not be read — so it gets "could not be read" wording, matching {@code
+   * VerdictBuilder.checkSummaryForResult} and the "CI Status Unavailable" section rather than
+   * misreporting an unread status as failing. Reached only via {@link
+   * ReviewResult#ciHoldsApproval}, so no offending check implies the hold is an unreadable source.
+   */
+  private static void appendCiHold(StringBuilder sb, ReviewResult result) {
+    boolean offending = !result.offendingCiChecks().isEmpty();
+    boolean truncated = result.truncated();
+    String ciPhrase = result.requiredContextsKnown() ? "required CI" : "CI";
+    if (offending && truncated) {
+      sb.append(
+              "No new issues found in the reviewed portion of this PR, but it cannot be approved: ")
+          .append(ciPhrase)
+          .append(
+              " is not confirmed green, and the diff was too large to review in full (a partial review).\n\n");
+    } else if (offending) {
+      sb.append("No new issues found in this PR, but the review cannot be approved until ")
+          .append(ciPhrase)
+          .append(" is confirmed green.\n\n");
+    } else if (truncated) {
+      sb.append(
+          "No new issues found in the reviewed portion of this PR, but it cannot be approved: the CI status could not be read, and the diff was too large to review in full (a partial review).\n\n");
+    } else {
+      sb.append(
+          "No new issues found in this PR, but the CI status could not be read, so the review cannot be approved until it can be confirmed.\n\n");
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -33,7 +33,11 @@ public record ReviewResult(
     List<PreviousFindingStatus> previousStatuses,
     List<CiCheck> offendingCiChecks,
     int omittedFiles,
-    boolean ciUnreadable) {
+    boolean ciUnreadable,
+    // False in fail-closed gate-all mode: the required-context set could not be resolved, so every
+    // check is gated. The rendered CI copy then drops "required", which would misdescribe checks
+    // branch protection never named (#302).
+    boolean requiredContextsKnown) {
   public ReviewResult {
     findings = List.copyOf(findings);
     previousStatuses = List.copyOf(previousStatuses);
@@ -73,6 +77,43 @@ public record ReviewResult(
         offendingCiChecks,
         omittedFiles,
         false);
+  }
+
+  /**
+   * Convenience constructor for results built before the required-context flag existed (and tests):
+   * assumes the required set was resolved, so rendered CI copy keeps the accurate "required"
+   * wording. The production path ({@code VerdictBuilder}) passes the real flag through the
+   * canonical constructor.
+   */
+  public ReviewResult(
+      List<Finding> findings,
+      int criticalCount,
+      int highCount,
+      int mediumCount,
+      int lowCount,
+      RiskLevel highestRisk,
+      ReviewState reviewState,
+      boolean isFirstReview,
+      String summaryMarkdown,
+      List<PreviousFindingStatus> previousStatuses,
+      List<CiCheck> offendingCiChecks,
+      int omittedFiles,
+      boolean ciUnreadable) {
+    this(
+        findings,
+        criticalCount,
+        highCount,
+        mediumCount,
+        lowCount,
+        highestRisk,
+        reviewState,
+        isFirstReview,
+        summaryMarkdown,
+        previousStatuses,
+        offendingCiChecks,
+        omittedFiles,
+        ciUnreadable,
+        true);
   }
 
   /** How many findings the PR summary lists under "Key Findings". */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -126,9 +126,12 @@ public class VerdictBuilder {
                 + " confirmed."
             : "";
     if (!result.offendingCiChecks().isEmpty()) {
+      // Drop "required" in fail-closed gate-all mode: the checks are gated because the required set
+      // was unknown, not because branch protection named them required (#302).
+      var checkLabel = result.requiredContextsKnown() ? "required CI check(s)" : "CI check(s)";
       return String.format(
-              "No new issues found, but %d required CI check(s) are still pending or failing.",
-              result.offendingCiChecks().size())
+              "No new issues found, but %d %s are still pending or failing.",
+              result.offendingCiChecks().size(), checkLabel)
           + unreadableSuffix
           + truncationSuffix;
     }
@@ -193,6 +196,7 @@ public class VerdictBuilder {
       List<ReviewResult.PreviousFindingStatus> backstopUnresolved) {
     var offendingCiChecks = ciEvaluation.offendingChecks();
     var ciUnreadable = ciEvaluation.unreadable();
+    var requiredContextsKnown = ciEvaluation.requiredContextsKnown();
     var tally = tallyFindings(aiResponse);
 
     // The review may only approve when nothing is outstanding: new findings AND previous
@@ -248,7 +252,8 @@ public class VerdictBuilder {
                 // and reports a partial review instead of the all-clear celebration; passing 0 here
                 // made that branch dead and let the celebration contradict the truncation banner.
                 diffStats.omittedFiles(),
-                ciUnreadable));
+                ciUnreadable,
+                requiredContextsKnown));
     if (diffStats.truncated()) {
       summaryMarkdown = ReviewResult.truncationNotice(diffStats.omittedFiles()) + summaryMarkdown;
     }
@@ -266,7 +271,8 @@ public class VerdictBuilder {
         previousStatuses,
         offendingCiChecks,
         diffStats.omittedFiles(),
-        ciUnreadable);
+        ciUnreadable,
+        requiredContextsKnown);
   }
 
   /** Findings parsed from the model response, with per-severity counts and the highest risk. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluatorTest.java
@@ -242,6 +242,32 @@ class CiStatusEvaluatorTest {
     }
 
     @Test
+    void requiredContextsKnownReflectsWhetherRequiredListWasResolved() {
+      // #302: the evaluation records whether a required-context set was resolved, so the rendered
+      // copy can drop "required" in fail-closed gate-all mode (requiredContexts == null) and keep
+      // it
+      // when a concrete list was resolved.
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(
+              new GitHubCheckRunClient.CheckRunsResponse(
+                  1,
+                  List.of(
+                      new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                          1L, "build", "completed", "success", null))));
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CombinedStatus("success", 0, List.of()));
+
+      assertFalse(
+          evaluator.evaluateCiChecks("auth", "owner", "repo", "sha", null).requiredContextsKnown(),
+          "a null required set (gate-all mode) is not a resolved list");
+      assertTrue(
+          evaluator
+              .evaluateCiChecks("auth", "owner", "repo", "sha", List.of("build"))
+              .requiredContextsKnown(),
+          "a resolved required list is recorded as known");
+    }
+
+    @Test
     void unreadableCiInGateSpecificModeAlsoHoldsApproval() {
       // #5: gate-specific mode is NOT automatically safe. The Check Runs source throws, so a
       // required check reporting only there could be hidden; the missing-required backfill still

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -666,6 +666,46 @@ class PrSummaryGeneratorTest {
     assertTrue(summary.contains("CI Status Unavailable"));
     assertTrue(summary.contains("could not be read"));
     assertFalse(summary.contains(PrSummaryGenerator.ZERO_ISSUES_MESSAGE));
+    // #302 follow-up: an unreadable-only hold must read as "could not be read", not be framed as a
+    // "not confirmed green" result — that lead misreports an unread status as failing.
+    assertTrue(
+        summary.contains(
+            "the CI status could not be read, so the review cannot be approved until it can be"
+                + " confirmed"),
+        summary);
+    assertFalse(summary.contains("confirmed green"), summary);
+  }
+
+  @Test
+  void unreadableCiWithTruncationReportsBothWithoutClaimingNotGreen() {
+    // #302 follow-up: an unreadable-only CI hold alongside a truncated diff reports the read
+    // failure
+    // as "could not be read" (not "not confirmed green") and still discloses the partial review.
+    var result =
+        new ReviewResult(
+            List.of(),
+            0,
+            0,
+            0,
+            0,
+            null,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            2,
+            true);
+
+    var summary = generator.generate(1, 5, 0, List.of(), null, result);
+
+    assertTrue(
+        summary.contains(
+            "the CI status could not be read, and the diff was too large to review in full"),
+        summary);
+    assertFalse(summary.contains("confirmed green"), summary);
+    assertTrue(summary.contains("partial review"), summary);
+    assertTrue(summary.contains("CI Status Unavailable"), summary);
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -341,6 +341,43 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
+  void showsNeutralCiChecksStatusWhenRequiredSetUnknown() {
+    // #302: in fail-closed gate-all mode (required set unresolved) the summary must not label the
+    // gated checks "required" — branch protection never named them; they are gated because the
+    // required set was unknown.
+    var checks =
+        List.of(
+            new ReviewResult.CiCheck("build", "check-run", "failing", null),
+            new ReviewResult.CiCheck("test", "status", "pending", "pending"));
+    var result =
+        new ReviewResult(
+            List.of(),
+            0,
+            0,
+            0,
+            0,
+            null,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            checks,
+            0,
+            false,
+            false);
+
+    var summary = generator.generate(1, 10, 2, List.of(), null, result);
+
+    assertFalse(summary.contains("Everything's coming up Thrillhouse"));
+    assertTrue(summary.contains("until CI is confirmed green"), summary);
+    assertFalse(summary.contains("required CI is confirmed green"), summary);
+    assertTrue(summary.contains("### ⚠️ CI Checks Status"), summary);
+    assertFalse(summary.contains("Required CI Checks Status"), summary);
+    assertTrue(summary.contains("Some checks are still pending or have failed"), summary);
+    assertFalse(summary.contains("Some required checks are still pending or have failed"), summary);
+  }
+
+  @Test
   void cleanReviewHeldByBothCiAndTruncationReportsBoth() {
     // When CI holds approval AND the diff was truncated, the summary must disclose both — the CI
     // message must not mask the partial review.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -907,6 +907,36 @@ class ReviewOrchestratorTest {
       assertFalse(summary.contains("Everything's coming up Thrillhouse"));
       assertTrue(summary.contains("required CI check(s) are still pending or failing"));
     }
+
+    @Test
+    void checkSummaryUsesNeutralCiWordingWhenRequiredSetUnknown() {
+      // #302: in fail-closed gate-all mode (required set unresolved) the offending checks are gated
+      // because the required set was unknown, not because branch protection named them required —
+      // so
+      // the caption drops the word "required" and calls them plain "CI check(s)".
+      var offending = List.of(new ReviewResult.CiCheck("build", "check-run", "failing", "failure"));
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.COMMENT,
+              true,
+              "",
+              List.of(),
+              offending,
+              0,
+              false,
+              false);
+
+      String summary = VerdictBuilder.checkSummaryForResult(result);
+
+      assertTrue(summary.contains("1 CI check(s) are still pending or failing"), summary);
+      assertFalse(summary.contains("required CI check(s)"), summary);
+    }
   }
 
   @Nested


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

When branch-protection required contexts cannot be resolved,
`CiStatusEvaluator.resolveRequiredContexts` returns `Optional.empty()`,
which `ReviewOrchestrator.resolveCiEvaluation` maps to `null`. In that
**fail-closed gate-all** mode `evaluateCiChecks` treats every
non-passing check as gating-worthy (intentional). But the user-facing
copy still called those checks **required** — misleading, because the
bot is gating on all checks since the required set was *unknown*, not
because branch protection named them required.

This threads a `requiredContextsKnown` flag (`requiredContexts != null`)
from `evaluateCiChecks` → `CiEvaluation` → `ReviewResult`, and branches
the rendered copy:

- **Unknown required set (gating all checks)** → neutral wording: `"%d
CI check(s) are still pending or failing"`, `### ⚠️ CI Checks Status`,
`"until CI is confirmed green"`.
- **Known required list resolved** → accurate `"required"` wording
preserved.

Surfaces updated:
- `VerdictBuilder.checkSummaryForResult` (check-run summary)
- `PrSummaryGenerator.appendFindingsOrCelebration` + `appendCiChecks`
(summary comment)

Fail-closed gating behavior is unchanged: an unknown required set still
gates every non-passing check and holds APPROVE.
(`ReviewPublisher.noIssuesBody` already used neutral "some checks"
wording, so the review body needed no change.)

## Related Issues

Fixes #302

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- `CiStatusEvaluatorTest` — `requiredContextsKnown` is `false` for
`requiredContexts == null` and `true` for a resolved list.
- `ReviewOrchestratorTest` (`CheckRunPresentation`) — check-run caption
uses neutral `"CI check(s)"` when the required set is unknown; existing
test keeps `"required CI check(s)"` when known.
- `PrSummaryGeneratorTest` — summary renders `### ⚠️ CI Checks Status` /
`"until CI is confirmed green"` (no "required") in gate-all mode;
existing tests keep the "required" wording when a list was resolved.
- Full suite green locally: **1406 tests, 0 failures**. Spotless +
SpotBugs clean; all changed production lines covered per JaCoCo (Codecov
patch confirmed 100%).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A — copy-only clarification covered by unit tests. The neutral wording
renders in the check-run summary (`"%d CI check(s) are still pending or
failing"`) and the PR summary comment (`### ⚠️ CI Checks Status`) when
the required-context set is unknown; the accurate "required" wording is
preserved when a concrete list is resolved.

## Additional Notes

- No behavior change to CI gating — copy-only clarification plus the
flag that drives it.
- Groundwork adjacent to #322 (configurable CI gating strictness), which
explicitly references this issue.