### PR TITLE
feat(review): per-PR automatic review rate limit (#328)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ GITHUB_WEBHOOK_SECRET=your_webhook_secret
 # Optional: upper bound on the manual /review write-access check (token mint + permission call) on the
 # webhook ack thread; fails closed (denies the trigger) if GitHub is slower.
 #MANUAL_TRIGGER_AUTH_TIMEOUT=5s
+# Optional: minimum interval between automatic reviews of the same PR (pushes within the window are
+# skipped; a manual /review always bypasses; 0 disables)
+#AUTO_REVIEW_MIN_INTERVAL=1h
 # Optional: automatic review trigger filters. Defaults review every PR; a manual /review always runs.
 #WEBHOOK_SKIP_DRAFTS=true
 #WEBHOOK_REQUIRED_LABELS=ai-review

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ variables are the ones you will change per provider:
 | `WEBHOOK_DEDUP_TTL` | Webhook deduplication time-to-live for GitHub redeliveries | `24h` |
 | `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` | Comma-separated allowlist of logins permitted to trigger manual `/review` without repo access | _(empty)_ |
 | `MANUAL_TRIGGER_AUTH_TIMEOUT` | Upper bound on the manual-trigger write-access check on the webhook ACK thread; fails closed (denies) if GitHub is slower | `5s` |
+| `AUTO_REVIEW_MIN_INTERVAL` | Minimum interval between automatic reviews of the same PR — pushes within the window are skipped silently, even on a new head SHA (in-memory, per replica). A manual `/review` always bypasses; `0` disables | `1h` |
 | `WEBHOOK_SKIP_DRAFTS` | Skip auto-review while a PR is a draft (reviewed once marked ready / on later pushes) | `false` |
 | `WEBHOOK_REQUIRED_LABELS` | Comma-separated labels; only auto-review PRs carrying at least one (case-insensitive) | _(empty — no gate)_ |
 | `WEBHOOK_EXCLUDED_LABELS` | Comma-separated labels; skip auto-review of PRs carrying any (wins over required) | _(empty)_ |

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -204,6 +204,17 @@ public interface ThrillhouseConfig {
     @WithName("manual-trigger-auth-timeout")
     Duration manualTriggerAuthTimeout();
 
+    /**
+     * Minimum interval between automatic (webhook-triggered) reviews of the same PR. While the last
+     * automatic review completed less than this ago, {@code pull_request} events for the PR are
+     * skipped silently — even when the head SHA changed — capping AI spend on noisy repositories. A
+     * manual {@code /review} always bypasses and never shifts the window. Zero (or negative)
+     * disables throttling. Tracked in-memory per replica.
+     */
+    @WithDefault("1h")
+    @WithName("auto-review-min-interval")
+    Duration autoReviewMinInterval();
+
     LabelsConfig labels();
 
     DiagramConfig diagram();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AutoReviewRateLimiter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AutoReviewRateLimiter.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+
+/**
+ * Throttles automatic (webhook-triggered) reviews per PR: while the last automatic review of a PR
+ * completed less than {@code thrillhousebot.review.auto-review-min-interval} ago, new {@code
+ * pull_request} events for it are skipped — even when the head SHA changed — so noisy repositories
+ * that push frequently do not burn AI spend and GitHub API budget on every commit.
+ *
+ * <p>Only the automatic path consults this limiter; a manual {@code /review} (or {@code
+ * @thrillhousebot review}) never checks it and never records into it, so explicit triggers always
+ * run and do not shift the automatic window. State is in-memory per replica, like {@link
+ * dev.thiagogonzaga.thrillhousebot.webhook.WebhookDeduplicator}.
+ */
+@ApplicationScoped
+public class AutoReviewRateLimiter {
+
+  /** Sweep expired PRs once the map reaches this size, mirroring the other in-memory TTL caches. */
+  static final int SWEEP_THRESHOLD = 10_000;
+
+  /** PR key → epoch-millis deadline until which automatic reviews of that PR are throttled. */
+  final ConcurrentHashMap<String, Long> deadlines = new ConcurrentHashMap<>();
+
+  private final long intervalMillis;
+  private final int sweepThreshold;
+  private final LongSupplier clock;
+
+  @Inject
+  public AutoReviewRateLimiter(ThrillhouseConfig config) {
+    this(
+        config.review().autoReviewMinInterval().toMillis(),
+        SWEEP_THRESHOLD,
+        System::currentTimeMillis);
+  }
+
+  /** Visible for tests: allows controlling the interval, clock, and sweep threshold. */
+  AutoReviewRateLimiter(long intervalMillis, int sweepThreshold, LongSupplier clock) {
+    this.intervalMillis = intervalMillis;
+    this.sweepThreshold = Math.max(1, sweepThreshold);
+    this.clock = clock;
+  }
+
+  /**
+   * @return {@code true} if an automatic review of this PR completed within the configured
+   *     interval, so the caller should skip dispatching a new automatic review. Always {@code
+   *     false} when the interval is zero or negative (throttling disabled).
+   */
+  public boolean isThrottled(String owner, String repo, int prNumber) {
+    if (intervalMillis <= 0) {
+      return false;
+    }
+    Long deadline = deadlines.get(key(owner, repo, prNumber));
+    return deadline != null && deadline > clock.getAsLong();
+  }
+
+  /**
+   * Records that an automatic review of this PR just completed, starting a fresh throttle window.
+   * Callers must not record manual reviews — an explicit {@code /review} should not delay the next
+   * automatic review. No-op when throttling is disabled.
+   */
+  public void recordCompletion(String owner, String repo, int prNumber) {
+    if (intervalMillis <= 0) {
+      return;
+    }
+    long now = clock.getAsLong();
+    deadlines.put(key(owner, repo, prNumber), now + intervalMillis);
+    sweepExpired(now);
+  }
+
+  /**
+   * {@link #recordCompletion} refreshes a PR's deadline but never shrinks the map, so PRs that stop
+   * receiving pushes would accumulate forever. Sweep expired entries once the map is large enough
+   * that the scan is worthwhile; live entries are never removed, so a throttled PR can never slip
+   * through.
+   */
+  void sweepExpired(long now) {
+    if (deadlines.size() < sweepThreshold) {
+      return;
+    }
+    deadlines.values().removeIf(deadline -> deadline <= now);
+  }
+
+  private static String key(String owner, String repo, int prNumber) {
+    return owner + "/" + repo + "#" + prNumber;
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
@@ -117,10 +117,11 @@ public final class ReviewDispatcher {
       logReviewStart(batch.request(), batch.coalesced(), batch.queueWaitMs());
 
       try {
-        orchestrator.review(batch.request());
-        // Start the throttle window at completion (not dispatch) so a long-running review does
-        // not eat into it; manual reviews never shift the automatic window.
-        if (!batch.request().isManualTrigger()) {
+        var surfaced = orchestrator.review(batch.request());
+        // Start the throttle window only when a review was actually posted, and at completion
+        // (not dispatch) so a long-running review does not eat into it. A failed review must not
+        // block the retry on the next push, and manual reviews never shift the automatic window.
+        if (surfaced && !batch.request().isManualTrigger()) {
           autoReviewRateLimiter.recordCompletion(
               batch.request().owner(), batch.request().repo(), batch.request().prNumber());
         }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
@@ -115,14 +115,16 @@ public final class ReviewDispatcher {
     while (true) {
       var batch = state.takeNextReview();
 
-      // The controller's rate-limit gate ran before dispatch, but a request coalesced behind an
-      // in-flight review passed that gate before the window opened — re-check here so it cannot
-      // run a second automatic review right after the one that just recorded its completion.
+      // The controller's rate-limit gate ran before dispatch, so a request that passed it before
+      // the window opened can reach this worker — coalesced behind the in-flight review that then
+      // recorded its completion, or dispatched in the gap between a prior worker's
+      // recordCompletion and its state removal. Re-checking every batch closes both paths: no
+      // batch is reviewed once the window is closed, whichever way it got here.
       var req = batch.request();
       if (!req.isManualTrigger()
           && autoReviewRateLimiter.isThrottled(req.owner(), req.repo(), req.prNumber())) {
         log.info(
-            "Skipping coalesced automatic review for {}/{} #{} — within the auto-review "
+            "Skipping automatic review for {}/{} #{} — within the auto-review "
                 + "rate window (manual /review bypasses)",
             req.owner(),
             req.repo(),

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
@@ -114,30 +114,48 @@ public final class ReviewDispatcher {
   private void drainReviews(PrKey key, PerPrState state) {
     while (true) {
       var batch = state.takeNextReview();
-      logReviewStart(batch.request(), batch.coalesced(), batch.queueWaitMs());
 
-      try {
-        var surfaced = orchestrator.review(batch.request());
-        // Start the throttle window only when a review was actually posted, and at completion
-        // (not dispatch) so a long-running review does not eat into it. A failed review must not
-        // block the retry on the next push, and manual reviews never shift the automatic window.
-        if (surfaced && !batch.request().isManualTrigger()) {
-          autoReviewRateLimiter.recordCompletion(
-              batch.request().owner(), batch.request().repo(), batch.request().prNumber());
-        }
-      } catch (RuntimeException e) {
-        log.error(
-            "Review failed for {}/{} #{}",
-            batch.request().owner(),
-            batch.request().repo(),
-            batch.request().prNumber(),
-            e);
+      // The controller's rate-limit gate ran before dispatch, but a request coalesced behind an
+      // in-flight review passed that gate before the window opened — re-check here so it cannot
+      // run a second automatic review right after the one that just recorded its completion.
+      var req = batch.request();
+      if (!req.isManualTrigger()
+          && autoReviewRateLimiter.isThrottled(req.owner(), req.repo(), req.prNumber())) {
+        log.info(
+            "Skipping coalesced automatic review for {}/{} #{} — within the auto-review "
+                + "rate window (manual /review bypasses)",
+            req.owner(),
+            req.repo(),
+            req.prNumber());
+      } else {
+        reviewBatch(batch);
       }
 
       if (state.tryRetireIfIdle()) {
         states.remove(key, state);
         return;
       }
+    }
+  }
+
+  private void reviewBatch(PerPrState.ReviewBatch batch) {
+    logReviewStart(batch.request(), batch.coalesced(), batch.queueWaitMs());
+    try {
+      var surfaced = orchestrator.review(batch.request());
+      // Start the throttle window only when a review was actually posted, and at completion
+      // (not dispatch) so a long-running review does not eat into it. A failed review must not
+      // block the retry on the next push, and manual reviews never shift the automatic window.
+      if (surfaced && !batch.request().isManualTrigger()) {
+        autoReviewRateLimiter.recordCompletion(
+            batch.request().owner(), batch.request().repo(), batch.request().prNumber());
+      }
+    } catch (RuntimeException e) {
+      log.error(
+          "Review failed for {}/{} #{}",
+          batch.request().owner(),
+          batch.request().repo(),
+          batch.request().prNumber(),
+          e);
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
@@ -36,14 +36,18 @@ public final class ReviewDispatcher {
 
   private final ExecutorService reviewExecutor;
   private final ReviewOrchestrator orchestrator;
+  private final AutoReviewRateLimiter autoReviewRateLimiter;
 
   private final ConcurrentHashMap<PrKey, PerPrState> states = new ConcurrentHashMap<>();
 
   @Inject
   public ReviewDispatcher(
-      @ReviewExecutor ExecutorService reviewExecutor, ReviewOrchestrator orchestrator) {
+      @ReviewExecutor ExecutorService reviewExecutor,
+      ReviewOrchestrator orchestrator,
+      AutoReviewRateLimiter autoReviewRateLimiter) {
     this.reviewExecutor = reviewExecutor;
     this.orchestrator = orchestrator;
+    this.autoReviewRateLimiter = autoReviewRateLimiter;
   }
 
   /**
@@ -114,6 +118,12 @@ public final class ReviewDispatcher {
 
       try {
         orchestrator.review(batch.request());
+        // Start the throttle window at completion (not dispatch) so a long-running review does
+        // not eat into it; manual reviews never shift the automatic window.
+        if (!batch.request().isManualTrigger()) {
+          autoReviewRateLimiter.recordCompletion(
+              batch.request().owner(), batch.request().repo(), batch.request().prNumber());
+        }
       } catch (RuntimeException e) {
         log.error(
             "Review failed for {}/{} #{}",

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -194,9 +194,13 @@ public class ReviewOrchestrator {
   /**
    * Main entry point for reviewing a PR. Called from WebhookController for pull_request (opened,
    * synchronize) and /review triggers.
+   *
+   * @return {@code true} when the review result was surfaced to GitHub (post-result steps may still
+   *     have failed); {@code false} when the review failed before posting, so callers must not
+   *     treat it as a completed review (e.g. for rate-limit accounting).
    */
   @ActivateRequestContext
-  public void review(ReviewRequest request) {
+  public boolean review(ReviewRequest request) {
     Log.infof(
         "Starting review for %s/%s #%d (sha: %s)",
         request.owner(), request.repo(), request.prNumber(), request.commitSha());
@@ -330,6 +334,7 @@ public class ReviewOrchestrator {
         handleReviewFailure(auth, req, session, checkRunId, e);
       }
     }
+    return resultSurfaced;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -17,6 +17,7 @@ package dev.thiagogonzaga.thrillhousebot.webhook;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import dev.thiagogonzaga.thrillhousebot.review.AutoReviewRateLimiter;
 import dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyService;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
@@ -40,6 +41,7 @@ public class WebhookController {
   private final WebhookVerifier verifier;
   private final TriggerDetector triggerDetector;
   private final ReviewTriggerFilter triggerFilter;
+  private final AutoReviewRateLimiter autoReviewRateLimiter;
   private final ReviewDispatcher reviewDispatcher;
   private final MaintainerReplyDispatcher replyDispatcher;
   private final WebhookDeduplicator deduplicator;
@@ -54,6 +56,7 @@ public class WebhookController {
       WebhookVerifier verifier,
       TriggerDetector triggerDetector,
       ReviewTriggerFilter triggerFilter,
+      AutoReviewRateLimiter autoReviewRateLimiter,
       ReviewDispatcher reviewDispatcher,
       MaintainerReplyDispatcher replyDispatcher,
       WebhookDeduplicator deduplicator,
@@ -65,6 +68,7 @@ public class WebhookController {
     this.verifier = verifier;
     this.triggerDetector = triggerDetector;
     this.triggerFilter = triggerFilter;
+    this.autoReviewRateLimiter = autoReviewRateLimiter;
     this.reviewDispatcher = reviewDispatcher;
     this.replyDispatcher = replyDispatcher;
     this.deduplicator = deduplicator;
@@ -189,6 +193,18 @@ public class WebhookController {
               pr.number(),
               repo.fullName(),
               skipReason.get());
+          yield true;
+        }
+
+        // Per-PR automatic review rate limit — a fresh push within the window is skipped silently
+        // (a manual /review always bypasses; a review already running coalesces in the dispatcher).
+        if (autoReviewRateLimiter.isThrottled(repo.owner().login(), repo.name(), pr.number())) {
+          log.info(
+              "Skipping automatic review for PR #{} in {} — last automatic review completed "
+                  + "less than {} ago (manual /review bypasses)",
+              pr.number(),
+              repo.fullName(),
+              config.review().autoReviewMinInterval());
           yield true;
         }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -82,6 +82,10 @@ thrillhousebot.review.ignored-files=**/pom.xml,**/package-lock.json,**/*.lock,**
 # Upper bound on the manual-trigger write-access check (token mint + collaborator-permission call)
 # that runs on the webhook ACK thread; fails closed if GitHub is too slow to answer within the SLA.
 thrillhousebot.review.manual-trigger-auth-timeout=${MANUAL_TRIGGER_AUTH_TIMEOUT:5s}
+# Per-PR automatic review rate limit — while the last automatic review of a PR completed less than
+# this ago, new pull_request events for it are skipped silently, even when the head SHA changed
+# (in-memory, per replica). A manual /review always bypasses and never shifts the window; 0 disables.
+thrillhousebot.review.auto-review-min-interval=${AUTO_REVIEW_MIN_INTERVAL:1h}
 
 # Context-aware PR labels (opt-in). When enabled, the model is shown the repo's existing labels
 # and picks the ones that best describe the change. apply=false (default) only posts a suggestion

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/AutoReviewRateLimiterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/AutoReviewRateLimiterTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import org.junit.jupiter.api.Test;
+
+class AutoReviewRateLimiterTest {
+
+  private static final long INTERVAL_MS = 3_600_000L;
+  private static final int BIG_THRESHOLD = 10_000;
+
+  @Test
+  void injectionConstructorReadsIntervalFromConfig() {
+    var config = mock(ThrillhouseConfig.class);
+    var reviewConfig = mock(ThrillhouseConfig.ReviewConfig.class);
+    when(config.review()).thenReturn(reviewConfig);
+    when(reviewConfig.autoReviewMinInterval()).thenReturn(Duration.ofHours(1));
+
+    var limiter = new AutoReviewRateLimiter(config);
+
+    // The config-wired bean behaves like any other: throttled right after a completion (well
+    // within the 1h interval), open before any completion was recorded.
+    assertFalse(limiter.isThrottled("owner", "repo", 1));
+    limiter.recordCompletion("owner", "repo", 1);
+    assertTrue(limiter.isThrottled("owner", "repo", 1));
+  }
+
+  @Test
+  void prWithoutRecordedReviewIsNotThrottled() {
+    var limiter = new AutoReviewRateLimiter(INTERVAL_MS, BIG_THRESHOLD, new MutableClock(0));
+
+    assertFalse(limiter.isThrottled("owner", "repo", 1));
+  }
+
+  @Test
+  void prIsThrottledWithinIntervalEvenAcrossRepeatedChecks() {
+    var limiter = new AutoReviewRateLimiter(INTERVAL_MS, BIG_THRESHOLD, new MutableClock(0));
+
+    limiter.recordCompletion("owner", "repo", 1);
+
+    // Unlike the webhook deduplicator, checking never extends the window — only completions do.
+    assertTrue(limiter.isThrottled("owner", "repo", 1));
+    assertTrue(limiter.isThrottled("owner", "repo", 1));
+  }
+
+  @Test
+  void distinctPrsAreThrottledIndependently() {
+    var limiter = new AutoReviewRateLimiter(INTERVAL_MS, BIG_THRESHOLD, new MutableClock(0));
+
+    limiter.recordCompletion("owner", "repo", 1);
+
+    assertTrue(limiter.isThrottled("owner", "repo", 1));
+    assertFalse(limiter.isThrottled("owner", "repo", 2));
+    assertFalse(limiter.isThrottled("owner", "other-repo", 1));
+    assertFalse(limiter.isThrottled("other-owner", "repo", 1));
+  }
+
+  @Test
+  void prOpensAgainAfterIntervalElapses() {
+    var clock = new MutableClock(0);
+    var limiter = new AutoReviewRateLimiter(INTERVAL_MS, BIG_THRESHOLD, clock);
+
+    limiter.recordCompletion("owner", "repo", 1);
+    assertTrue(limiter.isThrottled("owner", "repo", 1));
+
+    // Step past the interval: the window has lapsed and the next event may review again.
+    clock.advance(INTERVAL_MS + 1);
+    assertFalse(limiter.isThrottled("owner", "repo", 1));
+  }
+
+  @Test
+  void prStillThrottledJustBeforeIntervalElapses() {
+    var clock = new MutableClock(0);
+    var limiter = new AutoReviewRateLimiter(INTERVAL_MS, BIG_THRESHOLD, clock);
+
+    limiter.recordCompletion("owner", "repo", 1);
+    // One tick before the deadline the window is still closed.
+    clock.advance(INTERVAL_MS - 1);
+    assertTrue(limiter.isThrottled("owner", "repo", 1));
+  }
+
+  @Test
+  void prOpensExactlyAtIntervalBoundary() {
+    var clock = new MutableClock(0);
+    var limiter = new AutoReviewRateLimiter(INTERVAL_MS, BIG_THRESHOLD, clock);
+
+    limiter.recordCompletion("owner", "repo", 1);
+    // At exactly the deadline the window has lapsed (the deadline is the first open instant),
+    // pinning the `deadline > now` boundary.
+    clock.advance(INTERVAL_MS);
+    assertFalse(limiter.isThrottled("owner", "repo", 1));
+  }
+
+  @Test
+  void newCompletionRestartsTheWindow() {
+    var clock = new MutableClock(0);
+    var limiter = new AutoReviewRateLimiter(INTERVAL_MS, BIG_THRESHOLD, clock);
+
+    limiter.recordCompletion("owner", "repo", 1);
+    clock.advance(INTERVAL_MS + 1);
+    assertFalse(limiter.isThrottled("owner", "repo", 1));
+
+    // The next completed review starts a fresh full-length window from its completion time.
+    limiter.recordCompletion("owner", "repo", 1);
+    clock.advance(INTERVAL_MS - 1);
+    assertTrue(limiter.isThrottled("owner", "repo", 1));
+  }
+
+  @Test
+  void zeroIntervalDisablesThrottlingAndRecordsNothing() {
+    var limiter = new AutoReviewRateLimiter(0, BIG_THRESHOLD, new MutableClock(0));
+
+    limiter.recordCompletion("owner", "repo", 1);
+
+    // Interval 0 keeps the pre-#328 behavior: every event reviews, and no state accumulates.
+    assertFalse(limiter.isThrottled("owner", "repo", 1));
+    assertEquals(0, limiter.deadlines.size());
+  }
+
+  @Test
+  void negativeIntervalDisablesThrottlingAndRecordsNothing() {
+    var limiter = new AutoReviewRateLimiter(-1, BIG_THRESHOLD, new MutableClock(0));
+
+    limiter.recordCompletion("owner", "repo", 1);
+
+    assertFalse(limiter.isThrottled("owner", "repo", 1));
+    assertEquals(0, limiter.deadlines.size());
+  }
+
+  @Test
+  void expiredEntriesAreReclaimedOnceThresholdReached() {
+    var clock = new MutableClock(0);
+    int threshold = 4;
+    var limiter = new AutoReviewRateLimiter(INTERVAL_MS, threshold, clock);
+
+    // Fill exactly to the sweep threshold; nothing has expired yet so nothing is reclaimed.
+    for (int i = 0; i < threshold; i++) {
+      limiter.recordCompletion("owner", "repo", i);
+    }
+    assertEquals(threshold, limiter.deadlines.size());
+
+    // Let every window lapse, then record one more completion: that record crosses the threshold
+    // and triggers the sweep, which must reclaim all four expired PRs and leave only the new one.
+    clock.advance(INTERVAL_MS + 1);
+    limiter.recordCompletion("owner", "repo", 100);
+
+    // Fails if the expired sweep is removed — the 4 stale PRs would still be in the map.
+    assertEquals(1, limiter.deadlines.size());
+  }
+
+  @Test
+  void liveEntriesAreNeverSweptAndStayThrottled() {
+    var clock = new MutableClock(0);
+    int threshold = 10;
+    var limiter = new AutoReviewRateLimiter(INTERVAL_MS, threshold, clock);
+
+    // Record far more than the threshold of distinct, still-live PRs within the interval.
+    int count = threshold * 3;
+    for (int i = 0; i < count; i++) {
+      limiter.recordCompletion("owner", "repo", i);
+    }
+
+    // Sweep-on-expiry set, not a hard cap: live PRs are retained past the threshold (no forced
+    // eviction), so every one of them stays throttled.
+    assertEquals(count, limiter.deadlines.size());
+    for (int i = 0; i < count; i++) {
+      assertTrue(limiter.isThrottled("owner", "repo", i), "live PR #" + i + " was forgotten");
+    }
+  }
+
+  /** A {@link LongSupplier} clock whose epoch-millis value can be advanced by tests. */
+  private static final class MutableClock implements LongSupplier {
+    private final AtomicLong millis;
+
+    MutableClock(long startMillis) {
+      this.millis = new AtomicLong(startMillis);
+    }
+
+    void advance(long byMillis) {
+      millis.addAndGet(byMillis);
+    }
+
+    @Override
+    public long getAsLong() {
+      return millis.get();
+    }
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcherTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcherTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -101,7 +102,7 @@ class ReviewDispatcherTest {
               reviewed.add(req);
               started.countDown();
               release.await(5, TimeUnit.SECONDS);
-              return null;
+              return true;
             })
         .when(orchestrator)
         .review(any(ReviewOrchestrator.ReviewRequest.class));
@@ -157,7 +158,7 @@ class ReviewDispatcherTest {
               firstReviewStarted.countDown();
               throw new RuntimeException("boom");
             })
-        .doAnswer(invocation -> null)
+        .doAnswer(invocation -> true)
         .when(orchestrator)
         .review(any(ReviewOrchestrator.ReviewRequest.class));
 
@@ -203,7 +204,7 @@ class ReviewDispatcherTest {
                 aborted.countDown();
                 throw new AssertionError("fatal");
               }
-              return null;
+              return true;
             })
         .when(orchestrator)
         .review(any(ReviewOrchestrator.ReviewRequest.class));
@@ -228,7 +229,7 @@ class ReviewDispatcherTest {
                 // Sneaks past the drain loop's RuntimeException catch to the worker guard
                 throw new Exception("unexpected checked failure");
               }
-              return null;
+              return true;
             })
         .when(orchestrator)
         .review(any(ReviewOrchestrator.ReviewRequest.class));
@@ -253,7 +254,7 @@ class ReviewDispatcherTest {
               invocation -> {
                 started.countDown();
                 release.await(5, TimeUnit.SECONDS);
-                return null;
+                return true;
               })
           .when(orchestrator)
           .review(any(ReviewOrchestrator.ReviewRequest.class));
@@ -338,6 +339,7 @@ class ReviewDispatcherTest {
   @Test
   void shouldRecordCompletionForAutomaticReview() {
     ReviewOrchestrator.ReviewRequest req = reviewRequest("owner", "repo", 13, "sha1");
+    when(orchestrator.review(req)).thenReturn(true);
 
     dispatcher.dispatch(req);
 
@@ -351,10 +353,24 @@ class ReviewDispatcherTest {
     var req =
         new ReviewOrchestrator.ReviewRequest(
             "owner", "repo", 14, "", "(manual)", "", "", "main", 1L, true);
+    when(orchestrator.review(req)).thenReturn(true);
 
     dispatcher.dispatch(req);
 
     // A manual /review must not shift the automatic throttle window.
+    verify(orchestrator, timeout(2000)).review(req);
+    verify(rateLimiter, after(500).never()).recordCompletion(anyString(), anyString(), anyInt());
+  }
+
+  @Test
+  void shouldNotRecordCompletionWhenReviewNotSurfaced() {
+    ReviewOrchestrator.ReviewRequest req = reviewRequest("owner", "repo", 16, "sha1");
+    when(orchestrator.review(req)).thenReturn(false);
+
+    dispatcher.dispatch(req);
+
+    // The orchestrator handled a failure internally and posted nothing, so the throttle window
+    // must not start — the next push may retry immediately.
     verify(orchestrator, timeout(2000)).review(req);
     verify(rateLimiter, after(500).never()).recordCompletion(anyString(), anyString(), anyInt());
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcherTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcherTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -399,6 +400,19 @@ class ReviewDispatcherTest {
     // ...but the drain loop re-checks, so only the first review runs and only one window starts.
     verify(orchestrator, times(1)).review(any(ReviewOrchestrator.ReviewRequest.class));
     verify(rateLimiter, times(1)).recordCompletion("owner", "repo", 17);
+  }
+
+  @Test
+  void shouldSkipAutomaticReviewWhenWindowClosedAfterDispatchGate() {
+    // Pins the dispatch race: the controller gate passed before a prior worker recorded its
+    // completion, so this fresh worker's very first batch must hit the re-check and skip.
+    when(rateLimiter.isThrottled("owner", "repo", 19)).thenReturn(true);
+
+    dispatcher.dispatch(reviewRequest("owner", "repo", 19, "sha1"));
+
+    awaitEmptyDispatcherState(dispatcher, 2, TimeUnit.SECONDS);
+    verify(orchestrator, never()).review(any(ReviewOrchestrator.ReviewRequest.class));
+    verify(rateLimiter, never()).recordCompletion(anyString(), anyString(), anyInt());
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcherTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcherTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -41,6 +43,7 @@ import org.mockito.MockitoAnnotations;
 class ReviewDispatcherTest {
 
   @Mock private ReviewOrchestrator orchestrator;
+  @Mock private AutoReviewRateLimiter rateLimiter;
 
   private ExecutorService reviewExecutor;
   private ReviewDispatcher dispatcher;
@@ -49,7 +52,7 @@ class ReviewDispatcherTest {
   void setUp() {
     MockitoAnnotations.openMocks(this);
     reviewExecutor = Executors.newSingleThreadExecutor();
-    dispatcher = new ReviewDispatcher(reviewExecutor, orchestrator);
+    dispatcher = new ReviewDispatcher(reviewExecutor, orchestrator, rateLimiter);
   }
 
   @AfterEach
@@ -172,7 +175,7 @@ class ReviewDispatcherTest {
   void shouldClearStateWhenExecutorRejectsWithoutRunningTask() {
     ExecutorService executor = mock(ExecutorService.class);
     doThrow(new RejectedExecutionException("shut down")).when(executor).execute(any());
-    dispatcher = new ReviewDispatcher(executor, orchestrator);
+    dispatcher = new ReviewDispatcher(executor, orchestrator, rateLimiter);
 
     dispatcher.dispatch(reviewRequest("owner", "repo", 10, "sha1"));
     verify(orchestrator, after(500).never()).review(any(ReviewOrchestrator.ReviewRequest.class));
@@ -283,7 +286,7 @@ class ReviewDispatcherTest {
   void shouldReturnFalseWhenExecutorRejectsTask() {
     ExecutorService executor = mock(ExecutorService.class);
     doThrow(new RejectedExecutionException("shut down")).when(executor).execute(any());
-    dispatcher = new ReviewDispatcher(executor, orchestrator);
+    dispatcher = new ReviewDispatcher(executor, orchestrator, rateLimiter);
 
     // A rejected task means no review will run, so callers can roll back dedup state.
     assertFalse(dispatcher.dispatch(reviewRequest("owner", "repo", 10, "sha1")));
@@ -307,7 +310,7 @@ class ReviewDispatcherTest {
         .when(executor)
         .execute(any());
 
-    dispatcher = new ReviewDispatcher(executor, orchestrator);
+    dispatcher = new ReviewDispatcher(executor, orchestrator, rateLimiter);
 
     dispatcher.dispatch(reviewRequest("owner", "repo", 8, "sha1"));
     dispatcher.dispatch(reviewRequest("owner", "repo", 8, "sha2"));
@@ -330,6 +333,43 @@ class ReviewDispatcherTest {
     // The review still runs — on a fresh state, never on the retired one
     verify(orchestrator, timeout(2000)).review(req);
     assertEquals(false, retired.running);
+  }
+
+  @Test
+  void shouldRecordCompletionForAutomaticReview() {
+    ReviewOrchestrator.ReviewRequest req = reviewRequest("owner", "repo", 13, "sha1");
+
+    dispatcher.dispatch(req);
+
+    // The throttle window starts when the automatic review finishes, keyed by the PR.
+    verify(orchestrator, timeout(2000)).review(req);
+    verify(rateLimiter, timeout(2000)).recordCompletion("owner", "repo", 13);
+  }
+
+  @Test
+  void shouldNotRecordCompletionForManualReview() {
+    var req =
+        new ReviewOrchestrator.ReviewRequest(
+            "owner", "repo", 14, "", "(manual)", "", "", "main", 1L, true);
+
+    dispatcher.dispatch(req);
+
+    // A manual /review must not shift the automatic throttle window.
+    verify(orchestrator, timeout(2000)).review(req);
+    verify(rateLimiter, after(500).never()).recordCompletion(anyString(), anyString(), anyInt());
+  }
+
+  @Test
+  void shouldNotRecordCompletionWhenReviewThrows() {
+    doThrow(new RuntimeException("boom"))
+        .when(orchestrator)
+        .review(any(ReviewOrchestrator.ReviewRequest.class));
+
+    dispatcher.dispatch(reviewRequest("owner", "repo", 15, "sha1"));
+
+    // An unexpected failure means no review was surfaced, so the next event may retry immediately.
+    verify(orchestrator, timeout(2000)).review(any(ReviewOrchestrator.ReviewRequest.class));
+    verify(rateLimiter, after(500).never()).recordCompletion(anyString(), anyString(), anyInt());
   }
 
   private static ReviewOrchestrator.ReviewRequest reviewRequest(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcherTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcherTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -360,6 +361,75 @@ class ReviewDispatcherTest {
     // A manual /review must not shift the automatic throttle window.
     verify(orchestrator, timeout(2000)).review(req);
     verify(rateLimiter, after(500).never()).recordCompletion(anyString(), anyString(), anyInt());
+  }
+
+  @Test
+  void shouldSkipCoalescedAutomaticReviewWithinWindow() throws InterruptedException {
+    // Simulate the real limiter: throttled from the moment a completion is recorded.
+    var throttled = new java.util.concurrent.atomic.AtomicBoolean(false);
+    when(rateLimiter.isThrottled(anyString(), anyString(), anyInt()))
+        .thenAnswer(invocation -> throttled.get());
+    doAnswer(
+            invocation -> {
+              throttled.set(true);
+              return null;
+            })
+        .when(rateLimiter)
+        .recordCompletion(anyString(), anyString(), anyInt());
+
+    var started = new CountDownLatch(1);
+    var release = new CountDownLatch(1);
+    doAnswer(
+            invocation -> {
+              started.countDown();
+              release.await(5, TimeUnit.SECONDS);
+              return true;
+            })
+        .when(orchestrator)
+        .review(any(ReviewOrchestrator.ReviewRequest.class));
+
+    dispatcher.dispatch(reviewRequest("owner", "repo", 17, "sha1"));
+    assertTrue(started.await(2, TimeUnit.SECONDS));
+    // A push during the in-flight review passed the controller gate before the window opened...
+    dispatcher.dispatch(reviewRequest("owner", "repo", 17, "sha2"));
+    release.countDown();
+
+    awaitEmptyDispatcherState(dispatcher, 2, TimeUnit.SECONDS);
+
+    // ...but the drain loop re-checks, so only the first review runs and only one window starts.
+    verify(orchestrator, times(1)).review(any(ReviewOrchestrator.ReviewRequest.class));
+    verify(rateLimiter, times(1)).recordCompletion("owner", "repo", 17);
+  }
+
+  @Test
+  void shouldRunCoalescedManualReviewWithinWindow() throws InterruptedException {
+    // Even a closed window must not hold back an explicit /review that coalesced behind an
+    // in-flight automatic run.
+    when(rateLimiter.isThrottled(anyString(), anyString(), anyInt())).thenReturn(true);
+
+    var started = new CountDownLatch(1);
+    var release = new CountDownLatch(1);
+    var manualReq =
+        new ReviewOrchestrator.ReviewRequest(
+            "owner", "repo", 18, "", "(manual)", "", "", "main", 1L, true);
+    doAnswer(
+            invocation -> {
+              started.countDown();
+              release.await(5, TimeUnit.SECONDS);
+              return true;
+            })
+        .when(orchestrator)
+        .review(any(ReviewOrchestrator.ReviewRequest.class));
+
+    dispatcher.dispatch(
+        new ReviewOrchestrator.ReviewRequest(
+            "owner", "repo", 18, "", "(manual)", "", "", "main", 1L, true));
+    assertTrue(started.await(2, TimeUnit.SECONDS));
+    dispatcher.dispatch(manualReq);
+    release.countDown();
+
+    verify(orchestrator, timeout(5000).times(2))
+        .review(any(ReviewOrchestrator.ReviewRequest.class));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -22,11 +22,13 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import dev.thiagogonzaga.thrillhousebot.review.AutoReviewRateLimiter;
 import dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyService;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestrator;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,6 +54,8 @@ class WebhookControllerTest {
   @Mock private TriggerDetector triggerDetector;
 
   @Mock private ReviewTriggerFilter triggerFilter;
+
+  @Mock private AutoReviewRateLimiter autoReviewRateLimiter;
 
   @Mock private ReviewDispatcher reviewDispatcher;
 
@@ -85,6 +89,7 @@ class WebhookControllerTest {
             verifier,
             triggerDetector,
             triggerFilter,
+            autoReviewRateLimiter,
             reviewDispatcher,
             replyDispatcher,
             deduplicator,
@@ -449,6 +454,42 @@ class WebhookControllerTest {
   }
 
   @Test
+  void shouldSkipAutomaticReviewWithinRateLimitWindow() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(reviewConfig.autoReviewMinInterval()).thenReturn(Duration.ofHours(1));
+    when(autoReviewRateLimiter.isThrottled("owner", "repo", 55)).thenReturn(true);
+
+    // A new push (fresh head SHA) within the window is still skipped.
+    var body =
+        buildPullRequestPayload("synchronize", 55, "owner/repo", "fresh-sha", "main")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response =
+        controller.handleWebhook("sha256=valid", "pull_request", null, "delivery-throttled", body);
+    assertEquals(200, response.getStatus());
+
+    // A throttled PR must not be reviewed, and the dedup slot stays claimed (a deliberate
+    // decision, not a rejected dispatch), so a redelivery is ignored too.
+    verify(reviewDispatcher, never()).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+    verify(deduplicator, never()).forget(anyString());
+  }
+
+  @Test
+  void shouldDispatchAutomaticReviewWhenRateLimitWindowOpen() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(autoReviewRateLimiter.isThrottled("owner", "repo", 56)).thenReturn(false);
+
+    var body =
+        buildPullRequestPayload("synchronize", 56, "owner/repo", "sha56", "main")
+            .getBytes(StandardCharsets.UTF_8);
+
+    controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
+
+    verify(autoReviewRateLimiter).isThrottled("owner", "repo", 56);
+    verify(reviewDispatcher).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+  }
+
+  @Test
   void shouldPassParsedDraftAndLabelsToTriggerFilter() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
 
@@ -496,6 +537,30 @@ class WebhookControllerTest {
         .dispatch(
             new ReviewOrchestrator.ReviewRequest(
                 "owner", "repo", 77, "", "(manual review)", "", "", "main", 12345L, true));
+  }
+
+  @Test
+  void shouldTriggerManualReviewEvenWithinRateLimitWindow() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(triggerDetector.detectCommand("/review")).thenReturn(CommentCommand.REVIEW);
+    when(triggerDetector.isBotComment("octocat")).thenReturn(false);
+    when(manualReviewAuthorizer.isAuthorized("owner", "repo", 12345L, "octocat", "OWNER"))
+        .thenReturn(true);
+
+    var body =
+        buildIssueCommentPayload("created", 77, "owner/repo", "octocat", "/review")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response = controller.handleWebhook("sha256=valid", "issue_comment", null, DELIVERY, body);
+    assertEquals(200, response.getStatus());
+
+    // An explicit /review always runs — the manual path never consults the rate limiter, so
+    // even a PR deep inside the throttle window is reviewed on request.
+    verify(reviewDispatcher)
+        .dispatch(
+            new ReviewOrchestrator.ReviewRequest(
+                "owner", "repo", 77, "", "(manual review)", "", "", "main", 12345L, true));
+    verifyNoInteractions(autoReviewRateLimiter);
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature

## Description

Adds a configurable per-PR rate window for **automatic**
(webhook-triggered) reviews, implementing `PLAN.md` §20 suggestion **E**
("Don't review the same PR more than once per hour unless explicitly
`/review`'d"), scheduled for **v0.4.0**.

- New `AutoReviewRateLimiter` bean (`review` package): tracks the last
automatic review **completion** time per `(owner, repo, prNumber)` —
in-memory per replica, same pattern as `WebhookDeduplicator`
(`LongSupplier` clock, atomic map, sweep-on-threshold eviction).
Multi-replica shared state stays deferred to #23.
- New config knob `thrillhousebot.review.auto-review-min-interval` (env
`AUTO_REVIEW_MIN_INTERVAL`, default `1h`; `0` or negative disables and
keeps current behavior).
- `WebhookController.handlePullRequest` gates
`opened`/`reopened`/`synchronize`/`ready_for_review` right after the
existing trigger-filter check and before `ReviewDispatcher.dispatch`:
within the window the event is skipped **silently** with an info log (no
PR comment), even when the head SHA changed. The webhook dedup slot
stays claimed (deliberate skip, not a rejected dispatch), matching the
trigger-filter semantics.
- `ReviewDispatcher.drainReviews` records the completion after
`orchestrator.review(...)` returns, only when `!isManualTrigger()` — so
the window starts when the review finishes (a long-running review
doesn't eat into it) and a manual review never shifts the automatic
window.
- Manual `/review` and `@thrillhousebot review` (`handleReviewCommand`
path) are untouched — they never consult the limiter, so explicit
triggers always run.
- Documented in the README config table, `application.properties`, and
`.env.example`.

Distinct from #25 (GitHub API retry/backoff) and #42 (per-PR spend cap):
this throttles automatic review *frequency* per PR. Complements the
shipped webhook delivery dedup (`WebhookDeduplicator`) and same-PR
coalescing (`ReviewDispatcher`); SHA idempotency (PLAN §20 suggestion C)
remains tracked in #328's parent discussion.

### Acceptance criteria

- [x] Automatic reviews skipped when the same PR was reviewed within the
configured interval
- [x] `/review` and `@bot review` always run regardless of interval
- [x] Config property documented in README / config reference
- [x] Unit tests for: within-window skip, manual bypass, disabled
interval (`0`)
- [x] No change to conversational replies or slash commands other than
`/review` (their paths are untouched)

## Related Issues

Fixes #328

Related: #25 (API rate-limit retry — different layer), #42 (per-PR spend
cap), #315 (👀 ack on `/review` — manual bypass still gets it), #23
(multi-replica shared state, deferred), #50 (config docs)

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

- New `AutoReviewRateLimiterTest` (13 tests): window boundaries
(`deadline > now` pinned at the exact instant), independent PR keys,
window restart on a new completion, `0`/negative interval disables and
stores nothing, sweep-on-threshold eviction, live entries never swept,
config-wired constructor.
- `ReviewDispatcherTest`: records completion for automatic reviews,
never for manual ones, and not when the review throws.
- `WebhookControllerTest`: within-window `synchronize` (fresh SHA) skips
dispatch and keeps the dedup slot; open window dispatches; manual
`/review` dispatches without ever consulting the limiter.
- `./mvnw verify` (tests + JaCoCo gate + SpotBugs + Spotless) passes
locally; JaCoCo shows no missed lines/branches on the new code.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Skip log when throttled:

```
Skipping automatic review for PR #55 in owner/repo — last automatic review completed less than PT1H ago (manual /review bypasses)
```

## Additional Notes

Base is `release/v0.4.0` (v0.4.0 ops-hardening batch), not `main`.