### PR TITLE
refactor: drop decision-narrating inline comments, keep non-obvious invariants

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/BotIdentityProducer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/BotIdentityProducer.java
@@ -36,8 +36,7 @@ public class BotIdentityProducer {
    * @param config the application configuration providing {@code github.bot-logins}
    * @return the immutable identity shared by all review-pipeline collaborators
    */
-  // @Singleton (not @ApplicationScoped): BotIdentity is a record (final), so it can't be proxied by
-  // a normal scope; a pseudo-scope still gives one shared instance for the immutable value.
+  // @Singleton: BotIdentity is a record (final), so a normal scope can't proxy it.
   @Produces
   @Singleton
   public BotIdentity botIdentity(ThrillhouseConfig config) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -227,7 +227,6 @@ public class StartupConfigValidator {
   private void logDashboardStatus() {
     var hasClientId = config.dashboard().clientId().filter(s -> !s.isBlank()).isPresent();
     var hasClientSecret = config.dashboard().clientSecret().filter(s -> !s.isBlank()).isPresent();
-    // Message and log level live on the enum, so dispatch is a single boolean check.
     var status = dashboardOauthStatus(hasClientId, hasClientSecret);
     if (status.warn) {
       log.warn(status.message);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
@@ -237,10 +237,8 @@ public class DashboardAccessChecker {
       }
     } catch (RuntimeException e) {
       log.warn("Failed to list installed repositories for {}: {}", accountOwner, e.getMessage());
-      // Fail closed on owner mismatch: the cached snapshot may belong to a previous owner, so
-      // returning it here would re-introduce the cross-owner reuse this cache is keyed to prevent.
-      // Only fall back to it when it was resolved for the same owner (graceful degradation during a
-      // transient GitHub outage); otherwise deny by returning an empty snapshot for this owner.
+      // Fall back to the cached snapshot only if it was resolved for the same owner; a previous
+      // owner's snapshot must not be reused.
       var previous = cachedSnapshot.get();
       return accountOwner.equalsIgnoreCase(previous.owner())
           ? previous
@@ -359,9 +357,7 @@ public class DashboardAccessChecker {
           e.getMessage());
     }
 
-    // Cache both success and failure: the negative result is short-lived (OWNER_NEGATIVE_CACHE_TTL)
-    // so a misconfigured deployment stops hammering the GitHub App endpoint every request, while
-    // still recovering promptly once the owner becomes resolvable.
+    // Failures are cached too, briefly (OWNER_NEGATIVE_CACHE_TTL).
     ownerCache.set(new OwnerCache(resolved, clock.get()));
     return Optional.ofNullable(resolved);
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardWebSocketKeepAlive.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardWebSocketKeepAlive.java
@@ -49,7 +49,7 @@ public class DashboardWebSocketKeepAlive {
 
   void onStart(@Observes StartupEvent event) {
     var intervalMs = config.websocketKeepAliveMs();
-    // vertx.setPeriodic rejects delays < 1 with an exception that would abort startup
+    // vertx.setPeriodic rejects delays < 1 with an exception that would abort startup.
     if (intervalMs <= 0) {
       log.warn(
           "WEBSOCKET_KEEPALIVE_MS={} — keepalive disabled; stale session replay buffers "

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/SessionLinkResource.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/SessionLinkResource.java
@@ -45,7 +45,7 @@ public class SessionLinkResource {
   @GET
   @Path("/{publicId}")
   public Response redirectToSession(@PathParam("publicId") String publicId) {
-    // A matched path segment is never null, so the format check is the only guard needed
+    // A matched path segment is never null.
     if (!PUBLIC_ID_PATTERN.matcher(publicId).matches()) {
       return Response.seeOther(SESSIONS_PAGE).build();
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClient.java
@@ -44,12 +44,11 @@ public class GitHubAuthClient {
   private final ThrillhouseConfig config;
   private final GitHubTokenApi tokenApi;
 
-  // Cached tokens — installation access tokens expire after 1 hour
+  // Installation access tokens expire after 1 hour.
   private record CachedToken(String token, Instant expiresAt, long installationId) {}
 
   private final Map<Long, CachedToken> tokenCache = new ConcurrentHashMap<>();
 
-  // The configured private key never changes at runtime — parse it once.
   private final AtomicReference<RSAPrivateKey> cachedPrivateKey = new AtomicReference<>();
 
   @Inject
@@ -67,13 +66,9 @@ public class GitHubAuthClient {
       Instant now = Instant.now();
       var privateKey = privateKey();
 
-      // The issued-at and expiry claims are plain epoch seconds, which Nimbus serializes
-      // the same way as its Date-based builder methods — this keeps java.util.Date out
       var claims =
           new JWTClaimsSet.Builder()
-              // Strip surrounding whitespace to match StartupConfigValidator, which accepts a
-              // padded-but-numeric app id; without this an id that passes boot validation would
-              // still yield an "iss" GitHub rejects on the first call.
+              // GitHub rejects an "iss" with padding, but boot validation accepts a padded app id.
               .issuer(config.github().appId().strip())
               .claim("iat", now.getEpochSecond())
               .claim("exp", now.plus(10, ChronoUnit.MINUTES).getEpochSecond())
@@ -109,7 +104,7 @@ public class GitHubAuthClient {
     var response =
         tokenApi.createInstallationToken(authHeader, "application/vnd.github+json", installationId);
 
-    // Cache with 50-minute TTL (tokens expire at 60 min — safety margin)
+    // 50-minute TTL: tokens expire at 60 min, keep a safety margin.
     var newToken =
         new CachedToken(
             response.token(), Instant.now().plus(50, ChronoUnit.MINUTES), installationId);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
@@ -27,10 +27,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 @RegisterRestClient(configKey = "github-api")
 public interface GitHubCheckRunClient {
 
-  // GitHub serves 30 rows per page by default; request the 100 max and bound the page walk so the
-  // aggregating helpers below own the pagination (like the other GitHub clients) rather than
-  // leaking
-  // per_page/page to callers.
+  // GitHub serves 30 rows per page by default; 100 is the maximum.
   int CI_PER_PAGE = 100;
   int CI_MAX_PAGES = 50;
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
@@ -37,12 +37,7 @@ public interface GitHubCommentClient {
       @PathParam("issueNumber") int issueNumber,
       CreateCommentRequest request);
 
-  // GitHub serves 30 issue comments per page by default; request the 100 max and walk a bounded
-  // number of pages so the bot's summary is not missed on a busy PR. Comments are returned
-  // oldest-first and the summary is posted on the first review, so it normally sits among the
-  // earliest comments — but on a PR that already had many comments before that first review the
-  // summary can fall past page 1, and a single-page fetch would miss it and re-post a duplicate
-  // summary.
+  // GitHub serves 30 issue comments per page by default; 100 is the maximum.
   int COMMENTS_PER_PAGE = 100;
   int MAX_COMMENT_PAGES = 10;
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubPullRequestClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubPullRequestClient.java
@@ -25,9 +25,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 @RegisterRestClient(configKey = "github-api")
 public interface GitHubPullRequestClient {
 
-  // GitHub serves 30 PR files per page by default; request the 100 max and walk a bounded number of
-  // pages so a large PR's diff is not silently truncated. GitHub caps PR file listings at 3000
-  // files (≈ 30 pages of 100).
+  // GitHub serves 30 PR files per page by default (100 max) and caps listings at 3000 files.
   int FILES_PER_PAGE = 100;
   int MAX_FILE_PAGES = 30;
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/InstructionsResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/InstructionsResolver.java
@@ -49,10 +49,9 @@ public class InstructionsResolver {
   private final GitHubAuthClient authClient;
   private final GitHubPullRequestClient prClient;
 
-  // Simple TTL cache: repo + chain -> (content, expiry)
   private record CachedInstructions(String content, String source, long expiresAt) {}
 
-  // Package-private so tests can inspect cache state without reflection
+  // Package-private for tests.
   final ConcurrentHashMap<String, CachedInstructions> cache = new ConcurrentHashMap<>();
   static final long CACHE_TTL_MS = 5L * 60 * 1000; // 5 minutes
   static final int CACHE_SWEEP_THRESHOLD = 1_000;
@@ -120,8 +119,7 @@ public class InstructionsResolver {
     for (String path : fallbackChain) {
       try {
         var file = prClient.getFileContent(auth, ACCEPT_HEADER, owner, repo, path, defaultBranch);
-        // GitHub wraps base64 content in newlines — the strict decoder rejects any file beyond
-        // one base64 line (~57 bytes), so use the MIME decoder
+        // GitHub wraps base64 content in newlines; only the MIME decoder tolerates them.
         var content =
             new String(Base64.getMimeDecoder().decode(file.content()), StandardCharsets.UTF_8);
 
@@ -132,12 +130,11 @@ public class InstructionsResolver {
         log.info("Using instructions file: {} ({} bytes)", path, content.length());
         return new ResolvedInstructions(content, path);
       } catch (WebApplicationException | ProcessingException _) {
-        // 404 or network error — try next fallback
         log.debug("Instructions file not found: {}", path);
       }
     }
 
-    // No instructions file found — cache the negative result briefly (1 min)
+    // Cache the negative result briefly (1 min).
     cache.put(cacheKey, new CachedInstructions("", "none", clock.getAsLong() + 60_000));
     sweepExpiredEntries();
     log.debug("No instructions file found for {}/{}", owner, repo);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/ProjectStackResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/ProjectStackResolver.java
@@ -82,7 +82,7 @@ public class ProjectStackResolver {
 
   private record CachedStack(String content, long expiresAt) {}
 
-  // Package-private so tests can inspect cache state without reflection
+  // Package-private for tests.
   final ConcurrentHashMap<String, CachedStack> cache = new ConcurrentHashMap<>();
 
   private final GitHubAuthClient authClient;
@@ -153,11 +153,11 @@ public class ProjectStackResolver {
     try {
       var file = prClient.getFileContent(auth, ACCEPT_HEADER, owner, repo, path, defaultBranch);
       if (file.content() == null) {
-        // Directories, submodules, and oversized files come back without base64 content
+        // Directories, submodules, and oversized files come back without base64 content.
         log.debug("No content for manifest at {} in {}/{}", path, owner, repo);
         return Optional.empty();
       }
-      // GitHub wraps base64 content in newlines — the MIME decoder tolerates them
+      // GitHub wraps base64 content in newlines — the MIME decoder tolerates them.
       var content =
           new String(Base64.getMimeDecoder().decode(file.content()), StandardCharsets.UTF_8);
       if (content.isBlank()) {
@@ -196,8 +196,6 @@ public class ProjectStackResolver {
     return "### " + path + "\n" + summary;
   }
 
-  // Plain string scans instead of regexes: manifest content comes from arbitrary repos, and
-  // backtracking-prone patterns over attacker-controlled input are a DoS vector (java:S5852)
   private static String mavenArtifacts(String content) {
     var artifacts = new LinkedHashSet<String>();
     var index = 0;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/ReviewThreadService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/ReviewThreadService.java
@@ -47,8 +47,7 @@ public class ReviewThreadService {
       }
       """;
 
-  // A PR with more review threads than this (100 per page) is far beyond anything realistic; the
-  // bound just stops a malformed pageInfo from looping forever.
+  // Stops a malformed pageInfo from looping forever.
   private static final int MAX_THREAD_PAGES = 20;
 
   private static final String RESOLVE_MUTATION =

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
@@ -108,8 +108,6 @@ public abstract class AbstractPrSuggestionGenerator {
 
   private ReviewDiffFormatter.FormattedDiff fetchDiff(
       String auth, String owner, String repo, int prNumber, String command) {
-    // SoftLoaders.files degrades a failed fetch to an empty list; buildDiffStringWithStats then
-    // yields "(no changes detected)", which loadInputs treats the same as null (post nothing).
     var files = SoftLoaders.files(prClient, auth, owner, repo, prNumber, command);
     return diffFormatter.buildDiffStringWithStats(files);
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CheckRunManager.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CheckRunManager.java
@@ -33,8 +33,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 public class CheckRunManager {
 
   private static final String ACCEPT = "application/vnd.github+json";
-  // Single source of the bot's check-run name. Referenced by VerdictBuilder (check title) and
-  // CiStatusEvaluator (to skip the bot's own check when CI-gating), so a rename can't drift.
+  // Also referenced by VerdictBuilder (check title) and CiStatusEvaluator (self-check skip).
   static final String CHECK_NAME = "ThrillhouseBot Review";
   private static final String CHECK_STATUS_IN_PROGRESS = "in_progress";
   private static final String CHECK_STATUS_COMPLETED = "completed";

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluator.java
@@ -50,9 +50,7 @@ public class CiStatusEvaluator {
 
   private final GitHubCheckRunClient checkRunClient;
 
-  // Bot-identity tokens (the slug of each "<slug>[bot]" login), derived from the shared BotIdentity
-  // bean so check/app matching honors the configured logins — including the alternate slug — rather
-  // than a single hardcoded literal.
+  // Slug tokens of the configured "<slug>[bot]" logins, used for check/app matching.
   private final Set<String> botTokens;
 
   @Inject
@@ -82,12 +80,6 @@ public class CiStatusEvaluator {
   Optional<List<String>> resolveRequiredContexts(
       String auth, String owner, String repo, String baseBranch) {
     if (baseBranch == null || baseBranch.isBlank()) {
-      // The base branch was not carried on the request (e.g. a manual trigger whose PR lookup did
-      // not yield one): gate on all checks rather than guessing the target branch. The branch ref
-      // is
-      // resolved upstream (webhook payload / resolveMissingPrDetails), so this no longer fetches
-      // the
-      // PR here just to read it.
       return Optional.empty();
     }
     String branch = baseBranch;
@@ -210,13 +202,8 @@ public class CiStatusEvaluator {
 
     addMissingRequiredChecks(requiredContexts, seen, offending);
 
-    // Fail closed for the APPROVE decision: if either CI source could not be read (an
-    // exception or a null body — GitHub returns an empty list, never null, past the last page) we
-    // cannot confirm CI is green, so the verdict must not approve over CI we never saw. This
-    // holds in BOTH gate modes: gate-specific is not automatically safe, because
-    // addMissingRequiredChecks only catches required contexts that did not report — a source going
-    // unread can still hide a required check's true state. Reported as a first-class signal, not a
-    // synthetic check.
+    // GitHub returns an empty list, never null, past the last page — an exception or null body
+    // means the source was unreadable, which must hold approval even in gate-specific mode.
     boolean unreadable = !checkRunsReadable || !statusReadable;
     return new CiEvaluation(offending, unreadable, requiredContexts != null);
   }
@@ -331,9 +318,8 @@ public class CiStatusEvaluator {
     if (CONCLUSION_FAILURE.equalsIgnoreCase(state) || "error".equalsIgnoreCase(state)) {
       return CI_FAILING;
     }
-    // "pending", null, or any unrecognized state is not a confirmed pass: classify it as pending so
-    // an indeterminate required check holds the approval rather than being mistaken for success.
-    // Only an explicit "success" clears the gate.
+    // "pending", null, or any unrecognized state is not a confirmed pass — only an explicit
+    // "success" clears the gate.
     return CI_PENDING;
   }
 
@@ -346,9 +332,8 @@ public class CiStatusEvaluator {
     return app != null && (containsBotToken(app.slug()) || containsBotToken(app.name()));
   }
 
-  // Deliberately a substring test, not BotIdentity.matches (exact login set): a check's app slug or
-  // name lacks the "[bot]" suffix that BotIdentity strips, so an exact match would never recognise
-  // the bot's own check. This is why identity matching is not reused here.
+  // Substring test, not BotIdentity.matches: a check's app slug/name lacks the "[bot]" suffix,
+  // so an exact login match would never recognise the bot's own check.
   private boolean containsBotToken(String value) {
     if (value == null) {
       return false;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -82,8 +82,7 @@ public class DiffBudgetPlanner {
     }
 
     public boolean truncated() {
-      // A clipped file's unseen hunks were withheld just like an omitted file's whole diff: both
-      // make the review partial, so both hold APPROVE and demand disclosure.
+      // Clipped unseen hunks withhold coverage like omitted files — both hold APPROVE.
       return !omittedFiles.isEmpty() || !clippedFiles.isEmpty();
     }
 
@@ -197,7 +196,6 @@ public class DiffBudgetPlanner {
 
   private Rendered renderAndSize(
       List<GitHubPullRequestClient.FileDiff> reviewable, int diffBudgetTokens) {
-    // Highest-impact first so that, when bins fill, the files left out by name are the smallest.
     var ordered = new ArrayList<>(reviewable);
     ordered.sort(
         Comparator.comparingInt(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -109,11 +109,8 @@ public final class DiffLineResolver {
     if (exact != null && !exact.isEmpty()) {
       return exact.get(line);
     }
-    // Variant fallback: resolve to the UNIQUE FilePaths.same variant. On a suffix collision (two
-    // diff keys both matching, e.g. a/Handler.java and b/Handler.java) return null rather than
-    // guess
-    // whichever entry the map iterates first — mirrors resolveRightSideLinesForFileOrVariant, the
-    // safe direction.
+    // Variant fallback: resolve to the unique FilePaths.same variant; on a suffix collision
+    // (two diff keys both matching) return null rather than guess.
     Map<Integer, String> resolved = null;
     for (var entry : rightSideLineTextByFile.entrySet()) {
       var value = entry.getValue();
@@ -318,19 +315,11 @@ public final class DiffLineResolver {
     if (matchOffset == -1) {
       return Optional.empty();
     }
-    // Right-side line numbers are walked in ascending diff order, so a run of two or more matched
-    // lines always yields endLine > startLine — no degenerate single-line range to guard against.
     int startLine = lineNumbers.get(matchOffset);
     int endLine = lineNumbers.get(matchOffset + anchorLines.size() - 1);
-    // The match is contiguous in the trimmed-text list, but blank-line dropping lets it straddle a
-    // hunk boundary (last line of one hunk, first line of the next). A multi-line GitHub suggestion
-    // must stay within a single hunk — start_line and line in different hunks is rejected (422),
-    // even when the two hunks are numerically adjacent and the span has no missing line number.
-    // Fall
-    // back to a single-line comment when any hunk begins inside (startLine, endLine]. The key came
-    // from the parallel right-side-text map, populated in the same pass, so its hunk-starts entry
-    // is
-    // always present.
+    // GitHub rejects (422) a multi-line suggestion whose start_line and line fall in different
+    // hunks, and blank-line dropping lets a match straddle a hunk boundary — fall back to a
+    // single-line comment when any hunk begins inside (startLine, endLine].
     TreeSet<Integer> hunkStarts = rightSideHunkStartsByFile.get(key);
     if (!hunkStarts.subSet(startLine, false, endLine, true).isEmpty()) {
       return Optional.empty();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
@@ -215,9 +215,6 @@ public class DocGenerationService {
       String commitSha,
       List<GitHubPullRequestClient.FileDiff> reviewable,
       DocGenerationResponse response) {
-    // `reviewable` is the already ignore-glob-filtered list the caller computed, so use the
-    // overload
-    // that trusts that filter rather than re-walking the glob here.
     var lineResolver = new DiffLineResolver(diffFormatter.patchesByReviewableFiles(reviewable));
     int cap = config.review().maxReviewComments();
     int suggestions = 0;
@@ -226,8 +223,6 @@ public class DocGenerationService {
     var docs = response.docs();
     for (int i = 0; i < docs.size(); i++) {
       if (suggestions + notes >= cap) {
-        // Count the postable docs we're dropping because the cap is reached, so the summary can
-        // disclose them rather than silently under-documenting the PR.
         skippedByCap =
             (int) docs.subList(i, docs.size()).stream().filter(d -> d.isPostable()).count();
         Log.debugf(
@@ -257,10 +252,9 @@ public class DocGenerationService {
       DiffLineResolver lineResolver) {
     boolean multiLine = doc.suggestionOld().strip().contains("\n");
     var resolved = lineResolver.resolveRightSideLine(doc.file(), doc.line());
-    // A single-line docstring is anchored at doc.line() itself, so a snapped-to neighbour would
-    // rewrite the wrong line on commit — drop a near miss. A multi-line declaration is anchored by
-    // its verbatim range (below), so the exact line isn't required; only that the file is in the
-    // diff, which also gives the note fallback a valid line to attach to.
+    // A single-line docstring must anchor at doc.line() exactly — a snapped-to neighbour would
+    // rewrite the wrong line on commit. A multi-line declaration is anchored by its verbatim
+    // range below, so it only needs the file to be in the diff.
     if (resolved.isEmpty() || (!multiLine && resolved.getAsInt() != doc.line())) {
       Log.debugf(
           "Skipping /add-docs suggestion for %s:%d — declaration line is not in the diff",
@@ -273,19 +267,13 @@ public class DocGenerationService {
           doc.file(), doc.line());
       return DocPostResult.SKIPPED;
     }
-    // A wrapped declaration spans several lines, so a committable suggestion must overwrite the
-    // whole span, not just doc.line() — otherwise the commit replaces only the first line and
-    // leaves
-    // the rest in place, corrupting the file. Resolve the range from the verbatim old code's
-    // position in the diff, which also anchors it independently of doc.line().
+    // A multi-line suggestion must overwrite the whole declaration span, not just doc.line() —
+    // otherwise the commit replaces only the first line and corrupts the file.
     var range =
         multiLine
             ? lineResolver.resolveSuggestionRange(doc.file(), doc.suggestionOld())
             : Optional.<DiffLineResolver.LineRange>empty();
     if (multiLine && range.isEmpty()) {
-      // The multi-line declaration can't be anchored to a single hunk, so a committable suggestion
-      // would mis-apply. Still surface the missing-docs problem: post a note (anchored at the
-      // nearest in-diff line) with the drafted docs to add manually, rather than dropping it.
       boolean posted =
           postInline(
               auth,
@@ -365,8 +353,6 @@ public class DocGenerationService {
   private String baseSummaryMessage(DocGenerationResponse response, DocPostOutcome outcome) {
     int suggestions = outcome.suggestions();
     int notes = outcome.notes();
-    // When the per-run comment cap stopped further docs, disclose it rather than silently
-    // under-documenting the PR — the maintainer needs to know to re-run after addressing these.
     String capSuffix =
         outcome.skippedByCap() > 0
             ? " "
@@ -392,8 +378,6 @@ public class DocGenerationService {
           + capSuffix;
     }
     if (notes > 0) {
-      // Notes have no committable ```suggestion block, so don't tell the maintainer to "commit"
-      // them.
       return "📝 ThrillhouseBot drafted documentation for **"
           + notes
           + "** symbol(s) it couldn't post as committable suggestions (the declaration doesn't map"
@@ -401,8 +385,6 @@ public class DocGenerationService {
           + capSuffix;
     }
     if (outcome.skippedByCap() > 0) {
-      // Nothing posted, but the cap (e.g. maxReviewComments=0) stopped postable docs. Disclose the
-      // cap rather than falling through to COULD_NOT_PLACE, which would wrongly blame anchoring.
       return "📝 ThrillhouseBot posted no documentation: the per-run comment cap was reached, so **"
           + outcome.skippedByCap()
           + "** changed symbol(s) were not documented. Raise the comment cap or re-run `/add-docs`.";
@@ -410,8 +392,7 @@ public class DocGenerationService {
     return response.docs().isEmpty() ? NOTHING_TO_DOCUMENT : COULD_NOT_PLACE;
   }
 
-  // The command-specific guidance line for the repository-instructions section
-  // (PromptSections.instructionsSection renders the shared header, source attribution, and escape).
+  // Command-specific guidance for the repository-instructions section.
   private static final String INSTRUCTIONS_GUIDANCE =
       "The repository maintainers have provided these guidelines; respect them when writing"
           + " documentation.\n";

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/Finding.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/Finding.java
@@ -28,7 +28,7 @@ public record Finding(
     String suggestionOld,
     String suggestionNew) {
   public Finding {
-    // Findings created before the confidence field existed keep their blocking semantics
+    // Findings persisted before the confidence field existed keep their blocking semantics.
     if (confidence == null) {
       confidence = Confidence.HIGH;
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingDeduplicator.java
@@ -179,19 +179,12 @@ public class FindingDeduplicator {
             .map(f -> RiskLevel.fromString(f.risk()))
             .sorted(Comparator.naturalOrder())
             .toList();
-    // The list is sorted most-severe first (RiskLevel natural order is CRITICAL..LOW). An odd
-    // cluster uses the true median so a lone outlier cannot decide the severity; an even cluster
-    // has
-    // no single middle, so take the more severe of the two central values (the lower index) — never
-    // the less severe — so a single hedged duplicate cannot downgrade a blocking finding.
+    // RiskLevel natural order is most-severe-first (CRITICAL..LOW); an even cluster takes the more
+    // severe of the two central values (the lower index).
     int mid = ranked.size() / 2;
     RiskLevel severity = ranked.size() % 2 == 0 ? ranked.get(mid - 1) : ranked.get(mid);
-    // Confidence stays paired with the chosen severity: the highest confidence among the members
-    // that carry it. Taking it from an arbitrary member could either defuse a blocking
-    // critical/high-confidence finding via a hedged duplicate, or synthesize a blocking pair no
-    // single member ever asserted. Confidence is declared most-certain-first (HIGH < MEDIUM < LOW
-    // in
-    // natural order), so min() selects the highest confidence.
+    // Confidence natural order is most-certain-first (HIGH < MEDIUM < LOW), so min() selects the
+    // highest confidence among members carrying the chosen severity.
     Confidence confidence =
         cluster.stream()
             .filter(f -> RiskLevel.fromString(f.risk()) == severity)

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -174,7 +174,6 @@ public class FindingPipeline {
               batchResponse.previousFindingsStatus(), batch, plan, previousFilesById));
     }
 
-    // Finishing chain over the union — quote validation and verification already ran per batch.
     var aggregated = new ReviewResponse(allFindings, mergeBatchStatuses(batchStatuses), null);
     var refined = deduplicator.dedupe(aggregated);
     refined =
@@ -291,8 +290,7 @@ public class FindingPipeline {
       return "(changed-files overview withheld — summary input budget exhausted)\n";
     }
     var lines = overview.split("\n");
-    // The rollup note's tokens are reserved up front so appending it after truncation cannot push
-    // the overview past its share; the worst-case note (nothing listed) bounds all others.
+    // Rollup-note tokens are reserved up front so post-truncation append cannot exceed the share.
     var noteReserve = tokenCounter.estimateTokens(overviewRollupNote(lines.length));
     var sb = new StringBuilder();
     var used = 0;
@@ -341,8 +339,7 @@ public class FindingPipeline {
             + changedFilesOverview
             + promptInputs.previousFindings()
             + promptInputs.repoInstructions();
-    // The note's tokens are reserved up front so appending it after clamping cannot itself push
-    // the prompt back over the budget; the worst-case note (everything dropped) bounds all others.
+    // trueTotalsNote tokens are reserved up front so post-clamp append cannot exceed the budget.
     var noteReserve =
         findings.isEmpty()
             ? 0
@@ -503,8 +500,6 @@ public class FindingPipeline {
       List<String> priorAiResponseJsons,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       DiffLineResolver lineResolver) {
-    // Quote validation runs before dedupe so a merged finding can never inherit a phantom
-    // quote from one duplicate while a verbatim sibling gets discarded
     aiResponse = quoteValidator.validate(aiResponse, diff);
     aiResponse = deduplicator.dedupe(aiResponse);
     aiResponse =

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -95,9 +95,8 @@ public class FindingQuoteValidator {
               finding.title(), finding.file(), finding.line());
           changed = true;
         }
-        // FULL and NO_QUOTE keep the finding; default also keeps any future verdict rather than
-        // silently dropping it. Being a real, test-covered default removes the enum switch's
-        // synthetic-default branch, which otherwise left this line only partially covered.
+        // FULL and NO_QUOTE fall through here; default also keeps any future verdict rather than
+        // silently dropping it.
         default -> {
           if (descriptionCitesAbsentCode(finding, index)) {
             Log.infof(
@@ -191,10 +190,8 @@ public class FindingQuoteValidator {
     for (String expression : cited) {
       String needle = stripWhitespace(expression);
       if (appearsIn(needle, compactedScope)) {
-        // Present verbatim in the diff: the finding is grounded — keep it, whatever else it cites.
         return false;
       }
-      // Absent from the diff: a fabricated mechanism unless it merely restates the proposed fix.
       if (!compactedSuggestion.contains(needle)) {
         fabricated = true;
       }
@@ -270,7 +267,7 @@ public class FindingQuoteValidator {
     while (i < s.length() && s.charAt(i) == '.') {
       int nameEnd = skipIdentifier(s, i + 1);
       if (nameEnd == i + 1) {
-        break; // a '.' not followed by an identifier ends the chain
+        break;
       }
       i = nameEnd;
       afterArgs = skipBalancedParens(s, i);
@@ -326,7 +323,7 @@ public class FindingQuoteValidator {
       }
       i++;
     }
-    return start; // unbalanced — consume nothing
+    return start;
   }
 
   /**
@@ -344,7 +341,7 @@ public class FindingQuoteValidator {
     while (i < n) {
       char c = s.charAt(i);
       if (c == '\\') {
-        i += 2; // skip the escaped character
+        i += 2;
         continue;
       }
       if (c == quote) {
@@ -352,7 +349,7 @@ public class FindingQuoteValidator {
       }
       i++;
     }
-    return start + 1; // unterminated literal: treat the lone quote as an ordinary character
+    return start + 1;
   }
 
   private static boolean isIdentifierStart(char c) {
@@ -574,8 +571,8 @@ public class FindingQuoteValidator {
     for (String raw : diff.split("\n", -1)) {
       if (raw.startsWith("### ")) {
         current = fileLines.computeIfAbsent(sectionFilename(raw), k -> new ArrayList<>());
-        // A new file section restarts right-side numbering; don't carry the previous file's
-        // counter forward in case its first hunk header is missing or unparseable.
+        // A new file section restarts right-side numbering in case its first hunk header is
+        // missing or unparseable.
         rightLine = 0;
       } else if (raw.startsWith("@@")) {
         rightLine = hunkStartLine(raw, rightLine);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -466,8 +466,8 @@ public class FollowUpAnalyzer {
         if (!isSameFinding(finding, prior)) {
           continue;
         }
-        // Marker indices are only meaningful within their own round; across rounds the same
-        // index names unrelated findings, so the thread is located by file and title instead
+        // Marker indices are only meaningful within their own round; across rounds the same index
+        // names unrelated findings, so the thread is located by file and title instead.
         if (answeredRootComment(prior, inlineComments, botIdentity) != null) {
           return prior;
         }
@@ -481,21 +481,11 @@ public class FollowUpAnalyzer {
     if (finding.file() == null || !FilePaths.same(finding.file(), prior.file())) {
       return false;
     }
-    // Same file + close lines + similar title is the same finding re-raised. Severity is NOT part
-    // of identity: two distinct findings that merely share a severity (or both carry null/unknown
-    // risk, which maps to LOW) near the same line are different defects and must not be collapsed —
-    // doing so silently dropped a new finding whenever a same-severity neighbour had been replied
-    // to. A paraphrased re-raise whose title drifted is still caught by the content-overlap
-    // fallback below.
     if (Math.abs(finding.line() - prior.line()) <= DUPLICATE_LINE_TOLERANCE
         && FindingDeduplicator.titleSimilarity(finding.title(), prior.title())
             >= FindingDeduplicator.TITLE_SIMILARITY_THRESHOLD) {
       return true;
     }
-    // Paraphrased re-raises drift in both wording and line numbers as the PR evolves
-    // (observed: 29 lines and 0.12 title similarity); same file plus strongly overlapping
-    // title+description still identifies them, and suppression only ever fires when the
-    // prior thread carries a maintainer reply
     return FindingDeduplicator.contentOverlap(finding, prior)
         >= FindingDeduplicator.CONTENT_OVERLAP_THRESHOLD;
   }
@@ -877,7 +867,7 @@ public class FollowUpAnalyzer {
     var lastBotReview =
         priorReviews.stream()
             .filter(r -> botIdentity.matches(r.user().login()))
-            .reduce((first, second) -> second); // get last
+            .reduce((first, second) -> second);
 
     if (lastBotReview.isEmpty()) return "";
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
@@ -147,9 +147,6 @@ public class MaintainerReplyService {
     var root = findRoot(comments, task.rootCommentId());
     boolean rootIsBot =
         root != null && root.user() != null && triggerDetector.isBotComment(root.user().login());
-    // Only answer when the maintainer is actually addressing the bot: a reply on the bot's own
-    // finding thread, or an explicit mention. A reply between two humans on a human-started thread
-    // must not pull the bot in.
     if (!task.mentioned() && !rootIsBot) {
       Log.debugf(
           "Skipping review-thread reply on %s/%s #%d — not a bot thread and no mention",
@@ -260,8 +257,6 @@ public class MaintainerReplyService {
       long triggeringCommentId) {
     var sb = new StringBuilder();
     for (var c : comments) {
-      // Keep only the other replies on this thread: skip non-replies, replies to a different root,
-      // and the message that triggered this reply.
       if (c.inReplyToId() == null
           || c.inReplyToId() != rootCommentId
           || c.id() == triggeringCommentId) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrLabeler.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrLabeler.java
@@ -250,18 +250,14 @@ public class PrLabeler {
   }
 
   private void applyLabels(LabelRequest request, List<String> resolved) {
-    // GitHub's add-labels endpoint is additive, so without this guard a re-review with shifting
-    // suggestions would keep piling labels onto the PR — pushing it well past max-labels over time
-    // (max-labels is documented as a per-PR bound). Bound the additions against the labels already
-    // on the PR: skip ones already present and only top the PR up to max-labels in total.
+    // GitHub's add-labels endpoint is additive, so bound the additions against the labels
+    // already on the PR to keep max-labels a per-PR total.
     var current = currentLabelKeys(request);
     int max = Math.max(0, config.review().labels().maxLabels());
     int budget = Math.max(0, max - current.size());
     if (budget == 0) {
       return;
     }
-    // Skip labels already on the PR (re-adding is a no-op that wastes budget) and take only enough
-    // new ones to reach max-labels.
     var toAdd =
         resolved.stream()
             .filter(name -> !current.contains(name.toLowerCase(Locale.ROOT)))
@@ -270,8 +266,8 @@ public class PrLabeler {
     if (toAdd.isEmpty()) {
       return;
     }
-    // In allow-create mode, drop any label whose creation failed — GitHub 422s the whole
-    // add-labels request if a single name doesn't exist, which would apply nothing at all.
+    // GitHub 422s the whole add-labels request if a single name doesn't exist, so drop any
+    // label whose creation failed.
     List<String> applicable =
         config.review().labels().allowCreate() ? ensureLabelsExist(request, toAdd) : toAdd;
     if (applicable.isEmpty()) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -28,9 +28,8 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class PrSummaryGenerator {
 
-  // The walkthrough-diagram master switch, read once. The render is gated on it as well as the
-  // prompt request, so the documented "no diagram is requested or rendered unless enabled" holds
-  // even if the model volunteers a walkthrough_diagram the prompt never asked for.
+  // Walkthrough-diagram master switch; also gates rendering when the model volunteers an
+  // unrequested walkthrough_diagram.
   private final boolean diagramEnabled;
 
   @Inject
@@ -243,8 +242,6 @@ public class PrSummaryGenerator {
       }
       sb.append("\n");
     }
-    // Unreadable CI is a distinct hold from an offending check: render it as its own note rather
-    // than as a counterfeit row in the required-checks table.
     if (result.ciUnreadable()) {
       sb.append("### ⚠️ CI Status Unavailable\n");
       sb.append(
@@ -392,11 +389,10 @@ public class PrSummaryGenerator {
     if (raw == null || raw.isBlank()) {
       return null;
     }
-    // Drop every backtick run: Mermaid source never contains one, and removing them both unwraps an
-    // accidental ```mermaid ... ``` and prevents a stray ``` from closing our fence early.
+    // Mermaid source never contains a backtick; dropping them all unwraps an accidental
+    // ```mermaid fence and keeps a stray ``` from closing our fence early.
     String cleaned = raw.replace("`", "").strip();
-    // Unwrapping a ```mermaid fence leaves a bare "mermaid" language tag as the first line; drop it
-    // so the diagram keyword underneath is what gets validated.
+    // An unwrapped fence leaves a bare "mermaid" language tag as the first line; drop it.
     if (cleaned.regionMatches(true, 0, "mermaid", 0, "mermaid".length())) {
       int firstBreak = cleaned.indexOf('\n');
       cleaned = firstBreak < 0 ? "" : cleaned.substring(firstBreak + 1).strip();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PromptTemplateEscaper.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PromptTemplateEscaper.java
@@ -21,10 +21,7 @@ import java.util.HexFormat;
 /** Escapes user-provided prompt fragments before they are bound into a LangChain4j prompt. */
 public final class PromptTemplateEscaper {
 
-  // Per-review random fence around the diff. Because the token is unguessable, PR content cannot
-  // forge the boundary, so the diff is passed byte-exact — no rewriting that would corrupt
-  // marker-handling code under review. The prefix is fixed (the prompt names it); only the
-  // random suffix makes the full line unforgeable.
+  // The prefix is fixed (the prompt names it); only the random suffix makes a fence unforgeable.
   private static final String FENCE_PREFIX = "[[THRILLHOUSEBOT-UNTRUSTED-DATA-";
   private static final String FENCE_SUFFIX = "]]";
   private static final SecureRandom RANDOM = new SecureRandom();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
@@ -124,35 +124,17 @@ public class ReviewContextLoader {
       String auth, ReviewOrchestrator.ReviewRequest req, ReviewSession session, String repository) {
     var files = fetchPrFiles(auth, req.owner(), req.repo(), req.prNumber());
     var prTotals = fetchPrTotals(auth, req.owner(), req.repo(), req.prNumber());
-    // The ignore-glob filter runs once here; the already-filtered list feeds the diff render (so
-    // formatFileSection does not re-glob each file) and the line resolver alike, instead of either
-    // re-walking it.
     var reviewableFiles = diffFormatter.reviewableFiles(files);
     var diffResult = diffFormatter.buildDiffStringWithStats(files, reviewableFiles);
     var baseComparisonResult =
         buildBaseComparisonWithStats(auth, req.owner(), req.repo(), req.baseSha(), req.commitSha());
-    // Only the PR diff's omitted files gate the verdict: the base↔head comparison is
-    // supplementary regression context, so trimming it must not hold APPROVE or claim a partial
-    // review when the PR diff itself was reviewed in full.
     var omittedFiles = diffResult.omittedFiles();
-    // Built once here and shared via the context: the finding pipeline (anchor backfill), the
-    // verdict backstop, and the publisher's inline comments all resolve against the same diff.
     var lineResolver =
         new DiffLineResolver(diffFormatter.patchesByReviewableFiles(reviewableFiles));
 
     var priorReviews = fetchPriorReviews(auth, req.owner(), req.repo(), req.prNumber());
-    // Two independent flags decouple UX presentation from context loading:
-    //  • isFirstVisibleReview — true when the bot has posted nothing user-visible on the PR yet:
-    //    neither a review nor a summary comment. Gates the first-review summary issue-comment and
-    //    the APPROVE celebration body. A review alone is not a reliable proxy: a first round held
-    //    back only by pending CI posts the summary comment but no review, so keying off the
-    //    review would re-post the summary every round until one finally creates a review. The
-    //    summary comment is the artifact we must not duplicate, so we look for it directly.
-    //  • hasContext — true when persistence holds prior AI responses (surviving force-push/
-    //    rebase). Gates previous-findings context loading, inline comment fetching, and the
-    //    deterministic backstop. A persisted-but-unreviewed prior round (e.g. createReview
-    //    failed after persistAiResponse) must still reconstruct context without suppressing
-    //    the first user-visible summary.
+    // isFirstVisibleReview keys off the summary comment directly, not reviews alone: a first
+    // round held back only by pending CI posts the summary comment but no review.
     List<String> priorAiResponseJsons =
         sessionPersistence.findAllPriorAiResponseJsons(repository, req.prNumber(), session.id);
     var isFirstVisibleReview =
@@ -184,8 +166,6 @@ public class ReviewContextLoader {
         instructionsResolver.resolve(
             req.owner(), req.repo(), req.defaultBranch(), req.installationId());
 
-    // Existing repo labels are fetched once (when the feature is on): they both constrain the
-    // model's suggestions in the prompt and are reused to reconcile its output afterwards.
     var repoLabels = labeler.fetchExistingLabels(auth, req.owner(), req.repo());
     var projectStack = resolveProjectStack(req);
 
@@ -247,10 +227,6 @@ public class ReviewContextLoader {
 
   List<GitHubPullRequestClient.FileDiff> fetchPrFiles(
       String auth, String owner, String repo, int prNumber) {
-    // A fetch failure must propagate to review()'s handler (failed check + "could not complete"
-    // notice). Swallowing it into an empty list is indistinguishable from a PR with no changes and
-    // produces a false APPROVE + green check on code that was never read. A genuinely empty
-    // PR returns an empty list with no exception and still takes the normal path.
     return prClient.getPullRequestFiles(auth, ACCEPT, owner, repo, prNumber);
   }
 
@@ -334,8 +310,7 @@ public class ReviewContextLoader {
   List<GitHubCommentClient.IssueComment> fetchIssueComments(
       String auth, String owner, String repo, int prNumber) {
     try {
-      // listComments paginates internally and always returns a non-null list (empty when there are
-      // no comments), so the only best-effort fallback needed here is the fetch throwing.
+      // listComments paginates internally and always returns a non-null list (empty when none).
       return commentClient.listComments(auth, ACCEPT, owner, repo, prNumber);
     } catch (RuntimeException e) {
       Log.debug("Could not fetch PR issue comments (continuing as if none exist)", e);
@@ -346,8 +321,7 @@ public class ReviewContextLoader {
   List<GitHubReviewClient.PullRequestComment> fetchPullRequestComments(
       String auth, String owner, String repo, int prNumber) {
     try {
-      // The client walks every page and never returns null, so the only failure to absorb here is
-      // the fetch throwing.
+      // The client walks every page and never returns null.
       return reviewClient.listPullRequestComments(auth, ACCEPT, owner, repo, prNumber);
     } catch (RuntimeException e) {
       Log.warn("Failed to fetch PR inline comments, continuing without thread context", e);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
@@ -351,8 +351,6 @@ public class ReviewDiffFormatter {
             .append(" -")
             .append(file.deletions())
             .append(")\n");
-    // Membership in the caller's precomputed reviewable set, not a fresh isIgnored() glob match, so
-    // the ignore-glob filter is walked once per review rather than again here for every file.
     if (!reviewableNames.contains(file.filename())) {
       sb.append(
               String.format(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
@@ -101,8 +101,8 @@ public final class ReviewDispatcher {
       log.error("Review worker aborted for {}/{} #{}", key.owner(), key.repo(), key.prNumber(), e);
       retire(key, state);
     } finally {
-      // Errors (OOM, assertion failures) propagate to the executor thread, but the state
-      // must still be retired so later dispatches for this PR are not coalesced forever
+      // Even when an Error propagates, the state must be retired or later dispatches for this
+      // PR would be coalesced forever.
       if (!completed) {
         log.error(
             "Review worker aborted fatally for {}/{} #{}", key.owner(), key.repo(), key.prNumber());
@@ -115,11 +115,8 @@ public final class ReviewDispatcher {
     while (true) {
       var batch = state.takeNextReview();
 
-      // The controller's rate-limit gate ran before dispatch, so a request that passed it before
-      // the window opened can reach this worker — coalesced behind the in-flight review that then
-      // recorded its completion, or dispatched in the gap between a prior worker's
-      // recordCompletion and its state removal. Re-checking every batch closes both paths: no
-      // batch is reviewed once the window is closed, whichever way it got here.
+      // Re-check after dispatch: a request can pass the controller gate then reach here once the
+      // window closed (coalesce or recordCompletion gap).
       var req = batch.request();
       if (!req.isManualTrigger()
           && autoReviewRateLimiter.isThrottled(req.owner(), req.repo(), req.prNumber())) {
@@ -144,9 +141,7 @@ public final class ReviewDispatcher {
     logReviewStart(batch.request(), batch.coalesced(), batch.queueWaitMs());
     try {
       var surfaced = orchestrator.review(batch.request());
-      // Start the throttle window only when a review was actually posted, and at completion
-      // (not dispatch) so a long-running review does not eat into it. A failed review must not
-      // block the retry on the next push, and manual reviews never shift the automatic window.
+      // recordCompletion at post time, not dispatch; manual reviews are out of scope.
       if (surfaced && !batch.request().isManualTrigger()) {
         autoReviewRateLimiter.recordCompletion(
             batch.request().owner(), batch.request().repo(), batch.request().prNumber());
@@ -248,9 +243,8 @@ public final class ReviewDispatcher {
 
     DispatchResult onDispatch(ReviewOrchestrator.ReviewRequest req) {
       synchronized (lock) {
-        // A finishing worker can retire the state between the map lookup above and this
-        // lock; reviving a retired state would let two workers run for the same PR, so
-        // drop the dead mapping and retry with a fresh state.
+        // A finishing worker can retire the state between the map lookup and this lock;
+        // reviving it would let two workers run for the same PR.
         if (retired) {
           return new DispatchResult(true, false, 0);
         }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -33,11 +33,8 @@ import java.util.function.Consumer;
 @ApplicationScoped
 public class ReviewOrchestrator {
 
-  // Check run status constant used when building the completion update (CheckRunManager owns
-  // create).
   private static final String CHECK_STATUS_COMPLETED = "completed";
 
-  // Check run conclusion constants
   private static final String CONCLUSION_FAILURE = "failure";
 
   private final ThrillhouseConfig config;
@@ -63,8 +60,6 @@ public class ReviewOrchestrator {
 
   private final FindingPipeline findingPipeline;
 
-  // The CI status I/O (required-context resolution + check evaluation) is independent of the model
-  // response, so it runs on this executor concurrently with the blocking AI call rather than after.
   private final ExecutorService reviewExecutor;
 
   /**
@@ -217,8 +212,6 @@ public class ReviewOrchestrator {
     sessionPersistence.create(session);
     broadcaster.broadcast(SessionEventBroadcaster.SessionEvent.started(session));
 
-    // Resolution happens inside the try: a failing PR fetch (deleted PR, rate limit) must take
-    // the same failure path as any other error — comment, failed session, broadcast.
     var req = request;
     var checkRunId = -1L;
     var resultSurfaced = false;
@@ -244,15 +237,8 @@ public class ReviewOrchestrator {
       var lineResolver = ctx.lineResolver();
 
       var promptInputs = promptAssembler.assemble(ctx, req);
-      // Planned from the fully assembled prompt so the overhead estimate covers every section a
-      // review call actually repeats — not just the loader-visible subset (#53).
       var plan = budgetPlanner.plan(ctx.reviewableFiles(), promptInputs);
 
-      // CI status (required-context resolution + check evaluation) depends only on the
-      // commit/branch,
-      // not the model response, so kick it off concurrently with the blocking AI call and join
-      // after
-      // — the GitHub latency overlaps the model latency instead of stacking on top of it.
       final var ciReq = req;
       var ciFuture =
           CompletableFuture.supplyAsync(() -> resolveCiEvaluation(auth, ciReq), reviewExecutor);
@@ -266,14 +252,11 @@ public class ReviewOrchestrator {
       String conclusion = VerdictBuilder.conclusionForResult(result);
       String checkTitle = VerdictBuilder.checkTitleForResult(result);
       String checkSummary = VerdictBuilder.checkSummaryForResult(result);
-      // The summary comment is first-review enrichment, not the review itself: a transient failure
-      // posting it must not abort before postReview and surface a hard FAILED check for a review
-      // that would otherwise post. Keep it best-effort; the review below is the critical step.
       boolean summaryPosted = publishSummaryBestEffort(auth, req, result);
       reviewPublisher.dismissPendingBotReviews(
           auth, req.owner(), req.repo(), req.prNumber(), priorReviews);
-      // The summary-only skip applies only when the regenerated summary actually landed on the
-      // PR — a failed best-effort summary post must leave the review as the run's visible outcome.
+      // summaryReposted gates the summary-only skip: a failed summary post leaves review
+      // posting enabled.
       reviewPublisher.postReview(
           new ReviewPublisher.PostReviewRequest(
               auth,
@@ -285,11 +268,6 @@ public class ReviewOrchestrator {
               lineResolver,
               req.forceSummary() && summaryPosted));
 
-      // The review and its comments are on the PR now. Everything past this point is
-      // best-effort and independent: each step runs in isolation so one failure can't abort the
-      // rest. In particular a failure in an earlier step must not skip the session completion and
-      // broadcast, which would otherwise leave the session stuck IN_PROGRESS in the dashboard even
-      // though the review was posted.
       resultSurfaced = true;
       final var doneReq = req;
       final var concludedCheckRunId = checkRunId;
@@ -326,12 +304,8 @@ public class ReviewOrchestrator {
           doneReq,
           "complete the session",
           () -> {
-            // Persist the completed status FIRST, then broadcast: the broadcast must not fire if
-            // the
-            // persistence write throws, or the dashboard would show a "completed" event over a row
-            // still IN_PROGRESS (and revert to IN_PROGRESS on reload). Keeping them in one step
-            // means
-            // a failed write skips the broadcast, so persisted and live state stay consistent.
+            // Persist first: a failed write must skip the broadcast so persisted and live
+            // dashboard state stay consistent.
             applyReviewResult(session, result);
             broadcaster.broadcast(SessionEventBroadcaster.SessionEvent.completed(session));
           });

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssembler.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssembler.java
@@ -31,8 +31,7 @@ import jakarta.inject.Inject;
 @ApplicationScoped
 public class ReviewPromptAssembler {
 
-  // The command-specific guidance line(s) for the review path's repository-instructions section
-  // (PromptSections.instructionsSection renders the shared header, source attribution, and escape).
+  // Command-specific guidance for the review path's repository-instructions section.
   private static final String INSTRUCTIONS_GUIDANCE =
       """
       The repository maintainers have provided these additional review guidelines.
@@ -53,17 +52,10 @@ public class ReviewPromptAssembler {
 
   AiReviewService.PromptInputs assemble(
       ReviewContextLoader.ReviewContext ctx, ReviewOrchestrator.ReviewRequest req) {
-    // The diff carries the code under review, so it is enclosed in a per-review random fence and
-    // passed byte-exact (no marker rewriting that would corrupt marker-handling code). The
-    // smaller prose slots keep the lightweight marker neutralization as defense-in-depth.
     String fencedDiff = PromptTemplateEscaper.fence(ctx.diff());
     String escapedStack = PromptTemplateEscaper.escape(ctx.projectStack());
-    // The label guidance and the repo-instructions file share the prompt's trailing
-    // {{repoInstructions}} slot; the label section is escaped (it carries repo label names),
-    // the instructions section escapes its own maintainer content.
     String labelGuidance = PrLabeler.buildLabelGuidance(ctx.repoLabels(), labeler.allowNewLabels());
-    // The diagram request is fixed guidance (no repo content), so it needs no escaping; its
-    // presence is what gates the model's walkthrough_diagram field.
+    // The diagram request's presence is what gates the model's walkthrough_diagram field.
     String diagramGuidance =
         config.review().diagram().enabled() ? PrReviewPrompts.DIAGRAM_REQUEST : "";
     String trailingGuidance =

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -196,15 +196,8 @@ public class ReviewPublisher {
     var result = post.result();
     var lineResolver = post.lineResolver();
     if (!result.hasIssues()) {
-      // A summary-only re-run (/summary) on a PR that already carries a formal bot review exists
-      // to regenerate the summary comment, which publishSummary just re-posted. A no-new-findings
-      // review here would only restate the verdict already on the PR right after that summary —
-      // skip it. First reviews keep posting (the /summary-before-any-review path), and new
-      // findings below always post (a re-run may genuinely surface them). Two exclusions mirror
-      // the first-review skip in postNoIssuesReview: unresolved previous findings still post
-      // (their COMMENT/REQUEST_CHANGES carries "reply on the thread" guidance the summary lacks)
-      // and a truncated diff still posts (the partial-review notice must not depend on the summary
-      // alone).
+      // Summary-only re-run: skip restating a clean verdict when the summary re-posted; first
+      // review, unresolved previous, and truncation still post.
       if (post.summaryReposted()
           && !result.isFirstReview()
           && result.unresolvedPreviousCount() == 0
@@ -225,12 +218,7 @@ public class ReviewPublisher {
 
     if (inline.posted() == 0) {
       // Inline anchoring failed for every finding (e.g. all lines fell outside the diff after a
-      // force-push). List them in the review body with their descriptions so they are never
-      // invisible. This does not point at the PR summary comment even on a first review: the
-      // summary
-      // is posted best-effort (a transient failure leaves no such comment), and its Key Findings is
-      // only a brief TOC without descriptions — so the body is the one place the detail is sure to
-      // appear.
+      // force-push); surface them in the review body instead.
       Log.warnf(
           "No inline comments posted for %s/%s #%d — surfacing findings in the review body",
           owner, repo, prNumber);
@@ -246,17 +234,10 @@ public class ReviewPublisher {
       return;
     }
 
-    // Some findings anchored inline. Still post a review body when there are changes to flag and/or
-    // findings that could not be anchored — so a finding whose line fell outside the diff is
-    // reported (with its description), not silently dropped just because its siblings anchored.
     var bodyParts = new ArrayList<String>();
     if (result.reviewState() == ReviewState.REQUEST_CHANGES) {
       bodyParts.add("ThrillhouseBot requested changes — see inline comments on the diff.");
     }
-    // List every un-anchored finding with its description, even on a first review where the summary
-    // comment also names it. The summary's Key Findings is a brief table of contents (risk, title,
-    // location — no description), so this body is the only place an un-anchored finding's detail is
-    // surfaced; repeating the title here is the acceptable cost of never dropping the problem.
     bodyParts.addAll(skippedFindingsBodyParts(inline));
     appendTruncationNotice(bodyParts, result);
     if (!bodyParts.isEmpty()) {
@@ -329,8 +310,6 @@ public class ReviewPublisher {
           .append(":")
           .append(f.line())
           .append("`)");
-      // No inline comment carries the detail here, so include the description to still explain the
-      // problem (a suggestion can't be placed, but the issue is reported).
       if (f.description() != null && !f.description().isBlank()) {
         sb.append("\n  ").append(f.description().strip().replace("\n", "\n  "));
       }
@@ -344,8 +323,6 @@ public class ReviewPublisher {
   private void postNoIssuesReview(
       String auth, String owner, String repo, int prNumber, String commitSha, ReviewResult result) {
     if (result.reviewState() == ReviewState.APPROVE) {
-      // On a first review the celebration is part of the summary comment, so the approval itself
-      // carries no body; follow-ups post no summary and keep the message here.
       var req =
           new GitHubReviewClient.CreateReviewRequest(
               commitSha,
@@ -355,24 +332,12 @@ public class ReviewPublisher {
       createReviewWithFallback(auth, owner, repo, prNumber, req);
       return;
     }
-    // A COMMENT held back only by pending/failed CI (no findings, nothing unresolved) merely
-    // restates the summary comment the first review already posts, so emitting it too would
-    // duplicate that message. Skip it on the first review and let the summary stand alone — EXCEPT
-    // when the hold is (also) a truncated diff: the summary comment is posted best-effort, so
-    // a transient failure would leave the partial review disclosed nowhere on the PR (CI holds stay
-    // visible via the red checks themselves; truncation has no other PR surface). Post the body for
-    // a truncated review so the partial-review notice is never lost.
-    // Unresolved previous findings are excluded — their COMMENT carries distinct "reply on the
-    // thread" guidance the summary lacks, so it still posts. Follow-ups post no summary, so the
-    // COMMENT is their only signal; REQUEST_CHANGES always posts; the merge gate is the check run.
     if (result.reviewState() == ReviewState.COMMENT
         && result.isFirstReview()
         && result.unresolvedPreviousCount() == 0
         && !result.truncated()) {
       return;
     }
-    // No new findings, but previous ones are still unresolved or CI checks are pending/failed —
-    // never claim a clean review.
     var req =
         new GitHubReviewClient.CreateReviewRequest(
             commitSha,
@@ -394,11 +359,6 @@ public class ReviewPublisher {
   private String noIssuesBody(ReviewResult result) {
     long unresolved = result.unresolvedPreviousCount();
     var sb = new StringBuilder();
-    // Offending checks and an unreadable CI source are independent hold reasons — a review can be
-    // held by both at once (one CI source failing while another is unreadable), so disclose each on
-    // its own rather than letting the offending branch suppress the unreadable note. This mirrors
-    // the
-    // summary table, which lists the two separately.
     boolean ciHeld = false;
     if (!result.offendingCiChecks().isEmpty()) {
       sb.append(
@@ -420,10 +380,6 @@ public class ReviewPublisher {
       sb.append(ciHeld ? "\nAdditionally, " : "")
           .append(ReviewResult.unresolvedPreviousMessage(unresolved));
     }
-    // Disclose the partial review here whenever the diff was truncated — on follow-ups (which post
-    // no summary) and on first reviews too: the first-review summary banner is posted best-effort,
-    // so relying on it alone would lose the only PR-visible notice if that post fails. The
-    // summary may repeat it; a duplicated notice is the acceptable cost of never dropping it.
     if (result.truncated()) {
       if (!sb.isEmpty()) {
         sb.append("\n\n");
@@ -459,13 +415,9 @@ public class ReviewPublisher {
     var capSkipped = new ArrayList<Finding>();
     var maxComments = config.review().maxReviewComments();
     for (var i = 0; i < result.findings().size(); i++) {
-      // The 1-based index doubles as the finding's id in the persisted response and the
-      // hidden comment marker, keeping thread matching deterministic on follow-up reviews
+      // The 1-based index doubles as the finding's id in the persisted response and the hidden
+      // comment marker, keeping thread matching deterministic on follow-up reviews.
       var finding = result.findings().get(i);
-      // The cap limits inline comments, not findings: once it's reached, remaining findings are
-      // returned as capSkipped (never tried for anchoring) so the caller reports them with the
-      // right
-      // reason — capped on noise, but never silently dropped or mislabeled as un-anchorable.
       if (posted >= maxComments) {
         capSkipped.add(finding);
         continue;
@@ -500,23 +452,16 @@ public class ReviewPublisher {
           finding.file(), finding.line(), resolvedLine);
     }
 
-    // A suggestion whose old code spans several lines is posted as a multi-line comment so the
-    // GitHub suggestion overwrites the whole range, not just the anchor line. The range is
-    // resolved from the verbatim old code's position in the diff; a blank/single-line/unresolvable
-    // anchor leaves it empty and the comment stays single-line.
+    // A GitHub suggestion overwrites the whole commented range, so multi-line old code needs a
+    // multi-line anchor; an unresolvable anchor leaves the range empty and the comment single-line.
     var range =
         finding.hasSuggestion()
             ? lineResolver.resolveSuggestionRange(finding.file(), finding.suggestionOld())
             : Optional.<DiffLineResolver.LineRange>empty();
 
-    // A multi-line suggestion must overwrite its whole range. When that range can't be resolved
-    // (the old code doesn't match the diff verbatim, is ambiguous, or straddles a hunk), attaching
-    // the suggestion would post it against a single line — applying it then overwrites only the
-    // anchor line and leaves the rest of the quoted block in place (the same multi-line
-    // corruption).
-    // In that case post the finding without the suggestion: the problem is still reported, just not
-    // as a one-click fix.
-    // hasSuggestion() already guarantees a non-blank suggestionOld, so the newline check is safe.
+    // A multi-line suggestion posted against a single line corrupts code when applied (only the
+    // anchor line is overwritten), so with no resolvable range the suggestion block is dropped.
+    // hasSuggestion() guarantees a non-blank suggestionOld, so the newline check is safe.
     var multiLineSuggestion =
         finding.hasSuggestion() && finding.suggestionOld().strip().contains("\n");
     var includeSuggestion = finding.hasSuggestion() && (!multiLineSuggestion || range.isPresent());
@@ -588,9 +533,7 @@ public class ReviewPublisher {
       List<GitHubReviewClient.ReviewResponse> priorReviews) {
     try {
       for (var review : priorReviews) {
-        // A review from a since-deleted account serializes as user:null; guard it (matching the
-        // first-visible-review check) so one ghost review can't NPE-abort the whole dismissal loop
-        // and leave the bot's own stale pending review undeleted.
+        // A review from a since-deleted account serializes as user:null.
         if ("PENDING".equals(review.state())
             && review.user() != null
             && botIdentity.matches(review.user().login())) {
@@ -617,8 +560,7 @@ public class ReviewPublisher {
     try {
       reviewClient.createReview(auth, ACCEPT, owner, repo, prNumber, req);
     } catch (RuntimeException e) {
-      // CreateReviewRequest's compact constructor normalizes a null comments list to List.of(), so
-      // only the isEmpty() check is ever reachable here.
+      // CreateReviewRequest's compact constructor normalizes a null comments list to List.of().
       if (req.comments().isEmpty()) {
         throw new ReviewPostException(
             "GitHub review rejected for " + owner + "/" + repo + " #" + prNumber, e);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -35,8 +35,8 @@ public record ReviewResult(
     List<CiCheck> offendingCiChecks,
     int omittedFiles,
     boolean ciUnreadable,
-    // False when the required-context set could not be resolved and every check is gated; the
-    // rendered CI copy then drops "required".
+    // False when the required-context set could not be resolved; rendered CI copy then drops
+    // "required".
     boolean requiredContextsKnown,
     TruncationDetail truncation) {
   public ReviewResult {
@@ -44,8 +44,7 @@ public record ReviewResult(
     previousStatuses = List.copyOf(previousStatuses);
     offendingCiChecks = offendingCiChecks == null ? List.of() : List.copyOf(offendingCiChecks);
     truncation = truncation == null ? TruncationDetail.EMPTY : truncation;
-    // Check-run conclusion derivation relies on a non-null state; fall back to the
-    // canonical risk mapping rather than NPE on an inconsistent record
+    // Check-run conclusion derivation relies on a non-null state.
     if (reviewState == null) {
       reviewState = ReviewState.fromHighestRisk(highestRisk);
     }
@@ -173,11 +172,8 @@ public record ReviewResult(
     return previousStatuses.stream().filter(s -> "unresolved".equalsIgnoreCase(s.status())).count();
   }
 
-  // A backstop-held finding can be summary-only — its flagged line was outside the diff when first
-  // raised, so it was never posted as an inline comment and has no thread to reply on.
-  // The guidance therefore qualifies the reply path ("where one exists") instead of promising a
-  // thread that may not be there; fixing the code, or a model resolved/justified verdict, still
-  // clears such a finding.
+  // A backstop-held finding may have no inline thread (its line was outside the diff when raised),
+  // hence the "where one exists" qualifier.
   public static String unresolvedPreviousMessage(long unresolved) {
     return String.format(
         "No new issues in this revision, but %d previous finding(s) remain unresolved — "

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -59,12 +59,7 @@ public class VerdictBuilder {
       ReviewResponse aiResponse,
       CiStatusEvaluator.CiEvaluation ciEvaluation,
       DiffBudgetPlanner.BudgetPlan plan) {
-    // Truncation must reflect what was actually sent (#53): with budgeting on, the plan's
-    // omitted-by-name files plus its hunk-clipped files (their unseen hunks were withheld too, so
-    // a clipped-only review must not silently approve) — the line-cap count belongs to the legacy
-    // diff string, which budgeted reviews never send. With budgeting off, only the line cap
-    // applies. Summing the mechanisms would disclose partial reviews that did not happen. The
-    // names ride along so every disclosure surface can report them, not just a count.
+    // Budgeted: plan omitted + clipped files; legacy: line-cap count — never sum both.
     var truncation =
         plan.budgeted()
             ? new ReviewResult.TruncationDetail(plan.omittedFiles(), plan.clippedFiles())
@@ -73,16 +68,10 @@ public class VerdictBuilder {
         plan.budgeted()
             ? plan.omittedFiles().size() + plan.clippedFiles().size()
             : ctx.omittedFiles();
-    // The "Changes Overview" reports GitHub's authoritative PR-level totals when available; the
-    // diff-derived counts (summed over the ignore-glob-filtered reviewable files) undercount
-    // whenever a changed file is dropped by the ignore-glob (#298). The reviewed-diff omitted-file
-    // count is preserved either way, so truncation gating and disclosure are unaffected.
+    // GitHub PR-level totals when available; ignore-glob drops can undercount diff-derived stats.
     var diffStats =
         DiffStats.fromFiles(ctx.reviewableFiles(), omitted, truncation)
             .withAuthoritativeTotals(ctx.prTotals());
-    // Budget-omitted files were never reviewed: listing them in the summary walkthrough as
-    // ordinary rows would present them as covered. They are disclosed by name in the truncation
-    // banner instead.
     var omittedNames = Set.copyOf(truncation.omittedFileNames());
     var changedFiles =
         toChangedFiles(
@@ -116,11 +105,6 @@ public class VerdictBuilder {
   }
 
   static String checkTitleForResult(ReviewResult result) {
-    // Derive the ✅ from the single verdict gate, not a parallel predicate: reviewState() is APPROVE
-    // only when nothing holds the review back — no findings, no unresolved previous findings, no
-    // offending CI, AND the diff was not truncated. Re-deriving the "all clear" condition by
-    // hand here used to omit the truncation guard, so a truncated-but-clean PR showed ✅ over a
-    // neutral (held) conclusion.
     if (result.reviewState() == ReviewState.APPROVE) {
       return CheckRunManager.CHECK_NAME + " ✅";
     }
@@ -144,10 +128,6 @@ public class VerdictBuilder {
               result.lowCount())
           + truncationSuffix;
     }
-    // An offending check and an unreadable CI source are independent hold reasons that can both
-    // apply at once; disclose the unreadable one alongside the offending message rather than
-    // letting the offending branch suppress it, matching the PR review comment
-    // (ReviewPublisher.noIssuesBody).
     var unreadableSuffix =
         result.ciUnreadable()
             ? " The CI status for some checks could not be read — holding approval until it can be"
@@ -166,8 +146,6 @@ public class VerdictBuilder {
           + " can be confirmed."
           + truncationSuffix;
     }
-    // A truncated diff holds approval at neutral; the summary must say so rather than fall
-    // through to the all-clear celebration, which would caption a held check run as "no issues".
     if (result.truncated()) {
       return "No new issues found, but the diff was too large to review in full ("
           + result.coverageGapBrief()
@@ -259,28 +237,19 @@ public class VerdictBuilder {
     var requiredContextsKnown = ciEvaluation.requiredContextsKnown();
     var tally = tallyFindings(aiResponse);
 
-    // The review may only approve when nothing is outstanding: new findings AND previous
-    // findings still unresolved (not fixed, no accepted justification) both count
     var outstanding = new ArrayList<Finding>(tally.findings());
     outstanding.addAll(unresolvedPrevious);
     ReviewState state = ReviewState.fromFindings(outstanding);
-    // Merge the model's previous-findings statuses with the backstop's reconstructed unresolved
-    // ones: the silently dropped findings then flow through the same gate, counts, and
-    // messages as any unresolved status, so no separate path is needed. Backstop statuses reach the
-    // gate but never `outstanding`, keeping the hold downgrade-only (APPROVE → COMMENT, never
-    // REQUEST_CHANGES).
+    // Backstop statuses reach the gate but never `outstanding`, keeping the hold downgrade-only
+    // (APPROVE → COMMENT, never REQUEST_CHANGES).
     var previousStatuses =
         new ArrayList<ReviewResult.PreviousFindingStatus>(
             followUpAnalyzer.toStatuses(aiResponse.previousFindingsStatus()));
     previousStatuses.addAll(backstopUnresolved);
-    // Unresolved statuses that could not be mapped back to stored findings (e.g. pre-persistence
-    // sessions), or that the model dropped but the backstop reconstructed, must still hold approval
     if (state == ReviewState.APPROVE && followUpAnalyzer.hasUnresolved(previousStatuses)) {
       state = ReviewState.COMMENT;
     }
 
-    // CI holds approval back when a required check is offending OR a CI source could not be read at
-    // all — an unread source means we cannot confirm CI is green, so we fail closed.
     if (state == ReviewState.APPROVE && (!offendingCiChecks.isEmpty() || ciUnreadable)) {
       state = ReviewState.COMMENT;
     }
@@ -308,9 +277,6 @@ public class VerdictBuilder {
                 "",
                 previousStatuses,
                 offendingCiChecks,
-                // Carry the real omitted-file count so the summary body's truncated() branch fires
-                // and reports a partial review instead of the all-clear celebration; passing 0 here
-                // made that branch dead and let the celebration contradict the truncation banner.
                 diffStats.omittedFiles(),
                 ciUnreadable,
                 requiredContextsKnown,
@@ -350,9 +316,8 @@ public class VerdictBuilder {
     var medium = 0;
     var low = 0;
     RiskLevel highest = null;
-    // ReviewResponse never returns null findings, so we iterate directly. The lowest risk level is
-    // counted by the catch-all branch — RiskLevel has exactly four values — which avoids the
-    // unreachable extra branch the compiler would otherwise generate and report as uncovered.
+    // RiskLevel has exactly four values; the catch-all counts LOW and avoids an unreachable
+    // extra branch that coverage would report as unhit.
     for (var ai : aiResponse.findings()) {
       Finding f = Finding.fromAiResponse(ai);
       findings.add(f);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewService.java
@@ -199,9 +199,7 @@ public class AiReviewService {
               token -> handlePartialToken(token, buffer, flushStream, cancelled, lastFlushNanos))
           .onCompleteResponse(
               response -> handleCompleteResponse(response, result, buffer, flushStream, cancelled))
-          // langchain4j requires exactly one of onError/ignoreErrors — never add ignoreErrors
-          // here: AiServiceTokenStream.start() rejects the chain with both registered
-          // (FakeTokenStream enforces the same contract so tests catch it)
+          // langchain4j requires exactly one of onError/ignoreErrors; start() rejects both.
           .onError(error -> handleStreamError(error, result, flushStream, cancelled))
           .start();
 
@@ -220,13 +218,9 @@ public class AiReviewService {
       throw new AiReviewException("AI review interrupted", 1, e);
     } finally {
       cancelled.set(true);
-      // Deregister this attempt on every exit, so a late callback from a dead stream can never
-      // record session data — the retry backoff window, the final attempt, and any exit path
-      // added later are all covered structurally. Tokens billed by a stream that completes
-      // after the client-side timeout are deliberately not attributed to the session (the OTel
-      // cost counter still records them globally). On the success path this is safe because
-      // langchain4j notifies ChatModelListener.onResponse before completing the handler that
-      // resolves the future — pinned by StreamingChatModelListenerOrderingTest.
+      // Invalidate on every exit so a late callback from a dead stream never records session
+      // data. Safe on success: langchain4j notifies ChatModelListener.onResponse before
+      // completing the handler that resolves the future.
       ReviewSessionContext.invalidate(session.id);
       ReviewSessionContext.clear();
     }
@@ -263,7 +257,7 @@ public class AiReviewService {
     }
     try {
       flushStream.run();
-      // ChatResponse guarantees a non-null aiMessage; its text may still be null
+      // ChatResponse guarantees a non-null aiMessage; its text may still be null.
       var text = buffer.textOrFallback(response.aiMessage().text());
       result.complete(parser.parse(text));
     } catch (RuntimeException e) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChangelogAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChangelogAssistant.java
@@ -28,10 +28,8 @@ import io.quarkiverse.langchain4j.RegisterAiService;
 @RegisterAiService
 public interface ChangelogAssistant {
 
-  // @UserMessage MUST be on the method, not a parameter: on a parameter quarkus-langchain4j sends
-  // only that parameter's raw value as the user message and never renders this template, silently
-  // dropping prNumber, currentTitle, currentDescription and repoInstructions (see
-  // AiServicePromptRenderingTest).
+  // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that
+  // parameter's raw value and silently drops every other @V.
   @SystemMessage(ChangelogAssistantPrompts.SYSTEM)
   @UserMessage(PrSuggestionPrompts.USER)
   String draft(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGenerationParser.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGenerationParser.java
@@ -36,8 +36,7 @@ public class DocGenerationParser {
       throw new IllegalArgumentException("Model returned an empty response");
     }
     try {
-      // Reuse the review parser's fence/noise stripping so a model that wraps its JSON in ```json
-      // fences or leading prose still parses.
+      // Models sometimes wrap the JSON in ```json fences or leading prose.
       return mapper.readValue(ReviewResponseParser.extractJson(raw), DocGenerationResponse.class);
     } catch (IOException e) {
       throw new IllegalArgumentException("Model response is not valid add-docs JSON", e);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGenerator.java
@@ -29,9 +29,8 @@ import io.quarkiverse.langchain4j.RegisterAiService;
 @RegisterAiService
 public interface DocGenerator {
 
-  // @UserMessage MUST be on the method, not a parameter: on a parameter quarkus-langchain4j sends
-  // only that parameter's raw value as the user message and never renders this template, silently
-  // dropping prContext, projectStack and repoInstructions (see AiServicePromptRenderingTest).
+  // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that
+  // parameter's raw value and silently drops every other @V.
   @SystemMessage(DocGeneratorPrompts.SYSTEM)
   @UserMessage(DocGeneratorPrompts.USER)
   String generate(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifier.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifier.java
@@ -24,9 +24,8 @@ import io.quarkiverse.langchain4j.RegisterAiService;
 @RegisterAiService
 public interface FindingVerifier {
 
-  // @UserMessage MUST stay on the method, not on a parameter: on a parameter quarkus-langchain4j
-  // uses that parameter's raw value (the findings) as the whole user message and never renders this
-  // template, silently dropping the diff, projectStack and previousFindings the audit needs.
+  // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that
+  // parameter's raw value and silently drops every other @V.
   @SystemMessage(FindingVerifierPrompts.SYSTEM)
   @UserMessage(FindingVerifierPrompts.USER)
   String verify(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrDescribeAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrDescribeAssistant.java
@@ -27,10 +27,8 @@ import io.quarkiverse.langchain4j.RegisterAiService;
 @RegisterAiService
 public interface PrDescribeAssistant {
 
-  // @UserMessage MUST be on the method, not a parameter: on a parameter quarkus-langchain4j sends
-  // only that parameter's raw value as the user message and never renders this template, silently
-  // dropping currentTitle, currentDescription and repoInstructions (see
-  // AiServicePromptRenderingTest).
+  // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that
+  // parameter's raw value and silently drops every other @V.
   @SystemMessage(PrDescribeAssistantPrompts.SYSTEM)
   @UserMessage(PrSuggestionPrompts.USER)
   String describe(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewer.java
@@ -24,14 +24,11 @@ import io.quarkiverse.langchain4j.RegisterAiService;
 @RegisterAiService
 public interface PrReviewer {
 
-  // {{repoInstructions}} carries the orchestrator's pre-rendered trailing guidance: the available
-  // repository labels (when labelling is on) followed by any repo instructions file. Folding both
-  // into one template variable keeps this method within a sane parameter count.
+  // {{repoInstructions}} carries the pre-rendered trailing guidance: available repository labels
+  // (when labelling is on) followed by any repo instructions file.
   //
-  // @UserMessage MUST stay on the method, not on a parameter: on a parameter quarkus-langchain4j
-  // uses that parameter's raw value (the diff) as the whole user message and never renders this
-  // template, silently dropping prContext, baseComparison, projectStack, relatedTests,
-  // previousFindings and repoInstructions.
+  // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that
+  // parameter's raw value and silently drops every other @V.
   @SystemMessage(PrReviewPrompts.SYSTEM)
   @UserMessage(PrReviewPrompts.USER)
   TokenStream reviewStream(
@@ -43,10 +40,7 @@ public interface PrReviewer {
       @V("previousFindings") String previousFindings,
       @V("repoInstructions") String repoInstructions);
 
-  // Final summary call for a large multi-call review (#53): rolls the per-batch findings up into
-  // the
-  // PR-level summary object + previous_findings_status. @UserMessage stays on the method (same
-  // reason as reviewStream — on a parameter every other @V var is silently dropped).
+  // @UserMessage MUST stay on the method (same reason as reviewStream).
   @SystemMessage(PrReviewPrompts.SUMMARY_SYSTEM)
   @UserMessage(PrReviewPrompts.SUMMARY_USER)
   TokenStream summarizeStream(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReplyAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReplyAssistant.java
@@ -27,9 +27,8 @@ import io.quarkiverse.langchain4j.RegisterAiService;
 @RegisterAiService
 public interface ReplyAssistant {
 
-  // @UserMessage MUST stay on the method, not on a parameter: on a parameter quarkus-langchain4j
-  // uses that parameter's raw value as the whole user message and never renders this template, so
-  // every other @V (prContext, finding, codeContext, thread) is silently dropped.
+  // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that
+  // parameter's raw value and silently drops every other @V.
   @SystemMessage(ReplyAssistantPrompts.SYSTEM)
   @UserMessage(ReplyAssistantPrompts.USER)
   String reply(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponse.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponse.java
@@ -77,15 +77,12 @@ public record ReviewResponse(
       @JsonProperty("description_gaps") List<String> descriptionGaps,
       @JsonProperty("suggested_labels") List<String> suggestedLabels,
       @JsonProperty("file_summaries") List<FileSummary> fileSummaries,
-      // Optional Mermaid source for a control-flow diagram of the change (no ``` fences). Populated
-      // only when the diagram feature is enabled and the change is non-trivial; null/blank
-      // otherwise.
+      // Optional Mermaid source (no ``` fences); null/blank unless the diagram feature is enabled
+      // and the change is non-trivial.
       @JsonProperty("walkthrough_diagram") String walkthroughDiagram) {
     public Summary {
-      // The AI may emit null elements inside these arrays (e.g. ["bug", null]); a bare List.copyOf
-      // would throw an NPE that fails the whole review, even though both lists are best-effort
-      // metadata. Drop the nulls first, then copy. List.copyOf is kept inline rather than folded
-      // into the helper so SpotBugs still sees the defensive copy and does not flag EI_EXPOSE_REP.
+      // The AI may emit null elements inside these arrays; drop them before List.copyOf. copyOf
+      // stays inline so SpotBugs sees the defensive copy (EI_EXPOSE_REP).
       descriptionGaps = List.copyOf(withoutNulls(descriptionGaps));
       suggestedLabels = List.copyOf(withoutNulls(suggestedLabels));
       fileSummaries = List.copyOf(withoutNulls(fileSummaries));

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/AckReactionService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/AckReactionService.java
@@ -96,7 +96,7 @@ public class AckReactionService {
     try {
       reaction.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
     } catch (TimeoutException _) {
-      // Abandon the wait but let the POST finish in the background — a late 👀 is still useful.
+      // Abandon the wait; the POST may still finish in the background.
       log.warn(
           "👀 ack reaction on {} comment {} on {}/{} exceeded {} on the ACK path — continuing"
               + " without waiting",
@@ -106,8 +106,7 @@ public class AckReactionService {
           repo,
           timeout);
     } catch (ExecutionException e) {
-      // Best-effort on an expected runtime failure, but let a fatal Error (OOM, etc.) propagate as
-      // it would have before the reaction ran on a separate thread, rather than masking it.
+      // Best-effort on runtime failure; let fatal Errors propagate from the worker thread.
       if (e.getCause() instanceof Error error) {
         throw error;
       }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
@@ -237,7 +237,6 @@ public class CommentCommandService {
             ctx.installationId(),
             auth);
     if (suggestion == null) {
-      // Nothing to suggest (no diff) or the model produced no usable answer — already logged.
       return;
     }
     postComment(auth, ctx, suggestion);
@@ -267,7 +266,6 @@ public class CommentCommandService {
             ctx.installationId(),
             auth);
     if (entry == null) {
-      // Nothing changelog-worthy (no diff / model declined) or no usable answer — already logged.
       return;
     }
     postComment(auth, ctx, entry);
@@ -292,9 +290,6 @@ public class CommentCommandService {
         ctx.repo(),
         num(ctx),
         ctx.login());
-    // This already runs on the review executor (handle() submitted execute() to it), off the
-    // webhook ack thread, so the blocking AI call + GitHub round trips run here safely. The service
-    // is @ActivateRequestContext, so the LangChain4j AI call has an active request scope.
     docGenerationService.handle(
         new DocGenerationService.DocTask(
             ctx.owner(), ctx.repo(), ctx.prNumber(), ctx.defaultBranch(), ctx.installationId()));
@@ -318,7 +313,6 @@ public class CommentCommandService {
       if (thread == null || thread.resolved()) {
         continue;
       }
-      // A failure on one thread (e.g. a transient GraphQL error) must not abort the rest.
       try {
         if (reviewThreadService.resolve(auth, thread.id())) {
           resolved++;
@@ -346,7 +340,7 @@ public class CommentCommandService {
       return;
     }
     if (!pauseIfPossible(ctx)) {
-      return; // genuine failure already logged — do not post a misleading confirmation
+      return;
     }
     postComment(
         auth,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ManualReviewAuthorizer.java
@@ -137,8 +137,7 @@ public class ManualReviewAuthorizer {
           login,
           timeout);
     } catch (ExecutionException e) {
-      // Fail closed on an expected runtime failure, but let a fatal Error (OOM, etc.) propagate as
-      // it would have before the check ran on a separate thread, rather than masking it.
+      // Rethrow fatal Errors (OOM, etc.) instead of masking them as a denied check.
       if (e.getCause() instanceof Error error) {
         throw error;
       }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/ReviewTriggerFilter.java
@@ -122,7 +122,6 @@ public class ReviewTriggerFilter {
     }
     var names = new LinkedHashSet<String>();
     for (var label : pr.labels()) {
-      // pr.labels() comes from List.copyOf, so no null elements — only the name can be absent.
       if (label.name() != null && !label.name().isBlank()) {
         names.add(label.name().trim().toLowerCase(Locale.ROOT));
       }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
@@ -39,8 +39,6 @@ public class TriggerDetector {
   private static final Pattern MENTION_PATTERN =
       Pattern.compile(".*@thrillhousebot\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
-  // Fenced code (``` … ``` or ~~~ … ~~~), blockquote lines (> …) and inline code (`…`) are quoted
-  // context, not instructions: a maintainer quoting or documenting a command must not execute it.
   private static final Pattern FENCED_CODE = Pattern.compile("(?s)```.*?```|~~~.*?~~~");
   private static final Pattern BLOCKQUOTE_LINE = Pattern.compile("(?m)^[ \\t]*>.*$");
   private static final Pattern INLINE_CODE = Pattern.compile("`[^`\\n]*`");

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -107,8 +107,7 @@ public class WebhookController {
     log.info(
         "Received {} event (action: {}, delivery: {})", eventType, payload.action(), deliveryId);
 
-    // GitHub redelivers webhooks — manual redelivery or an automatic retry — reusing the same
-    // delivery id, so drop repeats to avoid a duplicate review and duplicate AI cost.
+    // GitHub redeliveries (manual or automatic retry) reuse the same delivery id.
     if (deduplicator.isDuplicate(deliveryId)) {
       log.info("Ignoring redelivered {} event (delivery: {})", eventType, deliveryId);
       return Response.ok("{\"status\":\"ignored\"}").build();
@@ -116,7 +115,7 @@ public class WebhookController {
 
     routeEvent(eventType, payload, deliveryId);
 
-    // GitHub expects 200 within 10 seconds; we acknowledge immediately
+    // GitHub expects a 200 within 10 seconds.
     return Response.ok("{\"status\":\"ok\"}").build();
   }
 
@@ -144,13 +143,9 @@ public class WebhookController {
             }
           };
       if (!handled) {
-        // The executor rejected the review (e.g. it is saturated), so nothing ran. Roll back the
-        // dedup slot so a manual redelivery of this id can retry.
         deduplicator.forget(deliveryId);
       }
     } catch (RuntimeException e) {
-      // An unexpected failure means the review was never handed off either, so roll back the dedup
-      // slot for the same reason before acknowledging.
       deduplicator.forget(deliveryId);
       log.error("Error processing webhook event", e);
     }
@@ -166,8 +161,7 @@ public class WebhookController {
     if (action == null) return true;
 
     return switch (action) {
-      // ready_for_review fires when a draft PR is marked ready; it is not followed by a
-      // synchronize, so without this the PR stays unreviewed until the next push.
+      // ready_for_review fires when a draft is marked ready and is not followed by a synchronize.
       case "opened", "reopened", "synchronize", "ready_for_review" -> {
         var pr = payload.pullRequest();
         var repo = payload.repository();
@@ -175,15 +169,11 @@ public class WebhookController {
           log.debug("Ignoring pull_request with missing pull_request, repository, or installation");
           yield true;
         }
-        // head/base drive the review request; a payload missing either would NPE below. The trigger
-        // filter already treats base as nullable, so guard here rather than crash the delivery.
         if (pr.head() == null || pr.base() == null) {
           log.debug("Ignoring pull_request #{} with missing head or base", pr.number());
           yield true;
         }
 
-        // A /pause on this PR silences automatic reviews until /resume — stay silent here, no
-        // comment, since the event was not user-initiated.
         if (prPauseService.isPaused(repo.owner().login(), repo.name(), pr.number())) {
           log.info("Skipping review for paused PR #{} in {}", pr.number(), repo.fullName());
           yield true;
@@ -199,8 +189,6 @@ public class WebhookController {
           yield true;
         }
 
-        // Per-PR automatic review rate limit — a fresh push within the window is skipped silently
-        // (a manual /review always bypasses; a review already running coalesces in the dispatcher).
         if (autoReviewRateLimiter.isThrottled(repo.owner().login(), repo.name(), pr.number())) {
           log.info(
               "Skipping automatic review for PR #{} in {} — last automatic review completed "
@@ -239,14 +227,12 @@ public class WebhookController {
    *     ignored.
    */
   private boolean handleIssueComment(WebhookPayload payload) {
-    // Only a freshly created comment is a trigger; editing or deleting one must not re-run a
-    // review.
     if (!"created".equals(payload.action())) {
       log.debug("Ignoring issue_comment action: {}", payload.action());
       return true;
     }
 
-    // Only act on PR comments, not issue comments
+    // issue_comment fires for both issues and PRs; the pull_request link marks a PR.
     if (payload.issue() == null || payload.issue().pullRequest() == null) {
       log.debug("Ignoring comment on issue (not PR)");
       return true;
@@ -257,7 +243,6 @@ public class WebhookController {
       return true;
     }
 
-    // Prevent infinite loops — skip bot's own comments
     if (triggerDetector.isBotComment(payload.comment().user().login())) {
       log.debug("Ignoring own comment");
       return true;
@@ -267,7 +252,6 @@ public class WebhookController {
     if (command != CommentCommand.NONE) {
       return handleCommentCommand(payload, command);
     }
-    // Not a command: a bare @thrillhousebot mention on a PR is a conversational question.
     return maybeDispatchConversationalMention(payload);
   }
 
@@ -282,8 +266,6 @@ public class WebhookController {
       log.debug("Ignoring {} command with missing repository or installation", command);
       return true;
     }
-    // 👀 ack before any pause/authorization gate or dispatch: every recognized command gets the
-    // "seen it" signal, even one that is then rejected. Conversational mentions never reach here.
     ackReactionService.addEyes(
         payload.installation().id(),
         repo.owner().login(),
@@ -320,7 +302,6 @@ public class WebhookController {
       log.debug("Ignoring bot mention with missing repository or installation");
       return true;
     }
-    // A /pause silences the bot on this PR — stay quiet rather than spend a paid reply.
     if (prPauseService.isPaused(repo.owner().login(), repo.name(), payload.issue().number())) {
       log.info(
           "Skipping conversational mention on paused PR #{} in {}",
@@ -372,7 +353,6 @@ public class WebhookController {
       log.debug("Ignoring review comment with missing author info");
       return true;
     }
-    // Prevent infinite loops — never answer the bot's own comments.
     if (triggerDetector.isBotComment(comment.user().login())) {
       log.debug("Ignoring own review comment");
       return true;
@@ -385,14 +365,11 @@ public class WebhookController {
       return true;
     }
 
-    // Only an explicit @-mention addresses the bot; a bare reply on a thread (even the bot's own
-    // finding) must not pull it in.
     if (!triggerDetector.containsBotMention(comment.body())) {
       log.debug("Ignoring review comment that does not mention the bot");
       return true;
     }
 
-    // A /pause silences the bot on this PR — stay quiet rather than spend a paid reply.
     if (prPauseService.isPaused(repo.owner().login(), repo.name(), pr.number())) {
       log.info(
           "Skipping conversational review-thread reply on paused PR #{} in {}",
@@ -401,8 +378,7 @@ public class WebhookController {
       return true;
     }
 
-    // The thread root is the reply target; a mention that is itself a reply targets the thread it
-    // replies to, otherwise the mention comment is its own root.
+    // GitHub thread roots carry no in_reply_to_id; a reply targets its thread's root.
     boolean isReply = comment.inReplyToId() != null;
     Long rootCommentId = isReply ? comment.inReplyToId() : comment.id();
     log.info(
@@ -441,8 +417,6 @@ public class WebhookController {
       commentCommandService.notifyPaused(ctx);
       return true;
     }
-    // Manual triggers spend the operator's API budget, so restrict them to users who actually
-    // hold write access to the repository (or are explicitly allowlisted).
     if (!manualReviewAuthorizer.isAuthorized(
         ctx.owner(), ctx.repo(), ctx.installationId(), ctx.login(), ctx.authorAssociation())) {
       log.info(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookPayload.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookPayload.java
@@ -97,8 +97,7 @@ public record WebhookPayload(
       String body,
       User user,
       @JsonProperty("author_association") String authorAssociation,
-      // The fields below are populated only on pull_request_review_comment events (inline review
-      // comments); they are null for issue_comment events.
+      // Fields below are populated only on pull_request_review_comment events; null otherwise.
       @JsonProperty("in_reply_to_id") Long inReplyToId,
       String path,
       @JsonProperty("diff_hunk") String diffHunk) {}


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor

## Description

A comment-policy pass over all of `src/main`: inline `//` comments
should explain genuinely non-obvious logic or external invariants — not
narrate or justify design decisions. This applies the same standard the
v0.3.1 prep applied to that cycle's comments, retroactively to the whole
codebase.

**Deleted** (~300 lines): comments that justify a choice the code
already makes plainly ("the acceptable cost of…", "rather than…", "this
mirrors…"), restate what the code does, or recount bug history.

**Kept, often shortened**: comments carrying facts invisible from the
code itself —
- GitHub API contracts and quirks (deleted accounts serialize as `user:
null`; the add-labels endpoint is additive; one unknown label 422s the
whole request; a suggestion spanning hunks is rejected; empty list —
never null — past the last page)
- Cross-file/cross-round invariants (the 1-based finding index doubles
as the persisted id and thread marker; compact constructors normalize
nulls, making local null checks redundant)
- Parsing/crypto subtleties (Mermaid fence handling, DER/PEM parsing,
hunk-header edge cases, enum-ordering facts behind `min()`/median picks)
- Short value legends on fields and record components

Javadoc, string literals, annotations, and code are untouched — the diff
is comment lines only.

## How Has This Been Tested?

- [x] Unit tests

`./mvnw clean test spotbugs:check` — **1432 tests, 0 failures**, 0
SpotBugs findings, Spotless clean. No behavior changes possible: only
`//` comment lines changed across 49 files (+127/−433).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors