### PR TITLE
fix(ci): prefetch Maven deps with dependency:resolve before Trivy scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,13 +268,11 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      # Trivy's Maven analyzer resolves transitive POMs from Maven Central whenever they are absent
-      # from ~/.m2. A cold cache made it fan out enough requests to trip a 429 IP block (Maven
-      # Central then refuses every request from the runner for 30 min). Populate the local
-      # repository first so Trivy reads every POM locally and makes no remote calls; the ~/.m2 cache
-      # keeps warm runs from re-downloading at all.
+      # Trivy's Maven analyzer fetches any POM missing from ~/.m2; a partial cache still fans out
+      # enough Central requests to trip a 429 IP block. dependency:resolve (not go-offline) covers
+      # the POM set Trivy's SBOM pass actually reads — see trivy.dev troubleshooting / Maven 429.
       - name: Populate local Maven repository
-        run: ./mvnw -q -B dependency:go-offline
+        run: ./mvnw -q -B dependency:resolve
       - uses: ./.github/actions/trivy-scan
         with:
           scan-type: fs


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🏗️ CI/CD

## Description

The Trivy filesystem job prefetched `~/.m2` with `dependency:go-offline`, but Trivy's Maven/SBOM pass still resolves POMs that goal does not download (e.g. `quarkus-qute-3.37.1.pom` on this repo). With a warm cache hit, Trivy could still make remote requests and hit Maven Central's per-IP 429 rate limit.

Switch the prefetch step to `dependency:resolve`, which matches [Trivy's recommended mitigation](https://trivy.dev/docs/latest/guide/references/troubleshooting/#maven-central-rate-limiting-http-429). The existing `~/.m2` GHA cache is unchanged — only the prefetch goal is corrected.

## Related Issues

N/A

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

CI on this PR — the `trivy` job should complete without a Maven Central 429 on the `Populate local Maven repository` / scan steps.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Example failure on `chore/comment-cleanup` (cache hit, then 429 on a POM `go-offline` never fetched):

```
Cache hit for: Linux-m2-ae38749ee83b1160189002905121666bd7add931446718a41cdb0b5138ae2969
Cache restored successfully
...
FATAL  Error  remote Maven repository returned 429 Too Many Requests for
https://repo.maven.apache.org/maven2/io/quarkus/quarkus-qute/3.37.1/quarkus-qute-3.37.1.pom. Retry-After: 653.
```

## Additional Notes

Docker `Dockerfile.multistage` still uses `dependency:go-offline` — that path is for air-gapped builds, not Trivy prefetch.