### PR TITLE
fix(review): drop false description gaps for ignored files

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DescriptionGapFilter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DescriptionGapFilter.java
@@ -30,10 +30,6 @@ import java.util.stream.Collectors;
  */
 final class DescriptionGapFilter {
 
-  private static final Pattern ABSENCE_CLAIM =
-      Pattern.compile(
-          "(?i)(not\\s+(?:include|present|in)|does\\s+not\\s+include|missing\\s+from|no\\s+\\S+\\s+changes|not\\s+shown|patch\\s+omitted|not\\s+in\\s+the\\s+(?:diff|change))");
-
   private DescriptionGapFilter() {}
 
   static List<String> dropIgnoredFilePresenceGaps(
@@ -61,20 +57,55 @@ final class DescriptionGapFilter {
   }
 
   private static boolean isIgnoredFilePresenceGap(String gap, Set<String> ignoredPaths) {
-    if (gap == null || gap.isBlank() || !ABSENCE_CLAIM.matcher(gap).find()) {
+    if (gap == null || gap.isBlank()) {
       return false;
     }
     var lower = gap.toLowerCase(Locale.ROOT);
     for (String path : ignoredPaths) {
-      if (lower.contains(path.toLowerCase(Locale.ROOT))) {
-        return true;
-      }
-      var base = basename(path);
-      if (!base.isBlank() && lower.contains(base.toLowerCase(Locale.ROOT))) {
+      if (absenceTargetsFile(lower, path)) {
         return true;
       }
     }
     return false;
+  }
+
+  /**
+   * True when the gap's absence claim is about {@code path} specifically — not merely when the path
+   * is mentioned elsewhere in the same sentence (e.g. "pom.xml changed, but README is not in the
+   * diff").
+   */
+  private static boolean absenceTargetsFile(String lower, String path) {
+    for (String name : fileNames(path)) {
+      String q = Pattern.quote(name);
+      if (Pattern.compile(
+              "(?:does|do)\\s+not\\s+include\\s+(?:any\\s+)?(?:the\\s+)?(?:\\S+\\s+)*?" + q)
+          .matcher(lower)
+          .find()) {
+        return true;
+      }
+      if (Pattern.compile("no\\s+" + q + "\\s+changes").matcher(lower).find()) {
+        return true;
+      }
+      if (Pattern.compile(
+              "\\b" + q + "\\b[^,]{0,40}\\b(?:is\\s+)?not\\s+(?:included|present|in|shown)\\b")
+          .matcher(lower)
+          .find()) {
+        return true;
+      }
+      if (Pattern.compile("\\b" + q + "\\b[^,]{0,30}\\bmissing\\b").matcher(lower).find()) {
+        return true;
+      }
+      if (Pattern.compile("\\b" + q + "\\b[^.]{0,30}patch\\s+omitted").matcher(lower).find()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static List<String> fileNames(String path) {
+    var file = path.toLowerCase(Locale.ROOT);
+    var base = basename(path).toLowerCase(Locale.ROOT);
+    return file.equals(base) ? List.of(file) : List.of(file, base);
   }
 
   private static String basename(String path) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DescriptionGapFilter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DescriptionGapFilter.java
@@ -16,6 +16,7 @@
 package dev.thiagogonzaga.thrillhousebot.review;
 
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -62,7 +63,7 @@ final class DescriptionGapFilter {
     }
     var lower = gap.toLowerCase(Locale.ROOT);
     for (String path : ignoredPaths) {
-      if (absenceTargetsFile(lower, path)) {
+      if (absenceTargetsFile(lower, path, ignoredPaths)) {
         return true;
       }
     }
@@ -72,10 +73,15 @@ final class DescriptionGapFilter {
   /**
    * True when the gap's absence claim is about {@code path} specifically — not merely when the path
    * is mentioned elsewhere in the same sentence (e.g. "pom.xml changed, but README is not in the
-   * diff").
+   * diff"), and not when a qualified path with the same basename refers to a different file (e.g.
+   * "module-b/pom.xml is not in the diff" while only {@code module-a/pom.xml} changed).
    */
-  private static boolean absenceTargetsFile(String lower, String path) {
-    for (String name : fileNames(path)) {
+  private static boolean absenceTargetsFile(String lower, String path, Set<String> ignoredPaths) {
+    var base = basename(path).toLowerCase(Locale.ROOT);
+    for (String name : fileNames(path, ignoredPaths)) {
+      if (name.equals(base) && gapMentionsDifferentQualifiedPath(lower, path, base)) {
+        continue;
+      }
       String q = Pattern.quote(name);
       if (Pattern.compile(
               "(?:does|do)\\s+not\\s+include\\s+(?:any\\s+)?(?:the\\s+)?(?:\\S+\\s+)*?" + q)
@@ -102,10 +108,39 @@ final class DescriptionGapFilter {
     return false;
   }
 
-  private static List<String> fileNames(String path) {
+  /**
+   * True when the gap cites a qualified path ending in {@code basename} that is not {@code path}
+   * (case-insensitive), e.g. {@code module-b/pom.xml} while the ignored change is {@code
+   * module-a/pom.xml}.
+   */
+  private static boolean gapMentionsDifferentQualifiedPath(
+      String lower, String path, String basename) {
+    var pattern = Pattern.compile("(?:[\\w.-]+/)+" + Pattern.quote(basename));
+    var matcher = pattern.matcher(lower);
+    var ignored = path.toLowerCase(Locale.ROOT);
+    while (matcher.find()) {
+      if (!matcher.group().equals(ignored)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static List<String> fileNames(String path, Set<String> ignoredPaths) {
     var file = path.toLowerCase(Locale.ROOT);
     var base = basename(path).toLowerCase(Locale.ROOT);
-    return file.equals(base) ? List.of(file) : List.of(file, base);
+    var names = new ArrayList<String>();
+    names.add(file);
+    if (!file.equals(base) && basenameCount(ignoredPaths, base) == 1) {
+      names.add(base);
+    } else if (file.equals(base) && basenameCount(ignoredPaths, base) == 1) {
+      // root-level ignored file — basename is the same as the full path, already added
+    }
+    return names;
+  }
+
+  private static long basenameCount(Set<String> ignoredPaths, String basename) {
+    return ignoredPaths.stream().filter(p -> basename(p).equalsIgnoreCase(basename)).count();
   }
 
   private static String basename(String path) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DescriptionGapFilter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DescriptionGapFilter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Drops {@code description_gaps} bullets that falsely claim an ignored file is missing from the PR.
+ * Ignored files (e.g. {@code pom.xml}, lockfiles) appear in the diff overview as {@code (path
+ * skipped: matches ignored pattern, +N -M)} without their patch; the model sometimes treats that as
+ * "not changed".
+ */
+final class DescriptionGapFilter {
+
+  private static final Pattern ABSENCE_CLAIM =
+      Pattern.compile(
+          "(?i)(not\\s+(?:include|present|in)|does\\s+not\\s+include|missing\\s+from|no\\s+\\S+\\s+changes|not\\s+shown|patch\\s+omitted|not\\s+in\\s+the\\s+(?:diff|change))");
+
+  private DescriptionGapFilter() {}
+
+  static List<String> dropIgnoredFilePresenceGaps(
+      List<String> gaps,
+      List<GitHubPullRequestClient.FileDiff> allFiles,
+      List<GitHubPullRequestClient.FileDiff> reviewableFiles) {
+    if (gaps == null || gaps.isEmpty() || allFiles == null || allFiles.isEmpty()) {
+      return gaps == null ? List.of() : gaps;
+    }
+    Set<String> reviewable =
+        reviewableFiles == null
+            ? Set.of()
+            : reviewableFiles.stream()
+                .map(GitHubPullRequestClient.FileDiff::filename)
+                .collect(Collectors.toSet());
+    Set<String> ignoredPaths =
+        allFiles.stream()
+            .map(GitHubPullRequestClient.FileDiff::filename)
+            .filter(path -> !reviewable.contains(path))
+            .collect(Collectors.toSet());
+    if (ignoredPaths.isEmpty()) {
+      return gaps;
+    }
+    return gaps.stream().filter(gap -> !isIgnoredFilePresenceGap(gap, ignoredPaths)).toList();
+  }
+
+  private static boolean isIgnoredFilePresenceGap(String gap, Set<String> ignoredPaths) {
+    if (gap == null || gap.isBlank() || !ABSENCE_CLAIM.matcher(gap).find()) {
+      return false;
+    }
+    var lower = gap.toLowerCase(Locale.ROOT);
+    for (String path : ignoredPaths) {
+      if (lower.contains(path.toLowerCase(Locale.ROOT))) {
+        return true;
+      }
+      var base = basename(path);
+      if (!base.isBlank() && lower.contains(base.toLowerCase(Locale.ROOT))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String basename(String path) {
+    int slash = path.lastIndexOf('/');
+    return slash >= 0 ? path.substring(slash + 1) : path;
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -91,13 +91,43 @@ public class VerdictBuilder {
                 botIdentity)
             : List.<ReviewResult.PreviousFindingStatus>of();
     return buildResult(
-        aiResponse,
+        withFilteredDescriptionGaps(aiResponse, ctx.files(), ctx.reviewableFiles()),
         ctx.isFirstVisibleReview(),
         diffStats,
         changedFiles,
         unresolvedPrevious,
         ciEvaluation,
         backstopUnresolved);
+  }
+
+  private static ReviewResponse withFilteredDescriptionGaps(
+      ReviewResponse response,
+      List<GitHubPullRequestClient.FileDiff> allFiles,
+      List<GitHubPullRequestClient.FileDiff> reviewableFiles) {
+    var summary = response.summary();
+    if (summary == null) {
+      return response;
+    }
+    var filtered =
+        DescriptionGapFilter.dropIgnoredFilePresenceGaps(
+            summary.descriptionGaps(), allFiles, reviewableFiles);
+    if (filtered.equals(summary.descriptionGaps())) {
+      return response;
+    }
+    var newSummary =
+        new ReviewResponse.Summary(
+            summary.totalFindings(),
+            summary.critical(),
+            summary.high(),
+            summary.medium(),
+            summary.low(),
+            summary.overallAssessment(),
+            summary.prPurpose(),
+            filtered,
+            summary.suggestedLabels(),
+            summary.fileSummaries(),
+            summary.walkthroughDiagram());
+    return new ReviewResponse(response.findings(), response.previousFindingsStatus(), newSummary);
   }
 
   static String conclusionForResult(ReviewResult result) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -204,7 +204,10 @@ public final class PrReviewPrompts {
             - description_gaps: when the PR title/description is provided, an array of concrete
               mismatches between what the author claims and what the code does (claimed changes
               that are missing, significant changes the description never mentions). Empty array
-              when there is no description or no mismatch.
+              when there is no description or no mismatch. Files marked "(path skipped: matches
+              ignored pattern, +N -M)" in the diff ARE changed in the PR — their patch is omitted
+              by design (pom.xml, lockfiles, etc.) — so do not report a gap when the only mismatch
+              is that such a file's patch is not shown.
             - file_summaries: an array of { path, summary } objects, one per changed file, that gives
               reviewers a file-by-file walkthrough. "path" must match the file path exactly as it
               appears in the diff; "summary" is a single line (max ~100 chars) describing what
@@ -237,7 +240,8 @@ public final class PrReviewPrompts {
             {{#if prContext}}
             ## PR Title and Description (author's stated intent)
             Compare the implementation against this stated intent and report mismatches
-            in summary.description_gaps.
+            in summary.description_gaps. Ignored files listed as "skipped: matches ignored
+            pattern" in the diff are still part of the PR — do not treat them as missing.
             {{prContext}}
             {{/if}}
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DescriptionGapFilterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DescriptionGapFilterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DescriptionGapFilterTest {
+
+  @Test
+  void dropsGapClaimingIgnoredPomXmlIsMissingFromDiff() {
+    var all = List.of(file("pom.xml", "modified", 1, 1), file("src/A.java", "modified", 5, 2));
+    var reviewable = List.of(file("src/A.java", "modified", 5, 2));
+    var gaps =
+        List.of(
+            "The PR description states the pom.xml is bumped to 0.4.0, but the provided diff does"
+                + " not include any pom.xml changes.");
+
+    var filtered = DescriptionGapFilter.dropIgnoredFilePresenceGaps(gaps, all, reviewable);
+
+    assertTrue(filtered.isEmpty());
+  }
+
+  @Test
+  void keepsGapAboutReviewableFiles() {
+    var all = List.of(file("src/A.java", "modified", 5, 2));
+    var reviewable = all;
+    var gaps = List.of("Description claims tests were added, but no test files changed");
+
+    var filtered = DescriptionGapFilter.dropIgnoredFilePresenceGaps(gaps, all, reviewable);
+
+    assertEquals(gaps, filtered);
+  }
+
+  @Test
+  void keepsSubstantiveGapMentioningIgnoredFileWithoutAbsenceClaim() {
+    var all = List.of(file("pom.xml", "modified", 1, 1), file("README.md", "modified", 2, 0));
+    var reviewable = List.of(file("README.md", "modified", 2, 0));
+    var gaps = List.of("Description says pom.xml pins Quarkus 3.37 but README still lists 3.36");
+
+    var filtered = DescriptionGapFilter.dropIgnoredFilePresenceGaps(gaps, all, reviewable);
+
+    assertEquals(gaps, filtered);
+  }
+
+  private static GitHubPullRequestClient.FileDiff file(
+      String name, String status, int additions, int deletions) {
+    return new GitHubPullRequestClient.FileDiff(
+        name, status, additions, deletions, additions + deletions, null);
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DescriptionGapFilterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DescriptionGapFilterTest.java
@@ -59,6 +59,67 @@ class DescriptionGapFilterTest {
     assertEquals(gaps, filtered);
   }
 
+  @Test
+  void keepsGapWhenAbsenceClaimTargetsReviewableFileDespiteIgnoredMention() {
+    var all = List.of(file("pom.xml", "modified", 1, 1), file("README.md", "modified", 2, 0));
+    var reviewable = List.of(file("README.md", "modified", 2, 0));
+    var gaps = List.of("pom.xml is changed, but README is not in the diff");
+
+    var filtered = DescriptionGapFilter.dropIgnoredFilePresenceGaps(gaps, all, reviewable);
+
+    assertEquals(gaps, filtered);
+  }
+
+  @Test
+  void dropsGapWhenIgnoredFileIsClaimedMissingByName() {
+    var all = List.of(file("frontend/package-lock.json", "modified", 10, 2));
+    var reviewable = List.<GitHubPullRequestClient.FileDiff>of();
+    var gaps = List.of("package-lock.json is not in the diff");
+
+    var filtered = DescriptionGapFilter.dropIgnoredFilePresenceGaps(gaps, all, reviewable);
+
+    assertTrue(filtered.isEmpty());
+  }
+
+  @Test
+  void returnsEmptyListForNullGaps() {
+    assertTrue(
+        DescriptionGapFilter.dropIgnoredFilePresenceGaps(
+                null, List.of(file("pom.xml", "modified", 1, 1)), List.of())
+            .isEmpty());
+  }
+
+  @Test
+  void returnsGapsUnchangedWhenNoIgnoredFiles() {
+    var all = List.of(file("src/A.java", "modified", 1, 0));
+    var gaps = List.of("Description claims tests were added, but no test files changed");
+
+    assertEquals(gaps, DescriptionGapFilter.dropIgnoredFilePresenceGaps(gaps, all, all));
+  }
+
+  @Test
+  void returnsGapsUnchangedWhenAllFilesListEmpty() {
+    var gaps = List.of("no changes");
+
+    assertEquals(
+        gaps, DescriptionGapFilter.dropIgnoredFilePresenceGaps(gaps, List.of(), List.of()));
+  }
+
+  @Test
+  void dropsOnlyTheIgnoredFileGapAndKeepsOthers() {
+    var all = List.of(file("pom.xml", "modified", 1, 1), file("src/A.java", "modified", 5, 2));
+    var reviewable = List.of(file("src/A.java", "modified", 5, 2));
+    var gaps =
+        List.of(
+            "The diff does not include any pom.xml changes.",
+            "Description claims tests were added, but no test files changed");
+
+    var filtered = DescriptionGapFilter.dropIgnoredFilePresenceGaps(gaps, all, reviewable);
+
+    assertEquals(
+        List.of("Description claims tests were added, but no test files changed"), filtered);
+  }
+
   private static GitHubPullRequestClient.FileDiff file(
       String name, String status, int additions, int deletions) {
     return new GitHubPullRequestClient.FileDiff(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DescriptionGapFilterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DescriptionGapFilterTest.java
@@ -120,6 +120,29 @@ class DescriptionGapFilterTest {
         List.of("Description claims tests were added, but no test files changed"), filtered);
   }
 
+  @Test
+  void keepsGapWhenQualifiedPathDiffersFromIgnoredFileWithSameBasename() {
+    var all =
+        List.of(file("module-a/pom.xml", "modified", 1, 1), file("src/A.java", "modified", 5, 2));
+    var reviewable = List.of(file("src/A.java", "modified", 5, 2));
+    var gaps = List.of("module-b/pom.xml is not in the diff");
+
+    var filtered = DescriptionGapFilter.dropIgnoredFilePresenceGaps(gaps, all, reviewable);
+
+    assertEquals(gaps, filtered);
+  }
+
+  @Test
+  void dropsGapWhenQualifiedPathMatchesIgnoredFile() {
+    var all = List.of(file("module-a/pom.xml", "modified", 1, 1));
+    var reviewable = List.<GitHubPullRequestClient.FileDiff>of();
+    var gaps = List.of("module-a/pom.xml is not in the diff");
+
+    var filtered = DescriptionGapFilter.dropIgnoredFilePresenceGaps(gaps, all, reviewable);
+
+    assertTrue(filtered.isEmpty());
+  }
+
   private static GitHubPullRequestClient.FileDiff file(
       String name, String status, int additions, int deletions) {
     return new GitHubPullRequestClient.FileDiff(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -163,5 +164,61 @@ class VerdictBuilderTest {
 
     assertEquals(2, result.omittedFiles());
     assertTrue(result.truncated());
+  }
+
+  @Test
+  void buildFiltersFalseDescriptionGapAboutIgnoredPomXml() {
+    var summary =
+        new ReviewResponse.Summary(
+            0,
+            0,
+            0,
+            0,
+            0,
+            "ok",
+            "Finalize release",
+            List.of(
+                "The PR description states the pom.xml is bumped to 0.4.0, but the provided diff"
+                    + " does not include any pom.xml changes."));
+    var response = new ReviewResponse(List.of(), List.of(), summary);
+    var ctx =
+        new ReviewContextLoader.ReviewContext(
+            List.of(
+                new FileDiff("pom.xml", "modified", 1, 1, 2, null),
+                new FileDiff("src/A.java", "modified", 5, 2, 7, "")),
+            "diff",
+            "",
+            0,
+            List.of(),
+            List.of(),
+            true,
+            false,
+            null,
+            List.of(),
+            "",
+            new InstructionsResolver.ResolvedInstructions("", ""),
+            List.of(),
+            "",
+            List.of(new FileDiff("src/A.java", "modified", 5, 2, 7, "")),
+            new DiffLineResolver(Map.of()),
+            null);
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), false);
+    var summaryCaptor = ArgumentCaptor.forClass(ReviewResponse.Summary.class);
+
+    builder.build(ctx, response, CI_CLEAR, plan);
+
+    verify(summaryGenerator)
+        .generate(anyInt(), anyInt(), anyInt(), any(), summaryCaptor.capture(), any());
+    assertTrue(summaryCaptor.getValue().descriptionGaps().isEmpty());
+  }
+
+  @Test
+  void buildLeavesResponseUnchangedWhenSummaryIsNull() {
+    var ctx = contextWithLineCapOmissions(0);
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), false);
+
+    builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    verify(summaryGenerator).generate(anyInt(), anyInt(), anyInt(), any(), eq(null), any());
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Filters false `description_gaps` bullets that claim ignored files (e.g. `pom.xml`, lockfiles) are missing from the PR when those files appear as `skipped: matches ignored pattern` in the diff. Also clarifies the review prompt so the model does not treat intentionally omitted patches as absent changes.

The filter only drops gaps whose absence claim targets the ignored file itself (not gaps that merely mention an ignored path elsewhere), and skips basename-only matching when the gap cites a different qualified path (e.g. keeps `module-b/pom.xml is not in the diff` when only `module-a/pom.xml` changed).

Fixes the false positive on PR #377 where a legitimate root `pom.xml` version bump was flagged as a description/implementation mismatch.

## Related Issues

N/A

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

```bash
mvn test -Dtest=DescriptionGapFilterTest,VerdictBuilderTest
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Targets `release/v0.4.0`. Re-run `/review` on a release PR that bumps `pom.xml` to confirm the "Description vs. Implementation" warning is gone.