### PR TITLE
fix(docs): repair architecture Mermaid diagrams on the docs site

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ flowchart TB
 
         WH --> RO --> AI
         RO --> GHC
-        AI -. live tokens / review.batch .-> DB
+        AI -.->|live tokens / review.batch| DB
     end
 
     IN -->|POST /api/webhook<br/>HMAC-verified| WH
@@ -50,7 +50,7 @@ flowchart TD
     AI -->|parse findings| RO
     RO -->|verify findings — 2nd AI call per batch, on by default| AI
     RO -->|post review + check run| GHC --> GH
-    AI -. live tokens or review.batch .-> DB[dashboard/ broadcaster]
+    AI -.->|live tokens or review.batch| DB[dashboard/ broadcaster]
     DB -->|WebSocket| FE[frontend/ Next.js UI]
     RO -->|persist session, cost, tokens| PG[(H2 / PostgreSQL)]
     AI -->|traces, token & cost metrics| OT[(OpenTelemetry)]


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [x] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Fixes broken Mermaid diagrams on the [architecture](https://devops-thiago.github.io/ThrillhouseBot/architecture/) docs page.

The dotted-edge syntax `-. label .->` treats `.` as a delimiter, so labels like `review.batch` caused lexical errors in **Components** and **Request flow**. Switched to pipe-style dotted arrows (`-.->|label|`), matching the other edges in those flowcharts.

Source: `docs/ARCHITECTURE.md` (included by `website/src/content/docs/architecture.md` at build time).

## Related Issues

N/A

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

```bash
cd website && npm run build
```

Build succeeds; link validation passes.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Before: `Error rendering diagram: Lexical error on line 9. Unrecognized text. ...review.batch .->`

After merge, redeploy docs (`gh workflow run docs.yml`) to refresh GitHub Pages.

## Additional Notes

No app or archived version snapshots changed — only the live docs include source.