### PR TITLE
fix: address Bugbot findings on release/v0.4.0

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionUpdater.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionUpdater.java
@@ -70,7 +70,7 @@ public class ReviewSessionUpdater {
     }
     session.setStatus(ReviewSession.STATUS_FAILED);
     session.setErrorMessage(errorMessage);
-    session.setDurationMs(durationMs);
+    session.setDurationMs(session.getDurationMs() + durationMs);
     session.persist();
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/SessionCostBackfill.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/SessionCostBackfill.java
@@ -75,6 +75,10 @@ public class SessionCostBackfill {
     for (ReviewSession session : candidates) {
       var modelPricing = pricing.get(session.getModel());
       if (modelPricing == null) {
+        if (!session.isPricingMissing()) {
+          session.setPricingMissing(true);
+          updated++;
+        }
         continue;
       }
       var cost =

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -50,6 +50,11 @@ import java.util.stream.IntStream;
 @ApplicationScoped
 public class FindingPipeline {
 
+  private record BatchOutcome(
+      int index,
+      List<ReviewResponse.Finding> findings,
+      List<ReviewResponse.PreviousFindingStatus> statuses) {}
+
   private final AiReviewService aiReviewService;
   private final FindingQuoteValidator quoteValidator;
   private final FindingDeduplicator deduplicator;
@@ -144,11 +149,13 @@ public class FindingPipeline {
    * calls on virtual threads), quote-validating and verifying each batch's findings against that
    * batch's own in-budget text (the combined diff would exceed the very budget the batches exist to
    * respect), union the results through the finishing chain, then a single summary call rolls them
-   * up into the PR-level summary. Previous-findings statuses are aggregated from the batch calls —
-   * they saw the diff; the code-blind summary call must not decide what was resolved. The passed
-   * {@code promptInputs} is reused as the shared-context template — only the diff slot changes per
-   * batch, and the base comparison is dropped (it is a near-duplicate of the diff that would
-   * otherwise be re-sent in every call).
+   * up into the PR-level summary. A batch that fails after {@link AiReviewService}'s internal
+   * retries is retried once more synchronously after the parallel pass — other batches keep their
+   * results instead of being discarded. Previous-findings statuses are aggregated from the batch
+   * calls — they saw the diff; the code-blind summary call must not decide what was resolved. The
+   * passed {@code promptInputs} is reused as the shared-context template — only the diff slot
+   * changes per batch, and the base comparison is dropped (it is a near-duplicate of the diff that
+   * would otherwise be re-sent in every call).
    */
   private ReviewResponse runMultiCall(
       ReviewSession session,
@@ -161,52 +168,49 @@ public class FindingPipeline {
     // findings; a batch may only close a prior finding whose file its own diff slice contained.
     var previousFilesById = followUpAnalyzer.previousFindingFilesById(ctx.previousAiResponseJson());
 
-    record BatchOutcome(
-        int index,
-        List<ReviewResponse.Finding> findings,
-        List<ReviewResponse.PreviousFindingStatus> statuses) {}
-
-    List<BatchOutcome> outcomes;
+    var outcomesByIndex = new BatchOutcome[batches.size()];
+    var failedIndices = new ArrayList<Integer>();
     try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
       var futures =
           IntStream.range(0, batches.size())
               .mapToObj(
                   i ->
                       CompletableFuture.supplyAsync(
-                          () -> {
-                            var batch = batches.get(i);
-                            var batchInputs =
-                                withDiff(
-                                    promptInputs, PromptTemplateEscaper.fence(batch.text()), "");
-                            var batchResponse =
-                                aiReviewService.reviewBatch(
-                                    session, batchInputs, i + 1, batches.size());
-                            var validated = quoteValidator.validate(batchResponse, batch.text());
-                            var verified =
-                                findingVerificationService.verify(
-                                    validated,
-                                    batchInputs.diff(),
-                                    promptInputs.projectStack(),
-                                    promptInputs.previousFindings());
-                            return new BatchOutcome(
-                                i,
-                                verified.findings(),
-                                scopeStatusesToBatch(
-                                    batchResponse.previousFindingsStatus(),
-                                    batch,
-                                    plan,
-                                    previousFilesById));
-                          },
+                          () ->
+                              processBatch(
+                                  i, batches, session, promptInputs, plan, previousFilesById),
                           executor))
               .toList();
-      outcomes =
-          futures.stream()
-              .map(CompletableFuture::join)
-              .sorted(Comparator.comparingInt(BatchOutcome::index))
-              .toList();
-    } catch (CompletionException e) {
-      throw unwrapParallelFailure(e);
+      for (int i = 0; i < futures.size(); i++) {
+        try {
+          outcomesByIndex[i] = futures.get(i).join();
+        } catch (CompletionException e) {
+          failedIndices.add(i);
+          var cause = e.getCause() != null ? e.getCause() : e;
+          Log.warnf(
+              cause,
+              "Batch %d/%d failed in the parallel pass; will retry after the other batches finish",
+              i + 1,
+              batches.size());
+        }
+      }
     }
+
+    for (int index : failedIndices) {
+      try {
+        outcomesByIndex[index] =
+            processBatch(index, batches, session, promptInputs, plan, previousFilesById);
+        Log.infof("Batch %d/%d succeeded on retry", index + 1, batches.size());
+      } catch (RuntimeException e) {
+        throw new IllegalStateException("Parallel batch review failed", e);
+      }
+    }
+
+    var outcomes =
+        IntStream.range(0, batches.size())
+            .mapToObj(i -> outcomesByIndex[i])
+            .sorted(Comparator.comparingInt(BatchOutcome::index))
+            .toList();
 
     var allFindings = new ArrayList<ReviewResponse.Finding>();
     var batchStatuses = new ArrayList<List<ReviewResponse.PreviousFindingStatus>>();
@@ -238,6 +242,31 @@ public class FindingPipeline {
             refined.findings(), refined.previousFindingsStatus(), summaryResponse.summary());
     persistAiResponse(session, merged);
     return merged;
+  }
+
+  private BatchOutcome processBatch(
+      int index,
+      List<DiffBudgetPlanner.DiffBatch> batches,
+      ReviewSession session,
+      AiReviewService.PromptInputs promptInputs,
+      DiffBudgetPlanner.BudgetPlan plan,
+      Map<Integer, String> previousFilesById) {
+    var batch = batches.get(index);
+    var batchInputs = withDiff(promptInputs, PromptTemplateEscaper.fence(batch.text()), "");
+    var batchResponse =
+        aiReviewService.reviewBatch(session, batchInputs, index + 1, batches.size());
+    var validated = quoteValidator.validate(batchResponse, batch.text());
+    var verified =
+        findingVerificationService.verify(
+            validated,
+            batchInputs.diff(),
+            promptInputs.projectStack(),
+            promptInputs.previousFindings());
+    return new BatchOutcome(
+        index,
+        verified.findings(),
+        scopeStatusesToBatch(
+            batchResponse.previousFindingsStatus(), batch, plan, previousFilesById));
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -186,9 +186,8 @@ public class FindingPipeline {
           outcomesByIndex[i] = futures.get(i).join();
         } catch (CompletionException e) {
           failedIndices.add(i);
-          var cause = e.getCause() != null ? e.getCause() : e;
           Log.warnf(
-              cause,
+              e,
               "Batch %d/%d failed in the parallel pass; will retry after the other batches finish",
               i + 1,
               batches.size());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionUpdaterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionUpdaterTest.java
@@ -99,6 +99,20 @@ class ReviewSessionUpdaterTest extends ReviewSessionTestSupport {
   }
 
   @Test
+  void shouldAccumulateDurationWhenFailureFollowsSuccessfulCalls() throws Exception {
+    var session = persistSession();
+
+    updater.recordModelUsage(session.id, "deepseek-chat", 1000, 200, 0.10, false, 2000);
+    updater.recordModelUsage(session.id, "deepseek-chat", 800, 150, 0.08, false, 1800);
+    updater.recordFailure(session.id, "batch blew up", 900);
+
+    ReviewSession loaded = ReviewSession.findById(session.id);
+    assertEquals(ReviewSession.STATUS_FAILED, loaded.getStatus());
+    assertEquals("batch blew up", loaded.getErrorMessage());
+    assertEquals(4700, loaded.getDurationMs());
+  }
+
+  @Test
   void shouldIgnoreMissingSessionId() {
     assertDoesNotThrow(() -> updater.recordModelUsage(999_999L, "model", 1, 1, 0.0, false, 1));
     assertDoesNotThrow(() -> updater.recordFailure(999_999L, "gone", 1));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/SessionCostBackfillTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/SessionCostBackfillTest.java
@@ -75,6 +75,7 @@ class SessionCostBackfillTest extends ReviewSessionTestSupport {
 
     ReviewSession loaded = ReviewSession.findById(id);
     assertEquals(0.0, loaded.getCost(), 1e-9);
+    assertTrue(loaded.isPricingMissing());
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -182,7 +182,33 @@ class FindingPipelineTest {
 
     assertEquals("Parallel batch review failed", thrown.getMessage());
     assertSame(failure, thrown.getCause());
+    verify(aiReviewService, times(2)).reviewBatch(eq(session), any(), eq(1), anyInt());
     verify(aiReviewService, never()).summarize(any(), any());
+  }
+
+  @Test
+  void multiCallRetriesFailedBatchWithoutDiscardingSuccessfulOnes() {
+    var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    var transientFailure = new AiReviewException("transient", 1, null);
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt()))
+        .thenThrow(transientFailure)
+        .thenReturn(new ReviewResponse(List.of(finding("a.java", "A")), List.of(), null));
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(2), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("b.java", "B")), List.of(), null));
+
+    var summary = new ReviewResponse.Summary(2, 0, 0, 2, 0, "ok", "does things", List.of());
+    when(aiReviewService.summarize(eq(session), any()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), summary));
+
+    var result =
+        pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+
+    verify(aiReviewService, times(2)).reviewBatch(eq(session), any(), eq(1), anyInt());
+    verify(aiReviewService).reviewBatch(eq(session), any(), eq(2), anyInt());
+    assertEquals(2, result.findings().size());
+    assertSame(summary, result.summary());
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Addresses the three medium-severity Bugbot findings on `release/v0.4.0`:

1. **Map-reduce batch failures** — parallel batches now complete independently; a failed batch is retried synchronously after the parallel pass instead of discarding successful batches. Other in-flight batches keep their results.
2. **Session cost backfill** — historical sessions with tokens but no pricing entry now get `pricingMissing=true` during startup backfill, so upgraded databases show "no pricing" instead of `$0.000000`.
3. **Failure duration** — `recordFailure` now accumulates `durationMs` across map-reduce calls instead of overwriting prior successful call durations.

## Related Issues

N/A — follow-up to Bugbot review of `release/v0.4.0`.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

```bash
mvn test -Dtest=FindingPipelineTest,SessionCostBackfillTest,ReviewSessionUpdaterTest
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Targets `release/v0.4.0` (not `main`).