### PR TITLE
ci: dual-gate merge policy (static + ThrillhouseBot) (#342)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,8 +1,11 @@
 name: "Dependency Review"
 
+# Static half of the dual-gate merge policy (see CONTRIBUTING.md):
+# blocks PRs that introduce high/critical advisories or disallowed licenses.
+# Complements ThrillhouseBot's LLM review — does not replace it.
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop, "release/**"]
 
 permissions:
   contents: read
@@ -18,6 +21,9 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
+          # High+ blocks merge (required check). Medium/low still appear in the
+          # PR summary for triage; non-applicable holds use osv-scanner.toml /
+          # .trivyignore with a documented reason (CONTRIBUTING dual-gate).
           fail-on-severity: high
           # Permissive/weak-copyleft licenses common in the Java and npm dependency
           # trees; replaces the deprecated deny-licenses option (see

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,8 +22,10 @@ jobs:
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           # High+ blocks merge (required check). Medium/low still appear in the
-          # PR summary for triage; non-applicable holds use osv-scanner.toml /
-          # .trivyignore with a documented reason (CONTRIBUTING dual-gate).
+          # PR summary for triage. Non-applicable advisories for *this* action
+          # need allow-ghsas (inline) or config-file →
+          # .github/dependency-review-config.yml — not osv-scanner.toml /
+          # .trivyignore (those are for Scorecard/OSV and Trivy; see CONTRIBUTING).
           fail-on-severity: high
           # Permissive/weak-copyleft licenses common in the Java and npm dependency
           # trees; replaces the deprecated deny-licenses option (see

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,8 @@ Run the Java verification locally before opening a PR:
 If you changed the dashboard, also run `cd frontend && npm ci && npm run test && npm run build`.
 
 To exercise the UI without a backend, run `cd frontend && npm run dev:mock`.
-CI additionally runs SonarCloud, Trivy, and a Docker build check on pull requests.
+CI additionally runs Dependency Review (required), SonarCloud, Trivy, and a Docker
+build check on pull requests — see **Dual-gate merge policy** below.
 To build a disposable test image for a branch or PR (JVM or native, without
 touching `latest`), use the **Docker test image** workflow in Actions
 (`.github/workflows/docker-test-image.yml`).
@@ -46,6 +47,32 @@ The bar, enforced by CI:
 - **Coverage doesn't drop** — JaCoCo, Codecov patch coverage, and the SonarCloud quality gate all run on every PR.
 - **SpotBugs clean** at `effort=Max`/`threshold=Low`. If you hit a false positive, prefer restructuring; document any exclusion in `config/spotbugs-exclude.xml` with a justification comment.
 - **No new Sonar issues** — the quality gate requires an A reliability/security rating on new code.
