### PR TITLE
feat(review): configurable blocking strictness (#323)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,12 @@ AI_TIMEOUT=300s
 # hedging guard still runs, and verifier errors always fail open.
 #REVIEW_VERIFIER_ENABLED=true
 
+# When findings block the merge (REQUEST_CHANGES). Default balanced matches v0.x:
+# only CRITICAL/HIGH risk with HIGH confidence. Use strict for security-heavy
+# repos (any CRITICAL/HIGH blocks, even after the verifier demotes confidence).
+# Use lenient to block only HIGH-confidence CRITICAL findings.
+#REVIEW_BLOCKING_STRICTNESS=balanced
+
 # Dashboard OAuth
 GITHUB_CLIENT_ID=your_oauth_client_id
 GITHUB_CLIENT_SECRET=your_oauth_client_secret

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ will change per provider:
 | `WEBHOOK_BASE_BRANCHES` | Comma-separated globs; only auto-review PRs whose base branch matches one (e.g. `main,release/*`). Globs are gitignore-style: `*` does **not** cross `/`, so use `**` to span slashes (`**` alone matches every branch) | _(empty — all branches)_ |
 | `WEBHOOK_IGNORED_BASE_BRANCHES` | Comma-separated globs; skip auto-review of PRs whose base branch matches one (wins over allowlist; same `*`/`**` rule — match nested branches with `**`, e.g. `dependabot/**`) | _(empty)_ |
 | `REVIEW_VERIFIER_ENABLED` | Second, skeptical AI pass that re-checks each finding against the diff before posting, dropping or downgrading what it can't confirm (see [AI call budget](#ai-call-budget)); fails open — a verifier error keeps the original findings | `true` |
+| `REVIEW_BLOCKING_STRICTNESS` | When findings escalate to `REQUEST_CHANGES`: `balanced` (CRITICAL/HIGH + HIGH confidence), `strict` (any CRITICAL/HIGH), or `lenient` (CRITICAL + HIGH confidence only). See [Blocking strictness](#blocking-strictness) | `balanced` |
 | `REVIEW_CONVERSATIONAL_REPLIES_ENABLED` | Answer `@thrillhousebot` mentions in PR threads (including finding replies) with an AI reply | `true` |
 | `REVIEW_ADD_DOCS_ENABLED` | Allow the on-demand `/add-docs` command to generate docstrings as committable suggestions | `true` |
 | `REVIEW_DIAGRAM_ENABLED` | Include an opt-in Mermaid control-flow diagram in the PR summary | `false` |
@@ -277,6 +278,32 @@ per-batch verification calls + one summary call. Set
 cost of more false positives; a deterministic hedging guard still runs, and a
 verifier failure never blocks the review (it fails open, keeping the original
 findings).
+
+### Blocking strictness
+
+By default (`REVIEW_BLOCKING_STRICTNESS=balanced`), only **CRITICAL** or **HIGH**
+risk findings that the model reports at **HIGH** confidence escalate the PR
+review to `REQUEST_CHANGES` (and fail the check run). Medium/low-confidence
+severity findings still post as comments with a neutral check.
+
+| Mode | Blocks merge when |
+|---|---|
+| `balanced` (default) | CRITICAL or HIGH risk **and** HIGH confidence |
+| `strict` | CRITICAL or HIGH risk, **any** confidence |
+| `lenient` | CRITICAL risk **and** HIGH confidence only |
+
+**Security-team recommendation:** use `strict` so a CRITICAL/HIGH finding cannot
+slip through as a comment just because confidence was demoted. Be aware that
+under `strict`, the finding verifier's confidence demotions (hedged claims →
+medium/low) no longer prevent a merge block — only risk reduction or dropping
+the finding does. Stay on `balanced` if you want verifier demotions to keep
+speculative severity findings non-blocking.
+
+This knob controls the **review verdict** only. Where findings are posted
+(inline thread vs summary) is separate confidence gating tracked in
+[#105](https://github.com/devops-thiago/ThrillhouseBot/issues/105); when that
+lands, low-confidence findings can move out of the inline stream without
+changing these blocking rules.
 
 The app validates configuration at startup and **fails fast** if a required value
 (`GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET`, `AI_API_KEY`) is missing or — for

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.config;
 
+import dev.thiagogonzaga.thrillhousebot.review.BlockingStrictness;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -87,6 +88,7 @@ public class StartupConfigValidator {
         "thrillhousebot.github.webhook-secret");
     requirePresent(problems, aiApiKey, "AI_API_KEY", "quarkus.langchain4j.openai.api-key");
     validateReviewBudget(problems, config.review());
+    validateBlockingStrictness(problems, config.review());
     validateModelSettings(problems, config.ai().models());
     validateEffectiveBudget(problems);
     validateReasoningEffort(problems, config.ai().reasoning());
@@ -101,6 +103,22 @@ public class StartupConfigValidator {
     log.info(
         "Configuration validated: GitHub App id, private key, webhook secret, and AI API key are"
             + " present.");
+  }
+
+  /**
+   * Rejects an unrecognized {@code REVIEW_BLOCKING_STRICTNESS} at boot — the same fail-fast pattern
+   * as {@link #validateReasoningEffort} — so a typo never silently falls back to balanced.
+   */
+  private static void validateBlockingStrictness(
+      List<String> problems, ThrillhouseConfig.ReviewConfig review) {
+    var raw = review.blockingStrictness();
+    if (BlockingStrictness.fromString(raw).isEmpty()) {
+      problems.add(
+          "REVIEW_BLOCKING_STRICTNESS must be one of "
+              + String.join(", ", BlockingStrictness.ALLOWED)
+              + " (thrillhousebot.review.blocking-strictness): "
+              + raw);
+    }
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -205,6 +205,16 @@ public interface ThrillhouseConfig {
     boolean verifierEnabled();
 
     /**
+     * How severely a finding must score before the review escalates to {@code REQUEST_CHANGES}. One
+     * of {@code balanced} (default — CRITICAL/HIGH + HIGH confidence), {@code strict} (any
+     * CRITICAL/HIGH regardless of confidence), or {@code lenient} (CRITICAL + HIGH confidence
+     * only). Case-insensitive; validated at boot by {@link StartupConfigValidator}.
+     */
+    @WithDefault("balanced")
+    @WithName("blocking-strictness")
+    String blockingStrictness();
+
+    /**
      * Whether the bot answers maintainer replies to its review findings and {@code @thrillhousebot}
      * mentions in PR threads with a contextual AI reply. Each reply spends the operator's AI
      * budget, so this is the operator's kill switch; replies are additionally restricted to the

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/BlockingStrictness.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/BlockingStrictness.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * How severely a finding must score before {@link ReviewState#fromFindings} escalates to {@link
+ * ReviewState#REQUEST_CHANGES}. Operators pick a mode for their risk appetite; the finding verifier
+ * still demotes hedged claims first — this only interprets the post-verifier risk/confidence pair.
+ */
+public enum BlockingStrictness {
+  /**
+   * Default: only {@link RiskLevel#CRITICAL}/{@link RiskLevel#HIGH} findings the model is {@link
+   * Confidence#HIGH}ly confident in block the merge.
+   */
+  BALANCED,
+
+  /**
+   * Any {@link RiskLevel#CRITICAL}/{@link RiskLevel#HIGH} finding blocks, regardless of confidence.
+   * Prefer for security-heavy repos; note that verifier demotions to medium/low confidence will
+   * still block under this mode.
+   */
+  STRICT,
+
+  /** Only {@link RiskLevel#CRITICAL} findings with {@link Confidence#HIGH} block the merge. */
+  LENIENT;
+
+  /** Values accepted by {@link #fromString(String)}, in ascending strictness order. */
+  public static final List<String> ALLOWED = List.of("lenient", "balanced", "strict");
+
+  /** Wire / config value normalized to lowercase. */
+  public static String normalize(String value) {
+    return value.strip().toLowerCase(Locale.ROOT);
+  }
+
+  /**
+   * Parses a config string into a mode. Returns empty when the value is not one of {@link #ALLOWED}
+   * (callers reject at boot rather than silently falling back).
+   */
+  public static Optional<BlockingStrictness> fromString(String value) {
+    if (value == null || value.isBlank()) {
+      return Optional.empty();
+    }
+    return switch (normalize(value)) {
+      case "balanced" -> Optional.of(BALANCED);
+      case "strict" -> Optional.of(STRICT);
+      case "lenient" -> Optional.of(LENIENT);
+      default -> Optional.empty();
+    };
+  }
+
+  /** Whether this finding alone is enough to escalate the review to {@code REQUEST_CHANGES}. */
+  public boolean isBlocking(Finding finding) {
+    if (finding == null) {
+      return false;
+    }
+    return switch (this) {
+      case BALANCED -> isCriticalOrHigh(finding.risk()) && finding.confidence() == Confidence.HIGH;
+      case STRICT -> isCriticalOrHigh(finding.risk());
+      case LENIENT ->
+          finding.risk() == RiskLevel.CRITICAL && finding.confidence() == Confidence.HIGH;
+    };
+  }
+
+  private static boolean isCriticalOrHigh(RiskLevel risk) {
+    return risk == RiskLevel.CRITICAL || risk == RiskLevel.HIGH;
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewState.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewState.java
@@ -24,21 +24,26 @@ public enum ReviewState {
   COMMENT; // Medium or Low only → neutral
 
   /**
-   * Derives the review event from the full finding list: only critical/high findings the model is
-   * highly confident in block the merge — lower-confidence ones still surface as comments, so a
-   * speculative claim about framework behavior can never fail the check run on its own.
+   * Derives the review event under {@link BlockingStrictness#BALANCED}: only critical/high findings
+   * the model is highly confident in block the merge. Prefer {@link #fromFindings(List,
+   * BlockingStrictness)} when the operator-configured mode is available.
    */
   public static ReviewState fromFindings(List<Finding> findings) {
+    return fromFindings(findings, BlockingStrictness.BALANCED);
+  }
+
+  /**
+   * Derives the review event from the full finding list under the given blocking mode. Findings
+   * that do not meet the mode's severity/confidence bar still surface as comments, so speculative
+   * claims never fail the check run unless the operator opted into {@link
+   * BlockingStrictness#STRICT}.
+   */
+  public static ReviewState fromFindings(List<Finding> findings, BlockingStrictness strictness) {
     if (findings == null || findings.isEmpty()) {
       return APPROVE;
     }
-    var blocking =
-        findings.stream()
-            .anyMatch(
-                f ->
-                    (f.risk() == RiskLevel.CRITICAL || f.risk() == RiskLevel.HIGH)
-                        && f.confidence() == Confidence.HIGH);
-    return blocking ? REQUEST_CHANGES : COMMENT;
+    var mode = strictness == null ? BlockingStrictness.BALANCED : strictness;
+    return findings.stream().anyMatch(mode::isBlocking) ? REQUEST_CHANGES : COMMENT;
   }
 
   public static ReviewState fromHighestRisk(RiskLevel highestRisk) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -16,6 +16,7 @@
 package dev.thiagogonzaga.thrillhousebot.review;
 
 import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -36,15 +37,33 @@ public class VerdictBuilder {
   private final PrSummaryGenerator summaryGenerator;
   private final FollowUpAnalyzer followUpAnalyzer;
   private final BotIdentity botIdentity;
+  private final BlockingStrictness blockingStrictness;
 
   @Inject
   public VerdictBuilder(
       PrSummaryGenerator summaryGenerator,
       FollowUpAnalyzer followUpAnalyzer,
-      BotIdentity botIdentity) {
+      BotIdentity botIdentity,
+      ThrillhouseConfig config) {
+    this(
+        summaryGenerator,
+        followUpAnalyzer,
+        botIdentity,
+        BlockingStrictness.fromString(config.review().blockingStrictness())
+            .orElse(BlockingStrictness.BALANCED));
+  }
+
+  /** Visible for tests: pins the blocking mode without booting the CDI container. */
+  VerdictBuilder(
+      PrSummaryGenerator summaryGenerator,
+      FollowUpAnalyzer followUpAnalyzer,
+      BotIdentity botIdentity,
+      BlockingStrictness blockingStrictness) {
     this.summaryGenerator = summaryGenerator;
     this.followUpAnalyzer = followUpAnalyzer;
     this.botIdentity = botIdentity;
+    this.blockingStrictness =
+        blockingStrictness == null ? BlockingStrictness.BALANCED : blockingStrictness;
   }
 
   /**
@@ -239,7 +258,7 @@ public class VerdictBuilder {
 
     var outstanding = new ArrayList<Finding>(tally.findings());
     outstanding.addAll(unresolvedPrevious);
-    ReviewState state = ReviewState.fromFindings(outstanding);
+    ReviewState state = ReviewState.fromFindings(outstanding, blockingStrictness);
     // Backstop statuses reach the gate but never `outstanding`, keeping the hold downgrade-only
     // (APPROVE → COMMENT, never REQUEST_CHANGES).
     var previousStatuses =

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -130,6 +130,9 @@ thrillhousebot.review.max-diff-lines=${REVIEW_MAX_DIFF_LINES:5000}
 thrillhousebot.review.instructions-file=.github/thrillhousebot.md
 # Second-pass AI audit that drops/downgrades unverifiable findings before they are posted
 thrillhousebot.review.verifier-enabled=${REVIEW_VERIFIER_ENABLED:true}
+# When a finding blocks the merge (REQUEST_CHANGES): balanced (default) = CRITICAL/HIGH + HIGH
+# confidence; strict = any CRITICAL/HIGH; lenient = CRITICAL + HIGH confidence only.
+thrillhousebot.review.blocking-strictness=${REVIEW_BLOCKING_STRICTNESS:balanced}
 # Answer maintainer replies to findings and @thrillhousebot mentions in PR threads with an AI reply
 thrillhousebot.review.conversational-replies-enabled=${REVIEW_CONVERSATIONAL_REPLIES_ENABLED:true}
 # Allow the on-demand /add-docs command to generate docstrings as committable suggestions

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -72,6 +73,7 @@ class StartupConfigValidatorTest {
     private double tokenSafetyMargin = 0.9;
     private boolean reasoningEnabled = false;
     private String reasoningEffort = "low";
+    private String blockingStrictness = "balanced";
     private String modelName = "deepseek-chat";
     private final Map<String, ThrillhouseConfig.AiPricingConfig.ModelSettings> models =
         new HashMap<>();
@@ -136,6 +138,11 @@ class StartupConfigValidatorTest {
       return this;
     }
 
+    ConfigBuilder blockingStrictness(String v) {
+      this.blockingStrictness = v;
+      return this;
+    }
+
     ConfigBuilder model(String name, ThrillhouseConfig.AiPricingConfig.ModelSettings settings) {
       this.models.put(name, settings);
       return this;
@@ -164,6 +171,7 @@ class StartupConfigValidatorTest {
       lenient().when(review.outputBufferTokens()).thenReturn(outputBufferTokens);
       lenient().when(review.maxAiCalls()).thenReturn(maxAiCalls);
       lenient().when(review.tokenSafetyMargin()).thenReturn(tokenSafetyMargin);
+      lenient().when(review.blockingStrictness()).thenReturn(blockingStrictness);
       lenient().when(ai.models()).thenReturn(models);
       return new StartupConfigValidator(
           config, aiApiKey, new ActiveModelSettings(config, modelName));
@@ -436,6 +444,22 @@ class StartupConfigValidatorTest {
     assertTrue(
         ex.getMessage().contains("AI_REASONING_EFFORT must be one of none, low, medium, high"),
         ex.getMessage());
+  }
+
+  @Test
+  void failsFastWhenBlockingStrictnessIsInvalid() {
+    var ex = assertFailsValidation(new ConfigBuilder().blockingStrictness("aggressive").build());
+    assertTrue(
+        ex.getMessage()
+            .contains("REVIEW_BLOCKING_STRICTNESS must be one of lenient, balanced, strict"),
+        ex.getMessage());
+  }
+
+  @Test
+  void acceptsEveryBlockingStrictnessCaseInsensitivelyWithWhitespace() {
+    for (var mode : List.of("balanced", " STRICT ", "Lenient")) {
+      new ConfigBuilder().blockingStrictness(mode).build().validate();
+    }
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -129,7 +129,8 @@ class ReviewOrchestratorTest {
             labeler,
             config,
             BOT_ID);
-    verdictBuilder = new VerdictBuilder(summaryGenerator, followUpAnalyzer, BOT_ID);
+    verdictBuilder =
+        new VerdictBuilder(summaryGenerator, followUpAnalyzer, BOT_ID, BlockingStrictness.BALANCED);
     findingPipeline =
         new FindingPipeline(
             aiReviewService,
@@ -288,7 +289,9 @@ class ReviewOrchestratorTest {
 
     @Test
     void truncatedCleanSummaryBodyDoesNotCelebrateEndToEnd() {
-      var realVerdict = new VerdictBuilder(new PrSummaryGenerator(false), followUpAnalyzer, BOT_ID);
+      var realVerdict =
+          new VerdictBuilder(
+              new PrSummaryGenerator(false), followUpAnalyzer, BOT_ID, BlockingStrictness.BALANCED);
       var aiResponse = new ReviewResponse(List.of(), List.of(), null);
 
       var result =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewStateTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewStateTest.java
@@ -15,11 +15,21 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class ReviewStateTest {
+
+  private static Finding finding(RiskLevel risk, Confidence confidence) {
+    return new Finding(risk, confidence, "f", 1, "t", "d", null, null);
+  }
 
   @Test
   void fromHighestRiskShouldApproveForNull() {
@@ -56,39 +66,104 @@ class ReviewStateTest {
   @Test
   void fromFindingsShouldApproveWhenEmptyOrNull() {
     assertEquals(ReviewState.APPROVE, ReviewState.fromFindings(null));
-    assertEquals(ReviewState.APPROVE, ReviewState.fromFindings(java.util.List.of()));
+    assertEquals(ReviewState.APPROVE, ReviewState.fromFindings(List.of()));
+    assertEquals(
+        ReviewState.APPROVE, ReviewState.fromFindings(List.of(), BlockingStrictness.STRICT));
   }
 
   @Test
-  void fromFindingsShouldRequestChangesForHighConfidenceCritical() {
-    var finding = new Finding(RiskLevel.CRITICAL, Confidence.HIGH, "f", 1, "t", "d", null, null);
-    assertEquals(ReviewState.REQUEST_CHANGES, ReviewState.fromFindings(java.util.List.of(finding)));
+  void fromFindingsDefaultOverloadUsesBalanced() {
+    var mediumConfidenceCritical = finding(RiskLevel.CRITICAL, Confidence.MEDIUM);
+    assertEquals(ReviewState.COMMENT, ReviewState.fromFindings(List.of(mediumConfidenceCritical)));
+    assertEquals(
+        ReviewState.COMMENT,
+        ReviewState.fromFindings(List.of(mediumConfidenceCritical), BlockingStrictness.BALANCED));
   }
 
-  @Test
-  void fromFindingsShouldRequestChangesForHighConfidenceHigh() {
-    var finding = new Finding(RiskLevel.HIGH, Confidence.HIGH, "f", 1, "t", "d", null, null);
-    assertEquals(ReviewState.REQUEST_CHANGES, ReviewState.fromFindings(java.util.List.of(finding)));
-  }
-
-  @Test
-  void fromFindingsShouldOnlyCommentForLowConfidenceCritical() {
-    var finding = new Finding(RiskLevel.CRITICAL, Confidence.MEDIUM, "f", 1, "t", "d", null, null);
-    assertEquals(ReviewState.COMMENT, ReviewState.fromFindings(java.util.List.of(finding)));
-  }
-
-  @Test
-  void fromFindingsShouldCommentForHighConfidenceMedium() {
-    var finding = new Finding(RiskLevel.MEDIUM, Confidence.HIGH, "f", 1, "t", "d", null, null);
-    assertEquals(ReviewState.COMMENT, ReviewState.fromFindings(java.util.List.of(finding)));
+  @ParameterizedTest
+  @CsvSource({
+    // mode, risk, confidence, expected REQUEST_CHANGES?
+    "BALANCED, CRITICAL, HIGH, true",
+    "BALANCED, HIGH, HIGH, true",
+    "BALANCED, CRITICAL, MEDIUM, false",
+    "BALANCED, HIGH, LOW, false",
+    "BALANCED, MEDIUM, HIGH, false",
+    "BALANCED, LOW, HIGH, false",
+    "STRICT, CRITICAL, HIGH, true",
+    "STRICT, HIGH, HIGH, true",
+    "STRICT, CRITICAL, MEDIUM, true",
+    "STRICT, HIGH, LOW, true",
+    "STRICT, MEDIUM, HIGH, false",
+    "STRICT, LOW, LOW, false",
+    "LENIENT, CRITICAL, HIGH, true",
+    "LENIENT, CRITICAL, MEDIUM, false",
+    "LENIENT, HIGH, HIGH, false",
+    "LENIENT, HIGH, LOW, false",
+    "LENIENT, MEDIUM, HIGH, false",
+  })
+  void fromFindingsHonorsModeWithMixedConfidenceAndRisk(
+      BlockingStrictness mode, RiskLevel risk, Confidence confidence, boolean blocks) {
+    var state = ReviewState.fromFindings(List.of(finding(risk, confidence)), mode);
+    assertEquals(blocks ? ReviewState.REQUEST_CHANGES : ReviewState.COMMENT, state);
   }
 
   @Test
   void fromFindingsShouldBlockWhenAnyFindingIsBlockingAmongNonBlocking() {
-    var speculative = new Finding(RiskLevel.CRITICAL, Confidence.LOW, "f", 1, "t", "d", null, null);
-    var verified = new Finding(RiskLevel.HIGH, Confidence.HIGH, "g", 2, "t", "d", null, null);
+    var speculative = finding(RiskLevel.CRITICAL, Confidence.LOW);
+    var verified = finding(RiskLevel.HIGH, Confidence.HIGH);
     assertEquals(
         ReviewState.REQUEST_CHANGES,
-        ReviewState.fromFindings(java.util.List.of(speculative, verified)));
+        ReviewState.fromFindings(List.of(speculative, verified), BlockingStrictness.BALANCED));
+  }
+
+  @Test
+  void strictModeBlocksLowConfidenceCriticalThatBalancedWouldComment() {
+    var hedged = finding(RiskLevel.CRITICAL, Confidence.LOW);
+    assertEquals(
+        ReviewState.COMMENT,
+        ReviewState.fromFindings(List.of(hedged), BlockingStrictness.BALANCED));
+    assertEquals(
+        ReviewState.REQUEST_CHANGES,
+        ReviewState.fromFindings(List.of(hedged), BlockingStrictness.STRICT));
+  }
+
+  @Test
+  void lenientModeCommentsOnHighConfidenceHighThatBalancedWouldBlock() {
+    var highRisk = finding(RiskLevel.HIGH, Confidence.HIGH);
+    assertEquals(
+        ReviewState.REQUEST_CHANGES,
+        ReviewState.fromFindings(List.of(highRisk), BlockingStrictness.BALANCED));
+    assertEquals(
+        ReviewState.COMMENT,
+        ReviewState.fromFindings(List.of(highRisk), BlockingStrictness.LENIENT));
+  }
+
+  @Test
+  void nullStrictnessFallsBackToBalanced() {
+    var hedged = finding(RiskLevel.CRITICAL, Confidence.MEDIUM);
+    assertEquals(ReviewState.COMMENT, ReviewState.fromFindings(List.of(hedged), null));
+  }
+
+  @ParameterizedTest
+  @EnumSource(BlockingStrictness.class)
+  void isBlockingNeverTrueForNullFinding(BlockingStrictness mode) {
+    assertFalse(mode.isBlocking(null));
+  }
+
+  @Test
+  void fromStringParsesAllowedModesCaseInsensitively() {
+    assertEquals(
+        BlockingStrictness.BALANCED, BlockingStrictness.fromString("Balanced").orElseThrow());
+    assertEquals(
+        BlockingStrictness.STRICT, BlockingStrictness.fromString(" STRICT ").orElseThrow());
+    assertEquals(
+        BlockingStrictness.LENIENT, BlockingStrictness.fromString("lenient").orElseThrow());
+  }
+
+  @Test
+  void fromStringRejectsUnknownAndBlank() {
+    assertTrue(BlockingStrictness.fromString("aggressive").isEmpty());
+    assertTrue(BlockingStrictness.fromString("").isEmpty());
+    assertTrue(BlockingStrictness.fromString(null).isEmpty());
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -45,7 +45,10 @@ class VerdictBuilderTest {
 
   private final VerdictBuilder builder =
       new VerdictBuilder(
-          summaryGenerator, followUpAnalyzer, BotIdentity.from(List.of("thrillhousebot[bot]")));
+          summaryGenerator,
+          followUpAnalyzer,
+          BotIdentity.from(List.of("thrillhousebot[bot]")),
+          BlockingStrictness.BALANCED);
 
   {
     lenient().when(followUpAnalyzer.unresolvedFindings(any(), any())).thenReturn(List.of());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -23,8 +23,10 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient.FileDiff;
 import dev.thiagogonzaga.thrillhousebot.github.InstructionsResolver;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
@@ -166,5 +168,81 @@ class VerdictBuilderTest {
 
     assertEquals(2, result.omittedFiles());
     assertTrue(result.truncated());
+  }
+
+  @Test
+  void configConstructorHonorsStrictBlockingMode() {
+    var config = mock(ThrillhouseConfig.class);
+    var review = mock(ThrillhouseConfig.ReviewConfig.class);
+    when(config.review()).thenReturn(review);
+    when(review.blockingStrictness()).thenReturn("strict");
+
+    var strictBuilder =
+        new VerdictBuilder(
+            summaryGenerator,
+            followUpAnalyzer,
+            BotIdentity.from(List.of("thrillhousebot[bot]")),
+            config);
+    var hedged =
+        new ReviewResponse.Finding("critical", "low", "a.java", 1, "title", "desc", null, null);
+    var response = new ReviewResponse(List.of(hedged), List.of(), null);
+
+    var result =
+        strictBuilder.build(
+            contextWithLineCapOmissions(0),
+            response,
+            CI_CLEAR,
+            new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), false));
+
+    assertEquals(ReviewState.REQUEST_CHANGES, result.reviewState());
+  }
+
+  @Test
+  void configConstructorFallsBackToBalancedOnUnrecognizedMode() {
+    var config = mock(ThrillhouseConfig.class);
+    var review = mock(ThrillhouseConfig.ReviewConfig.class);
+    when(config.review()).thenReturn(review);
+    when(review.blockingStrictness()).thenReturn("aggressive");
+
+    var fallbackBuilder =
+        new VerdictBuilder(
+            summaryGenerator,
+            followUpAnalyzer,
+            BotIdentity.from(List.of("thrillhousebot[bot]")),
+            config);
+    var hedged =
+        new ReviewResponse.Finding("critical", "medium", "a.java", 1, "title", "desc", null, null);
+    var response = new ReviewResponse(List.of(hedged), List.of(), null);
+
+    var result =
+        fallbackBuilder.build(
+            contextWithLineCapOmissions(0),
+            response,
+            CI_CLEAR,
+            new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), false));
+
+    assertEquals(ReviewState.COMMENT, result.reviewState());
+  }
+
+  @Test
+  void nullStrictnessInTestConstructorFallsBackToBalanced() {
+    var nullModeBuilder =
+        new VerdictBuilder(
+            summaryGenerator,
+            followUpAnalyzer,
+            BotIdentity.from(List.of("thrillhousebot[bot]")),
+            (BlockingStrictness) null);
+    var hedged =
+        new ReviewResponse.Finding("critical", "low", "a.java", 1, "title", "desc", null, null);
+    var response = new ReviewResponse(List.of(hedged), List.of(), null);
+
+    var result =
+        nullModeBuilder.build(
+            contextWithLineCapOmissions(0),
+            response,
+            CI_CLEAR,
+            new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), false));
+
+    assertEquals(ReviewState.COMMENT, result.reviewState());
   }
 }


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [x] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Adds `REVIEW_BLOCKING_STRICTNESS` (`thrillhousebot.review.blocking-strictness`) so operators can choose when findings escalate to `REQUEST_CHANGES`:

| Mode | Blocks when |
|---|---|
| `balanced` (default) | CRITICAL/HIGH + HIGH confidence (current v0.x behavior) |
| `strict` | any CRITICAL/HIGH (security-team recommendation) |
| `lenient` | CRITICAL + HIGH confidence only |

Startup validation rejects unknown values (same fail-fast pattern as #27 / reasoning effort). `ReviewState.fromFindings` and `VerdictBuilder` honor the configured mode. README documents the default, security recommendation, verifier interaction, and that inline placement gating remains separate (#105).

## Related Issues

Fixes #323

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- Parameterized `ReviewStateTest` fixtures across all three modes with mixed risk/confidence
- Startup validation tests for invalid / case-insensitive modes
- `VerdictBuilder` config-constructor coverage for strict mode and unrecognized-mode fallback
- `./mvnw spotless:check` and `./mvnw verify` pass locally

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A — backend config / verdict logic only.

## Additional Notes

#105 (inline vs summary placement) is intentionally not implemented here — this PR only documents the interaction. Verifier demotions still run first; under `strict`, demoted confidence no longer prevents a merge block by design (documented for operators who rely on demotion noise reduction).