### PR TITLE
fix(review): framework-aware false-positive guards for injection/constructor claims (#337)

### DIFF
--- a/.github/thrillhousebot.md
+++ b/.github/thrillhousebot.md
@@ -17,6 +17,13 @@ positives and recurring misses, not to lower the bar.
   (`.../pulls/{n}/comments`, `.../reviews`, `.../files`, `.../issues`, ...) and
   GraphQL connections return only the first page unless explicitly paginated.
 
+## Framework facts (do not re-derive or contradict these)
+
+- **CDI constructor injection is a valid bean.** In Quarkus/Jakarta CDI, a class
+  whose constructor is annotated `@Inject` is a well-formed bean; no no-arg or
+  default constructor is required. Do **not** raise "missing no-arg/default
+  constructor" findings on classes with an `@Inject` constructor.
+
 ## Review focus for this codebase
 
 - **Pagination / truncation.** When a change lists a GitHub collection, confirm it

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -57,6 +57,7 @@ public class FindingPipeline {
 
   private final AiReviewService aiReviewService;
   private final FindingQuoteValidator quoteValidator;
+  private final FrameworkFalsePositiveFilter frameworkFilter;
   private final FindingDeduplicator deduplicator;
   private final FindingVerificationService findingVerificationService;
   private final FollowUpAnalyzer followUpAnalyzer;
@@ -69,6 +70,7 @@ public class FindingPipeline {
   public FindingPipeline(
       AiReviewService aiReviewService,
       FindingQuoteValidator quoteValidator,
+      FrameworkFalsePositiveFilter frameworkFilter,
       FindingDeduplicator deduplicator,
       FindingVerificationService findingVerificationService,
       FollowUpAnalyzer followUpAnalyzer,
@@ -78,6 +80,7 @@ public class FindingPipeline {
       TokenCounter tokenCounter) {
     this.aiReviewService = aiReviewService;
     this.quoteValidator = quoteValidator;
+    this.frameworkFilter = frameworkFilter;
     this.deduplicator = deduplicator;
     this.findingVerificationService = findingVerificationService;
     this.followUpAnalyzer = followUpAnalyzer;
@@ -255,6 +258,7 @@ public class FindingPipeline {
     var batchResponse =
         aiReviewService.reviewBatch(session, batchInputs, index + 1, batches.size());
     var validated = quoteValidator.validate(batchResponse, batch.text());
+    validated = frameworkFilter.filter(validated, batch.text());
     var verified =
         findingVerificationService.verify(
             validated,
@@ -580,6 +584,7 @@ public class FindingPipeline {
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       DiffLineResolver lineResolver) {
     aiResponse = quoteValidator.validate(aiResponse, diff);
+    aiResponse = frameworkFilter.filter(aiResponse, diff);
     aiResponse = deduplicator.dedupe(aiResponse);
     aiResponse =
         findingVerificationService.verify(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FrameworkFalsePositiveFilter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FrameworkFalsePositiveFilter.java
@@ -41,13 +41,18 @@ import java.util.regex.Pattern;
 @ApplicationScoped
 public class FrameworkFalsePositiveFilter {
 
-  /** A "missing no-arg / default / zero-arg constructor" style claim, in title or description. */
-  private static final Pattern NO_ARG_CONSTRUCTOR_CLAIM =
-      Pattern.compile(
-          "\\b(?:no|zero)[\\s-]?arg(?:ument)?s?\\b[^.]{0,60}\\bconstructor\\b"
-              + "|\\bdefault\\s+(?:public\\s+)?constructor\\b"
-              + "|\\bconstructor\\b[^.]{0,60}\\b(?:no|zero)[\\s-]?arg(?:ument)?s?\\b",
-          Pattern.CASE_INSENSITIVE);
+  /** A "default constructor" claim; the no-arg/zero-arg variants pair the two tokens below. */
+  private static final Pattern DEFAULT_CONSTRUCTOR_CLAIM =
+      Pattern.compile("\\bdefault\\s+(?:public\\s+)?constructor\\b", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern NO_ARG_TOKEN =
+      Pattern.compile("\\b(?:no|zero)[\\s-]?arg(?:ument)?s?\\b", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern CONSTRUCTOR_TOKEN =
+      Pattern.compile("\\bconstructor\\b", Pattern.CASE_INSENSITIVE);
+
+  /** How far apart (in characters) the no-arg and constructor tokens may sit and still pair up. */
+  private static final int TOKEN_PROXIMITY = 60;
 
   /** An injection annotation, bare or fully qualified, possibly inlined with the declaration. */
   private static final Pattern INJECT_ANNOTATION =
@@ -102,7 +107,29 @@ public class FrameworkFalsePositiveFilter {
   }
 
   private static boolean matchesClaim(String text) {
-    return text != null && NO_ARG_CONSTRUCTOR_CLAIM.matcher(text).find();
+    if (text == null) {
+      return false;
+    }
+    return DEFAULT_CONSTRUCTOR_CLAIM.matcher(text).find()
+        || tokensAppearNearby(text, NO_ARG_TOKEN, CONSTRUCTOR_TOKEN);
+  }
+
+  /** Whether both tokens occur in {@code text} within {@link #TOKEN_PROXIMITY} characters. */
+  private static boolean tokensAppearNearby(String text, Pattern first, Pattern second) {
+    var firstMatcher = first.matcher(text);
+    while (firstMatcher.find()) {
+      var secondMatcher = second.matcher(text);
+      while (secondMatcher.find()) {
+        int gap =
+            Math.max(
+                secondMatcher.start() - firstMatcher.end(),
+                firstMatcher.start() - secondMatcher.end());
+        if (gap <= TOKEN_PROXIMITY) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /**
@@ -121,20 +148,31 @@ public class FrameworkFalsePositiveFilter {
     }
     Pattern constructorDecl = Pattern.compile("(?<![\\w.])" + Pattern.quote(className) + "\\s*\\(");
     for (int i = 0; i < keptLines.size(); i++) {
-      if (!INJECT_ANNOTATION.matcher(keptLines.get(i)).find()) {
-        continue;
-      }
-      if (declaresConstructor(keptLines.get(i), className, constructorDecl)) {
+      if (INJECT_ANNOTATION.matcher(keptLines.get(i)).find()
+          && constructorAtOrBelow(keptLines, i, className, constructorDecl)) {
         return true;
       }
-      for (int j = i + 1; j < keptLines.size() && j <= i + ANNOTATION_LOOKAHEAD; j++) {
-        String candidate = keptLines.get(j);
-        if (declaresConstructor(candidate, className, constructorDecl)) {
-          return true;
-        }
-        if (!candidate.startsWith("@")) {
-          break;
-        }
+    }
+    return false;
+  }
+
+  /**
+   * Whether the annotation line at {@code annotationIndex} — or one of the next few lines, with
+   * only further annotation lines allowed in between — declares a constructor of {@code className}.
+   */
+  private static boolean constructorAtOrBelow(
+      List<String> keptLines, int annotationIndex, String className, Pattern constructorDecl) {
+    if (declaresConstructor(keptLines.get(annotationIndex), className, constructorDecl)) {
+      return true;
+    }
+    int last = Math.min(keptLines.size() - 1, annotationIndex + ANNOTATION_LOOKAHEAD);
+    for (int j = annotationIndex + 1; j <= last; j++) {
+      String candidate = keptLines.get(j);
+      if (declaresConstructor(candidate, className, constructorDecl)) {
+        return true;
+      }
+      if (!candidate.startsWith("@")) {
+        return false;
       }
     }
     return false;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FrameworkFalsePositiveFilter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FrameworkFalsePositiveFilter.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService;
+import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Deterministic guard against recurring framework false positives the model produces from
+ * remembered — and wrong — framework rules. The first guarded pattern is the CDI/Spring
+ * constructor-injection claim: a finding that a class is "missing a no-arg/default constructor"
+ * when the diff itself shows a constructor annotated {@code @Inject} (or {@code @Autowired}) on
+ * that class. Constructor injection is the documented idiom in CDI (Quarkus/Jakarta) and Spring; no
+ * no-arg constructor is required, so the diff refutes the claim outright and the finding is
+ * dropped.
+ *
+ * <p>The check is conservative in the same direction as {@link FindingQuoteValidator}: a finding is
+ * dropped only when the refuting evidence — an injection-annotated constructor of the flagged
+ * file's class — is visible on the kept (context/added) side of that file's own diff section. When
+ * the constructor sits outside the diff window nothing is provable, and the finding passes through
+ * unchanged.
+ */
+@ApplicationScoped
+public class FrameworkFalsePositiveFilter {
+
+  /** A "missing no-arg / default / zero-arg constructor" style claim, in title or description. */
+  private static final Pattern NO_ARG_CONSTRUCTOR_CLAIM =
+      Pattern.compile(
+          "\\b(?:no|zero)[\\s-]?arg(?:ument)?s?\\b[^.]{0,60}\\bconstructor\\b"
+              + "|\\bdefault\\s+(?:public\\s+)?constructor\\b"
+              + "|\\bconstructor\\b[^.]{0,60}\\b(?:no|zero)[\\s-]?arg(?:ument)?s?\\b",
+          Pattern.CASE_INSENSITIVE);
+
+  /** An injection annotation, bare or fully qualified, possibly inlined with the declaration. */
+  private static final Pattern INJECT_ANNOTATION =
+      Pattern.compile("@(?:(?:jakarta|javax)\\.inject\\.)?Inject\\b|@(?:[\\w.]*\\.)?Autowired\\b");
+
+  /** How many kept diff lines after an injection annotation may hold the constructor. */
+  private static final int ANNOTATION_LOOKAHEAD = 5;
+
+  /** Drops findings the diff deterministically refutes; leaves everything else untouched. */
+  public ReviewResponse filter(ReviewResponse response, String diff) {
+    if (response.findings().isEmpty() || diff == null || diff.isBlank()) {
+      return response;
+    }
+    FindingQuoteValidator.DiffIndex index = FindingQuoteValidator.indexDiff(diff);
+    var kept = new ArrayList<ReviewResponse.Finding>(response.findings().size());
+    var changed = false;
+    for (ReviewResponse.Finding finding : response.findings()) {
+      if (isRefutedNoArgConstructorClaim(finding, index)) {
+        Log.infof(
+            "Dropping finding '%s' (%s:%d) — it claims a missing no-arg constructor but the diff"
+                + " shows an injection-annotated constructor; constructor injection needs no no-arg"
+                + " constructor in CDI/Spring",
+            finding.title(), finding.file(), finding.line());
+        changed = true;
+        continue;
+      }
+      kept.add(finding);
+    }
+    if (!changed) {
+      return response;
+    }
+    return new ReviewResponse(
+        kept,
+        response.previousFindingsStatus(),
+        FindingVerificationService.recount(response.summary(), kept));
+  }
+
+  private static boolean isRefutedNoArgConstructorClaim(
+      ReviewResponse.Finding finding, FindingQuoteValidator.DiffIndex index) {
+    if (!claimsMissingNoArgConstructor(finding)) {
+      return false;
+    }
+    String className = classNameOf(finding.file());
+    if (className.isEmpty()) {
+      return false;
+    }
+    return hasInjectedConstructor(index.diffLinesFor(finding.file()), className);
+  }
+
+  private static boolean claimsMissingNoArgConstructor(ReviewResponse.Finding finding) {
+    return matchesClaim(finding.title()) || matchesClaim(finding.description());
+  }
+
+  private static boolean matchesClaim(String text) {
+    return text != null && NO_ARG_CONSTRUCTOR_CLAIM.matcher(text).find();
+  }
+
+  /**
+   * Whether the kept (context/added) lines of the file's diff section show a constructor of {@code
+   * className} annotated for injection: the annotation either on the declaration line itself or on
+   * one of the few preceding lines, with only further annotation lines allowed in between. Deleted
+   * lines never count — an {@code @Inject} the PR removes is not evidence the bean still has it.
+   */
+  private static boolean hasInjectedConstructor(
+      List<FindingQuoteValidator.DiffLine> diffLines, String className) {
+    var keptLines = new ArrayList<String>();
+    for (var line : diffLines) {
+      if (line.marker() != '-') {
+        keptLines.add(line.normalizedText());
+      }
+    }
+    Pattern constructorDecl = Pattern.compile("(?<![\\w.])" + Pattern.quote(className) + "\\s*\\(");
+    for (int i = 0; i < keptLines.size(); i++) {
+      if (!INJECT_ANNOTATION.matcher(keptLines.get(i)).find()) {
+        continue;
+      }
+      if (declaresConstructor(keptLines.get(i), className, constructorDecl)) {
+        return true;
+      }
+      for (int j = i + 1; j < keptLines.size() && j <= i + ANNOTATION_LOOKAHEAD; j++) {
+        String candidate = keptLines.get(j);
+        if (declaresConstructor(candidate, className, constructorDecl)) {
+          return true;
+        }
+        if (!candidate.startsWith("@")) {
+          break;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean declaresConstructor(String line, String className, Pattern decl) {
+    if (line.contains("new " + className)) {
+      return false;
+    }
+    return decl.matcher(line).find();
+  }
+
+  /** The simple class name implied by the finding's file path, or empty when not a Java file. */
+  private static String classNameOf(String file) {
+    if (file == null || file.isBlank()) {
+      return "";
+    }
+    String name = file.substring(file.lastIndexOf('/') + 1);
+    int dot = name.lastIndexOf('.');
+    if (dot <= 0 || !name.endsWith(".java")) {
+      return "";
+    }
+    return name.substring(0, dot);
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
@@ -70,6 +70,10 @@ public final class FindingVerifierPrompts {
               present and lacks it) — that finding is demonstrable and stands.
             - The finding misstates language semantics — for example, claiming the string
               escape "\\n" produces a literal backslash and n rather than a newline.
+            - The finding claims a class is missing a required no-arg/default constructor for
+              dependency injection while the diff shows a constructor annotated @Inject (CDI /
+              Quarkus / Jakarta) or @Autowired (Spring) on that class — constructor injection is
+              the documented idiom and needs no no-arg constructor; the diff refutes the claim.
             - The diff already guards against the condition the finding claims is unhandled —
               not only an adjacent literal check (an existing null check on the flagged line) but
               an upstream guard earlier in the same method, including one on a value derived from

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -108,6 +108,10 @@ public final class PrReviewPrompts {
               description must name exactly what to verify.
             - When the project stack section lists a framework, prefer its documented idioms over
               generic assumptions; never flag idiomatic usage as broken without proof in the diff.
+            - Dependency-injection frameworks do not require a no-arg constructor on a bean whose
+              constructor is annotated for injection: in CDI (Quarkus/Jakarta) an @Inject
+              constructor makes the class a valid bean, and Spring behaves the same with
+              @Autowired. Never report a "missing no-arg/default constructor" on such a class.
             - If you are uncertain whether an issue is real at all, omit it rather than guess.
 
             Self-check before emitting each finding — drop the finding if any check fails:

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -56,6 +56,7 @@ class FindingPipelineTest {
 
   @Mock private AiReviewService aiReviewService;
   @Mock private FindingQuoteValidator quoteValidator;
+  @Mock private FrameworkFalsePositiveFilter frameworkFilter;
   @Mock private FindingDeduplicator deduplicator;
   @Mock private FindingVerificationService findingVerificationService;
   @Mock private FollowUpAnalyzer followUpAnalyzer;
@@ -70,6 +71,7 @@ class FindingPipelineTest {
         new FindingPipeline(
             aiReviewService,
             quoteValidator,
+            frameworkFilter,
             deduplicator,
             findingVerificationService,
             followUpAnalyzer,
@@ -78,6 +80,7 @@ class FindingPipelineTest {
             budgetPlanner,
             new TokenCounter());
     when(quoteValidator.validate(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+    when(frameworkFilter.filter(any(), any())).thenAnswer(inv -> inv.getArgument(0));
     when(deduplicator.dedupe(any())).thenAnswer(inv -> inv.getArgument(0));
     when(findingVerificationService.verify(any(), any(), any(), any()))
         .thenAnswer(inv -> inv.getArgument(0));
@@ -561,6 +564,7 @@ class FindingPipelineTest {
         new FindingPipeline(
             aiReviewService,
             quoteValidator,
+            frameworkFilter,
             deduplicator,
             findingVerificationService,
             followUpAnalyzer,

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FrameworkFalsePositiveFilterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FrameworkFalsePositiveFilterTest.java
@@ -321,11 +321,12 @@ class FrameworkFalsePositiveFilterTest {
     assertSame(response, filter.filter(response, INJECTED_CTOR_DIFF));
   }
 
-  @Test
-  void keepsClaimWhenFindingHasNoFile() {
+  @ParameterizedTest
+  @NullAndEmptySource
+  void keepsClaimWhenFindingHasNoFile(String file) {
     var response =
         response(
-            finding(null, "Missing no-arg constructor", "The class needs a default constructor."));
+            finding(file, "Missing no-arg constructor", "The class needs a default constructor."));
 
     assertSame(response, filter.filter(response, INJECTED_CTOR_DIFF));
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FrameworkFalsePositiveFilterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FrameworkFalsePositiveFilterTest.java
@@ -262,6 +262,71 @@ class FrameworkFalsePositiveFilterTest {
   }
 
   @Test
+  void dropsClaimWhenTitleIsNullAndDescriptionMatches() {
+    var f =
+        finding(
+            "src/main/java/dev/example/PrSummaryGenerator.java",
+            null,
+            "The class is missing a no-arg constructor required by CDI.");
+
+    var result = filter.filter(response(f), INJECTED_CTOR_DIFF);
+
+    assertEquals(0, result.findings().size());
+  }
+
+  @Test
+  void keepsClaimWhenConstructorIsBeyondTheAnnotationLookahead() {
+    var diff =
+        """
+        ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +8 -0)
+        ```diff
+        @@ -10,2 +10,10 @@
+         public class PrSummaryGenerator {
+        +  @Inject
+        +  @A
+        +  @B
+        +  @C
+        +  @D
+        +  @E
+        +  public PrSummaryGenerator(AiReviewService aiReviewService) {
+        +  }
+         }
+        ```
+        """;
+    var response = response(noArgClaim("Missing no-arg constructor"));
+
+    assertSame(response, filter.filter(response, diff));
+  }
+
+  @Test
+  void keepsClaimWhenAnnotationIsTheLastKeptLine() {
+    var diff =
+        """
+        ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +1 -0)
+        ```diff
+        @@ -10,2 +10,3 @@
+         public class PrSummaryGenerator {
+        +  @Inject
+        ```
+        """;
+    var response = response(noArgClaim("Missing no-arg constructor"));
+
+    assertSame(response, filter.filter(response, diff));
+  }
+
+  @Test
+  void keepsClaimOnExtensionOnlyFileName() {
+    var response =
+        response(
+            finding(
+                "src/.java",
+                "Missing no-arg constructor",
+                "The class needs a default constructor."));
+
+    assertSame(response, filter.filter(response, INJECTED_CTOR_DIFF));
+  }
+
+  @Test
   void keepsClaimWhenFindingHasNoFile() {
     var response =
         response(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FrameworkFalsePositiveFilterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FrameworkFalsePositiveFilterTest.java
@@ -17,11 +17,15 @@ package dev.thiagogonzaga.thrillhousebot.review;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -145,48 +149,97 @@ class FrameworkFalsePositiveFilterTest {
     assertEquals(0, result.findings().size());
   }
 
-  @Test
-  void keepsClaimWhenDiffShowsNoInjectedConstructor() {
-    var response = response(noArgClaim("Missing no-arg constructor"));
-
-    assertSame(response, filter.filter(response, NO_INJECT_DIFF));
+  /** Diffs that do not prove an injection-annotated constructor, so the claim must survive. */
+  static Stream<Arguments> nonRefutingDiffs() {
+    return Stream.of(
+        arguments("no @Inject constructor in the diff", NO_INJECT_DIFF),
+        arguments(
+            "@Inject on a field, not a constructor",
+            """
+            ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +2 -0)
+            ```diff
+            @@ -10,2 +10,4 @@
+             public class PrSummaryGenerator {
+            +  @Inject
+            +  AiReviewService aiReviewService;
+             }
+            ```
+            """),
+        arguments(
+            "the @Inject constructor was deleted by this PR",
+            """
+            ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +0 -3)
+            ```diff
+            @@ -10,5 +10,2 @@
+             public class PrSummaryGenerator {
+            -  @Inject
+            -  public PrSummaryGenerator(AiReviewService aiReviewService) {
+            -  }
+             }
+            ```
+            """),
+        arguments(
+            "constructor invocation, not a declaration",
+            """
+            ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +2 -0)
+            ```diff
+            @@ -10,2 +10,4 @@
+             public class PrSummaryGenerator {
+            +  @Inject
+            +  void setUp() { var x = new PrSummaryGenerator(null); }
+             }
+            ```
+            """),
+        arguments(
+            "constructor beyond the annotation lookahead",
+            """
+            ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +8 -0)
+            ```diff
+            @@ -10,2 +10,10 @@
+             public class PrSummaryGenerator {
+            +  @Inject
+            +  @A
+            +  @B
+            +  @C
+            +  @D
+            +  @E
+            +  public PrSummaryGenerator(AiReviewService aiReviewService) {
+            +  }
+             }
+            ```
+            """),
+        arguments(
+            "annotation is the last kept line",
+            """
+            ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +1 -0)
+            ```diff
+            @@ -10,2 +10,3 @@
+             public class PrSummaryGenerator {
+            +  @Inject
+            ```
+            """));
   }
 
-  @Test
-  void keepsClaimWhenInjectIsOnFieldNotConstructor() {
-    var diff =
-        """
-        ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +2 -0)
-        ```diff
-        @@ -10,2 +10,4 @@
-         public class PrSummaryGenerator {
-        +  @Inject
-        +  AiReviewService aiReviewService;
-         }
-        ```
-        """;
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("nonRefutingDiffs")
+  void keepsClaimWhenDiffDoesNotProveInjectedConstructor(String label, String diff) {
     var response = response(noArgClaim("Missing no-arg constructor"));
 
     assertSame(response, filter.filter(response, diff));
   }
 
   @Test
-  void keepsClaimWhenInjectedConstructorWasDeleted() {
-    var diff =
-        """
-        ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +0 -3)
-        ```diff
-        @@ -10,5 +10,2 @@
-         public class PrSummaryGenerator {
-        -  @Inject
-        -  public PrSummaryGenerator(AiReviewService aiReviewService) {
-        -  }
-         }
-        ```
-        """;
-    var response = response(noArgClaim("Missing no-arg constructor"));
+  void keepsFindingWhoseNoArgAndConstructorMentionsAreUnrelated() {
+    var f =
+        finding(
+            "src/main/java/dev/example/PrSummaryGenerator.java",
+            "Constructor stores mutable list",
+            "The constructor copies its input defensively before storing it in the internal cache"
+                + " field, which keeps later mutations of the caller's collection from leaking in."
+                + " Elsewhere, the CLI parser accepts no args, a separate concern entirely.");
+    var response = response(f);
 
-    assertSame(response, filter.filter(response, diff));
+    assertSame(response, filter.filter(response, INJECTED_CTOR_DIFF));
   }
 
   @Test
@@ -199,24 +252,6 @@ class FrameworkFalsePositiveFilterTest {
                 "OtherClass needs a default constructor."));
 
     assertSame(response, filter.filter(response, INJECTED_CTOR_DIFF));
-  }
-
-  @Test
-  void doesNotMistakeConstructorInvocationForDeclaration() {
-    var diff =
-        """
-        ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +2 -0)
-        ```diff
-        @@ -10,2 +10,4 @@
-         public class PrSummaryGenerator {
-        +  @Inject
-        +  void setUp() { var x = new PrSummaryGenerator(null); }
-         }
-        ```
-        """;
-    var response = response(noArgClaim("Missing no-arg constructor"));
-
-    assertSame(response, filter.filter(response, diff));
   }
 
   @Test
@@ -272,46 +307,6 @@ class FrameworkFalsePositiveFilterTest {
     var result = filter.filter(response(f), INJECTED_CTOR_DIFF);
 
     assertEquals(0, result.findings().size());
-  }
-
-  @Test
-  void keepsClaimWhenConstructorIsBeyondTheAnnotationLookahead() {
-    var diff =
-        """
-        ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +8 -0)
-        ```diff
-        @@ -10,2 +10,10 @@
-         public class PrSummaryGenerator {
-        +  @Inject
-        +  @A
-        +  @B
-        +  @C
-        +  @D
-        +  @E
-        +  public PrSummaryGenerator(AiReviewService aiReviewService) {
-        +  }
-         }
-        ```
-        """;
-    var response = response(noArgClaim("Missing no-arg constructor"));
-
-    assertSame(response, filter.filter(response, diff));
-  }
-
-  @Test
-  void keepsClaimWhenAnnotationIsTheLastKeptLine() {
-    var diff =
-        """
-        ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +1 -0)
-        ```diff
-        @@ -10,2 +10,3 @@
-         public class PrSummaryGenerator {
-        +  @Inject
-        ```
-        """;
-    var response = response(noArgClaim("Missing no-arg constructor"));
-
-    assertSame(response, filter.filter(response, diff));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FrameworkFalsePositiveFilterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FrameworkFalsePositiveFilterTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FrameworkFalsePositiveFilterTest {
+
+  private final FrameworkFalsePositiveFilter filter = new FrameworkFalsePositiveFilter();
+
+  /** An `@Inject`-constructor-only bean, the #270 false-positive shape. */
+  private static final String INJECTED_CTOR_DIFF =
+      """
+      ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +6 -0)
+      ```diff
+      @@ -10,3 +10,9 @@
+       public class PrSummaryGenerator {
+      +  private final AiReviewService aiReviewService;
+      +
+      +  @Inject
+      +  public PrSummaryGenerator(AiReviewService aiReviewService) {
+      +    this.aiReviewService = aiReviewService;
+      +  }
+       }
+      ```
+      """;
+
+  private static final String NO_INJECT_DIFF =
+      """
+      ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +1 -0)
+      ```diff
+      @@ -10,2 +10,3 @@
+       public class PrSummaryGenerator {
+      +  private final AiReviewService aiReviewService;
+       }
+      ```
+      """;
+
+  private static ReviewResponse.Finding finding(String file, String title, String description) {
+    return new ReviewResponse.Finding("medium", "medium", file, 12, title, description, null, null);
+  }
+
+  private static ReviewResponse.Finding noArgClaim(String title) {
+    return finding(
+        "src/main/java/dev/example/PrSummaryGenerator.java",
+        title,
+        "CDI requires a bean to be proxyable; add a constructor without arguments.");
+  }
+
+  private static ReviewResponse response(ReviewResponse.Finding... findings) {
+    return new ReviewResponse(
+        List.of(findings),
+        List.of(),
+        new ReviewResponse.Summary(
+            findings.length, 0, 0, findings.length, 0, "assessment", "purpose", List.of()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "Missing no-arg CDI constructor",
+        "Missing no-argument constructor for CDI proxying",
+        "Class lacks a default constructor",
+        "Bean constructor takes arguments but CDI needs a zero-arg constructor",
+        "Constructor should have no args for the CDI container"
+      })
+  void dropsNoArgConstructorClaimWhenDiffShowsInjectedConstructor(String title) {
+    var result = filter.filter(response(noArgClaim(title)), INJECTED_CTOR_DIFF);
+
+    assertEquals(0, result.findings().size());
+    assertEquals(0, result.summary().totalFindings());
+    assertEquals(0, result.summary().medium());
+  }
+
+  @Test
+  void dropsClaimWhenAnnotationIsInlineWithConstructorDeclaration() {
+    var diff =
+        """
+        ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +1 -0)
+        ```diff
+        @@ -10,2 +10,3 @@
+         public class PrSummaryGenerator {
+        +  @Inject public PrSummaryGenerator(AiReviewService aiReviewService) {}
+         }
+        ```
+        """;
+
+    var result = filter.filter(response(noArgClaim("Missing no-arg constructor")), diff);
+
+    assertEquals(0, result.findings().size());
+  }
+
+  @Test
+  void dropsClaimWhenOtherAnnotationsSitBetweenInjectAndConstructor() {
+    var diff =
+        """
+        ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +4 -0)
+        ```diff
+        @@ -10,2 +10,6 @@
+         public class PrSummaryGenerator {
+        +  @Inject
+        +  @Deprecated
+        +  public PrSummaryGenerator(AiReviewService aiReviewService) {
+        +  }
+         }
+        ```
+        """;
+
+    var result = filter.filter(response(noArgClaim("Missing default constructor")), diff);
+
+    assertEquals(0, result.findings().size());
+  }
+
+  @Test
+  void dropsClaimWhenClaimTextOnlyAppearsInDescription() {
+    var f =
+        finding(
+            "src/main/java/dev/example/PrSummaryGenerator.java",
+            "CDI bean instantiation failure",
+            "The container cannot instantiate this bean because it has no default constructor.");
+
+    var result = filter.filter(response(f), INJECTED_CTOR_DIFF);
+
+    assertEquals(0, result.findings().size());
+  }
+
+  @Test
+  void keepsClaimWhenDiffShowsNoInjectedConstructor() {
+    var response = response(noArgClaim("Missing no-arg constructor"));
+
+    assertSame(response, filter.filter(response, NO_INJECT_DIFF));
+  }
+
+  @Test
+  void keepsClaimWhenInjectIsOnFieldNotConstructor() {
+    var diff =
+        """
+        ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +2 -0)
+        ```diff
+        @@ -10,2 +10,4 @@
+         public class PrSummaryGenerator {
+        +  @Inject
+        +  AiReviewService aiReviewService;
+         }
+        ```
+        """;
+    var response = response(noArgClaim("Missing no-arg constructor"));
+
+    assertSame(response, filter.filter(response, diff));
+  }
+
+  @Test
+  void keepsClaimWhenInjectedConstructorWasDeleted() {
+    var diff =
+        """
+        ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +0 -3)
+        ```diff
+        @@ -10,5 +10,2 @@
+         public class PrSummaryGenerator {
+        -  @Inject
+        -  public PrSummaryGenerator(AiReviewService aiReviewService) {
+        -  }
+         }
+        ```
+        """;
+    var response = response(noArgClaim("Missing no-arg constructor"));
+
+    assertSame(response, filter.filter(response, diff));
+  }
+
+  @Test
+  void keepsClaimWhenInjectedConstructorBelongsToAnotherFile() {
+    var response =
+        response(
+            finding(
+                "src/main/java/dev/example/OtherClass.java",
+                "Missing no-arg constructor",
+                "OtherClass needs a default constructor."));
+
+    assertSame(response, filter.filter(response, INJECTED_CTOR_DIFF));
+  }
+
+  @Test
+  void doesNotMistakeConstructorInvocationForDeclaration() {
+    var diff =
+        """
+        ### src/main/java/dev/example/PrSummaryGenerator.java (modified, +2 -0)
+        ```diff
+        @@ -10,2 +10,4 @@
+         public class PrSummaryGenerator {
+        +  @Inject
+        +  void setUp() { var x = new PrSummaryGenerator(null); }
+         }
+        ```
+        """;
+    var response = response(noArgClaim("Missing no-arg constructor"));
+
+    assertSame(response, filter.filter(response, diff));
+  }
+
+  @Test
+  void keepsUnrelatedFindingsUntouched() {
+    var unrelated =
+        finding(
+            "src/main/java/dev/example/PrSummaryGenerator.java",
+            "Possible NPE on summary field",
+            "summary may be null when the model omits it.");
+    var response = response(unrelated);
+
+    assertSame(response, filter.filter(response, INJECTED_CTOR_DIFF));
+  }
+
+  @Test
+  void dropsOnlyTheRefutedFindingAndRecountsSummary() {
+    var kept =
+        finding(
+            "src/main/java/dev/example/PrSummaryGenerator.java",
+            "Possible NPE on summary field",
+            "summary may be null when the model omits it.");
+    var result =
+        filter.filter(response(noArgClaim("Missing no-arg constructor"), kept), INJECTED_CTOR_DIFF);
+
+    assertEquals(List.of(kept), result.findings());
+    assertEquals(1, result.summary().totalFindings());
+    assertEquals(1, result.summary().medium());
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void passesThroughOnBlankDiff(String diff) {
+    var response = response(noArgClaim("Missing no-arg constructor"));
+
+    assertSame(response, filter.filter(response, diff));
+  }
+
+  @Test
+  void passesThroughWhenThereAreNoFindings() {
+    var response = response();
+
+    assertSame(response, filter.filter(response, INJECTED_CTOR_DIFF));
+  }
+
+  @Test
+  void keepsClaimWhenFindingHasNoFile() {
+    var response =
+        response(
+            finding(null, "Missing no-arg constructor", "The class needs a default constructor."));
+
+    assertSame(response, filter.filter(response, INJECTED_CTOR_DIFF));
+  }
+
+  @Test
+  void keepsClaimOnNonJavaFile() {
+    var response =
+        response(
+            finding(
+                "src/main/js/generator.ts",
+                "Missing no-arg constructor",
+                "The class needs a default constructor."));
+
+    assertSame(response, filter.filter(response, INJECTED_CTOR_DIFF));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -83,6 +83,7 @@ class ReviewOrchestratorTest {
   @Mock private FindingVerificationService findingVerificationService;
 
   private final FindingQuoteValidator quoteValidator = new FindingQuoteValidator();
+  private final FrameworkFalsePositiveFilter frameworkFilter = new FrameworkFalsePositiveFilter();
 
   private final FindingDeduplicator deduplicator = new FindingDeduplicator();
 
@@ -134,6 +135,7 @@ class ReviewOrchestratorTest {
         new FindingPipeline(
             aiReviewService,
             quoteValidator,
+            frameworkFilter,
             deduplicator,
             findingVerificationService,
             followUpAnalyzer,
@@ -3646,6 +3648,7 @@ class ReviewOrchestratorTest {
           new FindingPipeline(
               aiReviewService,
               quoteValidator,
+              frameworkFilter,
               deduplicator,
               findingVerificationService,
               followUpAnalyzer,


### PR DESCRIPTION
## Summary
- Adds a deterministic `FrameworkFalsePositiveFilter` (`review/`) that drops "missing no-arg/default constructor" findings when the flagged file's own diff shows a constructor annotated `@Inject` (CDI/Quarkus/Jakarta, bare or fully qualified) or `@Autowired` (Spring) — constructor injection needs no no-arg constructor, so the diff refutes the claim outright. Conservative in the same direction as `FindingQuoteValidator`: deleted lines never count as evidence, other files' hunks can't refute, and when the constructor sits outside the diff window the finding passes through unchanged.
- Wires the filter into both `FindingPipeline` paths (single-call `refine` and per-batch `processBatch`), right after quote validation, with the summary recounted on drop.
- Adds the CDI constructor-injection fact to the reviewer prompt (`PrReviewPrompts.SYSTEM` confidence-calibration section) and as a rejection rule in `FindingVerifierPrompts.SYSTEM`, plus a new "Framework facts" section in `.github/thrillhousebot.md`.

Reproduces the #270 dogfood shape: the bot posted **MEDIUM — missing no-arg CDI constructor** on `PrSummaryGenerator` despite a valid `@Inject` constructor. That exact shape is the primary test fixture and is now suppressed deterministically, with the prompt guardrails preventing the claim upstream.

## Issue
Fixes #337

## Test plan
- [x] `FrameworkFalsePositiveFilterTest` (20 tests): drops the #270-class claim on an `@Inject` constructor-only bean (annotation above, inline, and with interleaved annotations; claim in title or description); keeps the finding when there is no `@Inject` constructor, when `@Inject` is on a field, when the annotated constructor was deleted, when the evidence is in another file, on constructor *invocations* (`new X(...)`), on non-Java/missing file paths, and on unrelated findings; recounts the summary when dropping.
- [x] `FindingPipelineTest`/`ReviewOrchestratorTest` updated for the new pipeline dependency.
- [x] `./mvnw verify` passes locally (1608 tests, SpotBugs, JaCoCo gate); new class at 99% instruction coverage with the one previously-missed line now covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)