### PR TITLE
perf(review): dedupe DiffLineResolver, prior-response parse, and status copy (#135)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffLineResolver.java
@@ -24,6 +24,7 @@ import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -36,6 +37,12 @@ public final class DiffLineResolver {
   // Shared with FindingQuoteValidator, which tracks the same right-side line numbers.
   static final Pattern HUNK_HEADER = Pattern.compile("@@ -\\d+(?:,\\d+)? \\+(\\d+)(?:,\\d+)? @@");
 
+  /**
+   * Package-visible construction counter so tests can assert one build per review (and none when a
+   * lazy supplier is never touched).
+   */
+  static final AtomicInteger CONSTRUCTION_COUNT = new AtomicInteger();
+
   private final Map<String, TreeSet<Integer>> rightSideLinesByFile;
   private final Map<String, List<String>> rightSideTextByFile;
   private final Map<String, List<Integer>> rightSideTextLineNumbersByFile;
@@ -43,6 +50,7 @@ public final class DiffLineResolver {
   private final Map<String, TreeSet<Integer>> rightSideHunkStartsByFile;
 
   public DiffLineResolver(Map<String, String> patchesByFile) {
+    CONSTRUCTION_COUNT.incrementAndGet();
     this.rightSideLinesByFile = new HashMap<>();
     this.rightSideTextByFile = new HashMap<>();
     this.rightSideTextLineNumbersByFile = new HashMap<>();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -131,7 +131,7 @@ public class FindingPipeline {
               aiResponse.previousFindingsStatus(),
               budgetedBatch,
               plan,
-              followUpAnalyzer.previousFindingFilesById(ctx.previousAiResponseJson()));
+              followUpAnalyzer.previousFindingFilesById(ctx.previousFindingsList()));
       aiResponse = new ReviewResponse(aiResponse.findings(), scoped, aiResponse.summary());
     }
     return refine(
@@ -166,7 +166,7 @@ public class FindingPipeline {
     var batches = plan.batches();
     // The id space of previous_findings_status entries maps 1-based onto the prior response's
     // findings; a batch may only close a prior finding whose file its own diff slice contained.
-    var previousFilesById = followUpAnalyzer.previousFindingFilesById(ctx.previousAiResponseJson());
+    var previousFilesById = followUpAnalyzer.previousFindingFilesById(ctx.previousFindingsList());
 
     var outcomesByIndex = new BatchOutcome[batches.size()];
     var failedIndices = new ArrayList<Integer>();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -531,6 +531,9 @@ public class FollowUpAnalyzer {
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       BotIdentity botIdentity) {
     var threads = new HashMap<Integer, Long>();
+    if (previous == null || previous.isEmpty()) {
+      return threads;
+    }
     for (var i = 0; i < previous.size(); i++) {
       Long rootId = rootCommentId(previous.get(i), i + 1, inlineComments, botIdentity);
       if (rootId != null) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -100,8 +100,26 @@ public class FollowUpAnalyzer {
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       List<String> olderAiResponseJsons,
       BotIdentity botIdentity) {
-    var structured = formatStructuredFindings(previousAiResponseJson, inlineComments, botIdentity);
-    var answered = formatAnsweredEarlier(olderAiResponseJsons, inlineComments, botIdentity);
+    return buildPreviousFindingsContext(
+        parsePreviousFindings(previousAiResponseJson),
+        priorReviews,
+        inlineComments,
+        parsePreviousResponses(olderAiResponseJsons),
+        botIdentity);
+  }
+
+  /**
+   * Same as the JSON overload, but consumes findings already deserialized for this review so the
+   * prior-response JSON is not re-parsed.
+   */
+  public String buildPreviousFindingsContext(
+      List<ReviewResponse.Finding> previousFindings,
+      List<GitHubReviewClient.ReviewResponse> priorReviews,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      List<ReviewResponse> olderAiResponses,
+      BotIdentity botIdentity) {
+    var structured = formatStructuredFindings(previousFindings, inlineComments, botIdentity);
+    var answered = formatAnsweredEarlier(olderAiResponses, inlineComments, botIdentity);
     if (!structured.isEmpty()) {
       return structured + answered;
     }
@@ -115,16 +133,16 @@ public class FollowUpAnalyzer {
    * previous_findings_status.
    */
   private String formatAnsweredEarlier(
-      List<String> olderAiResponseJsons,
+      List<ReviewResponse> olderAiResponses,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       BotIdentity botIdentity) {
-    if (olderAiResponseJsons == null || olderAiResponseJsons.isEmpty()) {
+    if (olderAiResponses == null || olderAiResponses.isEmpty()) {
       return "";
     }
     var sb = new StringBuilder();
     var seen = new HashSet<String>();
-    for (String json : olderAiResponseJsons) {
-      for (var finding : parsePreviousFindings(json)) {
+    for (var response : olderAiResponses) {
+      for (var finding : response.findings()) {
         appendAnsweredEntry(sb, seen, finding, inlineComments, botIdentity);
       }
     }
@@ -171,11 +189,10 @@ public class FollowUpAnalyzer {
    * ids the model references in previous_findings_status.
    */
   private String formatStructuredFindings(
-      String aiResponseJson,
+      List<ReviewResponse.Finding> previous,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       BotIdentity botIdentity) {
-    var previous = parsePreviousFindings(aiResponseJson);
-    if (previous.isEmpty()) {
+    if (previous == null || previous.isEmpty()) {
       return "";
     }
     // The prompt template provides the lead-in sentence; emit only the numbered findings
@@ -504,7 +521,15 @@ public class FollowUpAnalyzer {
       String previousAiResponseJson,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       BotIdentity botIdentity) {
-    var previous = parsePreviousFindings(previousAiResponseJson);
+    return matchFindingThreads(
+        parsePreviousFindings(previousAiResponseJson), inlineComments, botIdentity);
+  }
+
+  /** Same as the JSON overload, using findings already deserialized for this review. */
+  public Map<Integer, Long> matchFindingThreads(
+      List<ReviewResponse.Finding> previous,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      BotIdentity botIdentity) {
     var threads = new HashMap<Integer, Long>();
     for (var i = 0; i < previous.size(); i++) {
       Long rootId = rootCommentId(previous.get(i), i + 1, inlineComments, botIdentity);
@@ -521,11 +546,16 @@ public class FollowUpAnalyzer {
    */
   public List<Finding> unresolvedFindings(
       String previousAiResponseJson, List<ReviewResponse.PreviousFindingStatus> statuses) {
+    return unresolvedFindings(parsePreviousFindings(previousAiResponseJson), statuses);
+  }
+
+  /** Same as the JSON overload, using findings already deserialized for this review. */
+  public List<Finding> unresolvedFindings(
+      List<ReviewResponse.Finding> previous, List<ReviewResponse.PreviousFindingStatus> statuses) {
     if (statuses == null || statuses.isEmpty()) {
       return List.of();
     }
-    var previous = parsePreviousFindings(previousAiResponseJson);
-    if (previous.isEmpty()) {
+    if (previous == null || previous.isEmpty()) {
       return List.of();
     }
     var unresolvedIds = new HashSet<Integer>();
@@ -600,10 +630,28 @@ public class FollowUpAnalyzer {
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       DiffLineResolver lineResolver,
       BotIdentity botIdentity) {
-    if (priorAiResponseJsons == null || priorAiResponseJsons.isEmpty() || lineResolver == null) {
+    return unreportedUnresolvedStatusesFromParsed(
+        parsePreviousResponses(priorAiResponseJsons),
+        currentStatuses,
+        inlineComments,
+        lineResolver,
+        botIdentity);
+  }
+
+  /**
+   * Same as the JSON overload, using prior responses already deserialized for this review so each
+   * persisted round is not re-parsed.
+   */
+  public List<ReviewResult.PreviousFindingStatus> unreportedUnresolvedStatusesFromParsed(
+      List<ReviewResponse> priorAiResponses,
+      List<ReviewResponse.PreviousFindingStatus> currentStatuses,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      DiffLineResolver lineResolver,
+      BotIdentity botIdentity) {
+    if (priorAiResponses == null || priorAiResponses.isEmpty() || lineResolver == null) {
       return List.of();
     }
-    var chrono = toChronological(priorAiResponseJsons);
+    var chrono = toChronological(priorAiResponses);
     var open = openFindingsAcrossRounds(chrono, currentStatuses);
     var clusters = clusterByIdentity(open);
     return heldFromClusters(clusters, inlineComments, lineResolver, botIdentity);
@@ -614,10 +662,10 @@ public class FollowUpAnalyzer {
    * {@code previous_findings_status} (which reports on the round immediately before it) can close
    * the findings it addressed.
    */
-  private List<ReviewResponse> toChronological(List<String> priorAiResponseJsons) {
-    var chrono = new ArrayList<ReviewResponse>();
-    for (var i = priorAiResponseJsons.size() - 1; i >= 0; i--) {
-      chrono.add(parseResponse(priorAiResponseJsons.get(i)));
+  private static List<ReviewResponse> toChronological(List<ReviewResponse> priorAiResponses) {
+    var chrono = new ArrayList<ReviewResponse>(priorAiResponses.size());
+    for (var i = priorAiResponses.size() - 1; i >= 0; i--) {
+      chrono.add(priorAiResponses.get(i));
     }
     return chrono;
   }
@@ -824,8 +872,15 @@ public class FollowUpAnalyzer {
    * finding's file.
    */
   public Map<Integer, String> previousFindingFilesById(String previousAiResponseJson) {
-    var previous = parsePreviousFindings(previousAiResponseJson);
+    return previousFindingFilesById(parsePreviousFindings(previousAiResponseJson));
+  }
+
+  /** Same as the JSON overload, using findings already deserialized for this review. */
+  public Map<Integer, String> previousFindingFilesById(List<ReviewResponse.Finding> previous) {
     var filesById = new HashMap<Integer, String>();
+    if (previous == null) {
+      return filesById;
+    }
     for (var i = 0; i < previous.size(); i++) {
       filesById.put(i + 1, previous.get(i).file());
     }
@@ -837,11 +892,26 @@ public class FollowUpAnalyzer {
   }
 
   /**
+   * Deserializes every prior round's persisted AI response (newest first), once per review. Missing
+   * or unparseable entries become empty responses so callers can share one list without re-parsing.
+   */
+  public List<ReviewResponse> parsePreviousResponses(List<String> priorAiResponseJsons) {
+    if (priorAiResponseJsons == null || priorAiResponseJsons.isEmpty()) {
+      return List.of();
+    }
+    var parsed = new ArrayList<ReviewResponse>(priorAiResponseJsons.size());
+    for (var json : priorAiResponseJsons) {
+      parsed.add(parseResponse(json));
+    }
+    return List.copyOf(parsed);
+  }
+
+  /**
    * Full persisted previous response, with empty (never null) findings and statuses on a missing or
    * unparseable input — the backstop replay needs both lists, and the compact constructor of {@link
    * ReviewResponse} guarantees non-null copies.
    */
-  private ReviewResponse parseResponse(String aiResponseJson) {
+  ReviewResponse parseResponse(String aiResponseJson) {
     if (aiResponseJson == null || aiResponseJson.isBlank()) {
       return EMPTY_RESPONSE;
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
@@ -199,14 +199,12 @@ public class ReviewContextLoader {
         hasContext
             ? fetchPullRequestComments(auth, req.owner(), req.repo(), req.prNumber())
             : List.of();
+    List<ReviewResponse.Finding> latestFindings =
+        priorAiResponses.isEmpty() ? List.of() : priorAiResponses.get(0).findings();
     String previousFindings =
         hasContext
             ? followUpAnalyzer.buildPreviousFindingsContext(
-                priorAiResponses.isEmpty() ? List.of() : priorAiResponses.get(0).findings(),
-                priorReviews,
-                inlineComments,
-                olderAiResponses,
-                botIdentity)
+                latestFindings, priorReviews, inlineComments, olderAiResponses, botIdentity)
             : "";
 
     var instructions =

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
@@ -25,10 +25,12 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.github.InstructionsResolver;
 import dev.thiagogonzaga.thrillhousebot.github.ProjectStackResolver;
+import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.List;
+import java.util.function.Supplier;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 /**
@@ -101,6 +103,7 @@ public class ReviewContextLoader {
       int omittedFiles,
       List<GitHubReviewClient.ReviewResponse> priorReviews,
       List<String> priorAiResponseJsons,
+      List<ReviewResponse> priorAiResponses,
       boolean isFirstVisibleReview,
       boolean hasContext,
       String previousAiResponseJson,
@@ -110,15 +113,32 @@ public class ReviewContextLoader {
       List<GitHubLabelClient.Label> repoLabels,
       String projectStack,
       List<GitHubPullRequestClient.FileDiff> reviewableFiles,
-      DiffLineResolver lineResolver,
+      Supplier<DiffLineResolver> lineResolverSupplier,
       PrTotals prTotals) {
     public ReviewContext {
       files = List.copyOf(files);
       priorReviews = List.copyOf(priorReviews);
       priorAiResponseJsons = List.copyOf(priorAiResponseJsons);
+      priorAiResponses = List.copyOf(priorAiResponses);
       inlineComments = List.copyOf(inlineComments);
       repoLabels = List.copyOf(repoLabels);
       reviewableFiles = List.copyOf(reviewableFiles);
+    }
+
+    /**
+     * Memoized {@link DiffLineResolver} for this review — one construction shared by the finding
+     * pipeline, approve backstop, and {@code postReview}.
+     */
+    public DiffLineResolver lineResolver() {
+      return lineResolverSupplier.get();
+    }
+
+    /**
+     * Findings from the newest prior AI response (empty when this is a first review or the prior
+     * JSON was missing/unparseable). Parsed once in {@link #load}.
+     */
+    public List<ReviewResponse.Finding> previousFindingsList() {
+      return priorAiResponses.isEmpty() ? List.of() : priorAiResponses.get(0).findings();
     }
   }
 
@@ -148,8 +168,12 @@ public class ReviewContextLoader {
             : buildBaseComparisonWithStats(
                 auth, req.owner(), req.repo(), req.baseSha(), req.commitSha(), true);
     var omittedFiles = diffResult.omittedFiles();
-    var lineResolver =
-        new DiffLineResolver(diffFormatter.patchesByReviewableFiles(reviewableFiles));
+    // One DiffLineResolver per review, shared by the finding pipeline / backstop / postReview.
+    // Memoized so a no-context path that never touches it (e.g. VerdictBuilder when hasContext is
+    // false) does not pay for a full patch parse.
+    var patchesByFile = diffFormatter.patchesByReviewableFiles(reviewableFiles);
+    Supplier<DiffLineResolver> lineResolverSupplier =
+        memoize(() -> new DiffLineResolver(patchesByFile));
 
     var priorReviews = fetchPriorReviews(auth, req.owner(), req.repo(), req.prNumber());
     // isFirstVisibleReview keys off the summary comment directly, not reviews alone: a first
@@ -161,11 +185,15 @@ public class ReviewContextLoader {
                 .noneMatch(r -> r.user() != null && botIdentity.matches(r.user().login()))
             && !botSummaryCommentExists(auth, req.owner(), req.repo(), req.prNumber());
     var hasContext = !priorAiResponseJsons.isEmpty();
+    // Deserialize each prior response once for the whole review — context formatting, unresolved
+    // gate, approve backstop, and later thread matching all reuse these objects.
+    List<ReviewResponse> priorAiResponses =
+        followUpAnalyzer.parsePreviousResponses(priorAiResponseJsons);
     String previousAiResponseJson =
         priorAiResponseJsons.isEmpty() ? null : priorAiResponseJsons.get(0);
-    List<String> olderAiResponseJsons =
-        priorAiResponseJsons.size() > 1
-            ? priorAiResponseJsons.subList(1, priorAiResponseJsons.size())
+    List<ReviewResponse> olderAiResponses =
+        priorAiResponses.size() > 1
+            ? priorAiResponses.subList(1, priorAiResponses.size())
             : List.of();
     List<GitHubReviewClient.PullRequestComment> inlineComments =
         hasContext
@@ -174,10 +202,10 @@ public class ReviewContextLoader {
     String previousFindings =
         hasContext
             ? followUpAnalyzer.buildPreviousFindingsContext(
-                previousAiResponseJson,
+                priorAiResponses.isEmpty() ? List.of() : priorAiResponses.get(0).findings(),
                 priorReviews,
                 inlineComments,
-                olderAiResponseJsons,
+                olderAiResponses,
                 botIdentity)
             : "";
 
@@ -195,6 +223,7 @@ public class ReviewContextLoader {
         omittedFiles,
         priorReviews,
         priorAiResponseJsons,
+        priorAiResponses,
         isFirstVisibleReview,
         hasContext,
         previousAiResponseJson,
@@ -204,8 +233,29 @@ public class ReviewContextLoader {
         repoLabels,
         projectStack,
         reviewableFiles,
-        lineResolver,
+        lineResolverSupplier,
         prTotals);
+  }
+
+  /** Thread-safe memoizing supplier — the resolver is built at most once per review context. */
+  static <T> Supplier<T> memoize(Supplier<T> delegate) {
+    return new Supplier<>() {
+      private volatile T value;
+      private volatile boolean initialized;
+
+      @Override
+      public T get() {
+        if (!initialized) {
+          synchronized (this) {
+            if (!initialized) {
+              value = delegate.get();
+              initialized = true;
+            }
+          }
+        }
+        return value;
+      }
+    };
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
@@ -240,20 +240,19 @@ public class ReviewContextLoader {
   /** Thread-safe memoizing supplier — the resolver is built at most once per review context. */
   static <T> Supplier<T> memoize(Supplier<T> delegate) {
     return new Supplier<>() {
-      private volatile T value;
-      private volatile boolean initialized;
+      private final Object lock = new Object();
+      private boolean initialized;
+      private T value;
 
       @Override
       public T get() {
-        if (!initialized) {
-          synchronized (this) {
-            if (!initialized) {
-              value = delegate.get();
-              initialized = true;
-            }
+        synchronized (lock) {
+          if (!initialized) {
+            value = delegate.get();
+            initialized = true;
           }
+          return value;
         }
-        return value;
       }
     };
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -232,7 +232,7 @@ public class ReviewOrchestrator {
               auth, req.owner(), req.repo(), req.commitSha(), sessionUrl(session));
       var ctx = contextLoader.load(auth, req, session, repository);
       var priorReviews = ctx.priorReviews();
-      var previousAiResponseJson = ctx.previousAiResponseJson();
+      var previousFindings = ctx.previousFindingsList();
       var inlineComments = ctx.inlineComments();
       var lineResolver = ctx.lineResolver();
 
@@ -293,7 +293,7 @@ public class ReviewOrchestrator {
               reviewPublisher.resolveAddressedThreads(
                   auth,
                   doneReq,
-                  previousAiResponseJson,
+                  previousFindings,
                   inlineComments,
                   aiResponse.previousFindingsStatus()));
       runPostResultStep(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -586,7 +586,7 @@ public class ReviewPublisher {
   void resolveAddressedThreads(
       String auth,
       ReviewOrchestrator.ReviewRequest req,
-      String previousAiResponseJson,
+      List<ReviewResponse.Finding> previousFindings,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       List<ReviewResponse.PreviousFindingStatus> statuses) {
     try {
@@ -602,7 +602,7 @@ public class ReviewPublisher {
         return;
       }
       var rootByFinding =
-          followUpAnalyzer.matchFindingThreads(previousAiResponseJson, inlineComments, botIdentity);
+          followUpAnalyzer.matchFindingThreads(previousFindings, inlineComments, botIdentity);
       var threads =
           reviewThreadService.threadsByRootComment(auth, req.owner(), req.repo(), req.prNumber());
       var resolved = 0;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -80,11 +80,14 @@ public class VerdictBuilder {
                 .toList());
     var unresolvedPrevious =
         followUpAnalyzer.unresolvedFindings(
-            ctx.previousAiResponseJson(), aiResponse.previousFindingsStatus());
+            ctx.previousFindingsList(), aiResponse.previousFindingsStatus());
+    // Lazily resolve the shared DiffLineResolver only when the backstop runs — first reviews and
+    // other no-context paths never pay for a patch re-parse here (FindingPipeline / postReview
+    // still share the same memoized supplier when they need it).
     var backstopUnresolved =
         ctx.hasContext()
-            ? followUpAnalyzer.unreportedUnresolvedStatuses(
-                ctx.priorAiResponseJsons(),
+            ? followUpAnalyzer.unreportedUnresolvedStatusesFromParsed(
+                ctx.priorAiResponses(),
                 aiResponse.previousFindingsStatus(),
                 ctx.inlineComments(),
                 ctx.lineResolver(),
@@ -241,11 +244,11 @@ public class VerdictBuilder {
     outstanding.addAll(unresolvedPrevious);
     ReviewState state = ReviewState.fromFindings(outstanding);
     // Backstop statuses reach the gate but never `outstanding`, keeping the hold downgrade-only
-    // (APPROVE → COMMENT, never REQUEST_CHANGES).
+    // (APPROVE → COMMENT, never REQUEST_CHANGES). Keep the toStatuses list as-is on the common
+    // no-backstop path — no ArrayList wrap/copy when there is nothing to append.
     var previousStatuses =
-        new ArrayList<ReviewResult.PreviousFindingStatus>(
-            followUpAnalyzer.toStatuses(aiResponse.previousFindingsStatus()));
-    previousStatuses.addAll(backstopUnresolved);
+        mergePreviousStatuses(
+            followUpAnalyzer.toStatuses(aiResponse.previousFindingsStatus()), backstopUnresolved);
     if (state == ReviewState.APPROVE && followUpAnalyzer.hasUnresolved(previousStatuses)) {
       state = ReviewState.COMMENT;
     }
@@ -303,6 +306,22 @@ public class VerdictBuilder {
         ciUnreadable,
         requiredContextsKnown,
         diffStats.truncation());
+  }
+
+  /**
+   * Merges model-reported previous-finding statuses with the deterministic backstop. Returns {@code
+   * modelStatuses} unchanged when the backstop is empty so the common path does not allocate a
+   * fresh {@link ArrayList}.
+   */
+  static List<ReviewResult.PreviousFindingStatus> mergePreviousStatuses(
+      List<ReviewResult.PreviousFindingStatus> modelStatuses,
+      List<ReviewResult.PreviousFindingStatus> backstopUnresolved) {
+    if (backstopUnresolved == null || backstopUnresolved.isEmpty()) {
+      return modelStatuses;
+    }
+    var merged = new ArrayList<>(modelStatuses);
+    merged.addAll(backstopUnresolved);
+    return merged;
   }
 
   /** Findings parsed from the model response, with per-severity counts and the highest risk. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -106,7 +106,7 @@ public class VerdictBuilder {
         followUpAnalyzer.supersedeVanished(
             ctx.previousAiResponseJson(),
             rawStatuses,
-            rawStatuses == null || rawStatuses.isEmpty() ? null : ctx.lineResolver());
+            rawStatuses.isEmpty() ? null : ctx.lineResolver());
     var effectiveResponse =
         new ReviewResponse(aiResponse.findings(), effectiveStatuses, aiResponse.summary());
     var unresolvedPrevious =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -83,7 +83,14 @@ class FindingPipelineTest {
         .thenAnswer(inv -> inv.getArgument(0));
     when(followUpAnalyzer.dropRepliedDuplicates(any(), any(), any(), any()))
         .thenAnswer(inv -> inv.getArgument(0));
-    lenient().when(followUpAnalyzer.previousFindingFilesById(any())).thenReturn(Map.of());
+    lenient()
+        .when(
+            followUpAnalyzer.previousFindingFilesById(
+                org.mockito.ArgumentMatchers
+                    .<java.util.List<
+                            dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse.Finding>>
+                        any()))
+        .thenReturn(Map.of());
     lenient().when(budgetPlanner.perCallInputBudget()).thenReturn(Integer.MAX_VALUE);
   }
 
@@ -105,6 +112,7 @@ class FindingPipelineTest {
         0,
         List.of(),
         List.of(),
+        List.of(),
         true,
         false,
         null,
@@ -116,7 +124,7 @@ class FindingPipelineTest {
         List.of(
             new FileDiff("a.java", "modified", 3, 0, 3, ""),
             new FileDiff("b.java", "modified", 2, 0, 2, "")),
-        new DiffLineResolver(Map.of()),
+        () -> new DiffLineResolver(Map.of()),
         null);
   }
 
@@ -137,7 +145,11 @@ class FindingPipelineTest {
 
     var batchOneStatus = new ReviewResponse.PreviousFindingStatus(1, "unresolved", "not in slice");
     var batchTwoStatus = new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed");
-    when(followUpAnalyzer.previousFindingFilesById(any())).thenReturn(Map.of(1, "b.java"));
+    when(followUpAnalyzer.previousFindingFilesById(
+            org.mockito.ArgumentMatchers
+                .<java.util.List<dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse.Finding>>
+                    any()))
+        .thenReturn(Map.of(1, "b.java"));
     when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt()))
         .thenReturn(
             new ReviewResponse(List.of(finding("a.java", "A")), List.of(batchOneStatus), null));
@@ -262,7 +274,10 @@ class FindingPipelineTest {
     var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
     var ctx = reviewContext();
     var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
-    when(followUpAnalyzer.previousFindingFilesById(any()))
+    when(followUpAnalyzer.previousFindingFilesById(
+            org.mockito.ArgumentMatchers
+                .<java.util.List<dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse.Finding>>
+                    any()))
         .thenReturn(Map.of(1, "b.java", 2, "a.java"));
 
     when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt()))
@@ -297,7 +312,10 @@ class FindingPipelineTest {
     var session = ReviewSession.create("owner/repo", 1, "One clipped file", "sha");
     var ctx = reviewContext();
     var template = new AiReviewService.PromptInputs("raw", "ctx", "base", "s", "t", "", "");
-    when(followUpAnalyzer.previousFindingFilesById(any()))
+    when(followUpAnalyzer.previousFindingFilesById(
+            org.mockito.ArgumentMatchers
+                .<java.util.List<dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse.Finding>>
+                    any()))
         .thenReturn(Map.of(1, "a.java", 2, "b.java"));
     var batchFiles =
         List.of(
@@ -325,7 +343,11 @@ class FindingPipelineTest {
     var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
     var ctx = reviewContext();
     var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
-    when(followUpAnalyzer.previousFindingFilesById(any())).thenReturn(Map.of(1, "a.java"));
+    when(followUpAnalyzer.previousFindingFilesById(
+            org.mockito.ArgumentMatchers
+                .<java.util.List<dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse.Finding>>
+                    any()))
+        .thenReturn(Map.of(1, "a.java"));
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
             List.of(batch("a.java"), batch("b.java")), List.of(), List.of("a.java"), true);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -775,6 +775,10 @@ class FollowUpAnalyzerTest {
         analyzer.buildPreviousFindingsContext(previous, List.of(), List.of(), older, BOT_ID);
     assertTrue(withOlder.contains("src/A.java"));
     assertFalse(withOlder.contains("Answered in earlier rounds"));
+    assertTrue(
+        analyzer
+            .buildPreviousFindingsContext(previous, List.of(), List.of(), null, BOT_ID)
+            .contains("src/A.java"));
 
     assertTrue(
         analyzer

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -713,6 +713,7 @@ class FollowUpAnalyzerTest {
   void previousFindingFilesByIdIsEmptyForMissingOrBadInput() {
     assertTrue(analyzer.previousFindingFilesById((String) null).isEmpty());
     assertTrue(analyzer.previousFindingFilesById("not json").isEmpty());
+    assertTrue(analyzer.previousFindingFilesById((List<ReviewResponse.Finding>) null).isEmpty());
   }
 
   @Test
@@ -723,6 +724,68 @@ class FollowUpAnalyzerTest {
     assertTrue(analyzer.unresolvedFindings(PREVIOUS_JSON, List.of()).isEmpty());
     assertTrue(analyzer.unresolvedFindings((String) null, unresolvedStatus).isEmpty());
     assertTrue(analyzer.unresolvedFindings("not json", unresolvedStatus).isEmpty());
+    assertTrue(
+        analyzer
+            .unresolvedFindings((List<ReviewResponse.Finding>) null, unresolvedStatus)
+            .isEmpty());
+    assertTrue(analyzer.unresolvedFindings(List.of(), unresolvedStatus).isEmpty());
+  }
+
+  @Test
+  void parsePreviousResponsesHandlesNullEmptyAndValidJson() {
+    assertTrue(analyzer.parsePreviousResponses(null).isEmpty());
+    assertTrue(analyzer.parsePreviousResponses(List.of()).isEmpty());
+    var parsed = analyzer.parsePreviousResponses(List.of(PREVIOUS_JSON));
+    assertEquals(1, parsed.size());
+    assertEquals(2, parsed.get(0).findings().size());
+  }
+
+  @Test
+  void preParsedApisReuseFindingsWithoutReReadingJson() {
+    var previous = analyzer.parsePreviousResponses(List.of(PREVIOUS_JSON)).get(0).findings();
+    var unresolvedStatus = List.of(new ReviewResponse.PreviousFindingStatus(1, "unresolved", "x"));
+
+    assertEquals(1, analyzer.unresolvedFindings(previous, unresolvedStatus).size());
+    assertEquals("src/A.java", analyzer.previousFindingFilesById(previous).get(1));
+    assertTrue(
+        analyzer
+            .matchFindingThreads((List<ReviewResponse.Finding>) null, List.of(), BOT_ID)
+            .isEmpty());
+    assertTrue(analyzer.matchFindingThreads(List.of(), List.of(), BOT_ID).isEmpty());
+
+    var ctx =
+        analyzer.buildPreviousFindingsContext(previous, List.of(), List.of(), List.of(), BOT_ID);
+    assertTrue(ctx.contains("src/A.java"));
+    assertTrue(ctx.contains("src/B.java"));
+
+    // Null previous findings falls back to the prior-review body path (empty here).
+    assertEquals(
+        "",
+        analyzer.buildPreviousFindingsContext(
+            (List<ReviewResponse.Finding>) null, List.of(), List.of(), List.of(), BOT_ID));
+
+    // Older rounds with no maintainer reply contribute nothing to the answered-earlier section.
+    var older =
+        analyzer.parsePreviousResponses(
+            List.of(
+                "{\"findings\":[{\"risk\":\"low\",\"file\":\"src/Old.java\",\"line\":1,"
+                    + "\"title\":\"Old\",\"description\":\"d\",\"suggestion_old\":\"o\","
+                    + "\"suggestion_new\":\"n\"}],\"previous_findings_status\":[],\"summary\":null}"));
+    var withOlder =
+        analyzer.buildPreviousFindingsContext(previous, List.of(), List.of(), older, BOT_ID);
+    assertTrue(withOlder.contains("src/A.java"));
+    assertFalse(withOlder.contains("Answered in earlier rounds"));
+
+    assertTrue(
+        analyzer
+            .unreportedUnresolvedStatusesFromParsed(
+                null, List.of(), List.of(), new DiffLineResolver(Map.of()), BOT_ID)
+            .isEmpty());
+    assertTrue(
+        analyzer
+            .unreportedUnresolvedStatusesFromParsed(
+                List.of(), List.of(), List.of(), new DiffLineResolver(Map.of()), BOT_ID)
+            .isEmpty());
   }
 
   /** One-line patch whose only right-side line is {@code line}, for backstop presence tests. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -711,7 +711,7 @@ class FollowUpAnalyzerTest {
 
   @Test
   void previousFindingFilesByIdIsEmptyForMissingOrBadInput() {
-    assertTrue(analyzer.previousFindingFilesById(null).isEmpty());
+    assertTrue(analyzer.previousFindingFilesById((String) null).isEmpty());
     assertTrue(analyzer.previousFindingFilesById("not json").isEmpty());
   }
 
@@ -721,7 +721,7 @@ class FollowUpAnalyzerTest {
 
     assertTrue(analyzer.unresolvedFindings(PREVIOUS_JSON, null).isEmpty());
     assertTrue(analyzer.unresolvedFindings(PREVIOUS_JSON, List.of()).isEmpty());
-    assertTrue(analyzer.unresolvedFindings(null, unresolvedStatus).isEmpty());
+    assertTrue(analyzer.unresolvedFindings((String) null, unresolvedStatus).isEmpty());
     assertTrue(analyzer.unresolvedFindings("not json", unresolvedStatus).isEmpty());
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
@@ -24,6 +24,7 @@ import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSessionPersistence;
 import dev.thiagogonzaga.thrillhousebot.github.*;
+import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -768,15 +769,27 @@ class ReviewContextLoaderTest {
           "title":"T","description":"d","suggestion_old":"o","suggestion_new":"n"}],\
           "previous_findings_status":[],"summary":null}
           """;
+      var olderJson =
+          """
+          {"findings":[{"risk":"low","confidence":"high","file":"b.java","line":2,\
+          "title":"U","description":"d","suggestion_old":"o","suggestion_new":"n"}],\
+          "previous_findings_status":[],"summary":null}
+          """;
       var parsed =
           List.of(
-              new dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse(
+              new ReviewResponse(
                   List.of(
-                      new dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse.Finding(
+                      new ReviewResponse.Finding(
                           "medium", "high", "a.java", 1, "T", "d", "o", "n")),
                   List.of(),
+                  null),
+              new ReviewResponse(
+                  List.of(
+                      new ReviewResponse.Finding("low", "high", "b.java", 2, "U", "d", "o", "n")),
+                  List.of(),
                   null));
-      when(followUpAnalyzer.parsePreviousResponses(List.of(priorJson))).thenReturn(parsed);
+      when(followUpAnalyzer.parsePreviousResponses(List.of(priorJson, olderJson)))
+          .thenReturn(parsed);
       when(followUpAnalyzer.buildPreviousFindingsContext(
               anyList(), any(), any(), any(), any(BotIdentity.class)))
           .thenReturn("ctx");
@@ -784,7 +797,7 @@ class ReviewContextLoaderTest {
           List.of(
               new GitHubPullRequestClient.FileDiff(
                   "a.java", "modified", 1, 0, 1, "@@ -1 +1 @@\n+x")),
-          List.of(priorJson));
+          List.of(priorJson, olderJson));
       var session = ReviewSession.create("owner/repo", 1, "Title", "headsha1");
       session.id = 1L;
 
@@ -793,7 +806,14 @@ class ReviewContextLoaderTest {
       assertEquals(parsed, ctx.priorAiResponses());
       assertEquals(1, ctx.previousFindingsList().size());
       assertEquals("a.java", ctx.previousFindingsList().get(0).file());
-      verify(followUpAnalyzer, times(1)).parsePreviousResponses(List.of(priorJson));
+      verify(followUpAnalyzer, times(1)).parsePreviousResponses(List.of(priorJson, olderJson));
+      verify(followUpAnalyzer)
+          .buildPreviousFindingsContext(
+              eq(parsed.get(0).findings()),
+              any(),
+              any(),
+              eq(parsed.subList(1, parsed.size())),
+              any(BotIdentity.class));
     }
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
@@ -59,6 +59,7 @@ class ReviewContextLoaderTest {
     MockitoAnnotations.openMocks(this);
     // Default: budgeting off so existing formatter-driven assertions keep the line-capped path.
     when(activeModel.maxInputTokens()).thenReturn(0);
+    lenient().when(followUpAnalyzer.parsePreviousResponses(any())).thenReturn(List.of());
     loader =
         new ReviewContextLoader(
             prClient,
@@ -669,6 +670,130 @@ class ReviewContextLoaderTest {
                   "owner", "repo", 1, "sha", "title", "", "base", "main", 123L, false));
 
       assertEquals("", stack);
+    }
+  }
+
+  /**
+   * #135 — one memoized {@link DiffLineResolver} per review; prior AI responses deserialized once
+   * at load time.
+   */
+  @Nested
+  class DedupeHotPathLoad {
+
+    private static ReviewOrchestrator.ReviewRequest request() {
+      return new ReviewOrchestrator.ReviewRequest(
+          "owner",
+          "repo",
+          1,
+          "headsha1",
+          "Title",
+          "body",
+          "basesha1",
+          "main",
+          99L,
+          true,
+          "main",
+          false);
+    }
+
+    private void stubLoad(List<GitHubPullRequestClient.FileDiff> files, List<String> priorJsons) {
+      when(prClient.getPullRequestFiles(any(), any(), eq("owner"), eq("repo"), eq(1)))
+          .thenReturn(files);
+      when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(1)))
+          .thenReturn(
+              new GitHubPullRequestClient.PullRequestDetails(
+                  "Title",
+                  "body",
+                  new GitHubPullRequestClient.Ref("headsha1"),
+                  new GitHubPullRequestClient.Ref("basesha1"),
+                  1,
+                  1,
+                  0));
+      when(reviewClient.listReviews(any(), any(), eq("owner"), eq("repo"), eq(1)))
+          .thenReturn(List.of());
+      when(commentClient.listComments(any(), any(), eq("owner"), eq("repo"), eq(1)))
+          .thenReturn(List.of());
+      when(reviewClient.listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(1)))
+          .thenReturn(List.of());
+      when(sessionPersistence.findAllPriorAiResponseJsons(any(), eq(1), anyLong()))
+          .thenReturn(priorJsons);
+      when(instructionsResolver.resolve(any(), any(), any(), anyLong()))
+          .thenReturn(new InstructionsResolver.ResolvedInstructions("", ""));
+      when(labeler.fetchExistingLabels(any(), any(), any())).thenReturn(List.of());
+      when(projectStackResolver.resolve(any(), any(), any(), anyLong())).thenReturn("");
+    }
+
+    @Test
+    void lineResolverIsBuiltOnceAndSharedAcrossAccesses() {
+      stubLoad(
+          List.of(
+              new GitHubPullRequestClient.FileDiff(
+                  "a.java", "modified", 1, 0, 1, "@@ -1 +1 @@\n+x")),
+          List.of());
+      var session = ReviewSession.create("owner/repo", 1, "Title", "headsha1");
+      session.id = 1L;
+      DiffLineResolver.CONSTRUCTION_COUNT.set(0);
+
+      var ctx = loader.load("auth", request(), session, "owner/repo");
+      assertEquals(0, DiffLineResolver.CONSTRUCTION_COUNT.get());
+
+      var first = ctx.lineResolver();
+      var second = ctx.lineResolver();
+
+      assertSame(first, second);
+      assertEquals(1, DiffLineResolver.CONSTRUCTION_COUNT.get());
+    }
+
+    @Test
+    void lineResolverIsNotBuiltWhenNeverAccessed() {
+      stubLoad(
+          List.of(
+              new GitHubPullRequestClient.FileDiff(
+                  "a.java", "modified", 1, 0, 1, "@@ -1 +1 @@\n+x")),
+          List.of());
+      var session = ReviewSession.create("owner/repo", 1, "Title", "headsha1");
+      session.id = 1L;
+      DiffLineResolver.CONSTRUCTION_COUNT.set(0);
+
+      loader.load("auth", request(), session, "owner/repo");
+
+      assertEquals(0, DiffLineResolver.CONSTRUCTION_COUNT.get());
+    }
+
+    @Test
+    void priorAiResponsesAreParsedOnceAtLoad() {
+      var priorJson =
+          """
+          {"findings":[{"risk":"medium","confidence":"high","file":"a.java","line":1,\
+          "title":"T","description":"d","suggestion_old":"o","suggestion_new":"n"}],\
+          "previous_findings_status":[],"summary":null}
+          """;
+      var parsed =
+          List.of(
+              new dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse(
+                  List.of(
+                      new dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse.Finding(
+                          "medium", "high", "a.java", 1, "T", "d", "o", "n")),
+                  List.of(),
+                  null));
+      when(followUpAnalyzer.parsePreviousResponses(List.of(priorJson))).thenReturn(parsed);
+      when(followUpAnalyzer.buildPreviousFindingsContext(
+              anyList(), any(), any(), any(), any(BotIdentity.class)))
+          .thenReturn("ctx");
+      stubLoad(
+          List.of(
+              new GitHubPullRequestClient.FileDiff(
+                  "a.java", "modified", 1, 0, 1, "@@ -1 +1 @@\n+x")),
+          List.of(priorJson));
+      var session = ReviewSession.create("owner/repo", 1, "Title", "headsha1");
+      session.id = 1L;
+
+      var ctx = loader.load("auth", request(), session, "owner/repo");
+
+      assertEquals(parsed, ctx.priorAiResponses());
+      assertEquals(1, ctx.previousFindingsList().size());
+      assertEquals("a.java", ctx.previousFindingsList().get(0).file());
+      verify(followUpAnalyzer, times(1)).parsePreviousResponses(List.of(priorJson));
     }
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2104,7 +2104,7 @@ class ReviewOrchestratorTest {
             .thenReturn(List.of("{\"round\":2}", "{\"round\":1}"));
         var round2 = new ReviewResponse(List.of(), List.of(), null);
         var round1 = new ReviewResponse(List.of(), List.of(), null);
-        when(followUpAnalyzer.parsePreviousResponses(eq(List.of("{\"round\":2}", "{\"round\":1}"))))
+        when(followUpAnalyzer.parsePreviousResponses(List.of("{\"round\":2}", "{\"round\":1}")))
             .thenReturn(List.of(round2, round1));
         when(followUpAnalyzer.toStatuses(any())).thenReturn(List.of());
         when(suggestionFormatter.formatReviewComment(any())).thenReturn("**Medium** — fix this");
@@ -2132,8 +2132,7 @@ class ReviewOrchestratorTest {
 
         verify(commentClient, never())
             .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
-        verify(followUpAnalyzer)
-            .parsePreviousResponses(eq(List.of("{\"round\":2}", "{\"round\":1}")));
+        verify(followUpAnalyzer).parsePreviousResponses(List.of("{\"round\":2}", "{\"round\":1}"));
         verify(followUpAnalyzer)
             .buildPreviousFindingsContext(
                 eq(List.of()), any(), any(), eq(List.of(round1)), eq(BOT_ID));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -176,6 +177,23 @@ class ReviewOrchestratorTest {
         .thenAnswer(invocation -> invocation.getArgument(0));
     when(followUpAnalyzer.dropRepliedDuplicates(any(), any(), any(), any()))
         .thenAnswer(invocation -> invocation.getArgument(0));
+    lenient().when(followUpAnalyzer.parsePreviousResponses(any())).thenReturn(List.of());
+    lenient()
+        .when(
+            followUpAnalyzer.unreportedUnresolvedStatusesFromParsed(
+                any(), any(), any(), any(), any()))
+        .thenReturn(List.of());
+    lenient()
+        .when(
+            followUpAnalyzer.unresolvedFindings(
+                ArgumentMatchers.<List<ReviewResponse.Finding>>any(), any()))
+        .thenReturn(List.of());
+    lenient().when(followUpAnalyzer.toStatuses(any())).thenReturn(List.of());
+    lenient().when(followUpAnalyzer.hasUnresolved(any())).thenReturn(false);
+    lenient().when(followUpAnalyzer.previousFindingFilesById(any(List.class))).thenReturn(Map.of());
+    lenient()
+        .when(followUpAnalyzer.previousFindingFilesById(any(String.class)))
+        .thenReturn(Map.of());
     when(reviewClient.createPullRequestComment(
             anyString(), anyString(), anyString(), anyString(), anyInt(), any()))
         .thenReturn(new GitHubReviewClient.PullRequestCommentResponse(1L, "ok", "main.py", 10));
@@ -2079,10 +2097,15 @@ class ReviewOrchestratorTest {
                         new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]"))));
         when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
             .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
-        when(followUpAnalyzer.buildPreviousFindingsContext(any(), any(), any(), any(), eq(BOT_ID)))
+        when(followUpAnalyzer.buildPreviousFindingsContext(
+                anyList(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn("Previous finding context");
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of("{\"round\":2}", "{\"round\":1}"));
+        var round2 = new ReviewResponse(List.of(), List.of(), null);
+        var round1 = new ReviewResponse(List.of(), List.of(), null);
+        when(followUpAnalyzer.parsePreviousResponses(eq(List.of("{\"round\":2}", "{\"round\":1}"))))
+            .thenReturn(List.of(round2, round1));
         when(followUpAnalyzer.toStatuses(any())).thenReturn(List.of());
         when(suggestionFormatter.formatReviewComment(any())).thenReturn("**Medium** — fix this");
         when(aiReviewService.review(any(ReviewSession.class), any()))
@@ -2110,8 +2133,10 @@ class ReviewOrchestratorTest {
         verify(commentClient, never())
             .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
         verify(followUpAnalyzer)
+            .parsePreviousResponses(eq(List.of("{\"round\":2}", "{\"round\":1}")));
+        verify(followUpAnalyzer)
             .buildPreviousFindingsContext(
-                eq("{\"round\":2}"), any(), any(), eq(List.of("{\"round\":1}")), eq(BOT_ID));
+                eq(List.of()), any(), any(), eq(List.of(round1)), eq(BOT_ID));
         verify(followUpAnalyzer)
             .dropRepliedDuplicates(
                 any(), eq(List.of("{\"round\":2}", "{\"round\":1}")), any(), eq(BOT_ID));
@@ -4179,11 +4204,13 @@ class ReviewOrchestratorTest {
                         new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]"))));
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
-        when(followUpAnalyzer.buildPreviousFindingsContext(any(), any(), any(), any(), eq(BOT_ID)))
+        when(followUpAnalyzer.buildPreviousFindingsContext(
+                anyList(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn("1. [MEDIUM] src/Main.java:10 — Dropped finding");
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
-        when(followUpAnalyzer.unreportedUnresolvedStatuses(any(), any(), any(), any(), eq(BOT_ID)))
+        when(followUpAnalyzer.unreportedUnresolvedStatusesFromParsed(
+                any(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn(
                 List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still present")));
 
@@ -4207,7 +4234,8 @@ class ReviewOrchestratorTest {
             .thenReturn(session);
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
-        when(followUpAnalyzer.buildPreviousFindingsContext(any(), any(), any(), any(), eq(BOT_ID)))
+        when(followUpAnalyzer.buildPreviousFindingsContext(
+                anyList(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn("previous context");
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -4215,7 +4243,7 @@ class ReviewOrchestratorTest {
         orchestrator.review(followUpRequest());
 
         verify(followUpAnalyzer)
-            .buildPreviousFindingsContext(any(), any(), any(), any(), eq(BOT_ID));
+            .buildPreviousFindingsContext(anyList(), any(), any(), any(), eq(BOT_ID));
       }
     }
 
@@ -4228,7 +4256,8 @@ class ReviewOrchestratorTest {
             .thenReturn(session);
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
-        when(followUpAnalyzer.buildPreviousFindingsContext(any(), any(), any(), any(), eq(BOT_ID)))
+        when(followUpAnalyzer.buildPreviousFindingsContext(
+                anyList(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn("previous context");
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -4246,7 +4275,7 @@ class ReviewOrchestratorTest {
                 anyInt(),
                 argThat(req -> req.body().contains("ThrillhouseBot PR Summary")));
         verify(followUpAnalyzer)
-            .buildPreviousFindingsContext(any(), any(), any(), any(), eq(BOT_ID));
+            .buildPreviousFindingsContext(anyList(), any(), any(), any(), eq(BOT_ID));
       }
     }
 
@@ -4312,7 +4341,8 @@ class ReviewOrchestratorTest {
               new ReviewResponse.PreviousFindingStatus(2, "justified", "intentional"),
               new ReviewResponse.PreviousFindingStatus(3, "unresolved", "still"),
               new ReviewResponse.PreviousFindingStatus(4, "resolved", "fixed"));
-      when(followUpAnalyzer.matchFindingThreads(any(), any(), any()))
+      when(followUpAnalyzer.matchFindingThreads(
+              ArgumentMatchers.<List<ReviewResponse.Finding>>any(), any(), any()))
           .thenReturn(Map.of(1, 100L, 2, 200L, 3, 300L, 4, 400L));
       when(reviewThreadService.threadsByRootComment(AUTH, "owner", "repo", 5))
           .thenReturn(
@@ -4325,7 +4355,7 @@ class ReviewOrchestratorTest {
       when(reviewThreadService.resolve(AUTH, "T4")).thenReturn(false);
 
       reviewPublisher.resolveAddressedThreads(
-          AUTH, request(), "{}", List.of(rootComment()), statuses);
+          AUTH, request(), List.of(), List.of(rootComment()), statuses);
 
       verify(reviewThreadService).resolve(AUTH, "T1");
       verify(reviewThreadService).resolve(AUTH, "T4");
@@ -4336,11 +4366,13 @@ class ReviewOrchestratorTest {
     @Test
     void shouldSkipFindingsWithoutAMatchedThread() {
       var statuses = List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed"));
-      when(followUpAnalyzer.matchFindingThreads(any(), any(), any())).thenReturn(Map.of());
+      when(followUpAnalyzer.matchFindingThreads(
+              ArgumentMatchers.<List<ReviewResponse.Finding>>any(), any(), any()))
+          .thenReturn(Map.of());
       when(reviewThreadService.threadsByRootComment(AUTH, "owner", "repo", 5)).thenReturn(Map.of());
 
       reviewPublisher.resolveAddressedThreads(
-          AUTH, request(), "{}", List.of(rootComment()), statuses);
+          AUTH, request(), List.of(), List.of(rootComment()), statuses);
 
       verify(reviewThreadService, never()).resolve(anyString(), anyString());
     }
@@ -4352,8 +4384,8 @@ class ReviewOrchestratorTest {
       var resolved = List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed"));
 
       reviewPublisher.resolveAddressedThreads(
-          AUTH, request(), "{}", List.of(rootComment()), unresolvedOnly);
-      reviewPublisher.resolveAddressedThreads(AUTH, request(), "{}", List.of(), resolved);
+          AUTH, request(), List.of(), List.of(rootComment()), unresolvedOnly);
+      reviewPublisher.resolveAddressedThreads(AUTH, request(), List.of(), List.of(), resolved);
 
       verifyNoInteractions(reviewThreadService);
     }
@@ -4361,7 +4393,9 @@ class ReviewOrchestratorTest {
     @Test
     void shouldSwallowThreadResolutionFailures() {
       var statuses = List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed"));
-      when(followUpAnalyzer.matchFindingThreads(any(), any(), any())).thenReturn(Map.of(1, 100L));
+      when(followUpAnalyzer.matchFindingThreads(
+              ArgumentMatchers.<List<ReviewResponse.Finding>>any(), any(), any()))
+          .thenReturn(Map.of(1, 100L));
       when(reviewThreadService.threadsByRootComment(
               anyString(), anyString(), anyString(), anyInt()))
           .thenThrow(new RuntimeException("graphql down"));
@@ -4369,7 +4403,7 @@ class ReviewOrchestratorTest {
       assertDoesNotThrow(
           () ->
               reviewPublisher.resolveAddressedThreads(
-                  AUTH, request(), "{}", List.of(rootComment()), statuses));
+                  AUTH, request(), List.of(), List.of(rootComment()), statuses));
     }
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -17,6 +17,7 @@ package dev.thiagogonzaga.thrillhousebot.review;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -48,7 +49,15 @@ class VerdictBuilderTest {
           summaryGenerator, followUpAnalyzer, BotIdentity.from(List.of("thrillhousebot[bot]")));
 
   {
-    lenient().when(followUpAnalyzer.unresolvedFindings(any(), any())).thenReturn(List.of());
+    lenient()
+        .when(
+            followUpAnalyzer.unresolvedFindings(
+                org.mockito.ArgumentMatchers
+                    .<java.util.List<
+                            dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse.Finding>>
+                        any(),
+                any()))
+        .thenReturn(List.of());
     lenient()
         .when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any(), any()))
         .thenReturn("");
@@ -63,6 +72,7 @@ class VerdictBuilderTest {
         lineCapOmitted,
         List.of(),
         List.of(),
+        List.of(),
         true,
         false,
         null,
@@ -72,7 +82,7 @@ class VerdictBuilderTest {
         List.of(),
         "",
         List.of(new FileDiff("a.java", "modified", 1, 0, 1, "")),
-        new DiffLineResolver(Map.of()),
+        () -> new DiffLineResolver(Map.of()),
         null);
   }
 
@@ -163,5 +173,57 @@ class VerdictBuilderTest {
 
     assertEquals(2, result.omittedFiles());
     assertTrue(result.truncated());
+  }
+
+  @Test
+  void mergePreviousStatusesReusesModelListWhenBackstopIsEmpty() {
+    var model = List.of(new ReviewResult.PreviousFindingStatus(1, "resolved", "done"));
+    assertSame(model, VerdictBuilder.mergePreviousStatuses(model, List.of()));
+    assertSame(model, VerdictBuilder.mergePreviousStatuses(model, null));
+  }
+
+  @Test
+  void mergePreviousStatusesAppendsBackstopWithoutMutatingModelList() {
+    var model = List.of(new ReviewResult.PreviousFindingStatus(1, "resolved", "done"));
+    var backstop = List.of(new ReviewResult.PreviousFindingStatus(2, "unresolved", "held"));
+
+    var merged = VerdictBuilder.mergePreviousStatuses(model, backstop);
+
+    assertEquals(2, merged.size());
+    assertEquals(1, model.size());
+    assertEquals("unresolved", merged.get(1).status());
+  }
+
+  @Test
+  void noContextPathDoesNotTouchLineResolverSupplier() {
+    var touched = new boolean[] {false};
+    var ctx =
+        new ReviewContextLoader.ReviewContext(
+            List.of(),
+            "diff",
+            "",
+            0,
+            List.of(),
+            List.of(),
+            List.of(),
+            true,
+            false,
+            null,
+            List.of(),
+            "",
+            new InstructionsResolver.ResolvedInstructions("", ""),
+            List.of(),
+            "",
+            List.of(new FileDiff("a.java", "modified", 1, 0, 1, "")),
+            () -> {
+              touched[0] = true;
+              return new DiffLineResolver(Map.of());
+            },
+            null);
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), false);
+
+    builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    assertFalse(touched[0]);
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🚀 Performance
- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

The #118 approve backstop (PR #119) left three redundancies on every follow-up review. After the #250 orchestrator split those live in `ReviewContextLoader` / `VerdictBuilder` / `FollowUpAnalyzer`; this PR removes them with no behavior change:

**(a) One memoized `DiffLineResolver`.** Built lazily via a supplier on `ReviewContext`, shared by the finding pipeline, approve backstop, and `postReview`. A no-context verdict path that never touches the supplier does not parse patches at all (construction counter asserts this).

**(b) Prior AI JSON deserialized once.** `ReviewContextLoader.load` calls `parsePreviousResponses` once and stores `priorAiResponses` on the context. Context formatting, unresolved gating, the backstop, finding-file id maps, and thread matching reuse the parsed objects.

**(c) Conditional status merge.** `VerdictBuilder.mergePreviousStatuses` returns the `toStatuses` list unchanged when the backstop is empty — no `ArrayList` wrap/copy on the common path.

## Related Issues

Fixes #135

Related: #118 (parent backstop), #74 (reuse-fetched-data pattern), PR #119.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

New / updated coverage:
- `ReviewContextLoaderTest$DedupeHotPathLoad` — resolver built once / never when unused; prior responses parsed once at load
- `VerdictBuilderTest` — merge identity on empty backstop; no-context path does not touch the resolver supplier
- Existing `ReviewOrchestratorTest` / `FollowUpAnalyzerTest` / `FindingPipelineTest` updated for the parse-once APIs

Local verification:
- `./mvnw spotless:apply` / check ✅
- `./mvnw verify` ✅ — 1595 tests, SpotBugs clean, JaCoCo gate met

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No behavior change to merged `previousStatuses` ordering, counts, gate, or messages. `ReviewResult` still receives a non-null, copyable status list.


Made with [Cursor](https://cursor.com)