### PR TITLE
fix(sonar): clear maintainability issues introduced on main

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDispatcher.java
@@ -242,8 +242,8 @@ public final class ReviewDispatcher {
 
     DispatchResult onDispatch(ReviewOrchestrator.ReviewRequest req) {
       synchronized (lock) {
-        // A finishing worker can retire the state between the map lookup and this lock;
-        // reviving it would let two workers run for the same PR.
+        // A finishing worker can retire the state between the map lookup and this
+        // lock — reviving it would let two workers run for the same PR.
         if (retired) {
           return new DispatchResult(true, false, 0);
         }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardWebSocketConfiguratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardWebSocketConfiguratorTest.java
@@ -16,6 +16,8 @@
 package dev.thiagogonzaga.thrillhousebot.dashboard;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import jakarta.websocket.HandshakeResponse;
 import jakarta.websocket.server.HandshakeRequest;
@@ -24,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class DashboardWebSocketConfiguratorTest {
 
@@ -32,12 +33,12 @@ class DashboardWebSocketConfiguratorTest {
 
   @Test
   void shouldCopyCookieHeaderIntoUserProperties() {
-    var config = Mockito.mock(ServerEndpointConfig.class);
-    var request = Mockito.mock(HandshakeRequest.class);
-    var response = Mockito.mock(HandshakeResponse.class);
+    var config = mock(ServerEndpointConfig.class);
+    var request = mock(HandshakeRequest.class);
+    var response = mock(HandshakeResponse.class);
     var userProperties = new java.util.HashMap<String, Object>();
-    Mockito.when(config.getUserProperties()).thenReturn(userProperties);
-    Mockito.when(request.getHeaders())
+    when(config.getUserProperties()).thenReturn(userProperties);
+    when(request.getHeaders())
         .thenReturn(Map.of("Cookie", List.of("thrillhouse_session=abc123; path=/")));
 
     configurator.modifyHandshake(config, request, response);
@@ -47,13 +48,12 @@ class DashboardWebSocketConfiguratorTest {
 
   @Test
   void shouldAcceptLowercaseCookieHeader() {
-    var config = Mockito.mock(ServerEndpointConfig.class);
-    var request = Mockito.mock(HandshakeRequest.class);
-    var response = Mockito.mock(HandshakeResponse.class);
+    var config = mock(ServerEndpointConfig.class);
+    var request = mock(HandshakeRequest.class);
+    var response = mock(HandshakeResponse.class);
     var userProperties = new java.util.HashMap<String, Object>();
-    Mockito.when(config.getUserProperties()).thenReturn(userProperties);
-    Mockito.when(request.getHeaders())
-        .thenReturn(Map.of("cookie", List.of("thrillhouse_session=token")));
+    when(config.getUserProperties()).thenReturn(userProperties);
+    when(request.getHeaders()).thenReturn(Map.of("cookie", List.of("thrillhouse_session=token")));
 
     configurator.modifyHandshake(config, request, response);
 
@@ -62,12 +62,12 @@ class DashboardWebSocketConfiguratorTest {
 
   @Test
   void shouldLeaveUserPropertiesEmptyWhenNoCookieHeader() {
-    var config = Mockito.mock(ServerEndpointConfig.class);
-    var request = Mockito.mock(HandshakeRequest.class);
-    var response = Mockito.mock(HandshakeResponse.class);
+    var config = mock(ServerEndpointConfig.class);
+    var request = mock(HandshakeRequest.class);
+    var response = mock(HandshakeResponse.class);
     var userProperties = new HashMap<String, Object>();
-    Mockito.when(config.getUserProperties()).thenReturn(userProperties);
-    Mockito.when(request.getHeaders()).thenReturn(Map.of());
+    when(config.getUserProperties()).thenReturn(userProperties);
+    when(request.getHeaders()).thenReturn(Map.of());
 
     configurator.modifyHandshake(config, request, response);
 
@@ -76,15 +76,15 @@ class DashboardWebSocketConfiguratorTest {
 
   @Test
   void shouldSkipEmptyCookieHeaderAndUseLowercaseFallback() {
-    var config = Mockito.mock(ServerEndpointConfig.class);
-    var request = Mockito.mock(HandshakeRequest.class);
-    var response = Mockito.mock(HandshakeResponse.class);
+    var config = mock(ServerEndpointConfig.class);
+    var request = mock(HandshakeRequest.class);
+    var response = mock(HandshakeResponse.class);
     var userProperties = new HashMap<String, Object>();
     var headers = new HashMap<String, List<String>>();
     headers.put("Cookie", List.of());
     headers.put("cookie", List.of("thrillhouse_session=fallback-token"));
-    Mockito.when(config.getUserProperties()).thenReturn(userProperties);
-    Mockito.when(request.getHeaders()).thenReturn(headers);
+    when(config.getUserProperties()).thenReturn(userProperties);
+    when(request.getHeaders()).thenReturn(headers);
 
     configurator.modifyHandshake(config, request, response);
 
@@ -93,15 +93,15 @@ class DashboardWebSocketConfiguratorTest {
 
   @Test
   void shouldIgnoreNullCookieHeaderValues() {
-    var config = Mockito.mock(ServerEndpointConfig.class);
-    var request = Mockito.mock(HandshakeRequest.class);
-    var response = Mockito.mock(HandshakeResponse.class);
+    var config = mock(ServerEndpointConfig.class);
+    var request = mock(HandshakeRequest.class);
+    var response = mock(HandshakeResponse.class);
     var userProperties = new HashMap<String, Object>();
     var headers = new HashMap<String, List<String>>();
     headers.put("Cookie", null);
     headers.put("cookie", List.of("thrillhouse_session=from-lowercase"));
-    Mockito.when(config.getUserProperties()).thenReturn(userProperties);
-    Mockito.when(request.getHeaders()).thenReturn(headers);
+    when(config.getUserProperties()).thenReturn(userProperties);
+    when(request.getHeaders()).thenReturn(headers);
 
     configurator.modifyHandshake(config, request, response);
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [x] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Clears all 26 open [SonarCloud maintainability issues](https://sonarcloud.io/project/issues?impactSoftwareQualities=MAINTAINABILITY&issueStatuses=OPEN%2CCONFIRMED&id=devops-thiago_ThrillhouseBot) introduced on `main`:

| Rule | File | Count | Fix |
|------|------|-------|-----|
| `java:S125` | `ReviewDispatcher.java` | 1 | Rephrase race-condition comment (trailing `;` made Sonar treat it as commented-out code) |
| `java:S8924` | `DashboardWebSocketConfiguratorTest.java` | 25 | Use static imports for `mock` / `when` (matches other test classes) |

## Related Issues

N/A

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

```bash
./mvnw spotless:apply
./mvnw test -Dtest=DashboardWebSocketConfiguratorTest,ReviewDispatcherTest
```

27 tests, 0 failures.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Sonar issues addressed: 26 / 26 (all open maintainability findings).

## Additional Notes

No behaviour changes — comment wording and import style only.