### PR TITLE
fix(review): suppress duplicate CI-pending COMMENT only when the summary actually posted (#334)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -255,7 +255,7 @@ public class ReviewOrchestrator {
       boolean summaryPosted = publishSummaryBestEffort(auth, req, result);
       reviewPublisher.dismissPendingBotReviews(
           auth, req.owner(), req.repo(), req.prNumber(), priorReviews);
-      // summaryReposted gates the summary-only skip: a failed summary post leaves review
+      // summaryPosted gates the redundant-review skips: a failed summary post leaves review
       // posting enabled.
       reviewPublisher.postReview(
           new ReviewPublisher.PostReviewRequest(
@@ -266,7 +266,7 @@ public class ReviewOrchestrator {
               req.commitSha(),
               result,
               lineResolver,
-              req.forceSummary() && summaryPosted));
+              summaryPosted));
 
       resultSurfaced = true;
       final var doneReq = req;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -79,9 +79,10 @@ public class ReviewPublisher {
    * regenerate a summary that was deleted from the PR even though a review already ran.
    *
    * @return {@code true} when the summary comment was actually created; {@code false} when this
-   *     review posts no summary (follow-up, or nothing to post). {@code postReview} suppresses the
-   *     no-issues review on a summary-only re-run only when this returned {@code true} — a failed
-   *     or skipped summary must leave the review as the run's visible outcome.
+   *     review posts no summary (follow-up, or nothing to post). {@code postReview} suppresses a
+   *     redundant no-issues review (summary-only re-run, or a first review held back solely by
+   *     pending/failed CI) only when this returned {@code true} — a failed or skipped summary must
+   *     leave the review as the run's visible outcome.
    */
   boolean publishSummary(
       String auth,
@@ -155,10 +156,10 @@ public class ReviewPublisher {
   /**
    * Parameter object for {@link #postReview(PostReviewRequest)}.
    *
-   * @param summaryReposted {@code true} only on a summary-only re-run ({@code /summary}) whose
-   *     regenerated summary comment was actually posted — the caller must AND the request's {@code
-   *     forceSummary} with {@code publishSummary}'s outcome, so a failed summary post never
-   *     suppresses the review too and leave the run with no visible outcome at all.
+   * @param summaryPosted {@code true} only when this run's PR summary comment was actually created
+   *     ({@code publishSummary} returned {@code true}) — never assumed from {@code isFirstReview}
+   *     or {@code forceSummary} alone, so a failed or skipped summary post can never suppress the
+   *     review too and leave the run with no visible outcome at all.
    */
   record PostReviewRequest(
       String auth,
@@ -168,12 +169,11 @@ public class ReviewPublisher {
       String commitSha,
       ReviewResult result,
       DiffLineResolver lineResolver,
-      boolean summaryReposted) {}
+      boolean summaryPosted) {}
 
   /**
-   * Back-compat convenience for the automatic {@code pull_request} / {@code /review} paths and
-   * tests, which are never a summary-only re-run. Defaults {@code summaryReposted} to {@code
-   * false}.
+   * Back-compat convenience for tests and callers with no summary outcome to report. Defaults
+   * {@code summaryPosted} to {@code false}, so no review-suppressing skip can fire.
    */
   void postReview(
       String auth,
@@ -198,7 +198,7 @@ public class ReviewPublisher {
     if (!result.hasIssues()) {
       // Summary-only re-run: skip restating a clean verdict when the summary re-posted; first
       // review, unresolved previous, and truncation still post.
-      if (post.summaryReposted()
+      if (post.summaryPosted()
           && !result.isFirstReview()
           && result.unresolvedPreviousCount() == 0
           && !result.truncated()) {
@@ -208,7 +208,7 @@ public class ReviewPublisher {
             owner, repo, prNumber);
         return;
       }
-      postNoIssuesReview(auth, owner, repo, prNumber, commitSha, result);
+      postNoIssuesReview(auth, owner, repo, prNumber, commitSha, result, post.summaryPosted());
       return;
     }
 
@@ -318,10 +318,20 @@ public class ReviewPublisher {
   }
 
   /**
-   * Posts the review when there are no new findings: a bare APPROVE, or a COMMENT explaining why.
+   * Posts the review when there are no new findings: a bare APPROVE, or a COMMENT explaining why. A
+   * first-review COMMENT held back solely by CI is skipped only when the PR summary comment
+   * actually posted — its Required CI Checks table already carries the same pending/failed list, so
+   * a second surface with identical copy is pure noise (#334). When the summary post failed or was
+   * skipped, the COMMENT review is the round's only visible signal and always posts.
    */
   private void postNoIssuesReview(
-      String auth, String owner, String repo, int prNumber, String commitSha, ReviewResult result) {
+      String auth,
+      String owner,
+      String repo,
+      int prNumber,
+      String commitSha,
+      ReviewResult result,
+      boolean summaryPosted) {
     if (result.reviewState() == ReviewState.APPROVE) {
       var req =
           new GitHubReviewClient.CreateReviewRequest(
@@ -332,7 +342,8 @@ public class ReviewPublisher {
       createReviewWithFallback(auth, owner, repo, prNumber, req);
       return;
     }
-    if (result.reviewState() == ReviewState.COMMENT
+    if (summaryPosted
+        && result.reviewState() == ReviewState.COMMENT
         && result.isFirstReview()
         && result.unresolvedPreviousCount() == 0
         && !result.truncated()) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -3938,6 +3938,78 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void postReviewShouldStillPostUnresolvedCommentOnFirstReviewWhenSummaryPosted() {
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.COMMENT,
+              true,
+              "",
+              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still")),
+              List.of(new ReviewResult.CiCheck("build", "check-run", "pending", null)),
+              0);
+
+      reviewPublisher.postReview(
+          new ReviewPublisher.PostReviewRequest(
+              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true));
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      assertEquals("COMMENT", captor.getValue().event());
+      assertTrue(captor.getValue().body().contains("remain unresolved"));
+    }
+
+    @Test
+    void postReviewShouldStillPostTruncatedCommentOnFirstReviewWhenSummaryPosted() {
+      var result =
+          new ReviewResult(
+              List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, true, "", List.of(), List.of(), 3);
+
+      reviewPublisher.postReview(
+          new ReviewPublisher.PostReviewRequest(
+              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true));
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      assertEquals("COMMENT", captor.getValue().event());
+      assertTrue(captor.getValue().body().contains("partial review"));
+    }
+
+    @Test
+    void postReviewShouldStillPostRequestChangesWhenSummaryPosted() {
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.REQUEST_CHANGES,
+              true,
+              "",
+              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still")),
+              List.of(),
+              0);
+
+      reviewPublisher.postReview(
+          new ReviewPublisher.PostReviewRequest(
+              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true));
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      assertEquals("REQUEST_CHANGES", captor.getValue().event());
+    }
+
+    @Test
     void postReviewShouldStillPostCiPendingCommentOnFirstReviewWhenSummaryDidNotPost() {
       var result =
           new ReviewResult(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -3929,10 +3929,38 @@ class ReviewOrchestratorTest {
               List.of(new ReviewResult.CiCheck("build", "check-run", "pending", null)),
               0);
 
-      reviewPublisher.postReview("auth", "owner", "repo", 5, "sha", result, resolverFor());
+      reviewPublisher.postReview(
+          new ReviewPublisher.PostReviewRequest(
+              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true));
 
       verify(reviewClient, never())
           .createReview(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+    }
+
+    @Test
+    void postReviewShouldStillPostCiPendingCommentOnFirstReviewWhenSummaryDidNotPost() {
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.COMMENT,
+              true,
+              "",
+              List.of(),
+              List.of(new ReviewResult.CiCheck("build", "check-run", "pending", null)),
+              0);
+
+      reviewPublisher.postReview("auth", "owner", "repo", 5, "sha", result, resolverFor());
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      assertEquals("COMMENT", captor.getValue().event());
+      assertTrue(captor.getValue().body().contains("**build**"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Completes #334. The narrow skip from #175 already suppresses the duplicate CI-pending COMMENT review on first reviews, but it keyed on `isFirstReview` alone — it never verified that the PR summary comment (whose *Required CI Checks Status* table carries the same pending/failed list) was actually created. A first review held back solely by CI whose summary post failed (swallowed by `publishSummaryBestEffort`) or was skipped therefore left **no visible surface at all**.

- `ReviewPublisher.PostReviewRequest.summaryReposted` → `summaryPosted`: the orchestrator now passes `publishSummary`'s real outcome instead of `forceSummary && summaryPosted`.
- `postNoIssuesReview` skips the CI-pending COMMENT only when `summaryPosted` is true — one notification surface per round, never zero.
- The `/summary` re-run skip is unchanged in behavior (`summaryPosted && !isFirstReview` implies `forceSummary`).
- Findings path untouched: COMMENT/REQUEST_CHANGES reviews with findings post exactly as before. No config knob added, so no README change.

## Issue
Fixes #334

## Test plan
- [x] CI-only hold + summary posted → no duplicate COMMENT (`postReviewShouldSkipDuplicateCommentReviewOnFirstReviewWhenOnlyCiPending`, now via `PostReviewRequest(..., summaryPosted=true)`)
- [x] CI-only hold + summary NOT posted → COMMENT still posted (new `postReviewShouldStillPostCiPendingCommentOnFirstReviewWhenSummaryDidNotPost`)
- [x] Findings present → COMMENT review still carries them (existing suite, unchanged)
- [x] `./mvnw verify` passes locally (1590 tests, JaCoCo coverage checks met, Spotless + SpotBugs clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)