+
+## Dual-gate merge policy
+
+ThrillhouseBot's LLM review and the repo's static CI gates are **complementary**, not substitutes. Merge only when **both** are green (or explicitly waived by a maintainer with a written reason on the PR).
+
+| Gate | What it catches | Required on this repo |
+|------|-----------------|------------------------|
+| **Static** | Dependency CVEs/license regressions ([Dependency Review](https://github.com/devops-thiago/ThrillhouseBot/blob/main/.github/workflows/dependency-review.yml)), filesystem CVEs (Trivy), format/tests/frontend, SpotBugs/Sonar/CodeQL | Yes — `format`, `test`, `frontend`, `trivy`, and `dependency-review` are required status checks on `main`/`develop` |
+| **ThrillhouseBot** | Diff narrative, incomplete fixes, framework-context issues static tools miss | Soft gate — wait for the **ThrillhouseBot Review** check / posted review when the App is installed; do not merge solely because CI is green if the bot flagged open threads |
+
+Optional third signal: Cursor Bugbot (or similar) may run on PRs. It is **not** a merge requirement here — useful when present, never a replacement for the two gates above.
+
+This policy does **not** fold linters into the LLM prompt ([#34](https://github.com/devops-thiago/ThrillhouseBot/issues/34)); that work stays separate. The static gate is the CI safety net for supply-chain and compile-time classes of bug the bot can miss.
+
+### When the gates disagree
+
+Maintainers triage; do not "average" the signals away.
+
+| Static | ThrillhouseBot | What to do |
+|--------|----------------|------------|
+| Red | Green / quiet | **Fix or formally suppress the static finding.** LLM silence is not evidence the CVE is safe. Prefer a real version bump; if the advisory does not apply to this codebase, document the hold (e.g. `osv-scanner.toml` / `.trivyignore` with a full reason — see the Jackson GHSA pattern in [#308](https://github.com/devops-thiago/ThrillhouseBot/pull/308)). |
+| Green | Red / open threads | **Address or refute the bot findings** in the PR discussion before merge. Static green does not clear logic/copy/incomplete-fix issues. |
+| Red | Red | Clear the **static** gate first (often blocks merge already), then resolve bot threads. |
+| Same area, conflicting severity | — | Prefer the **static** tool for dependency/CVE/license facts; prefer the **bot** for intent, call-site context, and "did the PR actually finish the fix?" Prefer neither blindly — leave a short maintainer note on the PR. |
+
+Waivers (rare): only a maintainer may merge with a red soft gate or a documented static suppression, and the PR must record who waived what and why.
 
 ## Commit messages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Maintainers triage; do not "average" the signals away.
 
 | Static | ThrillhouseBot | What to do |
 |--------|----------------|------------|
-| Red | Green / quiet | **Fix or formally suppress the static finding.** LLM silence is not evidence the CVE is safe. Prefer a real version bump; if the advisory does not apply to this codebase, document the hold (e.g. `osv-scanner.toml` / `.trivyignore` with a full reason — see the Jackson GHSA pattern in [#308](https://github.com/devops-thiago/ThrillhouseBot/pull/308)). |
+| Red | Green / quiet | **Fix or formally suppress the static finding.** LLM silence is not evidence the CVE is safe. Prefer a real version bump; if the advisory does not apply to this codebase, document the hold with the file the failing tool actually reads — Dependency Review: `allow-ghsas` or `.github/dependency-review-config.yml`; Trivy: `.trivyignore`; OpenSSF Scorecard / osv-scanner: `osv-scanner.toml` (Jackson GHSA pattern in [#308](https://github.com/devops-thiago/ThrillhouseBot/pull/308)). |
 | Green | Red / open threads | **Address or refute the bot findings** in the PR discussion before merge. Static green does not clear logic/copy/incomplete-fix issues. |
 | Red | Red | Clear the **static** gate first (often blocks merge already), then resolve bot threads. |
 | Same area, conflicting severity | — | Prefer the **static** tool for dependency/CVE/license facts; prefer the **bot** for intent, call-site context, and "did the PR actually finish the fix?" Prefer neither blindly — leave a short maintainer note on the PR. |


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [x] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [x] 🔒 Security
- [ ] 📦 Dependency update
- [x] 🏗️ CI/CD

## Description

Closes the v0.3.1 dual-gate gap from #342: ThrillhouseBot's LLM review and static dependency CI are complementary, not substitutes.

### Changes
- **CONTRIBUTING.md** — documents the dual-gate merge policy, optional Bugbot as a non-required third signal, and maintainer triage when the gates disagree (including the Jackson GHSA hold pattern from #308).
- **dependency-review.yml** — runs on `main` / `develop` / `release/**` (aligned with CI), with comments tying the job to the dual-gate policy.
- **Repo ruleset (already applied)** — `dependency-review` added to required status checks on `main-protection` alongside `format`, `test`, `frontend`, `trivy`.

Does **not** duplicate ThrillhouseBot's LLM pass or implement linters-in-prompt (#34).

## Related Issues

Fixes #342

Related: #34 (linters in LLM context — separate), #308 (Jackson GHSA hold pattern), #113, #318

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

- Confirmed `main-protection` ruleset now requires `dependency-review`.
- Reviewed workflow YAML against existing SHA-pinned action versions.
- Docs-only / workflow-metadata change — no Java/frontend unit tests required.
- CI on this PR: `dependency-review`, `format`, `test`, `frontend`, `trivy`, Sonar, CodeQL, Codecov all green.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A — docs + workflow metadata only. Dependency Review summary on this PR: no vulnerabilities or license issues found.

## Additional Notes

- ThrillhouseBot remains a soft gate (check can be NEUTRAL/skipped); static `dependency-review` is now merge-blocking.
- Ruleset change is live on the repo already; merging this PR lands the docs + workflow branch-trigger alignment.