### PR TITLE
fix(dashboard): default pricingMissing so Postgres schema-update succeeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to ThrillhouseBot.
 ### Fixed
 
 - **Multi-call reviews accumulate session tokens and cost**: token-budgeted map-reduce (and verifier) reviews issue several AI calls per session, but each completion replaced the session's `inputTokens` / `outputTokens` / `cost` / `durationMs` with that call alone — so the dashboard showed essentially the last call (usually the small summary) instead of the full review spend. Usage is now accumulated across calls, and `pricingMissing` stays sticky if any call lacked pricing
+- **`pricingMissing` schema update no longer fails on existing Postgres rows**: Hibernate's `update` strategy added `pricingMissing boolean not null` with no default, which Postgres rejects when `ReviewSession` already has rows — leaving the column missing and breaking startup backfill / session reads. The column now declares `default false` so the ALTER succeeds on upgrade
 
 ## [0.3.1] — 2026-07-02
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSession.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSession.java
@@ -59,7 +59,11 @@ public class ReviewSession extends PanacheEntity {
    * thrillhousebot.ai.pricing} entry — distinguishes "pricing not configured" from a genuine $0 so
    * the dashboard can flag under-reported spend. Cleared by {@link SessionCostBackfill} once
    * pricing is added and the cost is recomputed.
+   *
+   * <p>{@code default false} is required so schema-update can add this NOT NULL column to a
+   * populated Postgres table (without it, existing rows are null and the ALTER fails).
    */
+  @Column(nullable = false, columnDefinition = "boolean not null default false")
   boolean pricingMissing;
 
   long durationMs;


### PR DESCRIPTION
## Summary
- Hibernate `schema-management.strategy=update` was adding `pricingMissing boolean not null` with no default; Postgres rejects that when `ReviewSession` already has rows, so the column never appears and startup backfill / session queries fail
- Declare `boolean not null default false` on the column so the ALTER succeeds on upgrade

## Test plan
- [x] `./mvnw test -Dtest=ReviewSessionUpdaterTest,SessionCostBackfillTest,DashboardResourceSummaryTest`
- [ ] On a Postgres DB that already has `ReviewSession` rows (no `pricingMissing` column), restart with this build and confirm the column is added without the DDL warning
- [ ] Confirm `SessionCostBackfill` no longer logs `column … pricingmissing does not exist`
- [ ] Optional unblock without redeploy: `ALTER TABLE ReviewSession ADD COLUMN IF NOT EXISTS pricingMissing boolean NOT NULL DEFAULT false;`