### PR TITLE
fix(dashboard): lock recordFailure for parallel batch updates

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionUpdater.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionUpdater.java
@@ -63,7 +63,7 @@ public class ReviewSessionUpdater {
 
   @Transactional(TxType.REQUIRES_NEW)
   public void recordFailure(long sessionId, String errorMessage, long durationMs) {
-    var session = repository.findById(sessionId);
+    var session = repository.findById(sessionId, LockModeType.PESSIMISTIC_WRITE);
     if (session == null) {
       return;
     }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionUpdaterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/ReviewSessionUpdaterTest.java
@@ -113,6 +113,20 @@ class ReviewSessionUpdaterTest extends ReviewSessionTestSupport {
   }
 
   @Test
+  void shouldAccumulateDurationWhenFailurePrecedesFurtherUsage() throws Exception {
+    var session = persistSession();
+
+    updater.recordModelUsage(session.id, "deepseek-chat", 500, 100, 0.05, false, 1000);
+    updater.recordFailure(session.id, "batch 2 failed", 600);
+    updater.recordModelUsage(session.id, "deepseek-chat", 300, 50, 0.03, false, 400);
+
+    ReviewSession loaded = ReviewSession.findById(session.id);
+    assertEquals(ReviewSession.STATUS_FAILED, loaded.getStatus());
+    assertEquals(2000, loaded.getDurationMs());
+    assertEquals(800, loaded.getInputTokens());
+  }
+
+  @Test
   void shouldIgnoreMissingSessionId() {
     assertDoesNotThrow(() -> updater.recordModelUsage(999_999L, "model", 1, 1, 0.0, false, 1));
     assertDoesNotThrow(() -> updater.recordFailure(999_999L, "gone", 1));


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`recordFailure` now acquires the same pessimistic write lock as `recordModelUsage` before accumulating `durationMs`. Parallel map-reduce batches can interleave success and error callbacks in separate `REQUIRES_NEW` transactions; without the lock, one duration increment could be lost.

## Related Issues

N/A — found by Bugbot on `release/v0.4.0` vs `main`.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

```bash
mvn test -Dtest=ReviewSessionUpdaterTest
```

Dogfood correlation (`out9.txt`, PR #363):

| Time (UTC) | Trigger | Result |
|------------|---------|--------|
| 20:39 manual `/review` | First dogfood pass | 2 findings, `COMMENT` — partial review (61 files omitted), expected on large release PR |
| 21:13 push (`072a092`) | Auto re-review | Resolved 2 prior threads, 0 new findings, `COMMENT` |
| 21:24 / 22:03 manual `/review` | Follow-up dogfood | 0 findings, `COMMENT` |
| 22:27 push (`107c22a`, includes #379) | Post-merge re-review | 0 findings, `COMMENT` |

All five PR #363 review runs completed without orchestrator failures. Five `MismatchedInputException: No content to map` Vert.x errors during the same windows look like empty dashboard SSE/REST responses, not review pipeline failures — reviews still posted successfully. Auto-review rate limiting on sibling PR #374 behaved correctly (`Skipping automatic review … within PT1H`). PR #363 CI is green (including `codecov/patch`, SonarCloud, CodeQL).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Targets `release/v0.4.0`. No dogfood regressions observed on #363 beyond the expected partial-review hold on the first large-diff pass.