### PR TITLE
fix: address ThrillhouseBot findings on PR #363

### DIFF
--- a/.github/workflows/docker-test-image.yml
+++ b/.github/workflows/docker-test-image.yml
@@ -133,7 +133,7 @@ jobs:
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+      - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           java-version: "25"
           distribution: "temurin"

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AutoReviewRateLimiter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AutoReviewRateLimiter.java
@@ -74,6 +74,15 @@ public class AutoReviewRateLimiter {
   }
 
   /**
+   * Clears any throttle window for this PR so the next automatic review can run immediately. Used
+   * when a draft is marked ready ({@code ready_for_review}) — that transition should always trigger
+   * a review even if a recent {@code synchronize} fell inside the interval.
+   */
+  public void clearForPr(String owner, String repo, int prNumber) {
+    deadlines.remove(key(owner, repo, prNumber));
+  }
+
+  /**
    * Records that an automatic review of this PR just completed, starting a fresh throttle window.
    * Callers must not record manual reviews — an explicit {@code /review} should not delay the next
    * automatic review. No-op when throttling is disabled.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -189,7 +189,12 @@ public class WebhookController {
           yield true;
         }
 
-        if (autoReviewRateLimiter.isThrottled(repo.owner().login(), repo.name(), pr.number())) {
+        if ("ready_for_review".equals(action)) {
+          // Draft → ready is not followed by synchronize; clear any throttle from pushes while
+          // draft (or a recent synchronize) so this transition always gets a review.
+          autoReviewRateLimiter.clearForPr(repo.owner().login(), repo.name(), pr.number());
+        } else if (autoReviewRateLimiter.isThrottled(
+            repo.owner().login(), repo.name(), pr.number())) {
           log.info(
               "Skipping automatic review for PR #{} in {} — last automatic review completed "
                   + "less than {} ago (manual /review bypasses)",

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/AutoReviewRateLimiterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/AutoReviewRateLimiterTest.java
@@ -105,6 +105,17 @@ class AutoReviewRateLimiterTest {
   }
 
   @Test
+  void clearForPrRemovesThrottleImmediately() {
+    var limiter = new AutoReviewRateLimiter(INTERVAL_MS, BIG_THRESHOLD, new MutableClock(0));
+
+    limiter.recordCompletion("owner", "repo", 1);
+    assertTrue(limiter.isThrottled("owner", "repo", 1));
+
+    limiter.clearForPr("owner", "repo", 1);
+    assertFalse(limiter.isThrottled("owner", "repo", 1));
+  }
+
+  @Test
   void newCompletionRestartsTheWindow() {
     var clock = new MutableClock(0);
     var limiter = new AutoReviewRateLimiter(INTERVAL_MS, BIG_THRESHOLD, clock);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -493,6 +493,24 @@ class WebhookControllerTest {
   }
 
   @Test
+  void shouldClearRateLimitAndDispatchReadyForReviewEvenWhenThrottled() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(reviewConfig.autoReviewMinInterval()).thenReturn(Duration.ofHours(1));
+    when(autoReviewRateLimiter.isThrottled("org", "svc", 57)).thenReturn(true);
+
+    var body =
+        buildPullRequestPayload("ready_for_review", 57, "org/svc", "sha57", "main")
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response = controller.handleWebhook("sha256=valid", "pull_request", null, DELIVERY, body);
+    assertEquals(200, response.getStatus());
+
+    verify(autoReviewRateLimiter).clearForPr("org", "svc", 57);
+    verify(autoReviewRateLimiter, never()).isThrottled("org", "svc", 57);
+    verify(reviewDispatcher).dispatch(any(ReviewOrchestrator.ReviewRequest.class));
+  }
+
+  @Test
   void shouldPassParsedDraftAndLabelsToTriggerFilter() {
     when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
 


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [x] 🏗️ CI/CD

## Description

Addresses valid ThrillhouseBot review findings on release PR #363:

- Align `actions/setup-java` pin in `docker-test-image.yml` with the rest of the workflows (`0f481fc`).
- Clear the auto-review rate-limit window on `ready_for_review` so marking a draft PR ready always triggers a review, even when a recent `synchronize` fell inside the throttle interval.

One bot finding was a false positive: the `live-reviews.test.ts` "drops completed sessions" test is correct — reverse iteration processes `started → batch → completed`, so the session is removed last. All three frontend tests pass unchanged.

## Related Issues

N/A — follow-up to ThrillhouseBot findings on #363.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

```bash
mvn test -Dtest=AutoReviewRateLimiterTest,WebhookControllerTest#shouldClearRateLimitAndDispatchReadyForReviewEvenWhenThrottled,WebhookControllerTest#shouldSkipAutomaticReviewWithinRateLimitWindow
npm test -- lib/live-reviews.test.ts
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Targets `release/v0.4.0` (not `main`). Merge into the release branch to clear the remaining bot findings before v0.4.0 ships.