### PR TITLE
feat(review): configurable CI gating strictness for APPROVE (#322)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ GITHUB_WEBHOOK_SECRET=your_webhook_secret
 # Optional: minimum interval between automatic reviews of the same PR (pushes within the window are
 # skipped; a manual /review always bypasses; unset or 0 = review every push — use /pause to silence)
 #AUTO_REVIEW_MIN_INTERVAL=1h
+# Optional: CI gating for APPROVE — strict (default) holds approval while required CI is pending,
+# failing, or unreadable; warn allows APPROVE but notes CI uncertainty in the summary/check; off
+# skips CI entirely (findings-only). Softer modes trade safety for flaky-CI / incomplete context setups.
+#REVIEW_CI_GATING=strict
 # Optional: automatic review trigger filters. Defaults review every PR; a manual /review always runs.
 #WEBHOOK_SKIP_DRAFTS=true
 #WEBHOOK_REQUIRED_LABELS=ai-review

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ will change per provider:
 | `MANUAL_TRIGGER_AUTH_TIMEOUT` | Upper bound on the manual-trigger write-access check on the webhook ACK thread; fails closed (denies) if GitHub is slower | `5s` |
 | `ACK_REACTION_TIMEOUT` | Upper bound on the 👀 command-ack reaction on the webhook ACK thread; the wait is abandoned (reaction may land late) if GitHub is slower | `3s` |
 | `AUTO_REVIEW_MIN_INTERVAL` | Minimum interval between automatic reviews of the same PR — pushes within the window are skipped silently, even on a new head SHA (in-memory, per replica). A manual `/review` always bypasses; unset or `0` reviews every push | `0` (disabled) |
+| `REVIEW_CI_GATING` | How strictly CI status factors into APPROVE: `strict` holds approval while required CI is pending, failing, or unreadable (fail-closed, safest); `warn` allows APPROVE but notes CI uncertainty in the summary/check; `off` skips CI entirely (findings-only). Prefer `strict` unless flaky CI or incomplete required-context resolution makes soft modes necessary | `strict` |
 | `WEBHOOK_SKIP_DRAFTS` | Skip auto-review while a PR is a draft (reviewed once marked ready / on later pushes) | `false` |
 | `WEBHOOK_REQUIRED_LABELS` | Comma-separated labels; only auto-review PRs carrying at least one (case-insensitive) | _(empty — no gate)_ |
 | `WEBHOOK_EXCLUDED_LABELS` | Comma-separated labels; skip auto-review of PRs carrying any (wins over required) | _(empty)_ |

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -87,6 +87,7 @@ public class StartupConfigValidator {
         "thrillhousebot.github.webhook-secret");
     requirePresent(problems, aiApiKey, "AI_API_KEY", "quarkus.langchain4j.openai.api-key");
     validateReviewBudget(problems, config.review());
+    validateCiGating(problems, config.review());
     validateModelSettings(problems, config.ai().models());
     validateEffectiveBudget(problems);
     validateReasoningEffort(problems, config.ai().reasoning());
@@ -97,6 +98,7 @@ public class StartupConfigValidator {
 
     logDashboardStatus();
     logReasoningStatus();
+    logCiGatingStatus();
     logActiveModelStatus();
     log.info(
         "Configuration validated: GitHub App id, private key, webhook secret, and AI API key are"
@@ -256,6 +258,35 @@ public class StartupConfigValidator {
               + " (thrillhousebot.ai.reasoning.effort): "
               + reasoning.effort());
     }
+  }
+
+  /**
+   * Rejects an unrecognized {@code REVIEW_CI_GATING} value at boot so a typo never silently falls
+   * through to the fail-closed default.
+   */
+  private static void validateCiGating(
+      List<String> problems, ThrillhouseConfig.ReviewConfig review) {
+    var allowed = ThrillhouseConfig.ReviewConfig.ALLOWED_CI_GATING;
+    if (!allowed.contains(ThrillhouseConfig.ReviewConfig.normalizeCiGating(review.ciGating()))) {
+      problems.add(
+          "REVIEW_CI_GATING must be one of "
+              + String.join(", ", allowed)
+              + " (thrillhousebot.review.ci-gating): "
+              + review.ciGating());
+    }
+  }
+
+  private void logCiGatingStatus() {
+    var normalized = ThrillhouseConfig.ReviewConfig.normalizeCiGating(config.review().ciGating());
+    if ("strict".equals(normalized)) {
+      return;
+    }
+    log.info(
+        "CI gating mode={} — APPROVE will {}.",
+        normalized,
+        "warn".equals(normalized)
+            ? "be allowed while CI is noted as uncertain in the summary/check"
+            : "ignore CI status (findings-only gate)");
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -267,6 +267,24 @@ public interface ThrillhouseConfig {
     @WithName("auto-review-min-interval")
     Duration autoReviewMinInterval();
 
+    /**
+     * How strictly CI status factors into the APPROVE decision: {@code strict} (default) holds
+     * approval while required CI is pending, failing, or unreadable; {@code warn} still evaluates
+     * CI and notes uncertainty in the summary/check but allows APPROVE; {@code off} skips CI
+     * entirely (findings-only gate). Validated at boot by {@link StartupConfigValidator}.
+     */
+    @WithDefault("strict")
+    @WithName("ci-gating")
+    String ciGating();
+
+    /** Values accepted by {@link #ciGating()}, matching {@code CiGatingMode}. */
+    List<String> ALLOWED_CI_GATING = List.of("strict", "warn", "off");
+
+    /** A {@link #ciGating()} value normalized to the lowercase wire form. */
+    static String normalizeCiGating(String raw) {
+      return raw.strip().toLowerCase(java.util.Locale.ROOT);
+    }
+
     LabelsConfig labels();
 
     DiagramConfig diagram();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiGatingMode.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiGatingMode.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * How strictly CI status factors into the APPROVE decision. Fail-closed {@link #STRICT} is the safe
+ * default; softer modes exist for teams with flaky CI or incomplete required-context resolution.
+ */
+public enum CiGatingMode {
+  /** Hold APPROVE while required CI is pending, failing, or unreadable (fail-closed). */
+  STRICT,
+  /** APPROVE is allowed, but the summary and check run still note CI uncertainty. */
+  WARN,
+  /** Ignore CI for the APPROVE decision (findings-only gate); CI is not fetched. */
+  OFF;
+
+  /** Values accepted by {@code thrillhousebot.review.ci-gating} / {@link #parse}. */
+  public static final List<String> ALLOWED = List.of("strict", "warn", "off");
+
+  /** Wire value normalized to the lowercase form operators and docs use. */
+  public static String normalize(String raw) {
+    return raw.strip().toLowerCase(Locale.ROOT);
+  }
+
+  /**
+   * Parses a configured value into a mode. Callers must validate against {@link #ALLOWED} first
+   * (startup) — this throws on an unrecognized token so a typo never silently falls through to
+   * {@link #STRICT}.
+   */
+  public static CiGatingMode parse(String raw) {
+    return valueOf(normalize(raw).toUpperCase(Locale.ROOT));
+  }
+
+  /** True when non-green / unreadable CI must downgrade APPROVE to COMMENT. */
+  public boolean holdsApproval() {
+    return this == STRICT;
+  }
+
+  /** True when CI checks are fetched and evaluated for the verdict path. */
+  public boolean evaluatesCi() {
+    return this != OFF;
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluator.java
@@ -16,6 +16,7 @@
 package dev.thiagogonzaga.thrillhousebot.review;
 
 import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubCheckRunClient;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -53,14 +54,29 @@ public class CiStatusEvaluator {
   // Slug tokens of the configured "<slug>[bot]" logins, used for check/app matching.
   private final Set<String> botTokens;
 
+  private final CiGatingMode ciGating;
+
   @Inject
   public CiStatusEvaluator(
-      @RestClient GitHubCheckRunClient checkRunClient, BotIdentity botIdentity) {
+      @RestClient GitHubCheckRunClient checkRunClient,
+      BotIdentity botIdentity,
+      ThrillhouseConfig config) {
+    this(checkRunClient, botIdentity, CiGatingMode.parse(config.review().ciGating()));
+  }
+
+  /** Visible for tests; defaults to fail-closed {@link CiGatingMode#STRICT}. */
+  CiStatusEvaluator(GitHubCheckRunClient checkRunClient, BotIdentity botIdentity) {
+    this(checkRunClient, botIdentity, CiGatingMode.STRICT);
+  }
+
+  CiStatusEvaluator(
+      GitHubCheckRunClient checkRunClient, BotIdentity botIdentity, CiGatingMode ciGating) {
     this.checkRunClient = checkRunClient;
     this.botTokens =
         botIdentity.logins().stream()
             .map(CiStatusEvaluator::loginToken)
             .collect(Collectors.toUnmodifiableSet());
+    this.ciGating = ciGating == null ? CiGatingMode.STRICT : ciGating;
   }
 
   /**
@@ -75,10 +91,14 @@ public class CiStatusEvaluator {
    * two GitHub mechanisms, unioned: repository/organization <em>rulesets</em> (modern; needs only
    * read access) and <em>classic branch protection</em> (legacy; needs admin). Returns an empty
    * {@link Optional} — which the caller maps to {@code null}, gating on every check — only when
-   * neither mechanism governs the branch or both lookups fail.
+   * neither mechanism governs the branch or both lookups fail. When CI gating is {@link
+   * CiGatingMode#OFF}, returns a present empty list without calling GitHub.
    */
   Optional<List<String>> resolveRequiredContexts(
       String auth, String owner, String repo, String baseBranch) {
+    if (!ciGating.evaluatesCi()) {
+      return Optional.of(List.of());
+    }
     if (baseBranch == null || baseBranch.isBlank()) {
       return Optional.empty();
     }
@@ -175,10 +195,13 @@ public class CiStatusEvaluator {
    * or (when required) missing entirely — plus whether either CI source could not be read. Passing
    * checks are deliberately excluded so the caller can gate APPROVE on a non-empty result; a
    * successful required check is recorded in {@code seen} so it is not later mistaken for a missing
-   * one.
+   * one. When CI gating is {@link CiGatingMode#OFF}, returns a clear evaluation without fetching.
    */
   CiEvaluation evaluateCiChecks(
       String auth, String owner, String repo, String commitSha, List<String> requiredContexts) {
+    if (!ciGating.evaluatesCi()) {
+      return new CiEvaluation(List.of(), false, true);
+    }
     var offending = new ArrayList<ReviewResult.CiCheck>();
     // Required contexts that reported in any state, so the missing-check pass does not re-flag a
     // green check as pending.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -244,12 +244,21 @@ public class PrSummaryGenerator {
     }
     if (result.ciUnreadable()) {
       sb.append("### ⚠️ CI Status Unavailable\n");
-      sb.append(
-          """
-          The CI status could not be read from GitHub, so approval is held until it can be \
-          confirmed.
+      if (result.reviewState() == ReviewState.APPROVE) {
+        sb.append(
+            """
+            The CI status could not be read from GitHub. Approval was still posted because CI \
+            gating is not strict — verify CI separately if needed.
 
-          """);
+            """);
+      } else {
+        sb.append(
+            """
+            The CI status could not be read from GitHub, so approval is held until it can be \
+            confirmed.
+
+            """);
+      }
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -217,48 +217,58 @@ public class PrSummaryGenerator {
   }
 
   private static void appendCiChecks(StringBuilder sb, ReviewResult result) {
-    if (!result.offendingCiChecks().isEmpty()) {
-      if (result.requiredContextsKnown()) {
-        sb.append("### ⚠️ Required CI Checks Status\n");
-        sb.append("Some required checks are still pending or have failed:\n\n");
-      } else {
-        sb.append("### ⚠️ CI Checks Status\n");
-        sb.append("Some checks are still pending or have failed:\n\n");
-      }
-      sb.append("| Check | Type | Status | Detail |\n");
-      sb.append("|-------|------|--------|--------|\n");
-      for (var check : result.offendingCiChecks()) {
-        String statusEmoji = check.isFailing() ? "❌ Failed" : "⏳ Pending";
-        String detail = check.conclusion() != null ? check.conclusion() : "-";
-        sb.append("| **")
-            .append(escapeTableCell(check.name()))
-            .append("** | ")
-            .append(escapeTableCell(check.type()))
-            .append(" | ")
-            .append(statusEmoji)
-            .append(" | ")
-            .append(escapeTableCell(detail))
-            .append(" |\n");
-      }
-      sb.append("\n");
+    appendOffendingCiChecks(sb, result);
+    appendUnreadableCiStatus(sb, result);
+  }
+
+  private static void appendOffendingCiChecks(StringBuilder sb, ReviewResult result) {
+    if (result.offendingCiChecks().isEmpty()) {
+      return;
     }
-    if (result.ciUnreadable()) {
-      sb.append("### ⚠️ CI Status Unavailable\n");
-      if (result.reviewState() == ReviewState.APPROVE) {
-        sb.append(
-            """
-            The CI status could not be read from GitHub. Approval was still posted because CI \
-            gating is not strict — verify CI separately if needed.
+    if (result.requiredContextsKnown()) {
+      sb.append("### ⚠️ Required CI Checks Status\n");
+      sb.append("Some required checks are still pending or have failed:\n\n");
+    } else {
+      sb.append("### ⚠️ CI Checks Status\n");
+      sb.append("Some checks are still pending or have failed:\n\n");
+    }
+    sb.append("| Check | Type | Status | Detail |\n");
+    sb.append("|-------|------|--------|--------|\n");
+    for (var check : result.offendingCiChecks()) {
+      String statusEmoji = check.isFailing() ? "❌ Failed" : "⏳ Pending";
+      String detail = check.conclusion() != null ? check.conclusion() : "-";
+      sb.append("| **")
+          .append(escapeTableCell(check.name()))
+          .append("** | ")
+          .append(escapeTableCell(check.type()))
+          .append(" | ")
+          .append(statusEmoji)
+          .append(" | ")
+          .append(escapeTableCell(detail))
+          .append(" |\n");
+    }
+    sb.append("\n");
+  }
 
-            """);
-      } else {
-        sb.append(
-            """
-            The CI status could not be read from GitHub, so approval is held until it can be \
-            confirmed.
+  private static void appendUnreadableCiStatus(StringBuilder sb, ReviewResult result) {
+    if (!result.ciUnreadable()) {
+      return;
+    }
+    sb.append("### ⚠️ CI Status Unavailable\n");
+    if (result.reviewState() == ReviewState.APPROVE) {
+      sb.append(
+          """
+          The CI status could not be read from GitHub. Approval was still posted because CI \
+          gating is not strict — verify CI separately if needed.
 
-            """);
-      }
+          """);
+    } else {
+      sb.append(
+          """
+          The CI status could not be read from GitHub, so approval is held until it can be \
+          confirmed.
+
+          """);
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -159,7 +159,10 @@ public record ReviewResult(
 
   /** True when CI holds approval back: a required check is offending, or CI could not be read. */
   public boolean ciHoldsApproval() {
-    return !offendingCiChecks.isEmpty() || ciUnreadable;
+    // Reflects the verdict after mode-aware gating: APPROVE means CI did not hold (strict), or the
+    // operator chose warn/off. Callers that only need "are there CI issues to surface" should check
+    // offendingCiChecks / ciUnreadable instead.
+    return reviewState != ReviewState.APPROVE && (!offendingCiChecks.isEmpty() || ciUnreadable);
   }
 
   /** True when the line budget dropped whole files, so this review covers only part of the diff. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -16,6 +16,7 @@
 package dev.thiagogonzaga.thrillhousebot.review;
 
 import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -28,7 +29,8 @@ import java.util.Set;
  * Builds the {@link ReviewResult} verdict from the model response and the review's gating inputs,
  * and derives the check-run conclusion/title/summary. The decision core: a review approves only
  * when there are no outstanding new findings AND no unresolved previous findings (backstop), no
- * offending CI checks, and the diff was not truncated.
+ * offending CI checks (when CI gating is {@link CiGatingMode#STRICT}), and the diff was not
+ * truncated.
  */
 @ApplicationScoped
 public class VerdictBuilder {
@@ -36,15 +38,38 @@ public class VerdictBuilder {
   private final PrSummaryGenerator summaryGenerator;
   private final FollowUpAnalyzer followUpAnalyzer;
   private final BotIdentity botIdentity;
+  private final CiGatingMode ciGating;
 
   @Inject
   public VerdictBuilder(
       PrSummaryGenerator summaryGenerator,
       FollowUpAnalyzer followUpAnalyzer,
+      BotIdentity botIdentity,
+      ThrillhouseConfig config) {
+    this(
+        summaryGenerator,
+        followUpAnalyzer,
+        botIdentity,
+        CiGatingMode.parse(config.review().ciGating()));
+  }
+
+  /** Visible for tests; defaults to fail-closed {@link CiGatingMode#STRICT}. */
+  VerdictBuilder(
+      PrSummaryGenerator summaryGenerator,
+      FollowUpAnalyzer followUpAnalyzer,
       BotIdentity botIdentity) {
+    this(summaryGenerator, followUpAnalyzer, botIdentity, CiGatingMode.STRICT);
+  }
+
+  VerdictBuilder(
+      PrSummaryGenerator summaryGenerator,
+      FollowUpAnalyzer followUpAnalyzer,
+      BotIdentity botIdentity,
+      CiGatingMode ciGating) {
     this.summaryGenerator = summaryGenerator;
     this.followUpAnalyzer = followUpAnalyzer;
     this.botIdentity = botIdentity;
+    this.ciGating = ciGating == null ? CiGatingMode.STRICT : ciGating;
   }
 
   /**
@@ -128,13 +153,23 @@ public class VerdictBuilder {
               result.lowCount())
           + truncationSuffix;
     }
+    boolean approvedDespiteCi = result.reviewState() == ReviewState.APPROVE;
     var unreadableSuffix =
         result.ciUnreadable()
-            ? " The CI status for some checks could not be read — holding approval until it can be"
-                + " confirmed."
+            ? (approvedDespiteCi
+                ? " Note: the CI status for some checks could not be read."
+                : " The CI status for some checks could not be read — holding approval until it can"
+                    + " be confirmed.")
             : "";
     if (!result.offendingCiChecks().isEmpty()) {
       var checkLabel = result.requiredContextsKnown() ? "required CI check(s)" : "CI check(s)";
+      if (approvedDespiteCi) {
+        return String.format(
+                "No new issues found. Note: %d %s are still pending or failing.",
+                result.offendingCiChecks().size(), checkLabel)
+            + unreadableSuffix
+            + truncationSuffix;
+      }
       return String.format(
               "No new issues found, but %d %s are still pending or failing.",
               result.offendingCiChecks().size(), checkLabel)
@@ -142,6 +177,9 @@ public class VerdictBuilder {
           + truncationSuffix;
     }
     if (result.ciUnreadable()) {
+      if (approvedDespiteCi) {
+        return "No new issues found. Note: the CI status could not be read." + truncationSuffix;
+      }
       return "No new issues found, but the CI status could not be read — holding approval until it"
           + " can be confirmed."
           + truncationSuffix;
@@ -250,7 +288,9 @@ public class VerdictBuilder {
       state = ReviewState.COMMENT;
     }
 
-    if (state == ReviewState.APPROVE && (!offendingCiChecks.isEmpty() || ciUnreadable)) {
+    if (state == ReviewState.APPROVE
+        && ciGating.holdsApproval()
+        && (!offendingCiChecks.isEmpty() || ciUnreadable)) {
       state = ReviewState.COMMENT;
     }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -154,13 +154,14 @@ public class VerdictBuilder {
           + truncationSuffix;
     }
     boolean approvedDespiteCi = result.reviewState() == ReviewState.APPROVE;
-    var unreadableSuffix =
-        result.ciUnreadable()
-            ? (approvedDespiteCi
-                ? " Note: the CI status for some checks could not be read."
-                : " The CI status for some checks could not be read — holding approval until it can"
-                    + " be confirmed.")
-            : "";
+    String unreadableSuffix = "";
+    if (result.ciUnreadable()) {
+      unreadableSuffix =
+          approvedDespiteCi
+              ? " Note: the CI status for some checks could not be read."
+              : " The CI status for some checks could not be read — holding approval until it can"
+                  + " be confirmed.";
+    }
     if (!result.offendingCiChecks().isEmpty()) {
       var checkLabel = result.requiredContextsKnown() ? "required CI check(s)" : "CI check(s)";
       if (approvedDespiteCi) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -147,6 +147,11 @@ thrillhousebot.review.ack-reaction-timeout=${ACK_REACTION_TIMEOUT:3s}
 # (in-memory, per replica). A manual /review always bypasses and never shifts the window; 0 disables.
 thrillhousebot.review.auto-review-min-interval=${AUTO_REVIEW_MIN_INTERVAL:0}
 
+# How strictly CI status factors into APPROVE: strict (default) holds approval while required CI is
+# pending/failing/unreadable; warn allows APPROVE but notes CI uncertainty in the summary/check;
+# off skips CI entirely (findings-only gate).
+thrillhousebot.review.ci-gating=${REVIEW_CI_GATING:strict}
+
 # Context-aware PR labels (opt-in). When enabled, the model is shown the repo's existing labels
 # and picks the ones that best describe the change. apply=false (default) only posts a suggestion
 # comment on the first review; apply=true adds the labels to the PR. allow-create lets the bot

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -70,6 +70,7 @@ class StartupConfigValidatorTest {
     private int outputBufferTokens = 8192;
     private int maxAiCalls = 6;
     private double tokenSafetyMargin = 0.9;
+    private String ciGating = "strict";
     private boolean reasoningEnabled = false;
     private String reasoningEffort = "low";
     private String modelName = "deepseek-chat";
@@ -126,6 +127,11 @@ class StartupConfigValidatorTest {
       return this;
     }
 
+    ConfigBuilder ciGating(String v) {
+      this.ciGating = v;
+      return this;
+    }
+
     ConfigBuilder reasoningEnabled(boolean v) {
       this.reasoningEnabled = v;
       return this;
@@ -164,6 +170,7 @@ class StartupConfigValidatorTest {
       lenient().when(review.outputBufferTokens()).thenReturn(outputBufferTokens);
       lenient().when(review.maxAiCalls()).thenReturn(maxAiCalls);
       lenient().when(review.tokenSafetyMargin()).thenReturn(tokenSafetyMargin);
+      lenient().when(review.ciGating()).thenReturn(ciGating);
       lenient().when(ai.models()).thenReturn(models);
       return new StartupConfigValidator(
           config, aiApiKey, new ActiveModelSettings(config, modelName));
@@ -436,6 +443,21 @@ class StartupConfigValidatorTest {
     assertTrue(
         ex.getMessage().contains("AI_REASONING_EFFORT must be one of none, low, medium, high"),
         ex.getMessage());
+  }
+
+  @Test
+  void failsFastWhenCiGatingIsInvalid() {
+    var ex = assertFailsValidation(new ConfigBuilder().ciGating("loose").build());
+    assertTrue(
+        ex.getMessage().contains("REVIEW_CI_GATING must be one of strict, warn, off"),
+        ex.getMessage());
+  }
+
+  @Test
+  void acceptsEveryCiGatingModeCaseInsensitivelyWithWhitespace() {
+    for (var mode : new String[] {"strict", "WARN", " Off "}) {
+      new ConfigBuilder().ciGating(mode).build().validate();
+    }
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/CiGatingModeTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/CiGatingModeTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CiGatingModeTest {
+
+  @Test
+  void normalizeTrimsAndLowercases() {
+    assertEquals("warn", CiGatingMode.normalize(" WARN "));
+  }
+
+  @Test
+  void parseAcceptsAllowedValuesCaseInsensitively() {
+    assertEquals(CiGatingMode.STRICT, CiGatingMode.parse("strict"));
+    assertEquals(CiGatingMode.WARN, CiGatingMode.parse("Warn"));
+    assertEquals(CiGatingMode.OFF, CiGatingMode.parse(" OFF "));
+  }
+
+  @Test
+  void parseRejectsUnknownTokens() {
+    assertThrows(IllegalArgumentException.class, () -> CiGatingMode.parse("loose"));
+  }
+
+  @Test
+  void helpersDistinguishStrictWarnAndOff() {
+    assertTrue(CiGatingMode.STRICT.holdsApproval());
+    assertTrue(CiGatingMode.STRICT.evaluatesCi());
+    assertFalse(CiGatingMode.WARN.holdsApproval());
+    assertTrue(CiGatingMode.WARN.evaluatesCi());
+    assertFalse(CiGatingMode.OFF.holdsApproval());
+    assertFalse(CiGatingMode.OFF.evaluatesCi());
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluatorTest.java
@@ -660,4 +660,54 @@ class CiStatusEvaluatorTest {
       assertTrue(evaluator.resolveRequiredContexts("auth", "owner", "repo", "main").isEmpty());
     }
   }
+
+  @Nested
+  class CiGatingModes {
+
+    @Test
+    void offModeSkipsCiFetchAndReturnsClearEvaluation() {
+      var off = new CiStatusEvaluator(checkRunClient, new BotIdentity(Set.of()), CiGatingMode.OFF);
+
+      var result = off.evaluateCiChecks("auth", "owner", "repo", "sha", List.of("build"));
+
+      assertTrue(result.offendingChecks().isEmpty());
+      assertFalse(result.unreadable());
+      assertTrue(result.requiredContextsKnown());
+      verify(checkRunClient, never()).getAllCheckRuns(any(), any(), any(), any(), any());
+      verify(checkRunClient, never()).getAllCombinedStatus(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void offModeSkipsRequiredContextLookup() {
+      var off = new CiStatusEvaluator(checkRunClient, new BotIdentity(Set.of()), CiGatingMode.OFF);
+
+      assertEquals(
+          List.of(), off.resolveRequiredContexts("auth", "owner", "repo", "main").orElseThrow());
+      verify(checkRunClient, never())
+          .getBranchRules(anyString(), anyString(), anyString(), anyString(), anyString());
+      verify(checkRunClient, never())
+          .getRequiredStatusChecks(anyString(), anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void warnModeStillEvaluatesOffendingChecks() {
+      var warn =
+          new CiStatusEvaluator(checkRunClient, new BotIdentity(Set.of()), CiGatingMode.WARN);
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(
+              new GitHubCheckRunClient.CheckRunsResponse(
+                  1,
+                  List.of(
+                      new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                          1L, "build", "completed", "failure", null))));
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CombinedStatus("failure", 0, List.of()));
+
+      var result = warn.evaluateCiChecks("auth", "owner", "repo", "sha", List.of("build"));
+
+      assertEquals(1, result.offendingChecks().size());
+      assertEquals("build", result.offendingChecks().get(0).name());
+      assertFalse(result.unreadable());
+    }
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/CiStatusEvaluatorTest.java
@@ -709,5 +709,39 @@ class CiStatusEvaluatorTest {
       assertEquals("build", result.offendingChecks().get(0).name());
       assertFalse(result.unreadable());
     }
+
+    @Test
+    void configConstructorParsesCiGatingMode() {
+      var config = mock(dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig.class);
+      var review =
+          mock(dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig.ReviewConfig.class);
+      when(config.review()).thenReturn(review);
+      when(review.ciGating()).thenReturn("off");
+
+      var fromConfig = new CiStatusEvaluator(checkRunClient, new BotIdentity(Set.of()), config);
+      var result = fromConfig.evaluateCiChecks("auth", "owner", "repo", "sha", List.of("build"));
+
+      assertTrue(result.offendingChecks().isEmpty());
+      verify(checkRunClient, never()).getAllCheckRuns(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void nullModeFallsBackToStrictAndStillEvaluates() {
+      var fallback =
+          new CiStatusEvaluator(checkRunClient, new BotIdentity(Set.of()), (CiGatingMode) null);
+      when(checkRunClient.getCheckRuns(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(
+              new GitHubCheckRunClient.CheckRunsResponse(
+                  1,
+                  List.of(
+                      new GitHubCheckRunClient.CheckRunsResponse.CheckRun(
+                          1L, "build", "completed", "failure", null))));
+      when(checkRunClient.getCombinedStatus(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+          .thenReturn(new GitHubCheckRunClient.CombinedStatus("failure", 0, List.of()));
+
+      var result = fallback.evaluateCiChecks("auth", "owner", "repo", "sha", List.of("build"));
+
+      assertEquals(1, result.offendingChecks().size());
+    }
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -670,6 +670,32 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
+  void approvedDespiteUnreadableCiNotesSoftGatingInSummary() {
+    var result =
+        new ReviewResult(
+            List.of(),
+            0,
+            0,
+            0,
+            0,
+            null,
+            ReviewState.APPROVE,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0,
+            true);
+
+    var summary = generator.generate(1, 5, 0, List.of(), null, result);
+
+    assertTrue(summary.contains(PrSummaryGenerator.ZERO_ISSUES_MESSAGE), summary);
+    assertTrue(summary.contains("CI Status Unavailable"), summary);
+    assertTrue(summary.contains("gating is not strict"), summary);
+    assertFalse(summary.contains("approval is held"), summary);
+  }
+
+  @Test
   void unreadableCiWithTruncationReportsBothWithoutClaimingNotGreen() {
     var result =
         new ReviewResult(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -452,6 +452,27 @@ class VerdictBuilderTest {
   }
 
   @Test
+  void threeArgConstructorDefaultsToStrictCiAndBalancedBlocking() {
+    var defaults =
+        new VerdictBuilder(
+            summaryGenerator, followUpAnalyzer, BotIdentity.from(List.of("thrillhousebot[bot]")));
+
+    var held =
+        defaults.build(contextWithLineCapOmissions(0), CLEAN_RESPONSE, CI_OFFENDING, FULL_COVERAGE);
+    assertEquals(ReviewState.COMMENT, held.reviewState());
+
+    var hedged =
+        new ReviewResponse.Finding("critical", "low", "a.java", 1, "title", "desc", null, null);
+    var nonBlocking =
+        defaults.build(
+            contextWithLineCapOmissions(0),
+            new ReviewResponse(List.of(hedged), List.of(), null),
+            CI_CLEAR,
+            FULL_COVERAGE);
+    assertEquals(ReviewState.COMMENT, nonBlocking.reviewState());
+  }
+
+  @Test
   void nullStrictnessInTestConstructorFallsBackToBalanced() {
     var nullModeBuilder =
         new VerdictBuilder(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient.FileDiff;
@@ -222,6 +223,56 @@ class VerdictBuilderTest {
     var summary = VerdictBuilder.checkSummaryForResult(result);
     assertTrue(summary.contains("Note: the CI status could not be read"), summary);
     assertFalse(summary.contains("holding approval"), summary);
+  }
+
+  @Test
+  void warnModeNotesUnreadableAlongsideOffendingChecks() {
+    var both =
+        new CiStatusEvaluator.CiEvaluation(
+            List.of(new ReviewResult.CiCheck("build", "check-run", "failing", "failure")), true);
+    var result =
+        builderWith(CiGatingMode.WARN)
+            .build(contextWithLineCapOmissions(0), CLEAN_RESPONSE, both, FULL_COVERAGE);
+
+    assertEquals(ReviewState.APPROVE, result.reviewState());
+    var summary = VerdictBuilder.checkSummaryForResult(result);
+    assertTrue(summary.contains("Note:"), summary);
+    assertTrue(summary.contains("still pending or failing"), summary);
+    assertTrue(summary.contains("could not be read"), summary);
+    assertFalse(summary.contains("holding approval"), summary);
+  }
+
+  @Test
+  void configConstructorParsesCiGatingMode() {
+    var config = mock(dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig.class);
+    var review = mock(dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig.ReviewConfig.class);
+    when(config.review()).thenReturn(review);
+    when(review.ciGating()).thenReturn("warn");
+
+    var fromConfig =
+        new VerdictBuilder(
+            summaryGenerator,
+            followUpAnalyzer,
+            BotIdentity.from(List.of("thrillhousebot[bot]")),
+            config);
+    var result =
+        fromConfig.build(
+            contextWithLineCapOmissions(0), CLEAN_RESPONSE, CI_OFFENDING, FULL_COVERAGE);
+
+    assertEquals(ReviewState.APPROVE, result.reviewState());
+  }
+
+  @Test
+  void nullModeFallsBackToStrict() {
+    var result =
+        new VerdictBuilder(
+                summaryGenerator,
+                followUpAnalyzer,
+                BotIdentity.from(List.of("thrillhousebot[bot]")),
+                (CiGatingMode) null)
+            .build(contextWithLineCapOmissions(0), CLEAN_RESPONSE, CI_OFFENDING, FULL_COVERAGE);
+
+    assertEquals(ReviewState.COMMENT, result.reviewState());
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -164,4 +164,86 @@ class VerdictBuilderTest {
     assertEquals(2, result.omittedFiles());
     assertTrue(result.truncated());
   }
+
+  private static final CiStatusEvaluator.CiEvaluation CI_OFFENDING =
+      new CiStatusEvaluator.CiEvaluation(
+          List.of(new ReviewResult.CiCheck("build", "check-run", "failing", "failure")), false);
+
+  private static final CiStatusEvaluator.CiEvaluation CI_UNREADABLE =
+      new CiStatusEvaluator.CiEvaluation(List.of(), true);
+
+  private static final DiffBudgetPlanner.BudgetPlan FULL_COVERAGE =
+      new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+
+  private VerdictBuilder builderWith(CiGatingMode mode) {
+    return new VerdictBuilder(
+        summaryGenerator, followUpAnalyzer, BotIdentity.from(List.of("thrillhousebot[bot]")), mode);
+  }
+
+  @Test
+  void strictModeHoldsApproveWhenRequiredCiFails() {
+    var result =
+        builderWith(CiGatingMode.STRICT)
+            .build(contextWithLineCapOmissions(0), CLEAN_RESPONSE, CI_OFFENDING, FULL_COVERAGE);
+
+    assertEquals(ReviewState.COMMENT, result.reviewState());
+    assertTrue(result.ciHoldsApproval());
+    assertFalse(result.offendingCiChecks().isEmpty());
+    var summary = VerdictBuilder.checkSummaryForResult(result);
+    assertTrue(summary.contains("still pending or failing"), summary);
+    assertFalse(summary.contains("Note:"), summary);
+  }
+
+  @Test
+  void warnModeAllowsApproveButNotesOffendingCi() {
+    var result =
+        builderWith(CiGatingMode.WARN)
+            .build(contextWithLineCapOmissions(0), CLEAN_RESPONSE, CI_OFFENDING, FULL_COVERAGE);
+
+    assertEquals(ReviewState.APPROVE, result.reviewState());
+    assertFalse(result.ciHoldsApproval());
+    assertFalse(result.offendingCiChecks().isEmpty());
+    var summary = VerdictBuilder.checkSummaryForResult(result);
+    assertTrue(summary.contains("Note:"), summary);
+    assertTrue(summary.contains("still pending or failing"), summary);
+    assertTrue(VerdictBuilder.checkTitleForResult(result).contains("✅"));
+    assertEquals("success", VerdictBuilder.conclusionForResult(result));
+  }
+
+  @Test
+  void warnModeAllowsApproveButNotesUnreadableCi() {
+    var result =
+        builderWith(CiGatingMode.WARN)
+            .build(contextWithLineCapOmissions(0), CLEAN_RESPONSE, CI_UNREADABLE, FULL_COVERAGE);
+
+    assertEquals(ReviewState.APPROVE, result.reviewState());
+    assertFalse(result.ciHoldsApproval());
+    assertTrue(result.ciUnreadable());
+    var summary = VerdictBuilder.checkSummaryForResult(result);
+    assertTrue(summary.contains("Note: the CI status could not be read"), summary);
+    assertFalse(summary.contains("holding approval"), summary);
+  }
+
+  @Test
+  void offModeIgnoresOffendingCiForApprove() {
+    // OFF still receives an evaluation when tests inject one; production skips the fetch. The
+    // verdict must not hold APPROVE on CI in this mode.
+    var result =
+        builderWith(CiGatingMode.OFF)
+            .build(contextWithLineCapOmissions(0), CLEAN_RESPONSE, CI_OFFENDING, FULL_COVERAGE);
+
+    assertEquals(ReviewState.APPROVE, result.reviewState());
+    assertFalse(result.ciHoldsApproval());
+  }
+
+  @Test
+  void strictModeHoldsApproveWhenCiIsUnreadable() {
+    var result =
+        builderWith(CiGatingMode.STRICT)
+            .build(contextWithLineCapOmissions(0), CLEAN_RESPONSE, CI_UNREADABLE, FULL_COVERAGE);
+
+    assertEquals(ReviewState.COMMENT, result.reviewState());
+    assertTrue(result.ciHoldsApproval());
+    assertTrue(VerdictBuilder.checkSummaryForResult(result).contains("holding approval"));
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [x] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Adds configurable CI gating strictness for the APPROVE decision (`thrillhousebot.review.ci-gating` / `REVIEW_CI_GATING`):

- **`strict`** (default) — current fail-closed behavior: hold APPROVE while required CI is pending, failing, or unreadable
- **`warn`** — APPROVE allowed; summary and check run still note CI uncertainty
- **`off`** — skip CI fetch/evaluation entirely (findings-only gate)

`CiStatusEvaluator` and `VerdictBuilder` both respect the mode. Invalid values fail at boot. Documented in README + `.env.example` with the safety trade-offs.

## Related Issues

Fixes #322

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- New tests cover strict vs warn vs off on offending/unreadable CI payloads (`VerdictBuilderTest`, `CiStatusEvaluatorTest`, `CiGatingModeTest`, `PrSummaryGeneratorTest`)
- Startup validation rejects invalid `REVIEW_CI_GATING` values
- `./mvnw spotless:check spotbugs:check verify` passes locally

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A — backend config / review-path change; no UI.

## Additional Notes

Related context from the ticket: #253/#254 (shipped CI fail-closed fixes), #302 (unknown required-context copy), #59 (future CI-into-prompt work, complementary). Prefer keeping `strict` unless flaky CI or incomplete required-context resolution makes a softer mode necessary.