### PR TITLE
fix(dashboard): show batch progress during map-reduce reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to ThrillhouseBot.
 
 ### Fixed
 
+- **Dashboard live feed no longer looks frozen during map-reduce reviews**: token-budgeted large-PR reviews disable per-token streaming and emit `review.batch` progress events instead; the overview page now handles those events and shows batch X/Y status rather than an empty "Waiting for model tokens…" panel for the entire multi-call run (#53)
 - **`/summary` no longer posts a duplicate "no issues found" review after the regenerated summary**: the command re-runs a review under the hood to rebuild the summary comment (#297), but the run's formal review still posted too — on an already-reviewed PR with no new findings, that meant a fresh "Everything's coming up Thrillhouse! No issues found" approval landing right after the summary it duplicates (dogfooded on ThrillhouseBot#256). A summary-only re-run now skips the no-new-findings review on a PR that already carries a formal bot review — but only when the regenerated summary actually posted (a failed best-effort summary post leaves the review as the run's visible outcome); a first review still posts normally, new findings still post, unresolved previous findings still post their reply-on-the-thread guidance, and a truncated diff still posts its partial-review disclosure
 
 

--- a/frontend/app/(dashboard)/overview/page.tsx
+++ b/frontend/app/(dashboard)/overview/page.tsx
@@ -4,20 +4,12 @@ import { useMemo } from 'react';
 import { api, SessionSummary } from '@/lib/api';
 import { useWebSocket, SessionEvent } from '@/hooks/useWebSocket';
 import { useDashboardFetch } from '@/hooks/useDashboardFetch';
-
-interface LiveReviewState {
-  sessionId: number;
-  repository: string;
-  prNumber: number;
-  prTitle: string;
-  status: 'streaming' | 'retrying' | 'stream_failed' | 'completed' | 'failed';
-  attempt: number;
-  maxAttempts: number;
-  tail: string;
-  totalChars: number;
-  reason?: string;
-  updatedAt: string;
-}
+import {
+  buildLiveReviews,
+  liveReviewProgressMessage,
+  liveReviewStatusLabel,
+  type LiveReviewState,
+} from '@/lib/live-reviews';
 
 export default function OverviewPage() {
   const { events, connected } = useWebSocket();
@@ -117,176 +109,6 @@ export default function OverviewPage() {
   );
 }
 
-function buildLiveReviews(events: SessionEvent[]): LiveReviewState[] {
-  const bySession = new Map<number, LiveReviewState>();
-
-  for (const event of [...events].reverse()) {
-    const data = event.data ?? {};
-    const attempt = Number(data.attempt ?? 1);
-    const maxAttempts = Number(data.maxAttempts ?? 5);
-
-    if (event.type === 'review.started') {
-      bySession.set(event.sessionId, {
-        sessionId: event.sessionId,
-        repository: event.repository,
-        prNumber: event.prNumber,
-        prTitle: event.prTitle,
-        status: 'streaming',
-        attempt: 1,
-        maxAttempts,
-        tail: '',
-        totalChars: 0,
-        updatedAt: event.timestamp,
-      });
-      continue;
-    }
-
-    const current = bySession.get(event.sessionId) ?? createLiveReviewFromEvent(event);
-    if (!bySession.has(event.sessionId)) {
-      bySession.set(event.sessionId, current);
-    }
-
-    if (event.type === 'review.stream') {
-      bySession.set(event.sessionId, {
-        ...current,
-        status: 'streaming',
-        attempt,
-        maxAttempts,
-        tail: String(data.tail ?? current.tail),
-        totalChars: Number(data.totalChars ?? current.totalChars),
-        updatedAt: event.timestamp,
-      });
-      continue;
-    }
-
-    if (event.type === 'review.retry') {
-      bySession.set(event.sessionId, {
-        ...current,
-        status: 'retrying',
-        attempt,
-        maxAttempts,
-        reason: String(data.reason ?? ''),
-        tail: '',
-        totalChars: 0,
-        updatedAt: event.timestamp,
-      });
-      continue;
-    }
-
-    if (event.type === 'review.stream.failed') {
-      bySession.set(event.sessionId, {
-        ...current,
-        status: 'stream_failed',
-        attempt,
-        maxAttempts,
-        reason: String(data.reason ?? ''),
-        updatedAt: event.timestamp,
-      });
-      continue;
-    }
-
-    if (event.type === 'review.completed') {
-      bySession.delete(event.sessionId);
-      continue;
-    }
-
-    if (event.type === 'review.failed') {
-      bySession.set(event.sessionId, {
-        ...current,
-        status: 'failed',
-        reason: String(data.errorType ?? 'Review failed'),
-        updatedAt: event.timestamp,
-      });
-    }
-  }
-
-  return [...bySession.values()]
-    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
-    .slice(0, 5);
-}
-
-function createLiveReviewFromEvent(event: SessionEvent): LiveReviewState {
-  const data = event.data ?? {};
-  const attempt = Number(data.attempt ?? 1);
-  const maxAttempts = Number(data.maxAttempts ?? 5);
-
-  if (event.type === 'review.stream') {
-    return {
-      sessionId: event.sessionId,
-      repository: event.repository,
-      prNumber: event.prNumber,
-      prTitle: event.prTitle,
-      status: 'streaming',
-      attempt,
-      maxAttempts,
-      tail: String(data.tail ?? ''),
-      totalChars: Number(data.totalChars ?? 0),
-      updatedAt: event.timestamp,
-    };
-  }
-
-  if (event.type === 'review.retry') {
-    return {
-      sessionId: event.sessionId,
-      repository: event.repository,
-      prNumber: event.prNumber,
-      prTitle: event.prTitle,
-      status: 'retrying',
-      attempt,
-      maxAttempts,
-      tail: '',
-      totalChars: 0,
-      reason: String(data.reason ?? ''),
-      updatedAt: event.timestamp,
-    };
-  }
-
-  if (event.type === 'review.stream.failed') {
-    return {
-      sessionId: event.sessionId,
-      repository: event.repository,
-      prNumber: event.prNumber,
-      prTitle: event.prTitle,
-      status: 'stream_failed',
-      attempt,
-      maxAttempts,
-      tail: '',
-      totalChars: 0,
-      reason: String(data.reason ?? ''),
-      updatedAt: event.timestamp,
-    };
-  }
-
-  if (event.type === 'review.failed') {
-    return {
-      sessionId: event.sessionId,
-      repository: event.repository,
-      prNumber: event.prNumber,
-      prTitle: event.prTitle,
-      status: 'failed',
-      attempt,
-      maxAttempts,
-      tail: '',
-      totalChars: 0,
-      reason: String(data.errorType ?? 'Review failed'),
-      updatedAt: event.timestamp,
-    };
-  }
-
-  return {
-    sessionId: event.sessionId,
-    repository: event.repository,
-    prNumber: event.prNumber,
-    prTitle: event.prTitle,
-    status: 'streaming',
-    attempt,
-    maxAttempts,
-    tail: '',
-    totalChars: 0,
-    updatedAt: event.timestamp,
-  };
-}
-
 function Card({ label, value, color }: { label: string; value: string | number; color?: string }) {
   return (
     <div style={styles.card}>
@@ -297,14 +119,7 @@ function Card({ label, value, color }: { label: string; value: string | number; 
 }
 
 function LiveReviewCard({ review }: { review: LiveReviewState }) {
-  const statusLabel =
-    review.status === 'streaming'
-      ? `Streaming attempt ${review.attempt}/${review.maxAttempts}`
-      : review.status === 'retrying'
-        ? `Retrying attempt ${review.attempt}/${review.maxAttempts}`
-        : review.status === 'stream_failed'
-          ? `Attempt ${review.attempt}/${review.maxAttempts} failed`
-          : 'Review failed';
+  const statusLabel = liveReviewStatusLabel(review);
 
   return (
     <div style={styles.liveCard}>
@@ -325,7 +140,7 @@ function LiveReviewCard({ review }: { review: LiveReviewState }) {
         </pre>
       ) : (
         <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem', margin: 0 }}>
-          Waiting for model tokens…
+          {liveReviewProgressMessage(review)}
         </p>
       )}
       {review.totalChars > 0 && (

--- a/frontend/hooks/useWebSocket.ts
+++ b/frontend/hooks/useWebSocket.ts
@@ -9,6 +9,7 @@ export interface SessionEvent {
     | "review.started"
     | "review.stream"
     | "review.stream.failed"
+    | "review.batch"
     | "review.retry"
     | "review.progress"
     | "review.completed"

--- a/frontend/lib/live-reviews.test.ts
+++ b/frontend/lib/live-reviews.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionEvent } from '@/hooks/useWebSocket';
+import {
+  buildLiveReviews,
+  liveReviewProgressMessage,
+  liveReviewStatusLabel,
+} from './live-reviews';
+
+function event(
+  type: SessionEvent['type'],
+  sessionId: number,
+  data: Record<string, unknown> = {},
+  timestamp = '2026-07-07T12:00:00.000Z',
+): SessionEvent {
+  return {
+    type,
+    sessionId,
+    repository: 'devops-thiago/ThrillhouseBot',
+    prNumber: 99,
+    prTitle: 'Large PR',
+    commitSha: 'abc1234',
+    timestamp,
+    data,
+  };
+}
+
+describe('buildLiveReviews', () => {
+  it('shows batch progress instead of a frozen empty stream', () => {
+    const reviews = buildLiveReviews([
+      event('review.batch', 42, { batchIndex: 2, batchCount: 4 }, '2026-07-07T12:00:02.000Z'),
+      event('review.started', 42, {}, '2026-07-07T12:00:01.000Z'),
+    ]);
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].status).toBe('batching');
+    expect(reviews[0].batchIndex).toBe(2);
+    expect(reviews[0].batchCount).toBe(4);
+    expect(liveReviewStatusLabel(reviews[0])).toBe('Reviewing batch 2/4');
+    expect(liveReviewProgressMessage(reviews[0])).toContain('batch 2 of 4');
+  });
+
+  it('returns to streaming when token events arrive on a normal review', () => {
+    const reviews = buildLiveReviews([
+      event(
+        'review.stream',
+        7,
+        { tail: '{"findings":[]}', totalChars: 16, attempt: 1, maxAttempts: 5 },
+        '2026-07-07T12:00:03.000Z',
+      ),
+      event('review.started', 7, {}, '2026-07-07T12:00:01.000Z'),
+    ]);
+
+    expect(reviews[0].status).toBe('streaming');
+    expect(reviews[0].totalChars).toBe(16);
+  });
+
+  it('drops completed sessions from the live feed', () => {
+    const reviews = buildLiveReviews([
+      event('review.completed', 5, {}, '2026-07-07T12:00:05.000Z'),
+      event('review.batch', 5, { batchIndex: 1, batchCount: 3 }, '2026-07-07T12:00:02.000Z'),
+      event('review.started', 5, {}, '2026-07-07T12:00:01.000Z'),
+    ]);
+
+    expect(reviews).toHaveLength(0);
+  });
+});

--- a/frontend/lib/live-reviews.ts
+++ b/frontend/lib/live-reviews.ts
@@ -1,0 +1,250 @@
+import type { SessionEvent } from '@/hooks/useWebSocket';
+
+export interface LiveReviewState {
+  sessionId: number;
+  repository: string;
+  prNumber: number;
+  prTitle: string;
+  status: 'streaming' | 'batching' | 'retrying' | 'stream_failed' | 'completed' | 'failed';
+  attempt: number;
+  maxAttempts: number;
+  tail: string;
+  totalChars: number;
+  batchIndex?: number;
+  batchCount?: number;
+  reason?: string;
+  updatedAt: string;
+}
+
+export function buildLiveReviews(events: SessionEvent[]): LiveReviewState[] {
+  const bySession = new Map<number, LiveReviewState>();
+
+  for (const event of [...events].reverse()) {
+    const data = event.data ?? {};
+    const attempt = Number(data.attempt ?? 1);
+    const maxAttempts = Number(data.maxAttempts ?? 5);
+
+    if (event.type === 'review.started') {
+      bySession.set(event.sessionId, {
+        sessionId: event.sessionId,
+        repository: event.repository,
+        prNumber: event.prNumber,
+        prTitle: event.prTitle,
+        status: 'streaming',
+        attempt: 1,
+        maxAttempts,
+        tail: '',
+        totalChars: 0,
+        updatedAt: event.timestamp,
+      });
+      continue;
+    }
+
+    const current = bySession.get(event.sessionId) ?? createLiveReviewFromEvent(event);
+    if (!bySession.has(event.sessionId)) {
+      bySession.set(event.sessionId, current);
+    }
+
+    if (event.type === 'review.stream') {
+      bySession.set(event.sessionId, {
+        ...current,
+        status: 'streaming',
+        attempt,
+        maxAttempts,
+        tail: String(data.tail ?? current.tail),
+        totalChars: Number(data.totalChars ?? current.totalChars),
+        updatedAt: event.timestamp,
+      });
+      continue;
+    }
+
+    if (event.type === 'review.batch') {
+      const batchIndex = Number(data.batchIndex ?? 0);
+      const batchCount = Number(data.batchCount ?? 0);
+      bySession.set(event.sessionId, {
+        ...current,
+        status: 'batching',
+        batchIndex,
+        batchCount,
+        updatedAt: event.timestamp,
+      });
+      continue;
+    }
+
+    if (event.type === 'review.retry') {
+      bySession.set(event.sessionId, {
+        ...current,
+        status: 'retrying',
+        attempt,
+        maxAttempts,
+        reason: String(data.reason ?? ''),
+        tail: '',
+        totalChars: 0,
+        updatedAt: event.timestamp,
+      });
+      continue;
+    }
+
+    if (event.type === 'review.stream.failed') {
+      bySession.set(event.sessionId, {
+        ...current,
+        status: 'stream_failed',
+        attempt,
+        maxAttempts,
+        reason: String(data.reason ?? ''),
+        updatedAt: event.timestamp,
+      });
+      continue;
+    }
+
+    if (event.type === 'review.completed') {
+      bySession.delete(event.sessionId);
+      continue;
+    }
+
+    if (event.type === 'review.failed') {
+      bySession.set(event.sessionId, {
+        ...current,
+        status: 'failed',
+        reason: String(data.errorType ?? 'Review failed'),
+        updatedAt: event.timestamp,
+      });
+    }
+  }
+
+  return [...bySession.values()]
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+    .slice(0, 5);
+}
+
+function createLiveReviewFromEvent(event: SessionEvent): LiveReviewState {
+  const data = event.data ?? {};
+  const attempt = Number(data.attempt ?? 1);
+  const maxAttempts = Number(data.maxAttempts ?? 5);
+
+  if (event.type === 'review.stream') {
+    return {
+      sessionId: event.sessionId,
+      repository: event.repository,
+      prNumber: event.prNumber,
+      prTitle: event.prTitle,
+      status: 'streaming',
+      attempt,
+      maxAttempts,
+      tail: String(data.tail ?? ''),
+      totalChars: Number(data.totalChars ?? 0),
+      updatedAt: event.timestamp,
+    };
+  }
+
+  if (event.type === 'review.batch') {
+    return {
+      sessionId: event.sessionId,
+      repository: event.repository,
+      prNumber: event.prNumber,
+      prTitle: event.prTitle,
+      status: 'batching',
+      attempt,
+      maxAttempts,
+      tail: '',
+      totalChars: 0,
+      batchIndex: Number(data.batchIndex ?? 0),
+      batchCount: Number(data.batchCount ?? 0),
+      updatedAt: event.timestamp,
+    };
+  }
+
+  if (event.type === 'review.retry') {
+    return {
+      sessionId: event.sessionId,
+      repository: event.repository,
+      prNumber: event.prNumber,
+      prTitle: event.prTitle,
+      status: 'retrying',
+      attempt,
+      maxAttempts,
+      tail: '',
+      totalChars: 0,
+      reason: String(data.reason ?? ''),
+      updatedAt: event.timestamp,
+    };
+  }
+
+  if (event.type === 'review.stream.failed') {
+    return {
+      sessionId: event.sessionId,
+      repository: event.repository,
+      prNumber: event.prNumber,
+      prTitle: event.prTitle,
+      status: 'stream_failed',
+      attempt,
+      maxAttempts,
+      tail: '',
+      totalChars: 0,
+      reason: String(data.reason ?? ''),
+      updatedAt: event.timestamp,
+    };
+  }
+
+  if (event.type === 'review.failed') {
+    return {
+      sessionId: event.sessionId,
+      repository: event.repository,
+      prNumber: event.prNumber,
+      prTitle: event.prTitle,
+      status: 'failed',
+      attempt,
+      maxAttempts,
+      tail: '',
+      totalChars: 0,
+      reason: String(data.errorType ?? 'Review failed'),
+      updatedAt: event.timestamp,
+    };
+  }
+
+  return {
+    sessionId: event.sessionId,
+    repository: event.repository,
+    prNumber: event.prNumber,
+    prTitle: event.prTitle,
+    status: 'streaming',
+    attempt,
+    maxAttempts,
+    tail: '',
+    totalChars: 0,
+    updatedAt: event.timestamp,
+  };
+}
+
+export function liveReviewStatusLabel(review: LiveReviewState): string {
+  if (review.status === 'batching') {
+    const index = review.batchIndex ?? 0;
+    const count = review.batchCount ?? 0;
+    if (count > 0) {
+      return `Reviewing batch ${index}/${count}`;
+    }
+    return 'Reviewing large PR';
+  }
+  if (review.status === 'streaming') {
+    return `Streaming attempt ${review.attempt}/${review.maxAttempts}`;
+  }
+  if (review.status === 'retrying') {
+    return `Retrying attempt ${review.attempt}/${review.maxAttempts}`;
+  }
+  if (review.status === 'stream_failed') {
+    return `Attempt ${review.attempt}/${review.maxAttempts} failed`;
+  }
+  return 'Review failed';
+}
+
+export function liveReviewProgressMessage(review: LiveReviewState): string {
+  if (review.status !== 'batching') {
+    return 'Waiting for model tokens…';
+  }
+  const index = review.batchIndex ?? 0;
+  const count = review.batchCount ?? 0;
+  if (count > 1) {
+    return `Large PR review in progress — batch ${index} of ${count}. Live token streaming is disabled between batches.`;
+  }
+  return 'Large PR review in progress — token streaming is disabled for map-reduce reviews.';
+}


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

The overview live feed ignored `review.batch` WebSocket events from token-budgeted map-reduce reviews. Those reviews disable per-token streaming, so the dashboard stayed on an empty “Waiting for model tokens…” panel for the whole multi-call run and looked hung.

This PR handles `review.batch` in the live feed, shows batch X/Y progress, extracts the event reducer into `frontend/lib/live-reviews.ts`, and adds unit tests.

## Related Issues

N/A (Bugbot finding on `release/v0.4.0` after merging #256 / related release work; follows up #53)

## How Has This Been Tested?

- [x] Unit tests — `cd frontend && npm run test` (includes `live-reviews.test.ts` for batch progress, streaming, and completion)
- [ ] Integration tests
- [ ] Manual testing — trigger a large-PR map-reduce review and confirm overview shows “Reviewing batch X/Y” while batches run

Also ran `cd frontend && npm run build`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Targets `release/v0.4.0`. CHANGELOG updated under Unreleased Fixed.