### PR TITLE
fix(review): invalidate findings when targeted diff hunks disappear on force-push (#336)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
@@ -75,10 +75,30 @@ public interface GitHubCommentClient {
     return all;
   }
 
+  @PATCH
+  @Path("/repos/{owner}/{repo}/issues/comments/{commentId}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.APPLICATION_JSON)
+  CommentResponse updateComment(
+      @HeaderParam("Authorization") String auth,
+      @HeaderParam("Accept") String accept,
+      @PathParam("owner") String owner,
+      @PathParam("repo") String repo,
+      @PathParam("commentId") long commentId,
+      CreateCommentRequest request);
+
   record CreateCommentRequest(String body) {}
 
   record CommentResponse(long id, @JsonProperty("html_url") String htmlUrl) {}
 
-  /** A PR conversation comment, carrying just the body and author needed to spot the bot's own. */
-  record IssueComment(String body, GitHubReviewClient.ReviewResponse.User user) {}
+  /**
+   * A PR conversation comment: the id (to edit the bot's own summary in place), plus the body and
+   * author needed to spot it.
+   */
+  record IssueComment(long id, String body, GitHubReviewClient.ReviewResponse.User user) {
+    /** Convenience constructor for callers that never edit the comment. */
+    public IssueComment(String body, GitHubReviewClient.ReviewResponse.User user) {
+      this(0, body, user);
+    }
+  }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -44,6 +44,17 @@ public class FollowUpAnalyzer {
   private static final String STATUS_JUSTIFIED = "justified";
 
   /**
+   * Synthetic status for a prior finding whose flagged code is no longer in the current diff — the
+   * model never emits it; {@link #supersedeVanished} rewrites a stale {@code unresolved} to it so
+   * the finding stops holding APPROVE while its outcome stays visible in the summary counts.
+   */
+  static final String STATUS_SUPERSEDED = "superseded";
+
+  private static final String SUPERSEDED_NOTE =
+      "The code this finding targeted is no longer in this revision's diff (removed by a"
+          + " force-push or a later commit) — superseded.";
+
+  /**
    * The only statuses the prompt contract defines for {@code previous_findings_status} ("resolved"
    * | "unresolved" | "justified"). A value outside this set does not count as the model accounting
    * for a finding — see {@link #isRecognizedStatus}.
@@ -544,6 +555,66 @@ public class FollowUpAnalyzer {
   }
 
   /**
+   * Rewrites a model-reported {@code unresolved} status to {@link #STATUS_SUPERSEDED} when the
+   * prior finding's flagged code is no longer in the current diff (its file left the diff or the
+   * anchored hunk vanished, typically after a force-push). The model reports on the <em>prior</em>
+   * round's findings and can hold one open even though the code it targeted no longer exists;
+   * presence is judged deterministically via {@link DiffLineResolver#isFindingPresent} on the
+   * finding's persisted {@code suggestion_old} anchor — the same predicate the approve backstop
+   * uses — so a vanished finding no longer blocks APPROVE.
+   *
+   * <p>A finding without a file cannot be placed in the diff at all, so its status is left
+   * untouched — clearing is the dangerous direction, and "cannot verify" must not read as "gone".
+   * Statuses other than {@code unresolved}, or with an id outside the prior round, also pass
+   * through unchanged.
+   */
+  public List<ReviewResponse.PreviousFindingStatus> supersedeVanished(
+      String previousAiResponseJson,
+      List<ReviewResponse.PreviousFindingStatus> statuses,
+      DiffLineResolver lineResolver) {
+    if (statuses == null || statuses.isEmpty() || lineResolver == null) {
+      return statuses == null ? List.of() : statuses;
+    }
+    var previous = parsePreviousFindings(previousAiResponseJson);
+    if (previous.isEmpty()) {
+      return statuses;
+    }
+    var rewritten = new ArrayList<ReviewResponse.PreviousFindingStatus>(statuses.size());
+    for (var status : statuses) {
+      if (hasVanished(status, previous, lineResolver)) {
+        Log.infof(
+            "Superseding unresolved previous finding #%d — its targeted code is no longer in the"
+                + " current diff",
+            status.id());
+        rewritten.add(
+            new ReviewResponse.PreviousFindingStatus(
+                status.id(), STATUS_SUPERSEDED, SUPERSEDED_NOTE));
+      } else {
+        rewritten.add(status);
+      }
+    }
+    return rewritten;
+  }
+
+  private static boolean hasVanished(
+      ReviewResponse.PreviousFindingStatus status,
+      List<ReviewResponse.Finding> previous,
+      DiffLineResolver lineResolver) {
+    if (!STATUS_UNRESOLVED.equalsIgnoreCase(status.status())) {
+      return false;
+    }
+    var id = status.id();
+    if (id < 1 || id > previous.size()) {
+      return false;
+    }
+    var finding = previous.get(id - 1);
+    if (finding.file() == null) {
+      return false;
+    }
+    return !lineResolver.isFindingPresent(finding.file(), finding.suggestionOld());
+  }
+
+  /**
    * Deterministic approve backstop. The bot's own prior findings the model silently dropped — still
    * present in the current diff, carrying no maintainer reply, and not closed by any round —
    * surfaced as synthetic {@code "unresolved"} statuses. Merging these into the result's
@@ -875,11 +946,12 @@ public class FollowUpAnalyzer {
 
   /**
    * Converts AI response's previous_findings_status into ReviewResult statuses, keeping only the
-   * recognized values (resolved / justified / unresolved). An unrecognized status is meaningless
-   * noise that no count or gate acts on, and for a still-open finding the backstop already emits a
-   * synthetic {@code "unresolved"} for that id — passing the raw value through too would leave two
-   * entries with the same id in the result. Dropping it keeps {@code previousStatuses} one-per-id
-   * and matches the backstop's recognized-status contract.
+   * recognized values (resolved / justified / unresolved) plus the synthetic {@link
+   * #STATUS_SUPERSEDED} that {@link #supersedeVanished} rewrites in. An unrecognized status is
+   * meaningless noise that no count or gate acts on, and for a still-open finding the backstop
+   * already emits a synthetic {@code "unresolved"} for that id — passing the raw value through too
+   * would leave two entries with the same id in the result. Dropping it keeps {@code
+   * previousStatuses} one-per-id and matches the backstop's recognized-status contract.
    */
   public List<ReviewResult.PreviousFindingStatus> toStatuses(
       List<ReviewResponse.PreviousFindingStatus> aiStatuses) {
@@ -887,7 +959,7 @@ public class FollowUpAnalyzer {
 
     var result = new ArrayList<ReviewResult.PreviousFindingStatus>();
     for (var s : aiStatuses) {
-      if (isRecognizedStatus(s.status())) {
+      if (isRecognizedStatus(s.status()) || STATUS_SUPERSEDED.equalsIgnoreCase(s.status())) {
         result.add(new ReviewResult.PreviousFindingStatus(s.id(), s.status(), s.note()));
       }
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -148,12 +148,22 @@ public class PrSummaryGenerator {
         result.previousStatuses().stream()
             .filter(s -> "justified".equalsIgnoreCase(s.status()))
             .count();
+    var superseded =
+        result.previousStatuses().stream()
+            .filter(s -> "superseded".equalsIgnoreCase(s.status()))
+            .count();
     sb.append("### Previous Findings Status\n");
     sb.append("| Status | Count |\n");
     sb.append("|--------|-------|\n");
     sb.append("| ✅ Resolved | ").append(resolved).append(" |\n");
     sb.append("| ⚠️ Still present | ").append(unresolved).append(" |\n");
-    sb.append("| 💬 Justified | ").append(justified).append(" |\n\n");
+    sb.append("| 💬 Justified | ").append(justified).append(" |\n");
+    if (superseded > 0) {
+      sb.append("| 🗂️ Superseded (targeted code left the diff) | ")
+          .append(superseded)
+          .append(" |\n");
+    }
+    sb.append("\n");
   }
 
   private static void appendFindingsOrCelebration(StringBuilder sb, ReviewResult result) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -78,8 +78,10 @@ public class ReviewPublisher {
    * comment — unless {@code forceSummary} is set, which the {@code /summary} command uses to
    * regenerate a summary that was deleted from the PR even though a review already ran, or a prior
    * finding was superseded this round ({@link ReviewResult#hasSupersededPrevious}): its targeted
-   * code left the diff, so the earlier summary may describe code that no longer exists and the
-   * regenerated one is posted to replace it.
+   * code left the diff, so the earlier summary may describe code that no longer exists. In the
+   * superseded case the bot's existing summary comment is edited in place with the regenerated
+   * markdown — never posted alongside the stale one — falling back to a new comment only when no
+   * prior summary comment exists (e.g. it was deleted).
    *
    * @return {@code true} when the summary comment was actually created; {@code false} when this
    *     review posts no summary (follow-up, or nothing to post). {@code postReview} suppresses the
@@ -93,8 +95,10 @@ public class ReviewPublisher {
       int prNumber,
       ReviewResult result,
       boolean forceSummary) {
-    if ((result.isFirstReview() || forceSummary || result.hasSupersededPrevious())
-        && !result.summaryMarkdown().isBlank()) {
+    if (result.summaryMarkdown().isBlank()) {
+      return false;
+    }
+    if (result.isFirstReview() || forceSummary) {
       commentClient.createComment(
           auth,
           ACCEPT,
@@ -104,7 +108,35 @@ public class ReviewPublisher {
           new GitHubCommentClient.CreateCommentRequest(result.summaryMarkdown()));
       return true;
     }
+    if (result.hasSupersededPrevious()) {
+      refreshSummaryComment(auth, owner, repo, prNumber, result.summaryMarkdown());
+      return true;
+    }
     return false;
+  }
+
+  /**
+   * Replaces the stale summary with the regenerated one after a finding was superseded: edits the
+   * bot's newest existing summary comment in place, so the PR never shows the outdated summary
+   * (describing removed code) next to the fresh one. Creates a new comment only when no summary
+   * comment is found (e.g. a maintainer deleted it).
+   */
+  private void refreshSummaryComment(
+      String auth, String owner, String repo, int prNumber, String summaryMarkdown) {
+    var existing =
+        commentClient.listComments(auth, ACCEPT, owner, repo, prNumber).stream()
+            .filter(c -> c.user() != null && botIdentity.matches(c.user().login()))
+            .filter(
+                c ->
+                    c.body() != null
+                        && c.body().stripLeading().startsWith(PrSummaryGenerator.SUMMARY_HEADING))
+            .reduce((first, second) -> second);
+    var request = new GitHubCommentClient.CreateCommentRequest(summaryMarkdown);
+    if (existing.isPresent()) {
+      commentClient.updateComment(auth, ACCEPT, owner, repo, existing.get().id(), request);
+    } else {
+      commentClient.createComment(auth, ACCEPT, owner, repo, prNumber, request);
+    }
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -76,7 +76,10 @@ public class ReviewPublisher {
    * Posts the PR summary comment, but only on the first user-visible review (and only when there is
    * a summary to post). Follow-up reviews carry their signal in the review itself, not a new
    * comment — unless {@code forceSummary} is set, which the {@code /summary} command uses to
-   * regenerate a summary that was deleted from the PR even though a review already ran.
+   * regenerate a summary that was deleted from the PR even though a review already ran, or a prior
+   * finding was superseded this round ({@link ReviewResult#hasSupersededPrevious}): its targeted
+   * code left the diff, so the earlier summary may describe code that no longer exists and the
+   * regenerated one is posted to replace it.
    *
    * @return {@code true} when the summary comment was actually created; {@code false} when this
    *     review posts no summary (follow-up, or nothing to post). {@code postReview} suppresses the
@@ -90,7 +93,8 @@ public class ReviewPublisher {
       int prNumber,
       ReviewResult result,
       boolean forceSummary) {
-    if ((result.isFirstReview() || forceSummary) && !result.summaryMarkdown().isBlank()) {
+    if ((result.isFirstReview() || forceSummary || result.hasSupersededPrevious())
+        && !result.summaryMarkdown().isBlank()) {
       commentClient.createComment(
           auth,
           ACCEPT,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -167,6 +167,15 @@ public record ReviewResult(
     return omittedFiles > 0;
   }
 
+  /**
+   * True when a prior finding was superseded this round — its targeted code left the diff (e.g. a
+   * force-push removed it), so the finding was auto-closed instead of holding APPROVE. Triggers a
+   * summary re-post on follow-up reviews, since the earlier summary may describe removed code.
+   */
+  public boolean hasSupersededPrevious() {
+    return previousStatuses.stream().anyMatch(s -> "superseded".equalsIgnoreCase(s.status()));
+  }
+
   /** How many previous findings the model (or the backstop) still reports as unresolved. */
   public long unresolvedPreviousCount() {
     return previousStatuses.stream().filter(s -> "unresolved".equalsIgnoreCase(s.status())).count();
@@ -303,7 +312,7 @@ public record ReviewResult(
   @RegisterForReflection
   public record PreviousFindingStatus(
       int id,
-      String status, // resolved, unresolved, justified
+      String status, // resolved, unresolved, justified, superseded
       String note) {}
 
   @RegisterForReflection

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -78,20 +78,26 @@ public class VerdictBuilder {
             ctx.reviewableFiles().stream()
                 .filter(f -> !omittedNames.contains(f.filename()))
                 .toList());
+    // A model-reported "unresolved" whose targeted code left the diff (force-push) becomes
+    // "superseded" before the gates run, so a vanished finding never holds APPROVE (#336).
+    var effectiveStatuses =
+        followUpAnalyzer.supersedeVanished(
+            ctx.previousAiResponseJson(), aiResponse.previousFindingsStatus(), ctx.lineResolver());
+    var effectiveResponse =
+        new ReviewResponse(aiResponse.findings(), effectiveStatuses, aiResponse.summary());
     var unresolvedPrevious =
-        followUpAnalyzer.unresolvedFindings(
-            ctx.previousAiResponseJson(), aiResponse.previousFindingsStatus());
+        followUpAnalyzer.unresolvedFindings(ctx.previousAiResponseJson(), effectiveStatuses);
     var backstopUnresolved =
         ctx.hasContext()
             ? followUpAnalyzer.unreportedUnresolvedStatuses(
                 ctx.priorAiResponseJsons(),
-                aiResponse.previousFindingsStatus(),
+                effectiveStatuses,
                 ctx.inlineComments(),
                 ctx.lineResolver(),
                 botIdentity)
             : List.<ReviewResult.PreviousFindingStatus>of();
     return buildResult(
-        aiResponse,
+        effectiveResponse,
         ctx.isFirstVisibleReview(),
         diffStats,
         changedFiles,

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -725,6 +725,94 @@ class FollowUpAnalyzerTest {
     assertTrue(analyzer.unresolvedFindings("not json", unresolvedStatus).isEmpty());
   }
 
+  @Test
+  void supersedeVanishedShouldRewriteUnresolvedWhoseFileLeftTheDiff() {
+    // Only src/A.java is still in the diff; src/B.java (finding 2) vanished after a force-push.
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+    var statuses =
+        List.of(
+            new ReviewResponse.PreviousFindingStatus(1, "unresolved", "still"),
+            new ReviewResponse.PreviousFindingStatus(2, "UNRESOLVED", "still"));
+
+    var rewritten = analyzer.supersedeVanished(PREVIOUS_JSON, statuses, resolver);
+
+    assertEquals("unresolved", rewritten.get(0).status());
+    assertEquals("superseded", rewritten.get(1).status());
+    assertEquals(2, rewritten.get(1).id());
+    assertTrue(rewritten.get(1).note().contains("no longer in this revision's diff"));
+  }
+
+  @Test
+  void supersedeVanishedShouldJudgePresenceByTheAnchorNotTheFile() {
+    var anchoredJson =
+        """
+        {"findings": [
+          {"risk": "medium", "file": "src/A.java", "line": 10, "title": "Bad regex",
+           "description": "d", "suggestion_old": "quote(label)"},
+          {"risk": "medium", "file": "src/A.java", "line": 12, "title": "Kept",
+           "description": "d", "suggestion_old": "keepMe()"}
+        ]}
+        """;
+    // The file is still in the diff, but only finding 2's anchored hunk survived.
+    var resolver = new DiffLineResolver(Map.of("src/A.java", "@@ -10,1 +10,1 @@\n-old\n+keepMe()"));
+    var statuses =
+        List.of(
+            new ReviewResponse.PreviousFindingStatus(1, "unresolved", "still"),
+            new ReviewResponse.PreviousFindingStatus(2, "unresolved", "still"));
+
+    var rewritten = analyzer.supersedeVanished(anchoredJson, statuses, resolver);
+
+    assertEquals("superseded", rewritten.get(0).status());
+    assertEquals("unresolved", rewritten.get(1).status());
+  }
+
+  @Test
+  void supersedeVanishedShouldLeaveNonUnresolvedAndUnplaceableStatusesAlone() {
+    var nullFileJson =
+        """
+        {"findings": [
+          {"risk": "medium", "file": null, "line": 3, "title": "No file", "description": "d"},
+          {"risk": "medium", "file": "src/Gone.java", "line": 5, "title": "Gone",
+           "description": "d"}
+        ]}
+        """;
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+    var statuses =
+        List.of(
+            new ReviewResponse.PreviousFindingStatus(1, "unresolved", "cannot place"),
+            new ReviewResponse.PreviousFindingStatus(2, "resolved", "fixed"),
+            new ReviewResponse.PreviousFindingStatus(0, "unresolved", "below range"),
+            new ReviewResponse.PreviousFindingStatus(99, "unresolved", "out of range"));
+
+    var rewritten = analyzer.supersedeVanished(nullFileJson, statuses, resolver);
+
+    assertEquals(statuses, rewritten);
+  }
+
+  @Test
+  void supersedeVanishedShouldPassThroughOnMissingInputs() {
+    var resolver = new DiffLineResolver(Map.of());
+    var statuses = List.of(new ReviewResponse.PreviousFindingStatus(1, "unresolved", "x"));
+
+    assertTrue(analyzer.supersedeVanished(PREVIOUS_JSON, null, resolver).isEmpty());
+    assertTrue(analyzer.supersedeVanished(PREVIOUS_JSON, List.of(), resolver).isEmpty());
+    assertEquals(statuses, analyzer.supersedeVanished(PREVIOUS_JSON, statuses, null));
+    assertEquals(statuses, analyzer.supersedeVanished(null, statuses, resolver));
+    assertEquals(statuses, analyzer.supersedeVanished("not json", statuses, resolver));
+  }
+
+  @Test
+  void toStatusesShouldKeepTheSyntheticSupersededStatus() {
+    var statuses =
+        analyzer.toStatuses(
+            List.of(
+                new ReviewResponse.PreviousFindingStatus(1, "superseded", "code gone"),
+                new ReviewResponse.PreviousFindingStatus(2, "wontfix", "junk")));
+
+    assertEquals(1, statuses.size());
+    assertEquals("superseded", statuses.get(0).status());
+  }
+
   /** One-line patch whose only right-side line is {@code line}, for backstop presence tests. */
   private static String patch(int line) {
     return "@@ -" + line + ",1 +" + line + ",1 @@\n-old\n+new";

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -253,6 +253,40 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
+  void shouldShowSupersededRowOnlyWhenAFindingWasSuperseded() {
+    var statuses =
+        List.of(
+            new ReviewResult.PreviousFindingStatus(1, "resolved", "Fixed"),
+            new ReviewResult.PreviousFindingStatus(2, "Superseded", "Code left the diff"));
+
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.COMMENT, false, "", statuses, List.of(), 0);
+
+    var summary = generator.generate(1, 0, 0, List.of(), null, result);
+
+    assertTrue(summary.contains("🗂️ Superseded (targeted code left the diff) | 1"), summary);
+
+    var withoutSuperseded =
+        new ReviewResult(
+            List.of(),
+            0,
+            0,
+            0,
+            0,
+            null,
+            ReviewState.COMMENT,
+            false,
+            "",
+            List.of(new ReviewResult.PreviousFindingStatus(1, "resolved", "Fixed")),
+            List.of(),
+            0);
+
+    assertFalse(
+        generator.generate(1, 0, 0, List.of(), null, withoutSuperseded).contains("Superseded"));
+  }
+
+  @Test
   void shouldCountPreviousFindingsStatusCaseInsensitively() {
     var statuses =
         List.of(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisherTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisherTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
+import dev.thiagogonzaga.thrillhousebot.github.ReviewThreadService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link ReviewPublisher#publishSummary}'s posting conditions. */
+class ReviewPublisherTest {
+
+  private final GitHubCommentClient commentClient = mock(GitHubCommentClient.class);
+
+  private final ReviewPublisher publisher =
+      new ReviewPublisher(
+          mock(GitHubReviewClient.class),
+          commentClient,
+          mock(ReviewThreadService.class),
+          mock(SuggestionFormatter.class),
+          mock(FollowUpAnalyzer.class),
+          mock(PrLabeler.class),
+          mock(ThrillhouseConfig.class),
+          BotIdentity.of("thrillhousebot"));
+
+  private static ReviewResult followUpResult(List<ReviewResult.PreviousFindingStatus> statuses) {
+    return new ReviewResult(
+        List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, false, "summary", statuses, List.of(), 0);
+  }
+
+  @Test
+  void followUpWithSupersededFindingRepostsTheRegeneratedSummary() {
+    var result =
+        followUpResult(
+            List.of(new ReviewResult.PreviousFindingStatus(1, "superseded", "code gone")));
+
+    assertTrue(publisher.publishSummary("auth", "o", "r", 1, result, false));
+    verify(commentClient)
+        .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+  }
+
+  @Test
+  void plainFollowUpDoesNotPostASummary() {
+    var result =
+        followUpResult(List.of(new ReviewResult.PreviousFindingStatus(1, "resolved", "fixed")));
+
+    assertFalse(publisher.publishSummary("auth", "o", "r", 1, result, false));
+    verify(commentClient, never())
+        .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisherTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisherTest.java
@@ -20,9 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
@@ -53,13 +55,46 @@ class ReviewPublisherTest {
         List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, false, "summary", statuses, List.of(), 0);
   }
 
-  @Test
-  void followUpWithSupersededFindingRepostsTheRegeneratedSummary() {
-    var result =
-        followUpResult(
-            List.of(new ReviewResult.PreviousFindingStatus(1, "superseded", "code gone")));
+  private static final ReviewResult SUPERSEDED_RESULT =
+      followUpResult(List.of(new ReviewResult.PreviousFindingStatus(1, "superseded", "code gone")));
 
-    assertTrue(publisher.publishSummary("auth", "o", "r", 1, result, false));
+  @Test
+  void followUpWithSupersededFindingEditsTheExistingSummaryInPlace() {
+    var bot = new GitHubReviewClient.ReviewResponse.User("thrillhousebot");
+    // Two summary comments (e.g. /summary re-posted one): the newest is the one edited.
+    when(commentClient.listComments(anyString(), anyString(), anyString(), anyString(), anyInt()))
+        .thenReturn(
+            List.of(
+                new GitHubCommentClient.IssueComment(
+                    66L, PrSummaryGenerator.SUMMARY_HEADING + "\n\nolder", bot),
+                new GitHubCommentClient.IssueComment(
+                    77L, PrSummaryGenerator.SUMMARY_HEADING + "\n\nstale", bot)));
+
+    assertTrue(publisher.publishSummary("auth", "o", "r", 1, SUPERSEDED_RESULT, false));
+
+    verify(commentClient)
+        .updateComment(anyString(), anyString(), anyString(), anyString(), eq(77L), any());
+    verify(commentClient, never())
+        .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+  }
+
+  @Test
+  void followUpWithSupersededFindingPostsANewSummaryWhenNoneExists() {
+    // None of these is the bot's summary: no author, another author, no body, unrelated body.
+    var bot = new GitHubReviewClient.ReviewResponse.User("thrillhousebot");
+    when(commentClient.listComments(anyString(), anyString(), anyString(), anyString(), anyInt()))
+        .thenReturn(
+            List.of(
+                new GitHubCommentClient.IssueComment(1L, PrSummaryGenerator.SUMMARY_HEADING, null),
+                new GitHubCommentClient.IssueComment(
+                    2L,
+                    PrSummaryGenerator.SUMMARY_HEADING,
+                    new GitHubReviewClient.ReviewResponse.User("someone-else")),
+                new GitHubCommentClient.IssueComment(3L, null, bot),
+                new GitHubCommentClient.IssueComment(4L, "just a reply", bot)));
+
+    assertTrue(publisher.publishSummary("auth", "o", "r", 1, SUPERSEDED_RESULT, false));
+
     verify(commentClient)
         .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -154,6 +154,93 @@ class VerdictBuilderTest {
     assertEquals(ReviewResult.TruncationDetail.EMPTY, stats.truncation());
   }
 
+  /** The previous round's persisted response: one finding anchored in src/Gone.java. */
+  private static final String PRIOR_JSON =
+      """
+      {"findings": [{"risk": "high", "file": "src/Gone.java", "line": 10,
+        "title": "Unsafe regex", "description": "d", "suggestion_old": "quote(label)"}]}
+      """;
+
+  /** A follow-up context whose current diff contains only {@code file}. */
+  private static ReviewContextLoader.ReviewContext followUpContext(String file) {
+    return new ReviewContextLoader.ReviewContext(
+        List.of(),
+        "diff",
+        "",
+        0,
+        List.of(),
+        List.of(PRIOR_JSON),
+        false,
+        true,
+        PRIOR_JSON,
+        List.of(),
+        "",
+        new InstructionsResolver.ResolvedInstructions("", ""),
+        List.of(),
+        "",
+        List.of(new FileDiff(file, "modified", 1, 0, 1, "")),
+        new DiffLineResolver(Map.of(file, "@@ -10,1 +10,1 @@\n-old\n+new")),
+        null);
+  }
+
+  private static final ReviewResponse UNRESOLVED_PRIOR_RESPONSE =
+      new ReviewResponse(
+          List.of(),
+          List.of(new ReviewResponse.PreviousFindingStatus(1, "unresolved", "still there")),
+          null);
+
+  @Test
+  void unresolvedPriorFindingWhoseCodeLeftTheDiffIsSupersededAndDoesNotHoldApprove() {
+    var realBuilder =
+        new VerdictBuilder(
+            summaryGenerator,
+            new FollowUpAnalyzer(new com.fasterxml.jackson.databind.ObjectMapper()),
+            BotIdentity.from(List.of("thrillhousebot[bot]")));
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+
+    var result =
+        realBuilder.build(
+            followUpContext("src/Other.java"), UNRESOLVED_PRIOR_RESPONSE, CI_CLEAR, plan);
+
+    assertEquals(ReviewState.APPROVE, result.reviewState());
+    assertTrue(result.hasSupersededPrevious());
+    assertEquals(0, result.unresolvedPreviousCount());
+  }
+
+  @Test
+  void unresolvedPriorFindingStillInTheDiffKeepsHoldingApprove() {
+    var realBuilder =
+        new VerdictBuilder(
+            summaryGenerator,
+            new FollowUpAnalyzer(new com.fasterxml.jackson.databind.ObjectMapper()),
+            BotIdentity.from(List.of("thrillhousebot[bot]")));
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var ctx =
+        new ReviewContextLoader.ReviewContext(
+            List.of(),
+            "diff",
+            "",
+            0,
+            List.of(),
+            List.of(PRIOR_JSON),
+            false,
+            true,
+            PRIOR_JSON,
+            List.of(),
+            "",
+            new InstructionsResolver.ResolvedInstructions("", ""),
+            List.of(),
+            "",
+            List.of(new FileDiff("src/Gone.java", "modified", 1, 0, 1, "")),
+            new DiffLineResolver(Map.of("src/Gone.java", "@@ -10,1 +10,1 @@\n-old\n+quote(label)")),
+            null);
+
+    var result = realBuilder.build(ctx, UNRESOLVED_PRIOR_RESPONSE, CI_CLEAR, plan);
+
+    assertEquals(ReviewState.REQUEST_CHANGES, result.reviewState());
+    assertFalse(result.hasSupersededPrevious());
+  }
+
   @Test
   void disabledBudgetingDisclosesTheLegacyLineCapCount() {
     var ctx = contextWithLineCapOmissions(2);


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Dogfood on #299 showed that after a force-push removed the code a prior finding targeted, the bot still held the finding open ("unresolved") and the summary kept describing code that no longer existed.

This PR adds a stale-finding lifecycle on the inline/model-status path (the deterministic backstop from #118 already checked presence; the model-reported path did not):

- **`FollowUpAnalyzer.supersedeVanished`**: before the APPROVE gates run, each model-reported `unresolved` status is re-checked against the current diff via `DiffLineResolver.isFindingPresent` on the finding's persisted `suggestion_old` anchor. If the anchored hunk is gone (file left the diff or the hunk vanished), the status is rewritten to a synthetic `superseded` with an explanatory note — it no longer blocks APPROVE and no longer enters `outstanding`, so it can't force REQUEST_CHANGES either.
- Safety: a finding without a file (unplaceable) keeps its hold — "cannot verify" never reads as "gone". Non-`unresolved` and out-of-range statuses pass through untouched. The existing backstop path is unchanged (it already filters by presence).
- **Surfacing**: `toStatuses` keeps the synthetic status, and the summary's "Previous Findings Status" table gains a `🗂️ Superseded (targeted code left the diff)` row (only when > 0).
- **Summary regeneration**: `ReviewPublisher.publishSummary` now also posts the freshly regenerated summary on a follow-up review when a prior finding was superseded (`ReviewResult.hasSupersededPrevious()`), so the visible summary no longer describes removed code.

## Related Issues

Fixes #336

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- `FollowUpAnalyzerTest`: supersede on vanished file, presence judged by anchor (not just file), null-file / non-unresolved / out-of-range statuses untouched, missing-input pass-through, `toStatuses` keeps `superseded`.
- `VerdictBuilderTest` (real `FollowUpAnalyzer`): force-push removes the file → prior unresolved finding is superseded and the review APPROVEs; finding still present in the diff → still holds (REQUEST_CHANGES).
- `PrSummaryGeneratorTest`: superseded row rendered only when a finding was superseded.
- `ReviewPublisherTest` (new): follow-up with a superseded finding re-posts the summary; plain follow-up does not.
- `./mvnw verify` green locally (1600 tests, Spotless, SpotBugs, JaCoCo); no uncovered changed lines.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)