### PR TITLE
feat(review): capture maintainer finding feedback for learnings (#324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to ThrillhouseBot.
 
 ## [Unreleased]
 
+### Added
+
+- **Finding feedback capture for the learnings pipeline**: records maintainer 👍/👎 reactions (and conservative "not useful" reply heuristics) on bot finding comments into a `finding_feedback` table, with per-repo aggregates on `GET /api/dashboard/feedback` and a documented data model/retention policy (`docs/FEEDBACK.md`). GitHub Apps have no `reaction` webhook, so reactions are polled via the Reactions API on review-thread replies and follow-up reviews. Precursor to cross-review learnings (#38); does not yet feed prompts (#324)
+
 ## [0.4.0] — 2026-07-12
 
 Token-budgeted reviews for large PRs, per-model AI settings, a published docs site, and a few operator-facing controls (command ack reactions, an opt-in auto-review interval, missing-pricing visibility on the dashboard).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ guide, configuration reference, architecture, comparison, and the hosted
 - Inline code suggestions on review comments that you can apply with one click
 - Every finding is tagged `critical`, `high`, `medium`, or `low`
 - Follow-up reviews track whether earlier findings were addressed or justified
+- Maintainer 👍/👎 (and "not useful" replies) on finding comments are recorded for a future learnings pipeline — see [docs/FEEDBACK.md](docs/FEEDBACK.md)
 - Conversational replies: `@thrillhousebot` it in a PR thread or finding reply and the bot answers in context
 - A summary comment on the first run, with a risk breakdown and a changed-files walkthrough
 - Operable from the PR with comment commands — `/help`, `/review`, `/summary`, `/describe`, `/changelog`, `/add-docs`, `/resolve`, `/pause`, `/resume`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ guide, configuration reference, architecture, comparison, and the hosted
 - Inline code suggestions on review comments that you can apply with one click
 - Every finding is tagged `critical`, `high`, `medium`, or `low`
 - Follow-up reviews track whether earlier findings were addressed or justified
-- Maintainer 👍/👎 (and "not useful" replies) on finding comments are recorded for a future learnings pipeline — see [docs/FEEDBACK.md](docs/FEEDBACK.md)
+- Maintainer 👍/👎 (and "not useful" replies) on finding comments are recorded for a future learnings pipeline — see [Finding feedback](https://devops-thiago.github.io/ThrillhouseBot/feedback/)
 - Conversational replies: `@thrillhousebot` it in a PR thread or finding reply and the bot answers in context
 - A summary comment on the first run, with a risk breakdown and a changed-files walkthrough
 - Operable from the PR with comment commands — `/help`, `/review`, `/summary`, `/describe`, `/changelog`, `/add-docs`, `/resolve`, `/pause`, `/resume`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -237,7 +237,8 @@ Each AI call is bounded by `AI_TIMEOUT` (LangChain4j) and
 OpenTelemetry. OAuth login sessions are opaque IDs in cookies with tokens kept
 server-side; review history persists in the database. Maintainer finding
 feedback (reactions and reply heuristics) is documented in
-[FEEDBACK.md](./FEEDBACK.md). See
+[Finding feedback](https://devops-thiago.github.io/ThrillhouseBot/feedback/)
+(source: [docs/FEEDBACK.md](https://github.com/devops-thiago/ThrillhouseBot/blob/main/docs/FEEDBACK.md)). See
 [SECURITY.md](https://github.com/devops-thiago/ThrillhouseBot/blob/main/SECURITY.md)
 for the reporting process.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -204,11 +204,11 @@ sequenceDiagram
 
 | Package | Responsibility | Notable classes |
 |---|---|---|
-| `webhook/` | Receives GitHub events, verifies the HMAC signature, decides whether an event triggers a review (trigger filters, per-PR pause state, auto-review rate limit), acks slash/mention commands with 👀, and runs the comment commands (`/help`, `/summary`, `/describe`, `/changelog`, `/add-docs`, `/resolve`, `/pause`, `/resume`) | `WebhookController`, `WebhookVerifier`, `TriggerDetector`, `ReviewTriggerFilter`, `AckReactionService`, `CommentCommandService`, `PrPauseService` |
-| `review/` | Orchestrates a review: plans the token budget, calls the AI layer (single-call or map-reduce), maps findings to a risk level and review state, writes the summary comment, optionally labels the PR, and answers maintainer replies/mentions in PR threads | `ReviewOrchestrator`, `ReviewDispatcher`, `DiffBudgetPlanner`, `FindingPipeline`, `AutoReviewRateLimiter`, `ReviewDiffFormatter`, `FollowUpAnalyzer`, `PrSummaryGenerator`, `PrLabeler`, `MaintainerReplyService`, `MaintainerReplyDispatcher` |
+| `webhook/` | Receives GitHub events, verifies the HMAC signature, decides whether an event triggers a review (trigger filters, per-PR pause state, auto-review rate limit), acks slash/mention commands with 👀, runs the comment commands (`/help`, `/summary`, `/describe`, `/changelog`, `/add-docs`, `/resolve`, `/pause`, `/resume`), and schedules finding-feedback capture on review-thread replies | `WebhookController`, `WebhookVerifier`, `TriggerDetector`, `ReviewTriggerFilter`, `AckReactionService`, `CommentCommandService`, `PrPauseService` |
+| `review/` | Orchestrates a review: plans the token budget, calls the AI layer (single-call or map-reduce), maps findings to a risk level and review state, writes the summary comment, optionally labels the PR, answers maintainer replies/mentions in PR threads, and persists maintainer finding feedback (👍/👎 / reply heuristics) for a future learnings pipeline | `ReviewOrchestrator`, `ReviewDispatcher`, `DiffBudgetPlanner`, `FindingPipeline`, `AutoReviewRateLimiter`, `ReviewDiffFormatter`, `FollowUpAnalyzer`, `FindingFeedbackCaptureService`, `FindingFeedbackService`, `PrSummaryGenerator`, `PrLabeler`, `MaintainerReplyService`, `MaintainerReplyDispatcher` |
 | `review/ai/` | The LangChain4j layer: streams or batches model responses, parses findings, runs a second pass to verify them, applies generation/reasoning customizers, and writes conversational replies | `PrReviewer`, `AiReviewService`, `ChatModelCustomizers`, `FindingVerifier`, `FindingVerificationService`, `ReviewResponseParser`, `ReplyAssistant` |
-| `github/` | Talks to the GitHub REST and GraphQL APIs: app auth, pull requests, reviews, check runs, comments, labels, and reading the repo instructions file | `GitHubAuthClient`, `GitHubReviewClient`, `GitHubCheckRunClient`, `GitHubLabelClient`, `InstructionsResolver` |
-| `dashboard/` | The live UI backend: OAuth login (in-memory sessions), WebSocket broadcaster (`review.stream` / `review.batch`), and review session persistence | `AuthResource`, `DashboardSessionStore`, `SessionEventBroadcaster`, `ReviewSessionRepository` |
+| `github/` | Talks to the GitHub REST and GraphQL APIs: app auth, pull requests, reviews, check runs, comments, labels, reactions (create + list), and reading the repo instructions file | `GitHubAuthClient`, `GitHubReviewClient`, `GitHubCheckRunClient`, `GitHubLabelClient`, `GitHubReactionClient`, `InstructionsResolver` |
+| `dashboard/` | The live UI backend: OAuth login (in-memory sessions), WebSocket broadcaster (`review.stream` / `review.batch`), review session persistence, and finding-feedback aggregates | `AuthResource`, `DashboardSessionStore`, `SessionEventBroadcaster`, `ReviewSessionRepository`, `DashboardResource` |
 | `config/` | Wiring: the outbound HTTP client, the review thread pool, typed config, active-model settings (caps, generation params), fail-fast startup validation, and the shared bot-identity used to recognize the bot's own activity | `HttpClientProducer`, `ReviewExecutorProducer`, `ThrillhouseConfig`, `ActiveModelSettings`, `StartupConfigValidator`, `BotIdentity` |
 | `frontend/` | The Next.js dashboard, built to a static export and served by Quarkus | — |
 
@@ -235,7 +235,9 @@ parallel pass completes.
 Each AI call is bounded by `AI_TIMEOUT` (LangChain4j) and
 `thrillhousebot.review.ai-timeout-seconds`. Cost and token metrics come from
 OpenTelemetry. OAuth login sessions are opaque IDs in cookies with tokens kept
-server-side; review history persists in the database. See
+server-side; review history persists in the database. Maintainer finding
+feedback (reactions and reply heuristics) is documented in
+[FEEDBACK.md](./FEEDBACK.md). See
 [SECURITY.md](https://github.com/devops-thiago/ThrillhouseBot/blob/main/SECURITY.md)
 for the reporting process.
 

--- a/docs/FEEDBACK.md
+++ b/docs/FEEDBACK.md
@@ -1,0 +1,85 @@
+# Finding feedback capture
+
+<!-- docs:feedback:start -->
+
+ThrillhouseBot records lightweight maintainer signals about review findings so a
+future cross-review learnings store ([#38](https://github.com/devops-thiago/ThrillhouseBot/issues/38))
+has training data. This is the precursor shipped for
+[#324](https://github.com/devops-thiago/ThrillhouseBot/issues/324); it does **not**
+yet inject preferences into review prompts.
+
+## Why poll instead of a reaction webhook?
+
+GitHub Apps do not receive a `reaction` webhook event. The bot therefore lists
+👍 (`+1`) and 👎 (`-1`) on finding comments via the
+[Reactions REST API](https://docs.github.com/en/rest/reactions/reactions) when:
+
+1. A human **replies** on an inline review thread (`pull_request_review_comment`
+   with `in_reply_to_id`), or
+2. A **follow-up review** already loaded prior finding threads.
+
+Capture is best-effort and never fails the webhook `200` or the review.
+
+## Signals
+
+| Signal | Source | Meaning |
+|--------|--------|---------|
+| `useful` | `reaction` (`+1`) | Maintainer marked the finding comment 👍 |
+| `not_useful` | `reaction` (`-1`) | Maintainer marked the finding comment 👎 |
+| `not_useful` | `reply_heuristic` | Reply body matched a conservative phrase (`not useful`, `false positive`, `noise`, 👎, `:-1:`) |
+
+Only comments that carry the hidden `<!-- thrillhousebot:finding=N -->` marker are
+eligible. The bot's own reactions (e.g. 👀 command ack) are ignored.
+
+## Data model
+
+Table `finding_feedback` (Hibernate schema-update; no Flyway):
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | bigint | Panache / sequence PK |
+| `repository` | string | `owner/repo` |
+| `prNumber` | int | PR on that repository |
+| `githubCommentId` | bigint | Finding root review-comment id |
+| `findingIndex` | int (nullable) | 1-based index from the marker |
+| `signal` | string | `useful` or `not_useful` |
+| `source` | string | `reaction` or `reply_heuristic` |
+| `reactorLogin` | string | GitHub login only (lower-cased) |
+| `githubReactionId` | bigint (nullable) | Unique when present (idempotent re-poll) |
+| `createdAt` | instant | Insert time |
+
+Unique constraints:
+
+- `githubReactionId` (when non-null) — reaction redeliveries / re-polls
+- `(githubCommentId, reactorLogin, signal, source)` — one logical event per actor
+
+## Privacy
+
+Stored PII is limited to the **GitHub login** already present on webhook and API
+payloads. No email, display name, IP, or reaction text beyond the fixed emoji
+content codes (`+1` / `-1`) is persisted. Finding title/description are not
+copied into this table.
+
+## Retention
+
+Rows are retained for the lifetime of the deployment database. There is no
+automatic purge. Operators may `DELETE` rows or drop the table when
+decommissioning an installation. Uninstalling the GitHub App does not currently
+auto-delete feedback rows (same posture as `ReviewSession` history).
+
+## Aggregation API (ContextProvider seam)
+
+`FindingFeedbackService.summarize(repository)` and `summarizeAll()` return
+per-repo `useful` / `not_useful` counts for a future `ContextProvider`. The
+dashboard exposes the same aggregates at `GET /api/dashboard/feedback` (session
+cookie required; optional `?repository=owner/repo`).
+
+## Notable classes
+
+- `FindingFeedback` / `FindingFeedbackRepository` / `FindingFeedbackService`
+- `FindingFeedbackCaptureService` — poll + heuristics
+- `GitHubReactionClient.listReviewCommentReactions`
+- `WebhookController` — schedules capture on review-thread replies
+- `ReviewOrchestrator` — capture pass on follow-up reviews
+
+<!-- docs:feedback:end -->

--- a/docs/FEEDBACK.md
+++ b/docs/FEEDBACK.md
@@ -16,7 +16,9 @@ GitHub Apps do not receive a `reaction` webhook event. The bot therefore lists
 
 1. A human **replies** on an inline review thread (`pull_request_review_comment`
    with `in_reply_to_id`), or
-2. A **follow-up review** already loaded prior finding threads.
+2. A **follow-up review** already loaded inline comments — every bot finding-root
+   comment across prior rounds is scanned (capped, ordered by comment id), not
+   only findings from the immediately previous AI response.
 
 Capture is best-effort and never fails the webhook `200` or the review.
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardResource.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardResource.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.dashboard;
 
+import dev.thiagogonzaga.thrillhousebot.review.FindingFeedbackService;
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.panache.common.Sort;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -95,12 +96,16 @@ public class DashboardResource {
 
   private final DashboardSessionValidator sessionValidator;
   private final ReviewSessionRepository reviewSessionRepository;
+  private final FindingFeedbackService findingFeedbackService;
 
   @Inject
   public DashboardResource(
-      DashboardSessionValidator sessionValidator, ReviewSessionRepository reviewSessionRepository) {
+      DashboardSessionValidator sessionValidator,
+      ReviewSessionRepository reviewSessionRepository,
+      FindingFeedbackService findingFeedbackService) {
     this.sessionValidator = sessionValidator;
     this.reviewSessionRepository = reviewSessionRepository;
+    this.findingFeedbackService = findingFeedbackService;
   }
 
   boolean isValidSession(String sessionToken) {
@@ -259,6 +264,57 @@ public class DashboardResource {
                 "byModel",
                 rows))
         .build();
+  }
+
+  /**
+   * Aggregated maintainer finding feedback (👍/👎 / reply heuristics) for the learnings pipeline
+   * precursor (#324). Optional {@code repository=owner/repo} filters to one repo; otherwise returns
+   * all repos ordered by event count.
+   */
+  @GET
+  @Path("/feedback")
+  public Response getFeedback(
+      @QueryParam("repository") String repository,
+      @CookieParam(COOKIE_SESSION) String sessionToken) {
+    if (!isValidSession(sessionToken)) {
+      return unauthorizedResponse();
+    }
+    if (repository != null && !repository.isBlank()) {
+      var summary = findingFeedbackService.summarize(repository.strip());
+      var recent = findingFeedbackService.listRecent(repository.strip(), 50);
+      return Response.ok(
+              Map.of(
+                  "repositories",
+                  List.of(
+                      Map.of(
+                          FIELD_REPOSITORY,
+                          summary.repository(),
+                          "usefulCount",
+                          summary.usefulCount(),
+                          "notUsefulCount",
+                          summary.notUsefulCount(),
+                          "totalEvents",
+                          summary.totalEvents())),
+                  "recent",
+                  recent))
+          .build();
+    }
+    var summaries = findingFeedbackService.summarizeAll();
+    var rows =
+        summaries.stream()
+            .map(
+                s ->
+                    Map.<String, Object>of(
+                        FIELD_REPOSITORY,
+                        s.repository(),
+                        "usefulCount",
+                        s.usefulCount(),
+                        "notUsefulCount",
+                        s.notUsefulCount(),
+                        "totalEvents",
+                        s.totalEvents()))
+            .toList();
+    return Response.ok(Map.of("repositories", rows)).build();
   }
 
   @GET

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReactionClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReactionClient.java
@@ -57,6 +57,10 @@ public interface GitHubReactionClient {
       @PathParam("commentId") long commentId,
       CreateReactionRequest request);
 
+  // GitHub serves up to 100 reactions per page.
+  int REACTIONS_PER_PAGE = 100;
+  int MAX_REACTION_PAGES = 10;
+
   @GET
   @Path("/repos/{owner}/{repo}/pulls/comments/{commentId}/reactions")
   @Produces(MediaType.APPLICATION_JSON)
@@ -67,7 +71,8 @@ public interface GitHubReactionClient {
       @PathParam("repo") String repo,
       @PathParam("commentId") long commentId,
       @QueryParam("content") String content,
-      @QueryParam("per_page") int perPage);
+      @QueryParam("per_page") int perPage,
+      @QueryParam("page") int page);
 
   @GET
   @Path("/repos/{owner}/{repo}/issues/comments/{commentId}/reactions")
@@ -79,7 +84,8 @@ public interface GitHubReactionClient {
       @PathParam("repo") String repo,
       @PathParam("commentId") long commentId,
       @QueryParam("content") String content,
-      @QueryParam("per_page") int perPage);
+      @QueryParam("per_page") int perPage,
+      @QueryParam("page") int page);
 
   /** One of GitHub's fixed reaction contents, e.g. {@code eyes}. */
   record CreateReactionRequest(String content) {}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReactionClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReactionClient.java
@@ -15,14 +15,20 @@
  */
 package dev.thiagogonzaga.thrillhousebot.github;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import java.util.List;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 /**
  * GitHub <a href="https://docs.github.com/en/rest/reactions/reactions">reactions API</a> for PR
- * conversation comments and inline review comments. Reactions ride on the existing {@code issues:
- * write} / {@code pull_requests: write} app permissions — no manifest change.
+ * conversation comments and inline review comments. Create and list ride on the existing {@code
+ * issues: write} / {@code pull_requests: write} app permissions — no manifest change. GitHub Apps
+ * do not receive a {@code reaction} webhook event, so listing is how finding feedback (#324) is
+ * captured.
  */
 @RegisterRestClient(configKey = "github-api")
 public interface GitHubReactionClient {
@@ -51,6 +57,40 @@ public interface GitHubReactionClient {
       @PathParam("commentId") long commentId,
       CreateReactionRequest request);
 
+  @GET
+  @Path("/repos/{owner}/{repo}/pulls/comments/{commentId}/reactions")
+  @Produces(MediaType.APPLICATION_JSON)
+  List<Reaction> listReviewCommentReactions(
+      @HeaderParam("Authorization") String auth,
+      @HeaderParam("Accept") String accept,
+      @PathParam("owner") String owner,
+      @PathParam("repo") String repo,
+      @PathParam("commentId") long commentId,
+      @QueryParam("content") String content,
+      @QueryParam("per_page") int perPage);
+
+  @GET
+  @Path("/repos/{owner}/{repo}/issues/comments/{commentId}/reactions")
+  @Produces(MediaType.APPLICATION_JSON)
+  List<Reaction> listIssueCommentReactions(
+      @HeaderParam("Authorization") String auth,
+      @HeaderParam("Accept") String accept,
+      @PathParam("owner") String owner,
+      @PathParam("repo") String repo,
+      @PathParam("commentId") long commentId,
+      @QueryParam("content") String content,
+      @QueryParam("per_page") int perPage);
+
   /** One of GitHub's fixed reaction contents, e.g. {@code eyes}. */
   record CreateReactionRequest(String content) {}
+
+  @RegisterForReflection
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record Reaction(
+      long id, String content, User user, @JsonProperty("created_at") String createdAt) {
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record User(String login, long id) {}
+  }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -91,6 +91,16 @@ public interface GitHubReviewClient {
       @QueryParam("per_page") int perPage,
       @QueryParam("page") int page);
 
+  @GET
+  @Path("/repos/{owner}/{repo}/pulls/comments/{commentId}")
+  @Produces(MediaType.APPLICATION_JSON)
+  PullRequestComment getPullRequestComment(
+      @HeaderParam("Authorization") String auth,
+      @HeaderParam("Accept") String accept,
+      @PathParam("owner") String owner,
+      @PathParam("repo") String repo,
+      @PathParam("commentId") long commentId);
+
   /**
    * Lists a PR's inline review comments, walking pages of {@value #COMMENTS_PER_PAGE} up to {@value
    * #MAX_COMMENT_PAGES} pages so a busy PR's threads are not silently truncated. A single-page

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedback.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedback.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+
+/**
+ * One maintainer signal about a bot finding comment — a 👍/👎 reaction or a reply heuristic such as
+ * "not useful". Persisted per repository so a future learnings {@code ContextProvider} (#38) can
+ * aggregate preferences without re-scraping GitHub. Stores only the GitHub login already present on
+ * webhook payloads — no email or other PII.
+ *
+ * <p>Retention: rows are kept for the life of the deployment database (no automatic purge).
+ * Operators may delete rows or drop the table when decommissioning an installation; there is no
+ * cross-installation export.
+ */
+@Entity
+@Table(
+    name = "finding_feedback",
+    indexes = {
+      @Index(name = "idx_findingfeedback_repository", columnList = "repository"),
+      @Index(name = "idx_findingfeedback_comment", columnList = "githubCommentId"),
+      @Index(name = "idx_findingfeedback_created", columnList = "createdAt")
+    },
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uq_findingfeedback_reaction_id",
+          columnNames = {"githubReactionId"}),
+      @UniqueConstraint(
+          name = "uq_findingfeedback_comment_reactor_signal_source",
+          columnNames = {"githubCommentId", "reactorLogin", "signal", "source"})
+    })
+@RegisterForReflection
+public class FindingFeedback extends PanacheEntity {
+
+  /** Useful reaction ({@code +1}). */
+  public static final String SIGNAL_USEFUL = "useful";
+
+  /** Not-useful reaction ({@code -1}) or reply heuristic. */
+  public static final String SIGNAL_NOT_USEFUL = "not_useful";
+
+  /** Captured from the GitHub Reactions REST API. */
+  public static final String SOURCE_REACTION = "reaction";
+
+  /** Captured from reply-body heuristics (e.g. "not useful", 👎). */
+  public static final String SOURCE_REPLY_HEURISTIC = "reply_heuristic";
+
+  /** Repository in {@code owner/repo} form. */
+  @Column(nullable = false, length = 255)
+  String repository;
+
+  /** Pull request number on {@link #repository}. */
+  @Column(nullable = false)
+  int prNumber;
+
+  /** GitHub review-comment id of the finding root (or the reacted comment). */
+  @Column(nullable = false)
+  long githubCommentId;
+
+  /**
+   * 1-based finding index from {@code <!-- thrillhousebot:finding=N -->} when the comment body was
+   * available; {@code null} when unknown.
+   */
+  Integer findingIndex;
+
+  /** {@link #SIGNAL_USEFUL} or {@link #SIGNAL_NOT_USEFUL}. */
+  @Column(nullable = false, length = 32)
+  String signal;
+
+  /** {@link #SOURCE_REACTION} or {@link #SOURCE_REPLY_HEURISTIC}. */
+  @Column(nullable = false, length = 32)
+  String source;
+
+  /** GitHub login of the reactor / reply author (no other PII). */
+  @Column(nullable = false, length = 255)
+  String reactorLogin;
+
+  /**
+   * GitHub reaction id when {@link #source} is {@link #SOURCE_REACTION}; {@code null} for reply
+   * heuristics. Unique so redeliveries / re-polls are idempotent.
+   */
+  Long githubReactionId;
+
+  @Column(nullable = false)
+  Instant createdAt;
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReactionClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.regex.Pattern;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Captures maintainer finding feedback from GitHub reactions and reply-body heuristics.
+ *
+ * <p>GitHub Apps do not receive a {@code reaction} webhook event, so reactions are polled via the
+ * Reactions REST API when (1) a human replies on a review thread or (2) a follow-up review already
+ * has prior finding threads loaded. Best-effort: failures are logged and never fail the webhook ACK
+ * or the review.
+ */
+@ApplicationScoped
+public class FindingFeedbackCaptureService {
+
+  private static final Logger log = LoggerFactory.getLogger(FindingFeedbackCaptureService.class);
+
+  private static final String ACCEPT = "application/vnd.github+json";
+  private static final String CONTENT_PLUS_ONE = "+1";
+  private static final String CONTENT_MINUS_ONE = "-1";
+  private static final int MAX_FINDINGS_PER_CAPTURE = 40;
+
+  /**
+   * Reply bodies that count as an explicit "not useful" signal when a human replies on a finding
+   * thread. Kept conservative to avoid false training data for #38.
+   */
+  private static final Pattern NOT_USEFUL_REPLY =
+      Pattern.compile(
+          "(?is).*\\b(not\\s+useful|false\\s+positive|not\\s+a\\s+(real\\s+)?(bug|issue)|noise)\\b.*"
+              + "|.*👎.*|.*:-1:.*");
+
+  private final FindingFeedbackService feedbackService;
+  private final FollowUpAnalyzer followUpAnalyzer;
+  private final BotIdentity botIdentity;
+  private final GitHubAuthClient authClient;
+  private final GitHubReactionClient reactionClient;
+  private final GitHubReviewClient reviewClient;
+
+  private final ExecutorService captureExecutor =
+      Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("finding-feedback-", 0).factory());
+
+  @Inject
+  public FindingFeedbackCaptureService(
+      FindingFeedbackService feedbackService,
+      FollowUpAnalyzer followUpAnalyzer,
+      BotIdentity botIdentity,
+      GitHubAuthClient authClient,
+      @RestClient GitHubReactionClient reactionClient,
+      @RestClient GitHubReviewClient reviewClient) {
+    this.feedbackService = feedbackService;
+    this.followUpAnalyzer = followUpAnalyzer;
+    this.botIdentity = botIdentity;
+    this.authClient = authClient;
+    this.reactionClient = reactionClient;
+    this.reviewClient = reviewClient;
+  }
+
+  @PreDestroy
+  void shutdown() {
+    captureExecutor.shutdownNow();
+  }
+
+  /**
+   * Schedules best-effort capture for a review-thread reply: fetch the root body (to confirm it is
+   * a bot finding), poll 👍/👎 on that root, and apply reply-body heuristics. Never blocks the
+   * webhook ACK thread beyond queueing the task.
+   */
+  public void scheduleCaptureOnReviewReply(
+      long installationId,
+      String owner,
+      String repo,
+      int prNumber,
+      long rootCommentId,
+      String replyAuthorLogin,
+      String replyBody) {
+    captureExecutor.execute(
+        () -> {
+          try {
+            captureOnReviewReply(
+                installationId, owner, repo, prNumber, rootCommentId, replyAuthorLogin, replyBody);
+          } catch (RuntimeException e) {
+            log.warn(
+                "Finding feedback capture failed for {}/{} #{} comment {} (continuing)",
+                owner,
+                repo,
+                prNumber,
+                rootCommentId,
+                e);
+          }
+        });
+  }
+
+  /**
+   * Polls reactions on prior finding threads during a follow-up review. Uses the already-loaded
+   * auth header and inline comments — no extra comment list fetch.
+   */
+  public void captureOnPriorFindings(
+      String auth,
+      String owner,
+      String repo,
+      int prNumber,
+      String previousAiResponseJson,
+      List<GitHubReviewClient.PullRequestComment> inlineComments) {
+    if (previousAiResponseJson == null
+        || previousAiResponseJson.isBlank()
+        || inlineComments == null
+        || inlineComments.isEmpty()) {
+      return;
+    }
+    try {
+      var roots =
+          followUpAnalyzer.matchFindingThreads(previousAiResponseJson, inlineComments, botIdentity);
+      int scanned = 0;
+      for (var entry : roots.entrySet()) {
+        if (scanned >= MAX_FINDINGS_PER_CAPTURE) {
+          break;
+        }
+        long commentId = entry.getValue();
+        String body =
+            inlineComments.stream()
+                .filter(c -> c.id() == commentId)
+                .map(GitHubReviewClient.PullRequestComment::body)
+                .findFirst()
+                .orElse(null);
+        captureReactions(auth, owner, repo, prNumber, commentId, body);
+        scanned++;
+      }
+    } catch (RuntimeException e) {
+      log.warn(
+          "Finding feedback capture on prior findings failed for {}/{} #{} (continuing)",
+          owner,
+          repo,
+          prNumber,
+          e);
+    }
+  }
+
+  void captureOnReviewReply(
+      long installationId,
+      String owner,
+      String repo,
+      int prNumber,
+      long rootCommentId,
+      String replyAuthorLogin,
+      String replyBody) {
+    var auth = authClient.getAuthHeader(installationId);
+    String rootBody = fetchCommentBody(auth, owner, repo, rootCommentId);
+    OptionalInt findingIndex = SuggestionFormatter.parseFindingMarker(rootBody);
+    if (findingIndex.isEmpty()) {
+      return;
+    }
+    captureReactions(auth, owner, repo, prNumber, rootCommentId, rootBody);
+    captureReplyHeuristic(
+        owner, repo, prNumber, rootCommentId, findingIndex.getAsInt(), replyAuthorLogin, replyBody);
+  }
+
+  private String fetchCommentBody(String auth, String owner, String repo, long commentId) {
+    try {
+      var comment = reviewClient.getPullRequestComment(auth, ACCEPT, owner, repo, commentId);
+      return comment != null ? comment.body() : null;
+    } catch (RuntimeException e) {
+      log.debug(
+          "Failed to fetch review comment {} on {}/{} for feedback capture (continuing)",
+          commentId,
+          owner,
+          repo,
+          e);
+      return null;
+    }
+  }
+
+  void captureReactions(
+      String auth, String owner, String repo, int prNumber, long commentId, String commentBody) {
+    OptionalInt findingIndex = SuggestionFormatter.parseFindingMarker(commentBody);
+    if (findingIndex.isEmpty()) {
+      return;
+    }
+    var repoKey = owner + "/" + repo;
+    Integer index = findingIndex.getAsInt();
+    listAndRecord(auth, owner, repo, repoKey, prNumber, commentId, index, CONTENT_PLUS_ONE);
+    listAndRecord(auth, owner, repo, repoKey, prNumber, commentId, index, CONTENT_MINUS_ONE);
+  }
+
+  private void listAndRecord(
+      String auth,
+      String owner,
+      String repo,
+      String repoKey,
+      int prNumber,
+      long commentId,
+      Integer findingIndex,
+      String content) {
+    List<GitHubReactionClient.Reaction> reactions;
+    try {
+      reactions =
+          reactionClient.listReviewCommentReactions(
+              auth, ACCEPT, owner, repo, commentId, content, 100);
+    } catch (RuntimeException e) {
+      log.debug(
+          "Failed to list {} reactions on review comment {} in {}/{} (continuing)",
+          content,
+          commentId,
+          owner,
+          repo,
+          e);
+      return;
+    }
+    if (reactions == null) {
+      return;
+    }
+    String signal =
+        CONTENT_PLUS_ONE.equals(content)
+            ? FindingFeedback.SIGNAL_USEFUL
+            : FindingFeedback.SIGNAL_NOT_USEFUL;
+    for (var reaction : reactions) {
+      if (reaction == null || reaction.user() == null || reaction.user().login() == null) {
+        continue;
+      }
+      if (botIdentity.matches(reaction.user().login())) {
+        continue;
+      }
+      feedbackService.record(
+          repoKey,
+          prNumber,
+          commentId,
+          findingIndex,
+          signal,
+          FindingFeedback.SOURCE_REACTION,
+          reaction.user().login(),
+          reaction.id());
+    }
+  }
+
+  void captureReplyHeuristic(
+      String owner,
+      String repo,
+      int prNumber,
+      long rootCommentId,
+      int findingIndex,
+      String replyAuthorLogin,
+      String replyBody) {
+    if (replyAuthorLogin == null
+        || replyAuthorLogin.isBlank()
+        || botIdentity.matches(replyAuthorLogin)
+        || replyBody == null
+        || replyBody.isBlank()
+        || !NOT_USEFUL_REPLY.matcher(replyBody).matches()) {
+      return;
+    }
+    feedbackService.record(
+        owner + "/" + repo,
+        prNumber,
+        rootCommentId,
+        findingIndex,
+        FindingFeedback.SIGNAL_NOT_USEFUL,
+        FindingFeedback.SOURCE_REPLY_HEURISTIC,
+        replyAuthorLogin,
+        null);
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
@@ -22,6 +22,7 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.Comparator;
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.concurrent.ExecutorService;
@@ -36,8 +37,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>GitHub Apps do not receive a {@code reaction} webhook event, so reactions are polled via the
  * Reactions REST API when (1) a human replies on a review thread or (2) a follow-up review already
- * has prior finding threads loaded. Best-effort: failures are logged and never fail the webhook ACK
- * or the review.
+ * has inline comments loaded. Best-effort: failures are logged and never fail the webhook ACK or
+ * the review.
  */
 @ApplicationScoped
 public class FindingFeedbackCaptureService {
@@ -61,7 +62,6 @@ public class FindingFeedbackCaptureService {
               + "|.*👎.*|.*:-1:.*");
 
   private final FindingFeedbackService feedbackService;
-  private final FollowUpAnalyzer followUpAnalyzer;
   private final BotIdentity botIdentity;
   private final GitHubAuthClient authClient;
   private final GitHubReactionClient reactionClient;
@@ -73,13 +73,11 @@ public class FindingFeedbackCaptureService {
   @Inject
   public FindingFeedbackCaptureService(
       FindingFeedbackService feedbackService,
-      FollowUpAnalyzer followUpAnalyzer,
       BotIdentity botIdentity,
       GitHubAuthClient authClient,
       @RestClient GitHubReactionClient reactionClient,
       @RestClient GitHubReviewClient reviewClient) {
     this.feedbackService = feedbackService;
-    this.followUpAnalyzer = followUpAnalyzer;
     this.botIdentity = botIdentity;
     this.authClient = authClient;
     this.reactionClient = reactionClient;
@@ -122,39 +120,31 @@ public class FindingFeedbackCaptureService {
   }
 
   /**
-   * Polls reactions on prior finding threads during a follow-up review. Uses the already-loaded
-   * auth header and inline comments — no extra comment list fetch.
+   * Polls reactions on bot finding-root comments already present in the loaded inline comment list
+   * (every prior round on the PR, not only the immediately previous AI response). Candidates are
+   * ordered by comment id ascending so the {@link #MAX_FINDINGS_PER_CAPTURE} cap is deterministic.
+   * Uses the already-loaded auth header and comments — no extra comment list fetch.
    */
   public void captureOnPriorFindings(
       String auth,
       String owner,
       String repo,
       int prNumber,
-      String previousAiResponseJson,
       List<GitHubReviewClient.PullRequestComment> inlineComments) {
-    if (previousAiResponseJson == null
-        || previousAiResponseJson.isBlank()
-        || inlineComments == null
-        || inlineComments.isEmpty()) {
+    if (inlineComments == null || inlineComments.isEmpty()) {
       return;
     }
     try {
-      var roots =
-          followUpAnalyzer.matchFindingThreads(previousAiResponseJson, inlineComments, botIdentity);
-      int scanned = 0;
-      for (var entry : roots.entrySet()) {
-        if (scanned >= MAX_FINDINGS_PER_CAPTURE) {
-          break;
-        }
-        long commentId = entry.getValue();
-        String body =
-            inlineComments.stream()
-                .filter(c -> c.id() == commentId)
-                .map(GitHubReviewClient.PullRequestComment::body)
-                .findFirst()
-                .orElse(null);
-        captureReactions(auth, owner, repo, prNumber, commentId, body);
-        scanned++;
+      var candidates =
+          inlineComments.stream()
+              .filter(c -> c != null && c.inReplyToId() == null)
+              .filter(c -> c.user() != null && botIdentity.matches(c.user().login()))
+              .filter(c -> SuggestionFormatter.parseFindingMarker(c.body()).isPresent())
+              .sorted(Comparator.comparingLong(GitHubReviewClient.PullRequestComment::id))
+              .limit(MAX_FINDINGS_PER_CAPTURE)
+              .toList();
+      for (var comment : candidates) {
+        captureReactions(auth, owner, repo, prNumber, comment.id(), comment.body());
       }
     } catch (RuntimeException e) {
       log.warn(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
@@ -224,7 +224,7 @@ public class FindingFeedbackCaptureService {
             : FindingFeedback.SIGNAL_NOT_USEFUL;
     for (int page = 1; page <= GitHubReactionClient.MAX_REACTION_PAGES; page++) {
       List<GitHubReactionClient.Reaction> reactions = fetchReactionPage(ctx, content, page);
-      if (reactions == null || reactions.isEmpty()) {
+      if (reactions.isEmpty()) {
         return;
       }
       persistEligibleReactions(ctx, signal, reactions);
@@ -237,15 +237,17 @@ public class FindingFeedbackCaptureService {
   private List<GitHubReactionClient.Reaction> fetchReactionPage(
       ReactionPollContext ctx, String content, int page) {
     try {
-      return reactionClient.listReviewCommentReactions(
-          ctx.auth(),
-          ACCEPT,
-          ctx.owner(),
-          ctx.repo(),
-          ctx.commentId(),
-          content,
-          GitHubReactionClient.REACTIONS_PER_PAGE,
-          page);
+      var reactions =
+          reactionClient.listReviewCommentReactions(
+              ctx.auth(),
+              ACCEPT,
+              ctx.owner(),
+              ctx.repo(),
+              ctx.commentId(),
+              content,
+              GitHubReactionClient.REACTIONS_PER_PAGE,
+              page);
+      return reactions == null ? List.of() : reactions;
     } catch (RuntimeException e) {
       log.debug(
           "Failed to list {} reactions on review comment {} in {}/{} page {} (continuing)",
@@ -255,7 +257,7 @@ public class FindingFeedbackCaptureService {
           ctx.repo(),
           page,
           e);
-      return null;
+      return List.of();
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
@@ -47,7 +47,9 @@ public class FindingFeedbackCaptureService {
   private static final String ACCEPT = "application/vnd.github+json";
   private static final String CONTENT_PLUS_ONE = "+1";
   private static final String CONTENT_MINUS_ONE = "-1";
-  private static final int MAX_FINDINGS_PER_CAPTURE = 40;
+
+  /** Cap on finding threads polled during a follow-up review (package-visible for tests). */
+  static final int MAX_FINDINGS_PER_CAPTURE = 40;
 
   /**
    * Reply bodies that count as an explicit "not useful" signal when a human replies on a finding

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
@@ -211,44 +211,57 @@ public class FindingFeedbackCaptureService {
       long commentId,
       Integer findingIndex,
       String content) {
-    List<GitHubReactionClient.Reaction> reactions;
-    try {
-      reactions =
-          reactionClient.listReviewCommentReactions(
-              auth, ACCEPT, owner, repo, commentId, content, 100);
-    } catch (RuntimeException e) {
-      log.debug(
-          "Failed to list {} reactions on review comment {} in {}/{} (continuing)",
-          content,
-          commentId,
-          owner,
-          repo,
-          e);
-      return;
-    }
-    if (reactions == null) {
-      return;
-    }
     String signal =
         CONTENT_PLUS_ONE.equals(content)
             ? FindingFeedback.SIGNAL_USEFUL
             : FindingFeedback.SIGNAL_NOT_USEFUL;
-    for (var reaction : reactions) {
-      if (reaction == null || reaction.user() == null || reaction.user().login() == null) {
-        continue;
+    for (int page = 1; page <= GitHubReactionClient.MAX_REACTION_PAGES; page++) {
+      List<GitHubReactionClient.Reaction> reactions;
+      try {
+        reactions =
+            reactionClient.listReviewCommentReactions(
+                auth,
+                ACCEPT,
+                owner,
+                repo,
+                commentId,
+                content,
+                GitHubReactionClient.REACTIONS_PER_PAGE,
+                page);
+      } catch (RuntimeException e) {
+        log.debug(
+            "Failed to list {} reactions on review comment {} in {}/{} page {} (continuing)",
+            content,
+            commentId,
+            owner,
+            repo,
+            page,
+            e);
+        return;
       }
-      if (botIdentity.matches(reaction.user().login())) {
-        continue;
+      if (reactions == null || reactions.isEmpty()) {
+        return;
       }
-      feedbackService.record(
-          repoKey,
-          prNumber,
-          commentId,
-          findingIndex,
-          signal,
-          FindingFeedback.SOURCE_REACTION,
-          reaction.user().login(),
-          reaction.id());
+      for (var reaction : reactions) {
+        if (reaction == null || reaction.user() == null || reaction.user().login() == null) {
+          continue;
+        }
+        if (botIdentity.matches(reaction.user().login())) {
+          continue;
+        }
+        feedbackService.record(
+            repoKey,
+            prNumber,
+            commentId,
+            findingIndex,
+            signal,
+            FindingFeedback.SOURCE_REACTION,
+            reaction.user().login(),
+            reaction.id());
+      }
+      if (reactions.size() < GitHubReactionClient.REACTIONS_PER_PAGE) {
+        return;
+      }
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
@@ -54,12 +54,17 @@ public class FindingFeedbackCaptureService {
 
   /**
    * Reply bodies that count as an explicit "not useful" signal when a human replies on a finding
-   * thread. Kept conservative to avoid false training data for #38.
+   * thread. Kept conservative to avoid false training data for #38. Split into simple patterns so
+   * each stays under Sonar's regex-complexity budget.
    */
-  private static final Pattern NOT_USEFUL_REPLY =
-      Pattern.compile(
-          "(?is).*\\b(not\\s+useful|false\\s+positive|not\\s+a\\s+(real\\s+)?(bug|issue)|noise)\\b.*"
-              + "|.*👎.*|.*:-1:.*");
+  private static final List<Pattern> NOT_USEFUL_REPLY_PATTERNS =
+      List.of(
+          Pattern.compile("(?is)\\bnot\\s+useful\\b"),
+          Pattern.compile("(?is)\\bfalse\\s+positive\\b"),
+          Pattern.compile("(?is)\\bnot\\s+a\\s+(?:real\\s+)?(?:bug|issue)\\b"),
+          Pattern.compile("(?is)\\bnoise\\b"),
+          Pattern.compile("👎"),
+          Pattern.compile(":-1:"));
 
   private final FindingFeedbackService feedbackService;
   private final BotIdentity botIdentity;
@@ -196,73 +201,91 @@ public class FindingFeedbackCaptureService {
     if (findingIndex.isEmpty()) {
       return;
     }
-    var repoKey = owner + "/" + repo;
-    Integer index = findingIndex.getAsInt();
-    listAndRecord(auth, owner, repo, repoKey, prNumber, commentId, index, CONTENT_PLUS_ONE);
-    listAndRecord(auth, owner, repo, repoKey, prNumber, commentId, index, CONTENT_MINUS_ONE);
+    var ctx =
+        new ReactionPollContext(
+            auth, owner, repo, owner + "/" + repo, prNumber, commentId, findingIndex.getAsInt());
+    listAndRecord(ctx, CONTENT_PLUS_ONE);
+    listAndRecord(ctx, CONTENT_MINUS_ONE);
   }
 
-  private void listAndRecord(
+  private record ReactionPollContext(
       String auth,
       String owner,
       String repo,
       String repoKey,
       int prNumber,
       long commentId,
-      Integer findingIndex,
-      String content) {
+      Integer findingIndex) {}
+
+  private void listAndRecord(ReactionPollContext ctx, String content) {
     String signal =
         CONTENT_PLUS_ONE.equals(content)
             ? FindingFeedback.SIGNAL_USEFUL
             : FindingFeedback.SIGNAL_NOT_USEFUL;
     for (int page = 1; page <= GitHubReactionClient.MAX_REACTION_PAGES; page++) {
-      List<GitHubReactionClient.Reaction> reactions;
-      try {
-        reactions =
-            reactionClient.listReviewCommentReactions(
-                auth,
-                ACCEPT,
-                owner,
-                repo,
-                commentId,
-                content,
-                GitHubReactionClient.REACTIONS_PER_PAGE,
-                page);
-      } catch (RuntimeException e) {
-        log.debug(
-            "Failed to list {} reactions on review comment {} in {}/{} page {} (continuing)",
-            content,
-            commentId,
-            owner,
-            repo,
-            page,
-            e);
-        return;
-      }
+      List<GitHubReactionClient.Reaction> reactions = fetchReactionPage(ctx, content, page);
       if (reactions == null || reactions.isEmpty()) {
         return;
       }
-      for (var reaction : reactions) {
-        if (reaction == null || reaction.user() == null || reaction.user().login() == null) {
-          continue;
-        }
-        if (botIdentity.matches(reaction.user().login())) {
-          continue;
-        }
-        feedbackService.record(
-            repoKey,
-            prNumber,
-            commentId,
-            findingIndex,
-            signal,
-            FindingFeedback.SOURCE_REACTION,
-            reaction.user().login(),
-            reaction.id());
-      }
+      persistEligibleReactions(ctx, signal, reactions);
       if (reactions.size() < GitHubReactionClient.REACTIONS_PER_PAGE) {
         return;
       }
     }
+  }
+
+  private List<GitHubReactionClient.Reaction> fetchReactionPage(
+      ReactionPollContext ctx, String content, int page) {
+    try {
+      return reactionClient.listReviewCommentReactions(
+          ctx.auth(),
+          ACCEPT,
+          ctx.owner(),
+          ctx.repo(),
+          ctx.commentId(),
+          content,
+          GitHubReactionClient.REACTIONS_PER_PAGE,
+          page);
+    } catch (RuntimeException e) {
+      log.debug(
+          "Failed to list {} reactions on review comment {} in {}/{} page {} (continuing)",
+          content,
+          ctx.commentId(),
+          ctx.owner(),
+          ctx.repo(),
+          page,
+          e);
+      return null;
+    }
+  }
+
+  private void persistEligibleReactions(
+      ReactionPollContext ctx, String signal, List<GitHubReactionClient.Reaction> reactions) {
+    for (var reaction : reactions) {
+      String login = humanReactorLogin(reaction);
+      if (login == null) {
+        continue;
+      }
+      feedbackService.recordFeedback(
+          new FindingFeedbackService.FeedbackInput(
+              ctx.repoKey(),
+              ctx.prNumber(),
+              ctx.commentId(),
+              ctx.findingIndex(),
+              signal,
+              FindingFeedback.SOURCE_REACTION,
+              login,
+              reaction.id()));
+    }
+  }
+
+  /** Non-bot reactor login, or {@code null} when the reaction should be ignored. */
+  private String humanReactorLogin(GitHubReactionClient.Reaction reaction) {
+    if (reaction == null || reaction.user() == null || reaction.user().login() == null) {
+      return null;
+    }
+    String login = reaction.user().login();
+    return botIdentity.matches(login) ? null : login;
   }
 
   void captureReplyHeuristic(
@@ -278,17 +301,22 @@ public class FindingFeedbackCaptureService {
         || botIdentity.matches(replyAuthorLogin)
         || replyBody == null
         || replyBody.isBlank()
-        || !NOT_USEFUL_REPLY.matcher(replyBody).matches()) {
+        || !isNotUsefulReply(replyBody)) {
       return;
     }
-    feedbackService.record(
-        owner + "/" + repo,
-        prNumber,
-        rootCommentId,
-        findingIndex,
-        FindingFeedback.SIGNAL_NOT_USEFUL,
-        FindingFeedback.SOURCE_REPLY_HEURISTIC,
-        replyAuthorLogin,
-        null);
+    feedbackService.recordFeedback(
+        new FindingFeedbackService.FeedbackInput(
+            owner + "/" + repo,
+            prNumber,
+            rootCommentId,
+            findingIndex,
+            FindingFeedback.SIGNAL_NOT_USEFUL,
+            FindingFeedback.SOURCE_REPLY_HEURISTIC,
+            replyAuthorLogin,
+            null));
+  }
+
+  private static boolean isNotUsefulReply(String body) {
+    return NOT_USEFUL_REPLY_PATTERNS.stream().anyMatch(p -> p.matcher(body).find());
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackRepository.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackRepository.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class FindingFeedbackRepository implements PanacheRepository<FindingFeedback> {}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackService.java
@@ -17,26 +17,21 @@ package dev.thiagogonzaga.thrillhousebot.review;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.persistence.PersistenceException;
 import jakarta.transaction.Transactional;
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Persists and aggregates {@link FindingFeedback} rows. Short DB transactions only — never spans a
  * GitHub API call. Idempotent inserts: duplicate reaction ids or the same (comment, reactor,
- * signal, source) are ignored.
+ * signal, source) are ignored via pre-insert existence checks.
  *
  * <p>{@link #summarize(String)} is the seam a future learnings {@code ContextProvider} (#38) will
  * read; it does not feed prompts yet.
  */
 @ApplicationScoped
 public class FindingFeedbackService {
-
-  private static final Logger log = LoggerFactory.getLogger(FindingFeedbackService.class);
 
   private final FindingFeedbackRepository repository;
 
@@ -95,20 +90,8 @@ public class FindingFeedbackService {
     row.reactorLogin = login;
     row.githubReactionId = githubReactionId;
     row.createdAt = Instant.now();
-    try {
-      repository.persist(row);
-      return true;
-    } catch (PersistenceException e) {
-      // Race with a concurrent insert on the unique constraints — treat as already recorded.
-      log.debug(
-          "Ignoring duplicate finding feedback on comment {} from @{} ({}/{})",
-          githubCommentId,
-          login,
-          signal,
-          source,
-          e);
-      return false;
-    }
+    repository.persist(row);
+    return true;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackService.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.PersistenceException;
+import jakarta.transaction.Transactional;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Persists and aggregates {@link FindingFeedback} rows. Short DB transactions only — never spans a
+ * GitHub API call. Idempotent inserts: duplicate reaction ids or the same (comment, reactor,
+ * signal, source) are ignored.
+ *
+ * <p>{@link #summarize(String)} is the seam a future learnings {@code ContextProvider} (#38) will
+ * read; it does not feed prompts yet.
+ */
+@ApplicationScoped
+public class FindingFeedbackService {
+
+  private static final Logger log = LoggerFactory.getLogger(FindingFeedbackService.class);
+
+  private final FindingFeedbackRepository repository;
+
+  @Inject
+  public FindingFeedbackService(FindingFeedbackRepository repository) {
+    this.repository = repository;
+  }
+
+  /**
+   * Per-repository preference counts for a future {@code ContextProvider}. Only {@code useful} /
+   * {@code not_useful} signals are counted.
+   */
+  public record FeedbackPreferenceSummary(
+      String repository, long usefulCount, long notUsefulCount, long totalEvents) {}
+
+  /** Records one feedback event; returns {@code true} when a new row was inserted. */
+  @Transactional
+  public boolean record(
+      String repositoryKey,
+      int prNumber,
+      long githubCommentId,
+      Integer findingIndex,
+      String signal,
+      String source,
+      String reactorLogin,
+      Long githubReactionId) {
+    if (repositoryKey == null
+        || repositoryKey.isBlank()
+        || signal == null
+        || source == null
+        || reactorLogin == null
+        || reactorLogin.isBlank()) {
+      return false;
+    }
+    var login = reactorLogin.strip().toLowerCase(Locale.ROOT);
+    if (githubReactionId != null
+        && repository.count("githubReactionId = ?1", githubReactionId) > 0) {
+      return false;
+    }
+    if (repository.count(
+            "githubCommentId = ?1 and reactorLogin = ?2 and signal = ?3 and source = ?4",
+            githubCommentId,
+            login,
+            signal,
+            source)
+        > 0) {
+      return false;
+    }
+    var row = new FindingFeedback();
+    row.repository = repositoryKey.strip();
+    row.prNumber = prNumber;
+    row.githubCommentId = githubCommentId;
+    row.findingIndex = findingIndex;
+    row.signal = signal;
+    row.source = source;
+    row.reactorLogin = login;
+    row.githubReactionId = githubReactionId;
+    row.createdAt = Instant.now();
+    try {
+      repository.persist(row);
+      return true;
+    } catch (PersistenceException e) {
+      // Race with a concurrent insert on the unique constraints — treat as already recorded.
+      log.debug(
+          "Ignoring duplicate finding feedback on comment {} from @{} ({}/{})",
+          githubCommentId,
+          login,
+          signal,
+          source,
+          e);
+      return false;
+    }
+  }
+
+  /**
+   * One persisted feedback row for dashboard / ops inspection. Reads every stored column so the
+   * entity fields stay live for static analysis and for a future {@code ContextProvider}.
+   */
+  public record FeedbackEvent(
+      long id,
+      String repository,
+      int prNumber,
+      long githubCommentId,
+      Integer findingIndex,
+      String signal,
+      String source,
+      String reactorLogin,
+      Long githubReactionId,
+      Instant createdAt) {}
+
+  /** Aggregated 👍/👎-style preferences for {@code owner/repo}. */
+  @Transactional
+  public FeedbackPreferenceSummary summarize(String repositoryKey) {
+    if (repositoryKey == null || repositoryKey.isBlank()) {
+      return new FeedbackPreferenceSummary("", 0, 0, 0);
+    }
+    var key = repositoryKey.strip();
+    long useful =
+        repository.count("repository = ?1 and signal = ?2", key, FindingFeedback.SIGNAL_USEFUL);
+    long notUseful =
+        repository.count("repository = ?1 and signal = ?2", key, FindingFeedback.SIGNAL_NOT_USEFUL);
+    return new FeedbackPreferenceSummary(key, useful, notUseful, useful + notUseful);
+  }
+
+  /** Newest events for a repository (dashboard detail); empty when the key is blank. */
+  @Transactional
+  public List<FeedbackEvent> listRecent(String repositoryKey, int limit) {
+    if (repositoryKey == null || repositoryKey.isBlank() || limit <= 0) {
+      return List.of();
+    }
+    return repository
+        .find("repository = ?1 order by createdAt desc", repositoryKey.strip())
+        .page(0, Math.min(limit, 100))
+        .list()
+        .stream()
+        .map(
+            f ->
+                new FeedbackEvent(
+                    f.id,
+                    f.repository,
+                    f.prNumber,
+                    f.githubCommentId,
+                    f.findingIndex,
+                    f.signal,
+                    f.source,
+                    f.reactorLogin,
+                    f.githubReactionId,
+                    f.createdAt))
+        .toList();
+  }
+
+  /** Per-repository summaries ordered by total events descending (dashboard / ops). */
+  @Transactional
+  public List<FeedbackPreferenceSummary> summarizeAll() {
+    List<Object[]> rows =
+        repository
+            .getEntityManager()
+            .createQuery(
+                """
+                select f.repository,
+                       sum(case when f.signal = :useful then 1 else 0 end),
+                       sum(case when f.signal = :notUseful then 1 else 0 end),
+                       count(f)
+                from FindingFeedback f
+                group by f.repository
+                order by count(f) desc
+                """,
+                Object[].class)
+            .setParameter("useful", FindingFeedback.SIGNAL_USEFUL)
+            .setParameter("notUseful", FindingFeedback.SIGNAL_NOT_USEFUL)
+            .getResultList();
+    return rows.stream()
+        .map(
+            r ->
+                new FeedbackPreferenceSummary(
+                    (String) r[0],
+                    ((Number) r[1]).longValue(),
+                    ((Number) r[2]).longValue(),
+                    ((Number) r[3]).longValue()))
+        .toList();
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackService.java
@@ -47,9 +47,8 @@ public class FindingFeedbackService {
   public record FeedbackPreferenceSummary(
       String repository, long usefulCount, long notUsefulCount, long totalEvents) {}
 
-  /** Records one feedback event; returns {@code true} when a new row was inserted. */
-  @Transactional
-  public boolean record(
+  /** Input for {@link #recordFeedback(FeedbackInput)}. */
+  public record FeedbackInput(
       String repositoryKey,
       int prNumber,
       long githubCommentId,
@@ -57,38 +56,43 @@ public class FindingFeedbackService {
       String signal,
       String source,
       String reactorLogin,
-      Long githubReactionId) {
-    if (repositoryKey == null
-        || repositoryKey.isBlank()
-        || signal == null
-        || source == null
-        || reactorLogin == null
-        || reactorLogin.isBlank()) {
+      Long githubReactionId) {}
+
+  /** Records one feedback event; returns {@code true} when a new row was inserted. */
+  @Transactional
+  public boolean recordFeedback(FeedbackInput input) {
+    if (input == null
+        || input.repositoryKey() == null
+        || input.repositoryKey().isBlank()
+        || input.signal() == null
+        || input.source() == null
+        || input.reactorLogin() == null
+        || input.reactorLogin().isBlank()) {
       return false;
     }
-    var login = reactorLogin.strip().toLowerCase(Locale.ROOT);
-    if (githubReactionId != null
-        && repository.count("githubReactionId = ?1", githubReactionId) > 0) {
+    var login = input.reactorLogin().strip().toLowerCase(Locale.ROOT);
+    if (input.githubReactionId() != null
+        && repository.count("githubReactionId = ?1", input.githubReactionId()) > 0) {
       return false;
     }
     if (repository.count(
             "githubCommentId = ?1 and reactorLogin = ?2 and signal = ?3 and source = ?4",
-            githubCommentId,
+            input.githubCommentId(),
             login,
-            signal,
-            source)
+            input.signal(),
+            input.source())
         > 0) {
       return false;
     }
     var row = new FindingFeedback();
-    row.repository = repositoryKey.strip();
-    row.prNumber = prNumber;
-    row.githubCommentId = githubCommentId;
-    row.findingIndex = findingIndex;
-    row.signal = signal;
-    row.source = source;
+    row.repository = input.repositoryKey().strip();
+    row.prNumber = input.prNumber();
+    row.githubCommentId = input.githubCommentId();
+    row.findingIndex = input.findingIndex();
+    row.signal = input.signal();
+    row.source = input.source();
     row.reactorLogin = login;
-    row.githubReactionId = githubReactionId;
+    row.githubReactionId = input.githubReactionId();
     row.createdAt = Instant.now();
     repository.persist(row);
     return true;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -60,6 +60,8 @@ public class ReviewOrchestrator {
 
   private final FindingPipeline findingPipeline;
 
+  private final FindingFeedbackCaptureService findingFeedbackCapture;
+
   private final ExecutorService reviewExecutor;
 
   /**
@@ -174,6 +176,7 @@ public class ReviewOrchestrator {
       ReviewPublisher reviewPublisher,
       VerdictBuilder verdictBuilder,
       FindingPipeline findingPipeline,
+      FindingFeedbackCaptureService findingFeedbackCapture,
       @ReviewExecutor ExecutorService reviewExecutor) {
     this.config = config;
     this.authClient = authClient;
@@ -187,6 +190,7 @@ public class ReviewOrchestrator {
     this.reviewPublisher = reviewPublisher;
     this.verdictBuilder = verdictBuilder;
     this.findingPipeline = findingPipeline;
+    this.findingFeedbackCapture = findingFeedbackCapture;
     this.reviewExecutor = reviewExecutor;
   }
 
@@ -296,6 +300,17 @@ public class ReviewOrchestrator {
                   previousAiResponseJson,
                   inlineComments,
                   aiResponse.previousFindingsStatus()));
+      runPostResultStep(
+          doneReq,
+          "capture finding feedback",
+          () ->
+              findingFeedbackCapture.captureOnPriorFindings(
+                  auth,
+                  doneReq.owner(),
+                  doneReq.repo(),
+                  doneReq.prNumber(),
+                  previousAiResponseJson,
+                  inlineComments));
       runPostResultStep(
           doneReq,
           "apply labels",

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -305,12 +305,7 @@ public class ReviewOrchestrator {
           "capture finding feedback",
           () ->
               findingFeedbackCapture.captureOnPriorFindings(
-                  auth,
-                  doneReq.owner(),
-                  doneReq.repo(),
-                  doneReq.prNumber(),
-                  previousAiResponseJson,
-                  inlineComments));
+                  auth, doneReq.owner(), doneReq.repo(), doneReq.prNumber(), inlineComments));
       runPostResultStep(
           doneReq,
           "apply labels",

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatter.java
@@ -17,12 +17,17 @@ package dev.thiagogonzaga.thrillhousebot.review;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Locale;
+import java.util.OptionalInt;
+import java.util.regex.Pattern;
 
 /** Formats suggestions as GitHub ```suggestion blocks for click-to-apply. */
 @ApplicationScoped
 public class SuggestionFormatter {
 
   private static final String CODE_FENCE_CLOSE = "\n```\n";
+
+  private static final Pattern FINDING_MARKER_PATTERN =
+      Pattern.compile("<!--\\s*thrillhousebot:finding=(\\d+)\\s*-->");
 
   /**
    * Wraps suggestion_old and suggestion_new in a GitHub suggestion block.
@@ -42,6 +47,25 @@ public class SuggestionFormatter {
    */
   public static String findingMarker(int findingId) {
     return "<!-- thrillhousebot:finding=" + findingId + " -->";
+  }
+
+  /**
+   * Parses the 1-based finding index from a comment body that carries {@link #findingMarker(int)},
+   * or empty when the marker is absent.
+   */
+  public static OptionalInt parseFindingMarker(String body) {
+    if (body == null || body.isBlank()) {
+      return OptionalInt.empty();
+    }
+    var matcher = FINDING_MARKER_PATTERN.matcher(body);
+    if (!matcher.find()) {
+      return OptionalInt.empty();
+    }
+    try {
+      return OptionalInt.of(Integer.parseInt(matcher.group(1)));
+    } catch (NumberFormatException e) {
+      return OptionalInt.empty();
+    }
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatter.java
@@ -63,7 +63,7 @@ public class SuggestionFormatter {
     }
     try {
       return OptionalInt.of(Integer.parseInt(matcher.group(1)));
-    } catch (NumberFormatException e) {
+    } catch (NumberFormatException _) {
       return OptionalInt.empty();
     }
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -18,6 +18,7 @@ package dev.thiagogonzaga.thrillhousebot.webhook;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.review.AutoReviewRateLimiter;
+import dev.thiagogonzaga.thrillhousebot.review.FindingFeedbackCaptureService;
 import dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyService;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
@@ -49,6 +50,7 @@ public class WebhookController {
   private final CommentCommandService commentCommandService;
   private final PrPauseService prPauseService;
   private final AckReactionService ackReactionService;
+  private final FindingFeedbackCaptureService findingFeedbackCapture;
   private final ObjectMapper mapper;
 
   @Inject
@@ -65,6 +67,7 @@ public class WebhookController {
       CommentCommandService commentCommandService,
       PrPauseService prPauseService,
       AckReactionService ackReactionService,
+      FindingFeedbackCaptureService findingFeedbackCapture,
       ObjectMapper mapper) {
     this.config = config;
     this.verifier = verifier;
@@ -78,6 +81,7 @@ public class WebhookController {
     this.commentCommandService = commentCommandService;
     this.prPauseService = prPauseService;
     this.ackReactionService = ackReactionService;
+    this.findingFeedbackCapture = findingFeedbackCapture;
     this.mapper = mapper;
   }
 
@@ -347,9 +351,6 @@ public class WebhookController {
       log.debug("Ignoring pull_request_review_comment action: {}", payload.action());
       return true;
     }
-    if (!config.review().conversationalRepliesEnabled()) {
-      return true;
-    }
 
     var comment = payload.comment();
     if (comment == null || comment.user() == null) {
@@ -368,6 +369,27 @@ public class WebhookController {
       return true;
     }
 
+    // GitHub thread roots carry no in_reply_to_id; a reply targets its thread's root.
+    boolean isReply = comment.inReplyToId() != null;
+    Long rootCommentId = isReply ? comment.inReplyToId() : comment.id();
+
+    // Finding feedback (#324): poll 👍/👎 on the finding root when a human replies. Independent of
+    // conversational replies — reactions are not delivered as a webhook event for GitHub Apps.
+    if (isReply) {
+      findingFeedbackCapture.scheduleCaptureOnReviewReply(
+          payload.installation().id(),
+          repo.owner().login(),
+          repo.name(),
+          pr.number(),
+          rootCommentId,
+          comment.user().login(),
+          comment.body());
+    }
+
+    if (!config.review().conversationalRepliesEnabled()) {
+      return true;
+    }
+
     if (!triggerDetector.containsBotMention(comment.body())) {
       log.debug("Ignoring review comment that does not mention the bot");
       return true;
@@ -381,9 +403,6 @@ public class WebhookController {
       return true;
     }
 
-    // GitHub thread roots carry no in_reply_to_id; a reply targets its thread's root.
-    boolean isReply = comment.inReplyToId() != null;
-    Long rootCommentId = isReply ? comment.inReplyToId() : comment.id();
     log.info(
         "Conversational review-thread reply from @{} on PR #{}",
         comment.user().login(),

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardResourceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardResourceTest.java
@@ -102,25 +102,27 @@ class DashboardResourceTest extends ReviewSessionTestSupport {
   }
 
   @Test
-  void shouldReturnFeedbackAggregates() throws Exception {
-    findingFeedbackService.record(
-        "owner/repo",
-        1,
-        10L,
-        1,
-        FindingFeedback.SIGNAL_USEFUL,
-        FindingFeedback.SOURCE_REACTION,
-        "octocat",
-        101L);
-    findingFeedbackService.record(
-        "owner/repo",
-        1,
-        10L,
-        1,
-        FindingFeedback.SIGNAL_NOT_USEFUL,
-        FindingFeedback.SOURCE_REACTION,
-        "alice",
-        102L);
+  void shouldReturnFeedbackAggregates() {
+    findingFeedbackService.recordFeedback(
+        new FindingFeedbackService.FeedbackInput(
+            "owner/repo",
+            1,
+            10L,
+            1,
+            FindingFeedback.SIGNAL_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "octocat",
+            101L));
+    findingFeedbackService.recordFeedback(
+        new FindingFeedbackService.FeedbackInput(
+            "owner/repo",
+            1,
+            10L,
+            1,
+            FindingFeedback.SIGNAL_NOT_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "alice",
+            102L));
 
     given()
         .cookie(COOKIE_NAME, VALID_TOKEN)

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardResourceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardResourceTest.java
@@ -21,11 +21,15 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
+import dev.thiagogonzaga.thrillhousebot.review.FindingFeedback;
+import dev.thiagogonzaga.thrillhousebot.review.FindingFeedbackService;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -38,10 +42,19 @@ class DashboardResourceTest extends ReviewSessionTestSupport {
 
   @InjectMock DashboardSessionValidator sessionValidator;
 
+  @Inject FindingFeedbackService findingFeedbackService;
+
   @BeforeEach
   void setUp() {
     when(sessionValidator.isValidSession(anyString())).thenReturn(true);
     when(sessionValidator.isValidSession(isNull())).thenReturn(false);
+  }
+
+  @AfterEach
+  void cleanupFeedback() throws Exception {
+    tx.begin();
+    FindingFeedback.deleteAll();
+    tx.commit();
   }
 
   @Test
@@ -81,6 +94,54 @@ class DashboardResourceTest extends ReviewSessionTestSupport {
   @Test
   void shouldReturnUnauthorizedForListSessionsWithoutCookie() {
     given().when().get("/sessions").then().statusCode(401);
+  }
+
+  @Test
+  void shouldReturnUnauthorizedForFeedbackWithoutCookie() {
+    given().when().get("/feedback").then().statusCode(401);
+  }
+
+  @Test
+  void shouldReturnFeedbackAggregates() throws Exception {
+    findingFeedbackService.record(
+        "owner/repo",
+        1,
+        10L,
+        1,
+        FindingFeedback.SIGNAL_USEFUL,
+        FindingFeedback.SOURCE_REACTION,
+        "octocat",
+        101L);
+    findingFeedbackService.record(
+        "owner/repo",
+        1,
+        10L,
+        1,
+        FindingFeedback.SIGNAL_NOT_USEFUL,
+        FindingFeedback.SOURCE_REACTION,
+        "alice",
+        102L);
+
+    given()
+        .cookie(COOKIE_NAME, VALID_TOKEN)
+        .queryParam("repository", "owner/repo")
+        .when()
+        .get("/feedback")
+        .then()
+        .statusCode(200)
+        .body("repositories[0].repository", equalTo("owner/repo"))
+        .body("repositories[0].usefulCount", equalTo(1))
+        .body("repositories[0].notUsefulCount", equalTo(1))
+        .body("repositories[0].totalEvents", equalTo(2))
+        .body("recent", hasSize(2));
+
+    given()
+        .cookie(COOKIE_NAME, VALID_TOKEN)
+        .when()
+        .get("/feedback")
+        .then()
+        .statusCode(200)
+        .body("repositories", not(empty()));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardResourceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardResourceTest.java
@@ -142,6 +142,15 @@ class DashboardResourceTest extends ReviewSessionTestSupport {
         .then()
         .statusCode(200)
         .body("repositories", not(empty()));
+
+    given()
+        .cookie(COOKIE_NAME, VALID_TOKEN)
+        .queryParam("repository", "   ")
+        .when()
+        .get("/feedback")
+        .then()
+        .statusCode(200)
+        .body("repositories", not(empty()));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReactionClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class FindingFeedbackCaptureServiceTest {
+
+  @Mock private FindingFeedbackService feedbackService;
+  @Mock private FollowUpAnalyzer followUpAnalyzer;
+  @Mock private GitHubAuthClient authClient;
+  @Mock private GitHubReactionClient reactionClient;
+  @Mock private GitHubReviewClient reviewClient;
+
+  private FindingFeedbackCaptureService capture;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    capture =
+        new FindingFeedbackCaptureService(
+            feedbackService,
+            followUpAnalyzer,
+            BotIdentity.of("thrillhousebot[bot]"),
+            authClient,
+            reactionClient,
+            reviewClient);
+  }
+
+  @Test
+  void captureReactionsRecordsPlusAndMinusOneFromNonBotUsers() {
+    when(reactionClient.listReviewCommentReactions(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("+1"), eq(100)))
+        .thenReturn(
+            List.of(
+                new GitHubReactionClient.Reaction(
+                    1L, "+1", new GitHubReactionClient.Reaction.User("octocat", 1), "t"),
+                new GitHubReactionClient.Reaction(
+                    2L,
+                    "+1",
+                    new GitHubReactionClient.Reaction.User("thrillhousebot[bot]", 2),
+                    "t")));
+    when(reactionClient.listReviewCommentReactions(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("-1"), eq(100)))
+        .thenReturn(
+            List.of(
+                new GitHubReactionClient.Reaction(
+                    3L, "-1", new GitHubReactionClient.Reaction.User("alice", 3), "t")));
+
+    var body = "finding\n" + SuggestionFormatter.findingMarker(2);
+    capture.captureReactions("Bearer t", "owner", "repo", 7, 99L, body);
+
+    verify(feedbackService)
+        .record(
+            "owner/repo",
+            7,
+            99L,
+            2,
+            FindingFeedback.SIGNAL_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "octocat",
+            1L);
+    verify(feedbackService)
+        .record(
+            "owner/repo",
+            7,
+            99L,
+            2,
+            FindingFeedback.SIGNAL_NOT_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "alice",
+            3L);
+    verify(feedbackService, never())
+        .record(any(), anyInt(), anyLong(), any(), any(), any(), eq("thrillhousebot[bot]"), any());
+  }
+
+  @Test
+  void captureReactionsSkipsCommentsWithoutFindingMarker() {
+    capture.captureReactions("Bearer t", "owner", "repo", 7, 99L, "just a human comment");
+    verifyNoInteractions(reactionClient);
+    verifyNoInteractions(feedbackService);
+  }
+
+  @Test
+  void captureOnReviewReplyFetchesRootAndRecordsHeuristic() {
+    when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
+    when(reviewClient.getPullRequestComment(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L)))
+        .thenReturn(
+            new GitHubReviewClient.PullRequestComment(
+                99L,
+                null,
+                "Main.java",
+                "**HIGH — Bug**\n" + SuggestionFormatter.findingMarker(1),
+                new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")));
+    when(reactionClient.listReviewCommentReactions(
+            any(), any(), any(), any(), anyLong(), any(), anyInt()))
+        .thenReturn(List.of());
+
+    capture.captureOnReviewReply(
+        9L, "owner", "repo", 7, 99L, "octocat", "this is a false positive");
+
+    verify(feedbackService)
+        .record(
+            "owner/repo",
+            7,
+            99L,
+            1,
+            FindingFeedback.SIGNAL_NOT_USEFUL,
+            FindingFeedback.SOURCE_REPLY_HEURISTIC,
+            "octocat",
+            null);
+  }
+
+  @Test
+  void captureOnReviewReplyIgnoresNonFindingThreads() {
+    when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
+    when(reviewClient.getPullRequestComment(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L)))
+        .thenReturn(
+            new GitHubReviewClient.PullRequestComment(
+                99L,
+                null,
+                "Main.java",
+                "human review note",
+                new GitHubReviewClient.ReviewResponse.User("alice")));
+
+    capture.captureOnReviewReply(9L, "owner", "repo", 7, 99L, "octocat", "not useful");
+
+    verifyNoInteractions(reactionClient);
+    verifyNoInteractions(feedbackService);
+  }
+
+  @Test
+  void captureOnPriorFindingsUsesMatchedThreads() {
+    var body = "x\n" + SuggestionFormatter.findingMarker(1);
+    var comments =
+        List.of(
+            new GitHubReviewClient.PullRequestComment(
+                50L,
+                null,
+                "A.java",
+                body,
+                new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")));
+    when(followUpAnalyzer.matchFindingThreads(anyString(), eq(comments), any()))
+        .thenReturn(java.util.Map.of(1, 50L));
+    when(reactionClient.listReviewCommentReactions(
+            any(), any(), any(), any(), anyLong(), any(), anyInt()))
+        .thenReturn(List.of());
+
+    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, "{\"findings\":[]}", comments);
+
+    verify(reactionClient, times(2))
+        .listReviewCommentReactions(
+            eq("Bearer t"), anyString(), eq("owner"), eq("repo"), eq(50L), anyString(), eq(100));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -74,27 +74,31 @@ class FindingFeedbackCaptureServiceTest {
     capture.captureReactions("Bearer t", "owner", "repo", 7, 99L, body);
 
     verify(feedbackService)
-        .record(
-            "owner/repo",
-            7,
-            99L,
-            2,
-            FindingFeedback.SIGNAL_USEFUL,
-            FindingFeedback.SOURCE_REACTION,
-            "octocat",
-            1L);
+        .recordFeedback(
+            eq(
+                new FindingFeedbackService.FeedbackInput(
+                    "owner/repo",
+                    7,
+                    99L,
+                    2,
+                    FindingFeedback.SIGNAL_USEFUL,
+                    FindingFeedback.SOURCE_REACTION,
+                    "octocat",
+                    1L)));
     verify(feedbackService)
-        .record(
-            "owner/repo",
-            7,
-            99L,
-            2,
-            FindingFeedback.SIGNAL_NOT_USEFUL,
-            FindingFeedback.SOURCE_REACTION,
-            "alice",
-            3L);
+        .recordFeedback(
+            eq(
+                new FindingFeedbackService.FeedbackInput(
+                    "owner/repo",
+                    7,
+                    99L,
+                    2,
+                    FindingFeedback.SIGNAL_NOT_USEFUL,
+                    FindingFeedback.SOURCE_REACTION,
+                    "alice",
+                    3L)));
     verify(feedbackService, never())
-        .record(any(), anyInt(), anyLong(), any(), any(), any(), eq("thrillhousebot[bot]"), any());
+        .recordFeedback(argThat(in -> "thrillhousebot[bot]".equals(in.reactorLogin())));
   }
 
   @Test
@@ -124,15 +128,17 @@ class FindingFeedbackCaptureServiceTest {
         9L, "owner", "repo", 7, 99L, "octocat", "this is a false positive");
 
     verify(feedbackService)
-        .record(
-            "owner/repo",
-            7,
-            99L,
-            1,
-            FindingFeedback.SIGNAL_NOT_USEFUL,
-            FindingFeedback.SOURCE_REPLY_HEURISTIC,
-            "octocat",
-            null);
+        .recordFeedback(
+            eq(
+                new FindingFeedbackService.FeedbackInput(
+                    "owner/repo",
+                    7,
+                    99L,
+                    1,
+                    FindingFeedback.SIGNAL_NOT_USEFUL,
+                    FindingFeedback.SOURCE_REPLY_HEURISTIC,
+                    "octocat",
+                    null)));
   }
 
   @Test
@@ -278,8 +284,7 @@ class FindingFeedbackCaptureServiceTest {
         .thenThrow(new RuntimeException("api down"));
     capture.captureReactions(
         "Bearer t", "owner", "repo", 7, 99L, "x\n" + SuggestionFormatter.findingMarker(1));
-    verify(feedbackService, never())
-        .record(any(), anyInt(), anyLong(), any(), any(), any(), any(), any());
+    verify(feedbackService, never()).recordFeedback(any());
   }
 
   @Test
@@ -311,15 +316,17 @@ class FindingFeedbackCaptureServiceTest {
         "Bearer t", "owner", "repo", 7, 99L, "x\n" + SuggestionFormatter.findingMarker(1));
 
     verify(feedbackService)
-        .record(
-            "owner/repo",
-            7,
-            99L,
-            1,
-            FindingFeedback.SIGNAL_USEFUL,
-            FindingFeedback.SOURCE_REACTION,
-            "bob",
-            3L);
+        .recordFeedback(
+            eq(
+                new FindingFeedbackService.FeedbackInput(
+                    "owner/repo",
+                    7,
+                    99L,
+                    1,
+                    FindingFeedback.SIGNAL_USEFUL,
+                    FindingFeedback.SOURCE_REACTION,
+                    "bob",
+                    3L)));
   }
 
   @Test
@@ -397,7 +404,7 @@ class FindingFeedbackCaptureServiceTest {
 
   @Test
   void shutdownStopsExecutor() {
-    capture.shutdown();
+    assertDoesNotThrow(capture::shutdown);
   }
 
   @Test
@@ -421,11 +428,9 @@ class FindingFeedbackCaptureServiceTest {
   }
 
   @Test
-  void scheduleCaptureOnReviewReplyRunsAsyncAndSwallowsErrors() throws Exception {
+  void scheduleCaptureOnReviewReplyRunsAsyncAndSwallowsErrors() {
     when(authClient.getAuthHeader(anyLong())).thenThrow(new RuntimeException("auth fail"));
     capture.scheduleCaptureOnReviewReply(1L, "o", "r", 1, 9L, "u", "not useful");
-    // Give the virtual thread a moment; failure must not escape.
-    Thread.sleep(200);
     verify(authClient, timeout(2000)).getAuthHeader(1L);
   }
 
@@ -443,8 +448,7 @@ class FindingFeedbackCaptureServiceTest {
         .thenReturn(null);
     capture.captureReactions(
         "Bearer t", "owner", "repo", 7, 99L, "x\n" + SuggestionFormatter.findingMarker(1));
-    verify(feedbackService, never())
-        .record(any(), anyInt(), anyLong(), any(), any(), any(), any(), any());
+    verify(feedbackService, never()).recordFeedback(any());
   }
 
   @Test
@@ -502,16 +506,7 @@ class FindingFeedbackCaptureServiceTest {
     capture.captureReactions(
         "Bearer t", "owner", "repo", 7, 99L, "x\n" + SuggestionFormatter.findingMarker(1));
 
-    verify(feedbackService, times(101))
-        .record(
-            eq("owner/repo"),
-            eq(7),
-            eq(99L),
-            eq(1),
-            eq(FindingFeedback.SIGNAL_USEFUL),
-            eq(FindingFeedback.SOURCE_REACTION),
-            anyString(),
-            any());
+    verify(feedbackService, times(101)).recordFeedback(any());
     verify(reactionClient)
         .listReviewCommentReactions(
             anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("+1"), eq(100), eq(2));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -161,6 +161,7 @@ class FindingFeedbackCaptureServiceTest {
     capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, null, List.of());
     capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, " ", List.of());
     capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, "{}", null);
+    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, "{}", List.of());
     verifyNoInteractions(followUpAnalyzer, reactionClient, feedbackService);
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -32,7 +32,6 @@ import org.mockito.MockitoAnnotations;
 class FindingFeedbackCaptureServiceTest {
 
   @Mock private FindingFeedbackService feedbackService;
-  @Mock private FollowUpAnalyzer followUpAnalyzer;
   @Mock private GitHubAuthClient authClient;
   @Mock private GitHubReactionClient reactionClient;
   @Mock private GitHubReviewClient reviewClient;
@@ -45,7 +44,6 @@ class FindingFeedbackCaptureServiceTest {
     capture =
         new FindingFeedbackCaptureService(
             feedbackService,
-            followUpAnalyzer,
             BotIdentity.of("thrillhousebot[bot]"),
             authClient,
             reactionClient,
@@ -158,27 +156,66 @@ class FindingFeedbackCaptureServiceTest {
 
   @Test
   void captureOnPriorFindingsNoopsOnEmptyInput() {
-    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, null, List.of());
-    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, " ", List.of());
-    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, "{}", null);
-    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, "{}", List.of());
-    verifyNoInteractions(followUpAnalyzer, reactionClient, feedbackService);
+    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, null);
+    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, List.of());
+    verifyNoInteractions(reactionClient, feedbackService);
   }
 
   @Test
-  void captureOnPriorFindingsSwallowsAnalyzerFailures() {
-    when(followUpAnalyzer.matchFindingThreads(anyString(), any(), any()))
-        .thenThrow(new RuntimeException("boom"));
-    capture.captureOnPriorFindings(
-        "Bearer t",
-        "owner",
-        "repo",
-        3,
-        "{}",
+  void captureOnPriorFindingsScansAllBotFindingRootsAcrossRounds() {
+    when(reactionClient.listReviewCommentReactions(
+            any(), any(), any(), any(), anyLong(), any(), anyInt()))
+        .thenReturn(List.of());
+    // Round-1 finding (id 10) plus a later-round finding (id 30); a human reply and a
+    // non-finding bot root must be ignored. Empty previous-AI JSON is irrelevant — we scan
+    // comments directly so reactions on older rounds are still polled.
+    var comments =
         List.of(
             new GitHubReviewClient.PullRequestComment(
-                1L, null, "A.java", "x", new GitHubReviewClient.ReviewResponse.User("bot"))));
-    verifyNoInteractions(reactionClient, feedbackService);
+                10L,
+                null,
+                "A.java",
+                "old\n" + SuggestionFormatter.findingMarker(1),
+                new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")),
+            new GitHubReviewClient.PullRequestComment(
+                11L,
+                10L,
+                "A.java",
+                "human reply",
+                new GitHubReviewClient.ReviewResponse.User("octocat")),
+            new GitHubReviewClient.PullRequestComment(
+                20L,
+                null,
+                "B.java",
+                "summary without marker",
+                new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")),
+            new GitHubReviewClient.PullRequestComment(
+                30L,
+                null,
+                "C.java",
+                "new\n" + SuggestionFormatter.findingMarker(1),
+                new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")),
+            new GitHubReviewClient.PullRequestComment(
+                40L,
+                null,
+                "D.java",
+                "human\n" + SuggestionFormatter.findingMarker(9),
+                new GitHubReviewClient.ReviewResponse.User("alice")));
+
+    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, comments);
+
+    verify(reactionClient, times(2))
+        .listReviewCommentReactions(
+            eq("Bearer t"), anyString(), eq("owner"), eq("repo"), eq(10L), anyString(), eq(100));
+    verify(reactionClient, times(2))
+        .listReviewCommentReactions(
+            eq("Bearer t"), anyString(), eq("owner"), eq("repo"), eq(30L), anyString(), eq(100));
+    verify(reactionClient, never())
+        .listReviewCommentReactions(any(), any(), any(), any(), eq(11L), anyString(), anyInt());
+    verify(reactionClient, never())
+        .listReviewCommentReactions(any(), any(), any(), any(), eq(20L), anyString(), anyInt());
+    verify(reactionClient, never())
+        .listReviewCommentReactions(any(), any(), any(), any(), eq(40L), anyString(), anyInt());
   }
 
   @Test
@@ -233,13 +270,13 @@ class FindingFeedbackCaptureServiceTest {
   }
 
   @Test
-  void captureOnPriorFindingsStopsAtMaxFindings() {
+  void captureOnPriorFindingsStopsAtMaxFindingsInDeterministicIdOrder() {
     var comments = new java.util.ArrayList<GitHubReviewClient.PullRequestComment>();
-    var roots = new java.util.LinkedHashMap<Integer, Long>();
     int max = FindingFeedbackCaptureService.MAX_FINDINGS_PER_CAPTURE;
-    for (int i = 1; i <= max + 2; i++) {
+    // Insert higher ids first so insertion order would prefer them; we must still poll the
+    // lowest comment ids and skip the highest.
+    for (int i = max + 2; i >= 1; i--) {
       long id = 1000L + i;
-      roots.put(i, id);
       comments.add(
           new GitHubReviewClient.PullRequestComment(
               id,
@@ -248,17 +285,26 @@ class FindingFeedbackCaptureServiceTest {
               "x\n" + SuggestionFormatter.findingMarker(i),
               new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")));
     }
-    when(followUpAnalyzer.matchFindingThreads(anyString(), eq(comments), any())).thenReturn(roots);
     when(reactionClient.listReviewCommentReactions(
             any(), any(), any(), any(), anyLong(), any(), anyInt()))
         .thenReturn(List.of());
 
-    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, "{\"findings\":[]}", comments);
+    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, comments);
 
-    // +1 and -1 per finding, capped at MAX
     verify(reactionClient, times(max * 2))
         .listReviewCommentReactions(
             eq("Bearer t"), anyString(), eq("owner"), eq("repo"), anyLong(), anyString(), eq(100));
+    long skippedLow = 1000L + max + 1;
+    long skippedHigh = 1000L + max + 2;
+    verify(reactionClient, never())
+        .listReviewCommentReactions(
+            any(), any(), any(), any(), eq(skippedLow), anyString(), anyInt());
+    verify(reactionClient, never())
+        .listReviewCommentReactions(
+            any(), any(), any(), any(), eq(skippedHigh), anyString(), anyInt());
+    verify(reactionClient, times(2))
+        .listReviewCommentReactions(
+            eq("Bearer t"), anyString(), eq("owner"), eq("repo"), eq(1001L), anyString(), eq(100));
   }
 
   @Test
@@ -328,7 +374,7 @@ class FindingFeedbackCaptureServiceTest {
   }
 
   @Test
-  void captureOnPriorFindingsUsesMatchedThreads() {
+  void captureOnPriorFindingsPollsMarkedBotRoots() {
     var body = "x\n" + SuggestionFormatter.findingMarker(1);
     var comments =
         List.of(
@@ -338,13 +384,11 @@ class FindingFeedbackCaptureServiceTest {
                 "A.java",
                 body,
                 new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")));
-    when(followUpAnalyzer.matchFindingThreads(anyString(), eq(comments), any()))
-        .thenReturn(java.util.Map.of(1, 50L));
     when(reactionClient.listReviewCommentReactions(
             any(), any(), any(), any(), anyLong(), any(), anyInt()))
         .thenReturn(List.of());
 
-    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, "{\"findings\":[]}", comments);
+    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, comments);
 
     verify(reactionClient, times(2))
         .listReviewCommentReactions(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -516,4 +516,59 @@ class FindingFeedbackCaptureServiceTest {
         .listReviewCommentReactions(
             anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("+1"), eq(100), eq(2));
   }
+
+  @Test
+  void listAndRecordStopsAtMaxReactionPages() {
+    var fullPage =
+        java.util.stream.IntStream.rangeClosed(1, GitHubReactionClient.REACTIONS_PER_PAGE)
+            .mapToObj(
+                i ->
+                    new GitHubReactionClient.Reaction(
+                        (long) i, "+1", new GitHubReactionClient.Reaction.User("u" + i, i), "t"))
+            .toList();
+    when(reactionClient.listReviewCommentReactions(
+            anyString(),
+            anyString(),
+            eq("owner"),
+            eq("repo"),
+            eq(99L),
+            eq("+1"),
+            eq(GitHubReactionClient.REACTIONS_PER_PAGE),
+            anyInt()))
+        .thenReturn(fullPage);
+    when(reactionClient.listReviewCommentReactions(
+            anyString(),
+            anyString(),
+            eq("owner"),
+            eq("repo"),
+            eq(99L),
+            eq("-1"),
+            anyInt(),
+            anyInt()))
+        .thenReturn(List.of());
+
+    capture.captureReactions(
+        "Bearer t", "owner", "repo", 7, 99L, "x\n" + SuggestionFormatter.findingMarker(1));
+
+    verify(reactionClient, times(GitHubReactionClient.MAX_REACTION_PAGES))
+        .listReviewCommentReactions(
+            anyString(),
+            anyString(),
+            eq("owner"),
+            eq("repo"),
+            eq(99L),
+            eq("+1"),
+            eq(GitHubReactionClient.REACTIONS_PER_PAGE),
+            anyInt());
+    verify(reactionClient, never())
+        .listReviewCommentReactions(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyLong(),
+            eq("+1"),
+            anyInt(),
+            eq(GitHubReactionClient.MAX_REACTION_PAGES + 1));
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -75,28 +75,26 @@ class FindingFeedbackCaptureServiceTest {
 
     verify(feedbackService)
         .recordFeedback(
-            eq(
-                new FindingFeedbackService.FeedbackInput(
-                    "owner/repo",
-                    7,
-                    99L,
-                    2,
-                    FindingFeedback.SIGNAL_USEFUL,
-                    FindingFeedback.SOURCE_REACTION,
-                    "octocat",
-                    1L)));
+            new FindingFeedbackService.FeedbackInput(
+                "owner/repo",
+                7,
+                99L,
+                2,
+                FindingFeedback.SIGNAL_USEFUL,
+                FindingFeedback.SOURCE_REACTION,
+                "octocat",
+                1L));
     verify(feedbackService)
         .recordFeedback(
-            eq(
-                new FindingFeedbackService.FeedbackInput(
-                    "owner/repo",
-                    7,
-                    99L,
-                    2,
-                    FindingFeedback.SIGNAL_NOT_USEFUL,
-                    FindingFeedback.SOURCE_REACTION,
-                    "alice",
-                    3L)));
+            new FindingFeedbackService.FeedbackInput(
+                "owner/repo",
+                7,
+                99L,
+                2,
+                FindingFeedback.SIGNAL_NOT_USEFUL,
+                FindingFeedback.SOURCE_REACTION,
+                "alice",
+                3L));
     verify(feedbackService, never())
         .recordFeedback(argThat(in -> "thrillhousebot[bot]".equals(in.reactorLogin())));
   }
@@ -129,16 +127,15 @@ class FindingFeedbackCaptureServiceTest {
 
     verify(feedbackService)
         .recordFeedback(
-            eq(
-                new FindingFeedbackService.FeedbackInput(
-                    "owner/repo",
-                    7,
-                    99L,
-                    1,
-                    FindingFeedback.SIGNAL_NOT_USEFUL,
-                    FindingFeedback.SOURCE_REPLY_HEURISTIC,
-                    "octocat",
-                    null)));
+            new FindingFeedbackService.FeedbackInput(
+                "owner/repo",
+                7,
+                99L,
+                1,
+                FindingFeedback.SIGNAL_NOT_USEFUL,
+                FindingFeedback.SOURCE_REPLY_HEURISTIC,
+                "octocat",
+                null));
   }
 
   @Test
@@ -317,16 +314,15 @@ class FindingFeedbackCaptureServiceTest {
 
     verify(feedbackService)
         .recordFeedback(
-            eq(
-                new FindingFeedbackService.FeedbackInput(
-                    "owner/repo",
-                    7,
-                    99L,
-                    1,
-                    FindingFeedback.SIGNAL_USEFUL,
-                    FindingFeedback.SOURCE_REACTION,
-                    "bob",
-                    3L)));
+            new FindingFeedbackService.FeedbackInput(
+                "owner/repo",
+                7,
+                99L,
+                1,
+                FindingFeedback.SIGNAL_USEFUL,
+                FindingFeedback.SOURCE_REACTION,
+                "bob",
+                3L));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -53,7 +53,7 @@ class FindingFeedbackCaptureServiceTest {
   @Test
   void captureReactionsRecordsPlusAndMinusOneFromNonBotUsers() {
     when(reactionClient.listReviewCommentReactions(
-            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("+1"), eq(100)))
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("+1"), eq(100), eq(1)))
         .thenReturn(
             List.of(
                 new GitHubReactionClient.Reaction(
@@ -64,7 +64,7 @@ class FindingFeedbackCaptureServiceTest {
                     new GitHubReactionClient.Reaction.User("thrillhousebot[bot]", 2),
                     "t")));
     when(reactionClient.listReviewCommentReactions(
-            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("-1"), eq(100)))
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("-1"), eq(100), eq(1)))
         .thenReturn(
             List.of(
                 new GitHubReactionClient.Reaction(
@@ -117,7 +117,7 @@ class FindingFeedbackCaptureServiceTest {
                 "**HIGH — Bug**\n" + SuggestionFormatter.findingMarker(1),
                 new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")));
     when(reactionClient.listReviewCommentReactions(
-            any(), any(), any(), any(), anyLong(), any(), anyInt()))
+            any(), any(), any(), any(), anyLong(), any(), anyInt(), anyInt()))
         .thenReturn(List.of());
 
     capture.captureOnReviewReply(
@@ -164,7 +164,7 @@ class FindingFeedbackCaptureServiceTest {
   @Test
   void captureOnPriorFindingsScansAllBotFindingRootsAcrossRounds() {
     when(reactionClient.listReviewCommentReactions(
-            any(), any(), any(), any(), anyLong(), any(), anyInt()))
+            any(), any(), any(), any(), anyLong(), any(), anyInt(), anyInt()))
         .thenReturn(List.of());
     // Round-1 finding (id 10) plus a later-round finding (id 30); a human reply and a
     // non-finding bot root must be ignored. Empty previous-AI JSON is irrelevant — we scan
@@ -213,18 +213,36 @@ class FindingFeedbackCaptureServiceTest {
 
     verify(reactionClient, times(2))
         .listReviewCommentReactions(
-            eq("Bearer t"), anyString(), eq("owner"), eq("repo"), eq(10L), anyString(), eq(100));
+            eq("Bearer t"),
+            anyString(),
+            eq("owner"),
+            eq("repo"),
+            eq(10L),
+            anyString(),
+            eq(100),
+            anyInt());
     verify(reactionClient, times(2))
         .listReviewCommentReactions(
-            eq("Bearer t"), anyString(), eq("owner"), eq("repo"), eq(30L), anyString(), eq(100));
+            eq("Bearer t"),
+            anyString(),
+            eq("owner"),
+            eq("repo"),
+            eq(30L),
+            anyString(),
+            eq(100),
+            anyInt());
     verify(reactionClient, never())
-        .listReviewCommentReactions(any(), any(), any(), any(), eq(11L), anyString(), anyInt());
+        .listReviewCommentReactions(
+            any(), any(), any(), any(), eq(11L), anyString(), anyInt(), anyInt());
     verify(reactionClient, never())
-        .listReviewCommentReactions(any(), any(), any(), any(), eq(20L), anyString(), anyInt());
+        .listReviewCommentReactions(
+            any(), any(), any(), any(), eq(20L), anyString(), anyInt(), anyInt());
     verify(reactionClient, never())
-        .listReviewCommentReactions(any(), any(), any(), any(), eq(25L), anyString(), anyInt());
+        .listReviewCommentReactions(
+            any(), any(), any(), any(), eq(25L), anyString(), anyInt(), anyInt());
     verify(reactionClient, never())
-        .listReviewCommentReactions(any(), any(), any(), any(), eq(40L), anyString(), anyInt());
+        .listReviewCommentReactions(
+            any(), any(), any(), any(), eq(40L), anyString(), anyInt(), anyInt());
   }
 
   @Test
@@ -249,7 +267,14 @@ class FindingFeedbackCaptureServiceTest {
   @Test
   void listReactionsFailureIsSwallowed() {
     when(reactionClient.listReviewCommentReactions(
-            anyString(), anyString(), anyString(), anyString(), anyLong(), anyString(), anyInt()))
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyString(),
+            anyInt(),
+            anyInt()))
         .thenThrow(new RuntimeException("api down"));
     capture.captureReactions(
         "Bearer t", "owner", "repo", 7, 99L, "x\n" + SuggestionFormatter.findingMarker(1));
@@ -269,7 +294,7 @@ class FindingFeedbackCaptureServiceTest {
   @Test
   void captureReactionsSkipsNullOrIncompleteReactions() {
     when(reactionClient.listReviewCommentReactions(
-            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("+1"), eq(100)))
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("+1"), eq(100), eq(1)))
         .thenReturn(
             java.util.Arrays.asList(
                 null,
@@ -279,7 +304,7 @@ class FindingFeedbackCaptureServiceTest {
                 new GitHubReactionClient.Reaction(
                     3L, "+1", new GitHubReactionClient.Reaction.User("bob", 3), "t")));
     when(reactionClient.listReviewCommentReactions(
-            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("-1"), eq(100)))
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("-1"), eq(100), eq(1)))
         .thenReturn(List.of());
 
     capture.captureReactions(
@@ -314,25 +339,39 @@ class FindingFeedbackCaptureServiceTest {
               new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")));
     }
     when(reactionClient.listReviewCommentReactions(
-            any(), any(), any(), any(), anyLong(), any(), anyInt()))
+            any(), any(), any(), any(), anyLong(), any(), anyInt(), anyInt()))
         .thenReturn(List.of());
 
     capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, comments);
 
     verify(reactionClient, times(max * 2))
         .listReviewCommentReactions(
-            eq("Bearer t"), anyString(), eq("owner"), eq("repo"), anyLong(), anyString(), eq(100));
+            eq("Bearer t"),
+            anyString(),
+            eq("owner"),
+            eq("repo"),
+            anyLong(),
+            anyString(),
+            eq(100),
+            anyInt());
     long skippedLow = 1000L + max + 1;
     long skippedHigh = 1000L + max + 2;
     verify(reactionClient, never())
         .listReviewCommentReactions(
-            any(), any(), any(), any(), eq(skippedLow), anyString(), anyInt());
+            any(), any(), any(), any(), eq(skippedLow), anyString(), anyInt(), anyInt());
     verify(reactionClient, never())
         .listReviewCommentReactions(
-            any(), any(), any(), any(), eq(skippedHigh), anyString(), anyInt());
+            any(), any(), any(), any(), eq(skippedHigh), anyString(), anyInt(), anyInt());
     verify(reactionClient, times(2))
         .listReviewCommentReactions(
-            eq("Bearer t"), anyString(), eq("owner"), eq("repo"), eq(1001L), anyString(), eq(100));
+            eq("Bearer t"),
+            anyString(),
+            eq("owner"),
+            eq("repo"),
+            eq(1001L),
+            anyString(),
+            eq(100),
+            anyInt());
   }
 
   @Test
@@ -347,7 +386,7 @@ class FindingFeedbackCaptureServiceTest {
                 "x\n" + SuggestionFormatter.findingMarker(1),
                 new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")));
     when(reactionClient.listReviewCommentReactions(
-            any(), any(), any(), any(), anyLong(), any(), anyInt()))
+            any(), any(), any(), any(), anyLong(), any(), anyInt(), anyInt()))
         .thenReturn(List.of());
 
     capture.scheduleCaptureOnReviewReply(9L, "owner", "repo", 7, 99L, "octocat", "thanks");
@@ -393,7 +432,14 @@ class FindingFeedbackCaptureServiceTest {
   @Test
   void nullReactionsListIsIgnored() {
     when(reactionClient.listReviewCommentReactions(
-            anyString(), anyString(), anyString(), anyString(), anyLong(), anyString(), anyInt()))
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyString(),
+            anyInt(),
+            anyInt()))
         .thenReturn(null);
     capture.captureReactions(
         "Bearer t", "owner", "repo", 7, 99L, "x\n" + SuggestionFormatter.findingMarker(1));
@@ -413,13 +459,61 @@ class FindingFeedbackCaptureServiceTest {
                 body,
                 new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")));
     when(reactionClient.listReviewCommentReactions(
-            any(), any(), any(), any(), anyLong(), any(), anyInt()))
+            any(), any(), any(), any(), anyLong(), any(), anyInt(), anyInt()))
         .thenReturn(List.of());
 
     capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, comments);
 
     verify(reactionClient, times(2))
         .listReviewCommentReactions(
-            eq("Bearer t"), anyString(), eq("owner"), eq("repo"), eq(50L), anyString(), eq(100));
+            eq("Bearer t"),
+            anyString(),
+            eq("owner"),
+            eq("repo"),
+            eq(50L),
+            anyString(),
+            eq(100),
+            anyInt());
+  }
+
+  @Test
+  void listAndRecordWalksReactionPages() {
+    var page1 =
+        java.util.stream.IntStream.rangeClosed(1, 100)
+            .mapToObj(
+                i ->
+                    new GitHubReactionClient.Reaction(
+                        (long) i, "+1", new GitHubReactionClient.Reaction.User("user" + i, i), "t"))
+            .toList();
+    var page2 =
+        List.of(
+            new GitHubReactionClient.Reaction(
+                101L, "+1", new GitHubReactionClient.Reaction.User("last", 101), "t"));
+    when(reactionClient.listReviewCommentReactions(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("+1"), eq(100), eq(1)))
+        .thenReturn(page1);
+    when(reactionClient.listReviewCommentReactions(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("+1"), eq(100), eq(2)))
+        .thenReturn(page2);
+    when(reactionClient.listReviewCommentReactions(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("-1"), eq(100), eq(1)))
+        .thenReturn(List.of());
+
+    capture.captureReactions(
+        "Bearer t", "owner", "repo", 7, 99L, "x\n" + SuggestionFormatter.findingMarker(1));
+
+    verify(feedbackService, times(101))
+        .record(
+            eq("owner/repo"),
+            eq(7),
+            eq(99L),
+            eq(1),
+            eq(FindingFeedback.SIGNAL_USEFUL),
+            eq(FindingFeedback.SOURCE_REACTION),
+            anyString(),
+            any());
+    verify(reactionClient)
+        .listReviewCommentReactions(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("+1"), eq(100), eq(2));
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -201,9 +201,108 @@ class FindingFeedbackCaptureServiceTest {
   }
 
   @Test
+  void captureReactionsSkipsNullOrIncompleteReactions() {
+    when(reactionClient.listReviewCommentReactions(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("+1"), eq(100)))
+        .thenReturn(
+            java.util.Arrays.asList(
+                null,
+                new GitHubReactionClient.Reaction(1L, "+1", null, "t"),
+                new GitHubReactionClient.Reaction(
+                    2L, "+1", new GitHubReactionClient.Reaction.User(null, 2), "t"),
+                new GitHubReactionClient.Reaction(
+                    3L, "+1", new GitHubReactionClient.Reaction.User("bob", 3), "t")));
+    when(reactionClient.listReviewCommentReactions(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("-1"), eq(100)))
+        .thenReturn(List.of());
+
+    capture.captureReactions(
+        "Bearer t", "owner", "repo", 7, 99L, "x\n" + SuggestionFormatter.findingMarker(1));
+
+    verify(feedbackService)
+        .record(
+            "owner/repo",
+            7,
+            99L,
+            1,
+            FindingFeedback.SIGNAL_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "bob",
+            3L);
+  }
+
+  @Test
+  void captureOnPriorFindingsStopsAtMaxFindings() {
+    var comments = new java.util.ArrayList<GitHubReviewClient.PullRequestComment>();
+    var roots = new java.util.LinkedHashMap<Integer, Long>();
+    int max = FindingFeedbackCaptureService.MAX_FINDINGS_PER_CAPTURE;
+    for (int i = 1; i <= max + 2; i++) {
+      long id = 1000L + i;
+      roots.put(i, id);
+      comments.add(
+          new GitHubReviewClient.PullRequestComment(
+              id,
+              null,
+              "A.java",
+              "x\n" + SuggestionFormatter.findingMarker(i),
+              new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")));
+    }
+    when(followUpAnalyzer.matchFindingThreads(anyString(), eq(comments), any())).thenReturn(roots);
+    when(reactionClient.listReviewCommentReactions(
+            any(), any(), any(), any(), anyLong(), any(), anyInt()))
+        .thenReturn(List.of());
+
+    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, "{\"findings\":[]}", comments);
+
+    // +1 and -1 per finding, capped at MAX
+    verify(reactionClient, times(max * 2))
+        .listReviewCommentReactions(
+            eq("Bearer t"), anyString(), eq("owner"), eq("repo"), anyLong(), anyString(), eq(100));
+  }
+
+  @Test
+  void scheduleCaptureOnReviewReplyRunsSuccessfully() {
+    when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
+    when(reviewClient.getPullRequestComment(any(), any(), eq("owner"), eq("repo"), eq(99L)))
+        .thenReturn(
+            new GitHubReviewClient.PullRequestComment(
+                99L,
+                null,
+                "Main.java",
+                "x\n" + SuggestionFormatter.findingMarker(1),
+                new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")));
+    when(reactionClient.listReviewCommentReactions(
+            any(), any(), any(), any(), anyLong(), any(), anyInt()))
+        .thenReturn(List.of());
+
+    capture.scheduleCaptureOnReviewReply(9L, "owner", "repo", 7, 99L, "octocat", "thanks");
+    verify(authClient, timeout(2000)).getAuthHeader(9L);
+    verify(reviewClient, timeout(2000))
+        .getPullRequestComment(any(), any(), eq("owner"), eq("repo"), eq(99L));
+  }
+
+  @Test
+  void shutdownStopsExecutor() {
+    capture.shutdown();
+  }
+
+  @Test
+  void fetchCommentBodyNullCommentSkipsCapture() {
+    when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
+    when(reviewClient.getPullRequestComment(any(), any(), any(), any(), anyLong()))
+        .thenReturn(null);
+    capture.captureOnReviewReply(9L, "owner", "repo", 7, 99L, "octocat", "not useful");
+    verifyNoInteractions(reactionClient, feedbackService);
+  }
+
+  @Test
   void replyHeuristicIgnoresBotAuthorAndNonMatchingBodies() {
     capture.captureReplyHeuristic("owner", "repo", 1, 9L, 1, "thrillhousebot[bot]", "not useful");
     capture.captureReplyHeuristic("owner", "repo", 1, 9L, 1, "octocat", "looks fine to me");
+    capture.captureReplyHeuristic("owner", "repo", 1, 9L, 1, null, "not useful");
+    capture.captureReplyHeuristic("owner", "repo", 1, 9L, 1, " ", "not useful");
+    capture.captureReplyHeuristic("owner", "repo", 1, 9L, 1, "octocat", null);
+    capture.captureReplyHeuristic("owner", "repo", 1, 9L, 1, "octocat", "");
     verifyNoInteractions(feedbackService);
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -170,7 +170,8 @@ class FindingFeedbackCaptureServiceTest {
     // non-finding bot root must be ignored. Empty previous-AI JSON is irrelevant — we scan
     // comments directly so reactions on older rounds are still polled.
     var comments =
-        List.of(
+        java.util.Arrays.asList(
+            null, // null entries must not abort the scan
             new GitHubReviewClient.PullRequestComment(
                 10L,
                 null,
@@ -189,6 +190,12 @@ class FindingFeedbackCaptureServiceTest {
                 "B.java",
                 "summary without marker",
                 new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")),
+            new GitHubReviewClient.PullRequestComment(
+                25L,
+                null,
+                "B2.java",
+                "marker but null user\n" + SuggestionFormatter.findingMarker(2),
+                null),
             new GitHubReviewClient.PullRequestComment(
                 30L,
                 null,
@@ -215,7 +222,28 @@ class FindingFeedbackCaptureServiceTest {
     verify(reactionClient, never())
         .listReviewCommentReactions(any(), any(), any(), any(), eq(20L), anyString(), anyInt());
     verify(reactionClient, never())
+        .listReviewCommentReactions(any(), any(), any(), any(), eq(25L), anyString(), anyInt());
+    verify(reactionClient, never())
         .listReviewCommentReactions(any(), any(), any(), any(), eq(40L), anyString(), anyInt());
+  }
+
+  @Test
+  void captureOnPriorFindingsSwallowsIterationFailures() {
+    var exploding =
+        new java.util.AbstractList<GitHubReviewClient.PullRequestComment>() {
+          @Override
+          public int size() {
+            return 1;
+          }
+
+          @Override
+          public GitHubReviewClient.PullRequestComment get(int index) {
+            throw new RuntimeException("boom");
+          }
+        };
+    assertDoesNotThrow(
+        () -> capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, exploding));
+    verifyNoInteractions(reactionClient, feedbackService);
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -157,6 +157,77 @@ class FindingFeedbackCaptureServiceTest {
   }
 
   @Test
+  void captureOnPriorFindingsNoopsOnEmptyInput() {
+    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, null, List.of());
+    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, " ", List.of());
+    capture.captureOnPriorFindings("Bearer t", "owner", "repo", 3, "{}", null);
+    verifyNoInteractions(followUpAnalyzer, reactionClient, feedbackService);
+  }
+
+  @Test
+  void captureOnPriorFindingsSwallowsAnalyzerFailures() {
+    when(followUpAnalyzer.matchFindingThreads(anyString(), any(), any()))
+        .thenThrow(new RuntimeException("boom"));
+    capture.captureOnPriorFindings(
+        "Bearer t",
+        "owner",
+        "repo",
+        3,
+        "{}",
+        List.of(
+            new GitHubReviewClient.PullRequestComment(
+                1L, null, "A.java", "x", new GitHubReviewClient.ReviewResponse.User("bot"))));
+    verifyNoInteractions(reactionClient, feedbackService);
+  }
+
+  @Test
+  void listReactionsFailureIsSwallowed() {
+    when(reactionClient.listReviewCommentReactions(
+            anyString(), anyString(), anyString(), anyString(), anyLong(), anyString(), anyInt()))
+        .thenThrow(new RuntimeException("api down"));
+    capture.captureReactions(
+        "Bearer t", "owner", "repo", 7, 99L, "x\n" + SuggestionFormatter.findingMarker(1));
+    verify(feedbackService, never())
+        .record(any(), anyInt(), anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void fetchCommentBodyFailureSkipsCapture() {
+    when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
+    when(reviewClient.getPullRequestComment(any(), any(), any(), any(), anyLong()))
+        .thenThrow(new RuntimeException("gone"));
+    capture.captureOnReviewReply(9L, "owner", "repo", 7, 99L, "octocat", "not useful");
+    verifyNoInteractions(reactionClient, feedbackService);
+  }
+
+  @Test
+  void replyHeuristicIgnoresBotAuthorAndNonMatchingBodies() {
+    capture.captureReplyHeuristic("owner", "repo", 1, 9L, 1, "thrillhousebot[bot]", "not useful");
+    capture.captureReplyHeuristic("owner", "repo", 1, 9L, 1, "octocat", "looks fine to me");
+    verifyNoInteractions(feedbackService);
+  }
+
+  @Test
+  void scheduleCaptureOnReviewReplyRunsAsyncAndSwallowsErrors() throws Exception {
+    when(authClient.getAuthHeader(anyLong())).thenThrow(new RuntimeException("auth fail"));
+    capture.scheduleCaptureOnReviewReply(1L, "o", "r", 1, 9L, "u", "not useful");
+    // Give the virtual thread a moment; failure must not escape.
+    Thread.sleep(200);
+    verify(authClient, timeout(2000)).getAuthHeader(1L);
+  }
+
+  @Test
+  void nullReactionsListIsIgnored() {
+    when(reactionClient.listReviewCommentReactions(
+            anyString(), anyString(), anyString(), anyString(), anyLong(), anyString(), anyInt()))
+        .thenReturn(null);
+    capture.captureReactions(
+        "Bearer t", "owner", "repo", 7, 99L, "x\n" + SuggestionFormatter.findingMarker(1));
+    verify(feedbackService, never())
+        .record(any(), anyInt(), anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
   void captureOnPriorFindingsUsesMatchedThreads() {
     var body = "x\n" + SuggestionFormatter.findingMarker(1);
     var comments =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackServiceTest.java
@@ -137,6 +137,14 @@ class FindingFeedbackServiceTest {
   }
 
   @Test
+  void summarizeAndListRecentHandleBlankKeys() {
+    assertEquals(0, service.summarize(null).totalEvents());
+    assertEquals(0, service.summarize(" ").totalEvents());
+    assertTrue(service.listRecent(null, 10).isEmpty());
+    assertTrue(service.listRecent("owner/repo", 0).isEmpty());
+  }
+
+  @Test
   void recordRejectsBlankInputs() {
     assertFalse(
         service.record(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackServiceTest.java
@@ -141,7 +141,33 @@ class FindingFeedbackServiceTest {
     assertEquals(0, service.summarize(null).totalEvents());
     assertEquals(0, service.summarize(" ").totalEvents());
     assertTrue(service.listRecent(null, 10).isEmpty());
+    assertTrue(service.listRecent(" ", 10).isEmpty());
     assertTrue(service.listRecent("owner/repo", 0).isEmpty());
+    assertTrue(service.listRecent("owner/repo", -1).isEmpty());
+  }
+
+  @Test
+  void recordAcceptsNullReactionIdAndRejectsNullReactor() {
+    assertTrue(
+        service.record(
+            "owner/repo",
+            1,
+            50L,
+            1,
+            FindingFeedback.SIGNAL_USEFUL,
+            FindingFeedback.SOURCE_REPLY_HEURISTIC,
+            "carol",
+            null));
+    assertFalse(
+        service.record(
+            "owner/repo",
+            1,
+            51L,
+            1,
+            FindingFeedback.SIGNAL_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            null,
+            77L));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackServiceTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.UserTransaction;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class FindingFeedbackServiceTest {
+
+  @Inject FindingFeedbackService service;
+  @Inject UserTransaction tx;
+
+  @AfterEach
+  void cleanup() throws Exception {
+    tx.begin();
+    FindingFeedback.deleteAll();
+    tx.commit();
+  }
+
+  @Test
+  void recordPersistsReactionAndIsIdempotentByReactionId() {
+    assertTrue(
+        service.record(
+            "owner/repo",
+            7,
+            100L,
+            1,
+            FindingFeedback.SIGNAL_NOT_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "octocat",
+            55L));
+    assertFalse(
+        service.record(
+            "owner/repo",
+            7,
+            100L,
+            1,
+            FindingFeedback.SIGNAL_NOT_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "octocat",
+            55L));
+
+    assertEquals(1, FindingFeedback.count());
+    var summary = service.summarize("owner/repo");
+    assertEquals(0, summary.usefulCount());
+    assertEquals(1, summary.notUsefulCount());
+    assertEquals(1, summary.totalEvents());
+  }
+
+  @Test
+  void recordNormalizesLoginAndIgnoresDuplicateCompositeKey() {
+    assertTrue(
+        service.record(
+            "owner/repo",
+            3,
+            200L,
+            2,
+            FindingFeedback.SIGNAL_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "OctoCat",
+            1L));
+    assertFalse(
+        service.record(
+            "owner/repo",
+            3,
+            200L,
+            2,
+            FindingFeedback.SIGNAL_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "octocat",
+            99L));
+
+    assertEquals(1, FindingFeedback.count());
+    FindingFeedback saved = FindingFeedback.<FindingFeedback>listAll().get(0);
+    assertEquals("octocat", saved.reactorLogin);
+
+    var recent = service.listRecent("owner/repo", 10);
+    assertEquals(1, recent.size());
+    assertEquals(2, recent.get(0).findingIndex());
+    assertEquals(1L, recent.get(0).githubReactionId());
+  }
+
+  @Test
+  void summarizeAllOrdersByTotalEvents() {
+    service.record(
+        "a/one",
+        1,
+        1L,
+        1,
+        FindingFeedback.SIGNAL_USEFUL,
+        FindingFeedback.SOURCE_REACTION,
+        "u1",
+        10L);
+    service.record(
+        "b/two",
+        1,
+        2L,
+        1,
+        FindingFeedback.SIGNAL_USEFUL,
+        FindingFeedback.SOURCE_REACTION,
+        "u1",
+        11L);
+    service.record(
+        "b/two",
+        1,
+        2L,
+        1,
+        FindingFeedback.SIGNAL_NOT_USEFUL,
+        FindingFeedback.SOURCE_REACTION,
+        "u2",
+        12L);
+
+    var all = service.summarizeAll();
+    assertEquals(2, all.size());
+    assertEquals("b/two", all.get(0).repository());
+    assertEquals(2, all.get(0).totalEvents());
+    assertEquals("a/one", all.get(1).repository());
+  }
+
+  @Test
+  void recordRejectsBlankInputs() {
+    assertFalse(
+        service.record(
+            "", 1, 1L, 1, FindingFeedback.SIGNAL_USEFUL, FindingFeedback.SOURCE_REACTION, "u", 1L));
+    assertFalse(
+        service.record(
+            "o/r",
+            1,
+            1L,
+            1,
+            FindingFeedback.SIGNAL_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            " ",
+            1L));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackServiceTest.java
@@ -159,5 +159,17 @@ class FindingFeedbackServiceTest {
             FindingFeedback.SOURCE_REACTION,
             " ",
             1L));
+    assertFalse(service.record("o/r", 1, 1L, 1, null, FindingFeedback.SOURCE_REACTION, "u", 1L));
+    assertFalse(service.record("o/r", 1, 1L, 1, FindingFeedback.SIGNAL_USEFUL, null, "u", 1L));
+    assertFalse(
+        service.record(
+            null,
+            1,
+            1L,
+            1,
+            FindingFeedback.SIGNAL_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "u",
+            1L));
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackServiceTest.java
@@ -39,25 +39,27 @@ class FindingFeedbackServiceTest {
   @Test
   void recordPersistsReactionAndIsIdempotentByReactionId() {
     assertTrue(
-        service.record(
-            "owner/repo",
-            7,
-            100L,
-            1,
-            FindingFeedback.SIGNAL_NOT_USEFUL,
-            FindingFeedback.SOURCE_REACTION,
-            "octocat",
-            55L));
+        service.recordFeedback(
+            new FindingFeedbackService.FeedbackInput(
+                "owner/repo",
+                7,
+                100L,
+                1,
+                FindingFeedback.SIGNAL_NOT_USEFUL,
+                FindingFeedback.SOURCE_REACTION,
+                "octocat",
+                55L)));
     assertFalse(
-        service.record(
-            "owner/repo",
-            7,
-            100L,
-            1,
-            FindingFeedback.SIGNAL_NOT_USEFUL,
-            FindingFeedback.SOURCE_REACTION,
-            "octocat",
-            55L));
+        service.recordFeedback(
+            new FindingFeedbackService.FeedbackInput(
+                "owner/repo",
+                7,
+                100L,
+                1,
+                FindingFeedback.SIGNAL_NOT_USEFUL,
+                FindingFeedback.SOURCE_REACTION,
+                "octocat",
+                55L)));
 
     assertEquals(1, FindingFeedback.count());
     var summary = service.summarize("owner/repo");
@@ -69,25 +71,27 @@ class FindingFeedbackServiceTest {
   @Test
   void recordNormalizesLoginAndIgnoresDuplicateCompositeKey() {
     assertTrue(
-        service.record(
-            "owner/repo",
-            3,
-            200L,
-            2,
-            FindingFeedback.SIGNAL_USEFUL,
-            FindingFeedback.SOURCE_REACTION,
-            "OctoCat",
-            1L));
+        service.recordFeedback(
+            new FindingFeedbackService.FeedbackInput(
+                "owner/repo",
+                3,
+                200L,
+                2,
+                FindingFeedback.SIGNAL_USEFUL,
+                FindingFeedback.SOURCE_REACTION,
+                "OctoCat",
+                1L)));
     assertFalse(
-        service.record(
-            "owner/repo",
-            3,
-            200L,
-            2,
-            FindingFeedback.SIGNAL_USEFUL,
-            FindingFeedback.SOURCE_REACTION,
-            "octocat",
-            99L));
+        service.recordFeedback(
+            new FindingFeedbackService.FeedbackInput(
+                "owner/repo",
+                3,
+                200L,
+                2,
+                FindingFeedback.SIGNAL_USEFUL,
+                FindingFeedback.SOURCE_REACTION,
+                "octocat",
+                99L)));
 
     assertEquals(1, FindingFeedback.count());
     FindingFeedback saved = FindingFeedback.<FindingFeedback>listAll().get(0);
@@ -101,33 +105,36 @@ class FindingFeedbackServiceTest {
 
   @Test
   void summarizeAllOrdersByTotalEvents() {
-    service.record(
-        "a/one",
-        1,
-        1L,
-        1,
-        FindingFeedback.SIGNAL_USEFUL,
-        FindingFeedback.SOURCE_REACTION,
-        "u1",
-        10L);
-    service.record(
-        "b/two",
-        1,
-        2L,
-        1,
-        FindingFeedback.SIGNAL_USEFUL,
-        FindingFeedback.SOURCE_REACTION,
-        "u1",
-        11L);
-    service.record(
-        "b/two",
-        1,
-        2L,
-        1,
-        FindingFeedback.SIGNAL_NOT_USEFUL,
-        FindingFeedback.SOURCE_REACTION,
-        "u2",
-        12L);
+    service.recordFeedback(
+        new FindingFeedbackService.FeedbackInput(
+            "a/one",
+            1,
+            1L,
+            1,
+            FindingFeedback.SIGNAL_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "u1",
+            10L));
+    service.recordFeedback(
+        new FindingFeedbackService.FeedbackInput(
+            "b/two",
+            1,
+            2L,
+            1,
+            FindingFeedback.SIGNAL_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "u1",
+            11L));
+    service.recordFeedback(
+        new FindingFeedbackService.FeedbackInput(
+            "b/two",
+            1,
+            2L,
+            1,
+            FindingFeedback.SIGNAL_NOT_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "u2",
+            12L));
 
     var all = service.summarizeAll();
     assertEquals(2, all.size());
@@ -149,53 +156,72 @@ class FindingFeedbackServiceTest {
   @Test
   void recordAcceptsNullReactionIdAndRejectsNullReactor() {
     assertTrue(
-        service.record(
-            "owner/repo",
-            1,
-            50L,
-            1,
-            FindingFeedback.SIGNAL_USEFUL,
-            FindingFeedback.SOURCE_REPLY_HEURISTIC,
-            "carol",
-            null));
+        service.recordFeedback(
+            new FindingFeedbackService.FeedbackInput(
+                "owner/repo",
+                1,
+                50L,
+                1,
+                FindingFeedback.SIGNAL_USEFUL,
+                FindingFeedback.SOURCE_REPLY_HEURISTIC,
+                "carol",
+                null)));
     assertFalse(
-        service.record(
-            "owner/repo",
-            1,
-            51L,
-            1,
-            FindingFeedback.SIGNAL_USEFUL,
-            FindingFeedback.SOURCE_REACTION,
-            null,
-            77L));
+        service.recordFeedback(
+            new FindingFeedbackService.FeedbackInput(
+                "owner/repo",
+                1,
+                51L,
+                1,
+                FindingFeedback.SIGNAL_USEFUL,
+                FindingFeedback.SOURCE_REACTION,
+                null,
+                77L)));
   }
 
   @Test
   void recordRejectsBlankInputs() {
+    assertFalse(service.recordFeedback(null));
     assertFalse(
-        service.record(
-            "", 1, 1L, 1, FindingFeedback.SIGNAL_USEFUL, FindingFeedback.SOURCE_REACTION, "u", 1L));
+        service.recordFeedback(
+            new FindingFeedbackService.FeedbackInput(
+                "",
+                1,
+                1L,
+                1,
+                FindingFeedback.SIGNAL_USEFUL,
+                FindingFeedback.SOURCE_REACTION,
+                "u",
+                1L)));
     assertFalse(
-        service.record(
-            "o/r",
-            1,
-            1L,
-            1,
-            FindingFeedback.SIGNAL_USEFUL,
-            FindingFeedback.SOURCE_REACTION,
-            " ",
-            1L));
-    assertFalse(service.record("o/r", 1, 1L, 1, null, FindingFeedback.SOURCE_REACTION, "u", 1L));
-    assertFalse(service.record("o/r", 1, 1L, 1, FindingFeedback.SIGNAL_USEFUL, null, "u", 1L));
+        service.recordFeedback(
+            new FindingFeedbackService.FeedbackInput(
+                "o/r",
+                1,
+                1L,
+                1,
+                FindingFeedback.SIGNAL_USEFUL,
+                FindingFeedback.SOURCE_REACTION,
+                " ",
+                1L)));
     assertFalse(
-        service.record(
-            null,
-            1,
-            1L,
-            1,
-            FindingFeedback.SIGNAL_USEFUL,
-            FindingFeedback.SOURCE_REACTION,
-            "u",
-            1L));
+        service.recordFeedback(
+            new FindingFeedbackService.FeedbackInput(
+                "o/r", 1, 1L, 1, null, FindingFeedback.SOURCE_REACTION, "u", 1L)));
+    assertFalse(
+        service.recordFeedback(
+            new FindingFeedbackService.FeedbackInput(
+                "o/r", 1, 1L, 1, FindingFeedback.SIGNAL_USEFUL, null, "u", 1L)));
+    assertFalse(
+        service.recordFeedback(
+            new FindingFeedbackService.FeedbackInput(
+                null,
+                1,
+                1L,
+                1,
+                FindingFeedback.SIGNAL_USEFUL,
+                FindingFeedback.SOURCE_REACTION,
+                "u",
+                1L)));
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -207,6 +207,7 @@ class ReviewOrchestratorTest {
         reviewPublisher,
         verdictBuilder,
         findingPipeline,
+        mock(FindingFeedbackCaptureService.class),
         reviewExecutor);
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatterTest.java
@@ -85,6 +85,8 @@ class SuggestionFormatterTest {
         SuggestionFormatter.parseFindingMarker("x\n<!-- thrillhousebot:finding=3 -->").getAsInt());
     assertTrue(SuggestionFormatter.parseFindingMarker("no marker").isEmpty());
     assertTrue(SuggestionFormatter.parseFindingMarker(null).isEmpty());
+    assertTrue(SuggestionFormatter.parseFindingMarker("").isEmpty());
+    assertTrue(SuggestionFormatter.parseFindingMarker("   ").isEmpty());
     assertTrue(
         SuggestionFormatter.parseFindingMarker(
                 "<!-- thrillhousebot:finding=99999999999999999999 -->")

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatterTest.java
@@ -85,6 +85,10 @@ class SuggestionFormatterTest {
         SuggestionFormatter.parseFindingMarker("x\n<!-- thrillhousebot:finding=3 -->").getAsInt());
     assertTrue(SuggestionFormatter.parseFindingMarker("no marker").isEmpty());
     assertTrue(SuggestionFormatter.parseFindingMarker(null).isEmpty());
+    assertTrue(
+        SuggestionFormatter.parseFindingMarker(
+                "<!-- thrillhousebot:finding=99999999999999999999 -->")
+            .isEmpty());
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatterTest.java
@@ -79,6 +79,15 @@ class SuggestionFormatterTest {
   }
 
   @Test
+  void shouldParseFindingMarkerFromCommentBody() {
+    assertEquals(
+        3,
+        SuggestionFormatter.parseFindingMarker("x\n<!-- thrillhousebot:finding=3 -->").getAsInt());
+    assertTrue(SuggestionFormatter.parseFindingMarker("no marker").isEmpty());
+    assertTrue(SuggestionFormatter.parseFindingMarker(null).isEmpty());
+  }
+
+  @Test
   void shouldOmitFindingMarkerWithoutId() {
     var finding = new Finding(RiskLevel.HIGH, "Main.java", 10, "Bug", "Fix it", null, null);
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.review.AutoReviewRateLimiter;
+import dev.thiagogonzaga.thrillhousebot.review.FindingFeedbackCaptureService;
 import dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyDispatcher;
 import dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyService;
 import dev.thiagogonzaga.thrillhousebot.review.ReviewDispatcher;
@@ -71,6 +72,8 @@ class WebhookControllerTest {
 
   @Mock private AckReactionService ackReactionService;
 
+  @Mock private FindingFeedbackCaptureService findingFeedbackCapture;
+
   private final ObjectMapper mapper = new ObjectMapper();
 
   /** A non-null delivery id; the mocked deduplicator reports it unseen unless a test overrides. */
@@ -99,6 +102,7 @@ class WebhookControllerTest {
             commentCommandService,
             prPauseService,
             ackReactionService,
+            findingFeedbackCapture,
             mapper);
   }
 
@@ -985,6 +989,10 @@ class WebhookControllerTest {
             "sha256=valid", "pull_request_review_comment", null, DELIVERY, body);
     assertEquals(200, response.getStatus());
 
+    verify(findingFeedbackCapture)
+        .scheduleCaptureOnReviewReply(
+            12345L, "owner", "repo", 42, 99L, "octocat", "@thrillhousebot why is this flagged?");
+
     verify(replyDispatcher)
         .dispatch(
             new MaintainerReplyService.ReplyTask(
@@ -1002,6 +1010,26 @@ class WebhookControllerTest {
                 1000L,
                 true,
                 "@@ -1 +1 @@"));
+  }
+
+  @Test
+  void shouldCaptureFindingFeedbackOnReviewReplyWithoutBotMention() {
+    when(verifier.verify(anyString(), any(byte[].class), anyString())).thenReturn(true);
+    when(triggerDetector.isBotComment("octocat")).thenReturn(false);
+    when(triggerDetector.containsBotMention("not useful")).thenReturn(false);
+
+    var body =
+        buildReviewCommentPayload("created", 42, "owner/repo", "octocat", "not useful", 99L, 1001L)
+            .getBytes(StandardCharsets.UTF_8);
+
+    var response =
+        controller.handleWebhook(
+            "sha256=valid", "pull_request_review_comment", null, DELIVERY, body);
+    assertEquals(200, response.getStatus());
+
+    verify(findingFeedbackCapture)
+        .scheduleCaptureOnReviewReply(12345L, "owner", "repo", 42, 99L, "octocat", "not useful");
+    verify(replyDispatcher, never()).dispatch(any(MaintainerReplyService.ReplyTask.class));
   }
 
   @Test

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -60,6 +60,7 @@ export default defineConfig({
         { label: "Configuration", slug: "configuration" },
         { label: "AI providers", slug: "providers" },
         { label: "Architecture", slug: "architecture" },
+        { label: "Finding feedback", slug: "feedback" },
         { label: "How it compares", slug: "comparison" },
         { label: "Contributing", slug: "contributing" },
       ],

--- a/website/src/content/docs/feedback.md
+++ b/website/src/content/docs/feedback.md
@@ -1,0 +1,6 @@
+---
+title: Finding feedback
+description: Data model, privacy, and retention for maintainer finding feedback signals.
+---
+
+<!-- include: ../../../../docs/FEEDBACK.md#feedback -->

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -29,6 +29,8 @@ local Ollama model, so no code has to leave your network.
   OpenAI-compatible endpoint of your choice.
 - **[Architecture](/ThrillhouseBot/architecture/)** — how a review flows
   through the system.
+- **[Finding feedback](/ThrillhouseBot/feedback/)** — maintainer 👍/👎 capture
+  for the learnings pipeline.
 - **[How it compares](/ThrillhouseBot/comparison/)** — an honest look at where
   ThrillhouseBot sits next to other AI code-review tools.
 - **[Contributing](/ThrillhouseBot/contributing/)** — development setup and the


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [x] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Captures maintainer finding feedback as a precursor to cross-review learnings (#38).

GitHub Apps do not receive a `reaction` webhook event, so the bot polls 👍 (`+1`) / 👎 (`-1`) on bot finding comments via the Reactions REST API when a human replies on a review thread or during follow-up reviews. Conservative reply heuristics (`not useful`, `false positive`, 👎, etc.) are recorded as well.

Persists events in `finding_feedback` (login only — no extra PII), exposes aggregates at `GET /api/dashboard/feedback`, and documents the data model + retention in `docs/FEEDBACK.md`. Does **not** feed preferences into review prompts yet.

## Related Issues

Fixes #324

Related: #38 (consumer), #315 (👀 ack — orthogonal, already shipped), #31 (conversational replies)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

- `FindingFeedbackServiceTest` — persist, idempotency, summarize, listRecent
- `FindingFeedbackCaptureServiceTest` — reaction poll, heuristics, marker gating, error paths
- `WebhookControllerTest` — schedules capture on review-thread replies (with and without @mention)
- `DashboardResourceTest` — `/api/dashboard/feedback` aggregates
- `./mvnw verify` (Spotless, SpotBugs, tests, JaCoCo) locally

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A — backend capture path + dashboard JSON API; no UI page in this PR.

## Additional Notes

Optional frontend feedback page was deferred; API + docs cover the optional dashboard acceptance criterion.