### PR TITLE
feat(review): eval/regression corpus for the review and verifier prompts (#113)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,37 @@ LangChain4j's OpenAI-compatible client, so a new provider is configuration: poin
 [README provider table](https://github.com/devops-thiago/ThrillhouseBot#provider-support) lists the ones that are known
 to work.
 
+## Prompt eval corpus
+
+Changes to the review or verifier prompts (`PrReviewPrompts`, `FindingVerifierPrompts`)
+should be checked against the labeled regression corpus in
+`src/test/resources/evalcorpus/` before they ship. Each case directory pins a real
+dogfood outcome — a `case.json` spec plus `diff.txt` in the exact format the review
+pipeline sends to the model:
+
+- **verifier** cases feed a candidate finding through the second-pass audit and assert
+  the expected verdict (`confirmed` / `downgraded` / `rejected`);
+- **generator** cases run the first-pass review prompt over a diff and assert that a
+  finding matching the case's keywords is (`must-find`) or is not (`must-not-find`)
+  raised on the target file.
+
+The corpus schema is validated by `EvalCorpusTest` in every build. The live suite is
+opt-in — it calls the configured AI provider:
+
+```bash
+QUARKUS_LANGCHAIN4J_OPENAI_API_KEY=<key> ./mvnw test -Peval -Dtest=PromptEvalTest
+```
+
+Point `AI_BASE_URL` / `AI_MODEL` at the provider you want to evaluate (defaults apply
+otherwise). Each case is sampled `-Deval.samples` times (default 3) and judged by
+majority; `-Deval.tolerated` (default 0) allows a known-unfixed label — one tracked by
+an open prompt-hardening issue — to fail without blocking unrelated prompt work.
+
+To add a case, create a new directory under `evalcorpus/` with `case.json` and
+`diff.txt` (see an existing case for the shape). Source new cases from resolved PR
+review threads: a refuted false positive becomes `expectedVerdicts: ["rejected"]`, a
+confirmed true positive `["confirmed"]`, and note the provenance in `why`.
+
 ## Reporting security issues
 
 Please **do not** open a public issue — see

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,9 @@
         <opentelemetry.alpha.version>1.62.0-alpha</opentelemetry.alpha.version>
         <jackson-bom.version>2.22.1</jackson-bom.version>
         <skipITs>true</skipITs>
+        <!-- JUnit tag filters for surefire; the eval profile flips them to run PromptEvalTest -->
+        <surefire.groups></surefire.groups>
+        <surefire.excluded.groups>eval</surefire.excluded.groups>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
         <!-- Default for @{argLine} in surefire; overwritten by the JaCoCo agent when active -->
         <argLine></argLine>
@@ -250,6 +253,8 @@
                 <configuration>
                     <!-- @{argLine} preserves the JaCoCo agent injected by prepare-agent -->
                     <argLine>@{argLine} -XX:+UseCompactObjectHeaders</argLine>
+                    <groups>${surefire.groups}</groups>
+                    <excludedGroups>${surefire.excluded.groups}</excludedGroups>
                     <systemPropertyVariables>
                         <java.util.logging.manager
                         >org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -392,6 +397,15 @@
             <properties>
                 <skipITs>false</skipITs>
                 <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+        </profile>
+        <profile>
+            <!-- Prompt eval/regression corpus (issue #113): runs only the eval-tagged suite
+                 against a live AI provider. See CONTRIBUTING.md "Prompt eval corpus". -->
+            <id>eval</id>
+            <properties>
+                <surefire.groups>eval</surefire.groups>
+                <surefire.excluded.groups></surefire.excluded.groups>
             </properties>
         </profile>
     </profiles>

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/eval/EvalCase.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/eval/EvalCase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.eval;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * One labeled regression case from the prompt eval corpus: a real dogfood outcome pinned as {@code
+ * (diff, candidate finding, expected verdict)} for verifier cases, or {@code (diff, expected
+ * finding presence)} for generator cases. Loaded from {@code src/test/resources/evalcorpus/<name>/}
+ * by {@link EvalCorpus}: {@code case.json} carries the spec, {@code diff.txt} the diff exactly as
+ * the review pipeline formats it ("### path (status, +A -D)" sections with fenced patches).
+ */
+public record EvalCase(String name, String diff, Spec spec) {
+
+  static final String KIND_VERIFIER = "verifier";
+  static final String KIND_GENERATOR = "generator";
+  static final String MUST_FIND = "must-find";
+  static final String MUST_NOT_FIND = "must-not-find";
+
+  /**
+   * The JSON body of {@code case.json}; unknown properties fail loading to keep fixtures honest.
+   */
+  public record Spec(
+      String kind,
+      int sourcePr,
+      String why,
+      List<String> expectedVerdicts,
+      CandidateFinding finding,
+      String expectation,
+      String targetFile,
+      List<String> keywords,
+      String prTitle,
+      String prDescription) {}
+
+  /** The candidate finding a verifier case feeds to the second-pass audit. */
+  public record CandidateFinding(
+      String risk,
+      String confidence,
+      String file,
+      int line,
+      String title,
+      String description,
+      @JsonProperty("suggestion_old") String suggestionOld,
+      @JsonProperty("suggestion_new") String suggestionNew) {}
+
+  boolean isVerifierCase() {
+    return KIND_VERIFIER.equals(spec.kind());
+  }
+
+  boolean isGeneratorCase() {
+    return KIND_GENERATOR.equals(spec.kind());
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/eval/EvalCorpus.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/eval/EvalCorpus.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.eval;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Loads the labeled prompt-regression corpus (issue #113). Each subdirectory of {@code
+ * src/test/resources/evalcorpus} is one {@link EvalCase}; new dogfood outcomes are added by
+ * dropping in a new directory with {@code case.json} + {@code diff.txt} — no code change needed.
+ */
+final class EvalCorpus {
+
+  static final Path CORPUS_DIR = Path.of("src", "test", "resources", "evalcorpus");
+
+  private EvalCorpus() {}
+
+  static List<EvalCase> load() {
+    var mapper = new ObjectMapper();
+    var cases = new ArrayList<EvalCase>();
+    try (Stream<Path> dirs = Files.list(CORPUS_DIR)) {
+      for (Path dir : dirs.filter(Files::isDirectory).sorted(Comparator.naturalOrder()).toList()) {
+        var spec = mapper.readValue(dir.resolve("case.json").toFile(), EvalCase.Spec.class);
+        var diff = Files.readString(dir.resolve("diff.txt"), StandardCharsets.UTF_8);
+        cases.add(new EvalCase(dir.getFileName().toString(), diff, spec));
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to load eval corpus from " + CORPUS_DIR, e);
+    }
+    return List.copyOf(cases);
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/eval/EvalCorpusTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/eval/EvalCorpusTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.eval;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Deterministic guard over the eval corpus itself — runs in every CI build (no AI call). It keeps
+ * fixtures well-formed so the opt-in {@link PromptEvalTest} can trust them, and so a malformed new
+ * case is caught at merge time rather than on the next eval run.
+ */
+class EvalCorpusTest {
+
+  private static final Set<String> VALID_VERDICTS = Set.of("confirmed", "downgraded", "rejected");
+
+  private final List<EvalCase> corpus = EvalCorpus.load();
+
+  @Test
+  void corpusIsSeededWithDogfoodOutcomes() {
+    assertFalse(corpus.isEmpty(), "eval corpus must not be empty");
+    assertEquals(corpus.size(), corpus.stream().map(EvalCase::name).distinct().count());
+  }
+
+  @Test
+  void everyCaseDeclaresKindProvenanceAndDiff() {
+    for (EvalCase c : corpus) {
+      assertTrue(
+          c.isVerifierCase() || c.isGeneratorCase(),
+          c.name() + ": kind must be 'verifier' or 'generator'");
+      assertTrue(c.spec().sourcePr() > 0, c.name() + ": sourcePr must reference the dogfood PR");
+      assertNotNull(c.spec().why(), c.name() + ": why must document the resolved outcome");
+      assertFalse(c.spec().why().isBlank(), c.name() + ": why must document the resolved outcome");
+      assertTrue(
+          c.diff().startsWith("### "),
+          c.name() + ": diff.txt must be in review-pipeline format (### path sections)");
+      assertTrue(c.diff().contains("```diff"), c.name() + ": diff.txt must fence its patch");
+    }
+  }
+
+  @Test
+  void verifierCasesCarryFindingAndValidExpectedVerdicts() {
+    for (EvalCase c : corpus) {
+      if (!c.isVerifierCase()) {
+        continue;
+      }
+      var finding = c.spec().finding();
+      assertNotNull(finding, c.name() + ": verifier case needs a candidate finding");
+      assertNotNull(finding.risk(), c.name() + ": finding.risk");
+      assertNotNull(finding.confidence(), c.name() + ": finding.confidence");
+      assertNotNull(finding.file(), c.name() + ": finding.file");
+      assertNotNull(finding.title(), c.name() + ": finding.title");
+      assertNotNull(finding.description(), c.name() + ": finding.description");
+      var expected = c.spec().expectedVerdicts();
+      assertNotNull(expected, c.name() + ": expectedVerdicts");
+      assertFalse(expected.isEmpty(), c.name() + ": expectedVerdicts must not be empty");
+      assertTrue(
+          VALID_VERDICTS.containsAll(expected),
+          c.name() + ": expectedVerdicts must be among " + VALID_VERDICTS);
+      assertTrue(
+          c.diff().contains(finding.file().substring(finding.file().lastIndexOf('/') + 1)),
+          c.name() + ": the finding's file must appear in the diff");
+    }
+  }
+
+  @Test
+  void generatorCasesCarryExpectationTargetAndKeywords() {
+    for (EvalCase c : corpus) {
+      if (!c.isGeneratorCase()) {
+        continue;
+      }
+      var expectation = c.spec().expectation();
+      assertTrue(
+          EvalCase.MUST_FIND.equals(expectation) || EvalCase.MUST_NOT_FIND.equals(expectation),
+          c.name() + ": expectation must be 'must-find' or 'must-not-find'");
+      assertNotNull(c.spec().targetFile(), c.name() + ": targetFile");
+      assertNotNull(c.spec().keywords(), c.name() + ": keywords");
+      assertFalse(c.spec().keywords().isEmpty(), c.name() + ": keywords must not be empty");
+    }
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/eval/PromptEvalTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/eval/PromptEvalTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.eval;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import dev.thiagogonzaga.thrillhousebot.review.PromptSections;
+import dev.thiagogonzaga.thrillhousebot.review.PromptTemplateEscaper;
+import dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService;
+import dev.thiagogonzaga.thrillhousebot.review.ai.PrReviewer;
+import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
+import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponseParser;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Opt-in regression suite for the review and verifier prompts (issue #113): replays each labeled
+ * corpus case against the live AI provider and asserts the expected outcome, so a prompt edit that
+ * fixes one false-positive class cannot silently reintroduce another.
+ *
+ * <p>Excluded from normal builds (JUnit tag {@code eval}, filtered by surefire); run it with a real
+ * provider key before shipping any change to {@code PrReviewPrompts} or {@code
+ * FindingVerifierPrompts}:
+ *
+ * <pre>{@code
+ * QUARKUS_LANGCHAIN4J_OPENAI_API_KEY=... ./mvnw test -Peval -Dtest=PromptEvalTest
+ * }</pre>
+ *
+ * <p>LLM nondeterminism is absorbed two ways: each case is sampled {@code -Deval.samples} times
+ * (default 3) and judged by majority, and the suite tolerates {@code -Deval.tolerated} failing
+ * cases (default 0) so a known-unfixed corpus label (an open prompt-hardening issue) can be carried
+ * without blocking unrelated prompt work.
+ *
+ * <p>Caveat: {@link FindingVerificationService#verify} fails open by design, so a provider outage
+ * during a verifier sample surfaces as a spurious "confirmed" — check the logged warning before
+ * trusting a failure.
+ */
+@QuarkusTest
+@Tag("eval")
+class PromptEvalTest {
+
+  private static final int SAMPLES = Integer.getInteger("eval.samples", 3);
+  private static final int TOLERATED = Integer.getInteger("eval.tolerated", 0);
+  private static final long SAMPLE_TIMEOUT_MINUTES = 10;
+
+  @Inject FindingVerificationService findingVerificationService;
+  @Inject PrReviewer prReviewer;
+  @Inject ReviewResponseParser reviewResponseParser;
+
+  @Test
+  void promptsReproduceLabeledDogfoodOutcomes() throws Exception {
+    assumeTrue(
+        System.getenv("QUARKUS_LANGCHAIN4J_OPENAI_API_KEY") != null,
+        "eval needs a real provider key in QUARKUS_LANGCHAIN4J_OPENAI_API_KEY");
+
+    var report = new StringBuilder();
+    var failed = 0;
+    for (EvalCase evalCase : EvalCorpus.load()) {
+      var passes = 0;
+      var outcomes = new StringBuilder();
+      for (var sample = 0; sample < SAMPLES; sample++) {
+        String outcome =
+            evalCase.isVerifierCase() ? verifierOutcome(evalCase) : generatorOutcome(evalCase);
+        outcomes.append(sample == 0 ? "" : ", ").append(outcome);
+        if (sampleMatchesExpectation(evalCase, outcome)) {
+          passes++;
+        }
+      }
+      var majority = passes * 2 > SAMPLES;
+      if (!majority) {
+        failed++;
+      }
+      report
+          .append(majority ? "PASS " : "FAIL ")
+          .append(evalCase.name())
+          .append(" — expected ")
+          .append(expectationOf(evalCase))
+          .append(", got [")
+          .append(outcomes)
+          .append("] (")
+          .append(passes)
+          .append('/')
+          .append(SAMPLES)
+          .append(")\n");
+    }
+
+    assertTrue(
+        failed <= TOLERATED,
+        "Prompt eval regressions: "
+            + failed
+            + " case(s) failed (tolerated "
+            + TOLERATED
+            + ")\n"
+            + report);
+  }
+
+  private static boolean sampleMatchesExpectation(EvalCase evalCase, String outcome) {
+    if (evalCase.isVerifierCase()) {
+      return evalCase.spec().expectedVerdicts().contains(outcome);
+    }
+    return outcome.equals(evalCase.spec().expectation());
+  }
+
+  private static String expectationOf(EvalCase evalCase) {
+    return evalCase.isVerifierCase()
+        ? String.join("|", evalCase.spec().expectedVerdicts())
+        : evalCase.spec().expectation();
+  }
+
+  /**
+   * Feeds the labeled candidate through the production verification path and classifies what came
+   * back: dropped → rejected, risk or confidence lowered → downgraded, unchanged → confirmed.
+   */
+  private String verifierOutcome(EvalCase evalCase) {
+    var f = evalCase.spec().finding();
+    var candidate =
+        new ReviewResponse.Finding(
+            f.risk(),
+            f.confidence(),
+            f.file(),
+            f.line(),
+            f.title(),
+            f.description(),
+            f.suggestionOld(),
+            f.suggestionNew());
+    var response = new ReviewResponse(List.of(candidate), List.of(), null);
+    var verified =
+        findingVerificationService.verify(
+            response, PromptTemplateEscaper.fence(evalCase.diff()), "", "");
+    if (verified.findings().isEmpty()) {
+      return "rejected";
+    }
+    var kept = verified.findings().get(0);
+    var lowered =
+        !kept.risk().equalsIgnoreCase(candidate.risk())
+            || !kept.confidence().equalsIgnoreCase(candidate.confidence());
+    return lowered ? "downgraded" : "confirmed";
+  }
+
+  /**
+   * Runs the first-pass review prompt over the case's diff and reports whether any finding on the
+   * target file mentions one of the case's keywords ("must-find" / "must-not-find").
+   */
+  private String generatorOutcome(EvalCase evalCase) throws Exception {
+    var raw = new CompletableFuture<String>();
+    prReviewer
+        .reviewStream(
+            PromptTemplateEscaper.fence(evalCase.diff()),
+            PromptTemplateEscaper.escape(
+                PromptSections.prContext(
+                    orEmpty(evalCase.spec().prTitle()), orEmpty(evalCase.spec().prDescription()))),
+            "",
+            "",
+            "",
+            "",
+            "")
+        .onPartialResponse(token -> {})
+        .onCompleteResponse(response -> raw.complete(response.aiMessage().text()))
+        .onError(raw::completeExceptionally)
+        .start();
+    var parsed = reviewResponseParser.parse(raw.get(SAMPLE_TIMEOUT_MINUTES, TimeUnit.MINUTES));
+    var found =
+        parsed.findings().stream()
+            .anyMatch(
+                finding -> targetsCase(evalCase, finding) && mentionsKeyword(evalCase, finding));
+    return found ? EvalCase.MUST_FIND : EvalCase.MUST_NOT_FIND;
+  }
+
+  private static boolean targetsCase(EvalCase evalCase, ReviewResponse.Finding finding) {
+    var target = evalCase.spec().targetFile();
+    return finding.file() != null
+        && (finding.file().equals(target) || target.endsWith("/" + finding.file()));
+  }
+
+  private static boolean mentionsKeyword(EvalCase evalCase, ReviewResponse.Finding finding) {
+    var text =
+        (orEmpty(finding.title()) + " " + orEmpty(finding.description())).toLowerCase(Locale.ROOT);
+    return evalCase.spec().keywords().stream()
+        .anyMatch(keyword -> text.contains(keyword.toLowerCase(Locale.ROOT)));
+  }
+
+  private static String orEmpty(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/src/test/resources/evalcorpus/pr100-empty-line-ioobe-false-positive/case.json
+++ b/src/test/resources/evalcorpus/pr100-empty-line-ioobe-false-positive/case.json
@@ -1,0 +1,16 @@
+{
+  "kind": "verifier",
+  "sourcePr": 100,
+  "why": "Refuted in PR #100 review thread: appendBodyLine returns at the normalized.isEmpty() guard before raw.charAt(0) is reached, so an empty trailing split token never crashes. A runtime-crash claim the diff refutes must be rejected.",
+  "expectedVerdicts": ["rejected"],
+  "finding": {
+    "risk": "medium",
+    "confidence": "low",
+    "file": "src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java",
+    "line": 153,
+    "title": "Empty line in diff input causes IndexOutOfBoundsException",
+    "description": "When the diff string ends with a newline (which is typical), `split(\"\\n\", -1)` produces an empty trailing token. In the loop, that empty string reaches `appendBodyLine` where `raw.charAt(0)` throws `StringIndexOutOfBoundsException` because the string is empty. This bug existed before but persists in the refactored code and can crash the validator.",
+    "suggestion_old": "    for (String raw : PromptTemplateEscaper.neutralizeMarkers(diff).split(\"\\n\", -1)) {\n      if (raw.startsWith(\"### \")) {",
+    "suggestion_new": "    for (String raw : PromptTemplateEscaper.neutralizeMarkers(diff).split(\"\\n\", -1)) {\n      if (raw.isEmpty()) {\n        continue;\n      }\n      if (raw.startsWith(\"### \")) {"
+  }
+}

--- a/src/test/resources/evalcorpus/pr100-empty-line-ioobe-false-positive/diff.txt
+++ b/src/test/resources/evalcorpus/pr100-empty-line-ioobe-false-positive/diff.txt
@@ -1,0 +1,286 @@
+### src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java (modified, +177 -39)
+```diff
+@@ -43,6 +43,8 @@ public class FindingQuoteValidator {
+ 
+   private static final String LOW_CONFIDENCE = "low";
+ 
++  public record DiffLine(String normalizedText, int rightLineNum, char marker) {}
++
+   /** Validates each finding's quoted code against the raw (unescaped) diff text. */
+   public ReviewResponse validate(ReviewResponse response, String diff) {
+     if (response.findings().isEmpty() || diff == null || diff.isBlank()) {
+@@ -52,7 +54,11 @@ public class FindingQuoteValidator {
+     var kept = new ArrayList<ReviewResponse.Finding>(response.findings().size());
+     var changed = false;
+     for (ReviewResponse.Finding finding : response.findings()) {
+-      QuoteMatch match = matchQuote(finding.suggestionOld(), index.linesFor(finding.file()));
++      List<String> quoted = normalizedLines(finding.suggestionOld());
++      QuoteMatch match = matchQuote(quoted, index.linesFor(finding.file()));
++      if (match == QuoteMatch.FULL) {
++        match = checkAmbiguity(quoted, finding.line(), index.diffLinesFor(finding.file()));
++      }
+       switch (match) {
+         case FULL, NO_QUOTE -> kept.add(finding);
+         case PARTIAL -> {
+@@ -63,6 +69,14 @@ public class FindingQuoteValidator {
+           kept.add(withoutSuggestion(finding));
+           changed = true;
+         }
++        case AMBIGUOUS -> {
++          Log.infof(
++              "Finding '%s' (%s:%d) quotes code that appears in multiple locations, but the finding's line is ambiguous —"
++                  + " dropping its suggestion and capping confidence",
++              finding.title(), finding.file(), finding.line());
++          kept.add(withoutSuggestion(finding));
++          changed = true;
++        }
+         case NONE -> {
+           Log.infof(
+               "Dropping finding '%s' (%s:%d) — the code it quotes does not appear in the diff",
+@@ -88,11 +102,14 @@ public class FindingQuoteValidator {
+     /** Some quoted lines are present, others are not. */
+     PARTIAL,
+     /** No quoted line is present in the diff. */
+-    NONE
++    NONE,
++    /**
++     * Quote is fully present in multiple locations, but finding line doesn't uniquely select one.
++     */
++    AMBIGUOUS
+   }
+ 
+-  static QuoteMatch matchQuote(String suggestionOld, Set<String> diffLines) {
+-    List<String> quoted = normalizedLines(suggestionOld);
++  static QuoteMatch matchQuote(List<String> quoted, Set<String> diffLines) {
+     if (quoted.isEmpty()) {
+       return QuoteMatch.NO_QUOTE;
+     }
+@@ -103,39 +120,122 @@ public class FindingQuoteValidator {
+     return present == 0 ? QuoteMatch.NONE : QuoteMatch.PARTIAL;
+   }
+ 
++  /**
++   * Disambiguates a quote the {@link #matchQuote} gate already accepted as FULL. Only quotes that
++   * appear as a contiguous run over the retained (context/deleted) lines are scrutinized: additions
++   * are dropped because {@code suggestion_old} is original code, and a quote found in two or more
++   * such locations is AMBIGUOUS unless the finding's line uniquely selects one (within a 3-line
++   * tolerance). Anything not matched contiguously here stays FULL — the conservative direction.
++   */
++  private static QuoteMatch checkAmbiguity(
++      List<String> quoted, int findingLine, List<DiffLine> diffLines) {
++    List<DiffLine> filtered = retainedLines(diffLines);
++    List<Integer> matchIndices = contiguousMatchStarts(filtered, quoted);
++    if (matchIndices.size() <= 1) {
++      return QuoteMatch.FULL;
++    }
++
++    int k = quoted.size();
++    int selectedCount = 0;
++    for (int idx : matchIndices) {
++      int startLine = filtered.get(idx).rightLineNum();
++      int endLine = filtered.get(idx + k - 1).rightLineNum();
++      if (findingLine >= startLine - 3 && findingLine <= endLine + 3) {
++        selectedCount++;
++      }
++    }
++    return selectedCount == 1 ? QuoteMatch.FULL : QuoteMatch.AMBIGUOUS;
++  }
++
++  /**
++   * The diff lines that {@code suggestion_old} can match: context and deletions, never additions.
++   */
++  private static List<DiffLine> retainedLines(List<DiffLine> diffLines) {
++    var filtered = new ArrayList<DiffLine>();
++    for (DiffLine dl : diffLines) {
++      if (dl.marker() != '+') {
++        filtered.add(dl);
++      }
++    }
++    return filtered;
++  }
++
++  /** Start indices where {@code quoted} appears as a contiguous run in {@code lines}. */
++  private static List<Integer> contiguousMatchStarts(List<DiffLine> lines, List<String> quoted) {
++    var starts = new ArrayList<Integer>();
++    int k = quoted.size();
++    for (int i = 0; i <= lines.size() - k; i++) {
++      if (matchesAt(lines, i, quoted)) {
++        starts.add(i);
++      }
++    }
++    return starts;
++  }
++
++  private static boolean matchesAt(List<DiffLine> lines, int offset, List<String> quoted) {
++    for (int j = 0; j < quoted.size(); j++) {
++      if (!lines.get(offset + j).normalizedText().equals(quoted.get(j))) {
++        return false;
++      }
++    }
++    return true;
++  }
++
+   /**
+    * The diff's normalized body lines, both as one union and scoped per file. A quote is checked
+    * against its finding's own file when that file is identifiable in the diff — the same text
+    * appearing in some other file's hunk must not validate a misattributed finding. The union is the
+    * conservative fallback for findings whose file cannot be matched to a diff section.
+    */
+-  record DiffIndex(Map<String, Set<String>> byFile, Set<String> all) {
++  record DiffIndex(
++      Map<String, List<DiffLine>> fileLines,
++      List<DiffLine> allLines,
++      Map<String, Set<String>> byFile,
++      Set<String> all) {
+ 
+     Set<String> linesFor(String file) {
+-      if (file == null || file.isBlank()) {
++      var sections = sectionKeysFor(file);
++      if (sections.isEmpty()) {
+         return all;
+       }
+-      Set<String> exact = byFile.get(file);
+-      if (exact != null) {
+-        return exact;
++      var scoped = new HashSet<String>();
++      for (String section : sections) {
++        scoped.addAll(byFile.get(section));
+       }
+-      // The model sometimes shortens or expands paths; suffix matches still scope. An
+-      // ambiguous name (Handler.java in several modules) scopes to the union of its
+-      // candidates, never to the whole diff — a quote from an unrelated file must not
+-      // validate just because the finding's path was ambiguous.
+-      var candidates =
+-          byFile.keySet().stream()
+-              .filter(k -> k.endsWith("/" + file) || file.endsWith("/" + k))
+-              .toList();
+-      if (candidates.isEmpty()) {
+-        return all;
++      return scoped;
++    }
++
++    List<DiffLine> diffLinesFor(String file) {
++      var sections = sectionKeysFor(file);
++      if (sections.isEmpty()) {
++        return allLines;
+       }
+-      var scoped = new HashSet<String>();
+-      for (String candidate : candidates) {
+-        scoped.addAll(byFile.get(candidate));
++      var scoped = new ArrayList<DiffLine>();
++      for (String section : sections) {
++        scoped.addAll(fileLines.get(section));
+       }
+       return scoped;
+     }
++
++    /**
++     * The diff-section keys a finding's file resolves to, or an empty list when the file cannot be
++     * matched and the caller must fall back to the whole-diff union. An exact section match wins;
++     * otherwise the model sometimes shortens or expands paths, so suffix matches still scope. An
++     * ambiguous name (Handler.java in several modules) scopes to the union of its candidates, never
++     * to the whole diff — a quote from an unrelated file must not validate just because the
++     * finding's path was ambiguous.
++     */
++    private List<String> sectionKeysFor(String file) {
++      if (file == null || file.isBlank()) {
++        return List.of();
++      }
++      if (fileLines.containsKey(file)) {
++        return List.of(file);
++      }
++      return fileLines.keySet().stream()
++          .filter(k -> k.endsWith("/" + file) || file.endsWith("/" + k))
++          .toList();
++    }
+   }
+ 
+   /**
+@@ -146,31 +246,69 @@ public class FindingQuoteValidator {
+    * File scoping follows the formatter's "### filename (status, +A -D)" section headers.
+    */
+   static DiffIndex indexDiff(String diff) {
+-    var byFile = new HashMap<String, Set<String>>();
+-    var all = new HashSet<String>();
+-    Set<String> current = null;
++    var fileLines = new HashMap<String, List<DiffLine>>();
++    var allLines = new ArrayList<DiffLine>();
++    List<DiffLine> current = null;
++    int rightLine = 0;
++
+     for (String raw : PromptTemplateEscaper.neutralizeMarkers(diff).split("\n", -1)) {
+       if (raw.startsWith("### ")) {
+-        current = byFile.computeIfAbsent(sectionFilename(raw), k -> new HashSet<>());
++        current = fileLines.computeIfAbsent(sectionFilename(raw), k -> new ArrayList<>());
++        // A new file section restarts right-side numbering; don't carry the previous file's
++        // counter forward in case its first hunk header is missing or unparseable.
++        rightLine = 0;
++      } else if (raw.startsWith("@@")) {
++        rightLine = hunkStartLine(raw, rightLine);
+       } else if (!isDiffStructureLine(raw)) {
+-        String normalized = bodyOf(raw).strip();
+-        if (!normalized.isEmpty()) {
+-          all.add(normalized);
+-          if (current != null) {
+-            current.add(normalized);
+-          }
+-        }
++        rightLine = appendBodyLine(raw, rightLine, allLines, current);
+       }
+     }
+-    return new DiffIndex(byFile, all);
++
++    var byFile = new HashMap<String, Set<String>>();
++    fileLines.forEach((file, lines) -> byFile.put(file, textSet(lines)));
++    return new DiffIndex(fileLines, allLines, byFile, textSet(allLines));
++  }
++
++  /** The right-side start line of a hunk header, or {@code fallback} when it can't be parsed. */
++  private static int hunkStartLine(String raw, int fallback) {
++    var matcher = DiffLineResolver.HUNK_HEADER.matcher(raw);
++    return matcher.find() ? Integer.parseInt(matcher.group(1)) : fallback;
+   }
+ 
+-  /** Hunk headers, file headers, and code fences are diff plumbing, never quotable content. */
++  /**
++   * Records a normalized body line into the union and (when scoped) its file, then returns the
++   * advanced right-side line counter — additions and context advance it; deletions do not.
++   */
++  private static int appendBodyLine(
++      String raw, int rightLine, List<DiffLine> allLines, List<DiffLine> current) {
++    String normalized = bodyOf(raw).strip();
++    if (normalized.isEmpty()) {
++      return rightLine;
++    }
++    // A non-empty normalized body implies a non-empty raw line, so charAt(0) is safe.
++    char marker = raw.charAt(0);
++    var diffLine = new DiffLine(normalized, rightLine, marker);
++    allLines.add(diffLine);
++    if (current != null) {
++      current.add(diffLine);
++    }
++    return marker == '+' || marker == ' ' ? rightLine + 1 : rightLine;
++  }
++
++  private static Set<String> textSet(List<DiffLine> lines) {
++    var set = new HashSet<String>();
++    for (var dl : lines) {
++      set.add(dl.normalizedText());
++    }
++    return set;
++  }
++
++  /**
++   * File headers and code fences are diff plumbing, never quotable content. Hunk headers
++   * ({@code @@}) are intercepted earlier for line tracking, so they never reach this check.
++   */
+   private static boolean isDiffStructureLine(String raw) {
+-    return raw.startsWith("+++")
+-        || raw.startsWith("---")
+-        || raw.startsWith("@@")
+-        || raw.startsWith("```");
++    return raw.startsWith("+++") || raw.startsWith("---") || raw.startsWith("```");
+   }
+ 
+   /** The line without its unified-diff marker column (+, -, space). */
+```

--- a/src/test/resources/evalcorpus/pr100-empty-line-ioobe-must-not-find/case.json
+++ b/src/test/resources/evalcorpus/pr100-empty-line-ioobe-must-not-find/case.json
@@ -1,0 +1,10 @@
+{
+  "kind": "generator",
+  "sourcePr": 100,
+  "why": "Refuted false positive from the PR #100 review: the empty-line IndexOutOfBounds claim is disproved by the normalized.isEmpty() guard visible in the same diff. The review prompt should not raise it.",
+  "expectation": "must-not-find",
+  "targetFile": "src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java",
+  "keywords": ["IndexOutOfBounds", "charAt(0)"],
+  "prTitle": "fix(review): drop suggestions and cap confidence for ambiguous quotes",
+  "prDescription": "Extends FindingQuoteValidator with line-aware ambiguity detection: a suggestion_old quote that appears in multiple diff locations is only kept when the finding's line uniquely selects one."
+}

--- a/src/test/resources/evalcorpus/pr100-empty-line-ioobe-must-not-find/diff.txt
+++ b/src/test/resources/evalcorpus/pr100-empty-line-ioobe-must-not-find/diff.txt
@@ -1,0 +1,286 @@
+### src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java (modified, +177 -39)
+```diff
+@@ -43,6 +43,8 @@ public class FindingQuoteValidator {
+ 
+   private static final String LOW_CONFIDENCE = "low";
+ 
++  public record DiffLine(String normalizedText, int rightLineNum, char marker) {}
++
+   /** Validates each finding's quoted code against the raw (unescaped) diff text. */
+   public ReviewResponse validate(ReviewResponse response, String diff) {
+     if (response.findings().isEmpty() || diff == null || diff.isBlank()) {
+@@ -52,7 +54,11 @@ public class FindingQuoteValidator {
+     var kept = new ArrayList<ReviewResponse.Finding>(response.findings().size());
+     var changed = false;
+     for (ReviewResponse.Finding finding : response.findings()) {
+-      QuoteMatch match = matchQuote(finding.suggestionOld(), index.linesFor(finding.file()));
++      List<String> quoted = normalizedLines(finding.suggestionOld());
++      QuoteMatch match = matchQuote(quoted, index.linesFor(finding.file()));
++      if (match == QuoteMatch.FULL) {
++        match = checkAmbiguity(quoted, finding.line(), index.diffLinesFor(finding.file()));
++      }
+       switch (match) {
+         case FULL, NO_QUOTE -> kept.add(finding);
+         case PARTIAL -> {
+@@ -63,6 +69,14 @@ public class FindingQuoteValidator {
+           kept.add(withoutSuggestion(finding));
+           changed = true;
+         }
++        case AMBIGUOUS -> {
++          Log.infof(
++              "Finding '%s' (%s:%d) quotes code that appears in multiple locations, but the finding's line is ambiguous —"
++                  + " dropping its suggestion and capping confidence",
++              finding.title(), finding.file(), finding.line());
++          kept.add(withoutSuggestion(finding));
++          changed = true;
++        }
+         case NONE -> {
+           Log.infof(
+               "Dropping finding '%s' (%s:%d) — the code it quotes does not appear in the diff",
+@@ -88,11 +102,14 @@ public class FindingQuoteValidator {
+     /** Some quoted lines are present, others are not. */
+     PARTIAL,
+     /** No quoted line is present in the diff. */
+-    NONE
++    NONE,
++    /**
++     * Quote is fully present in multiple locations, but finding line doesn't uniquely select one.
++     */
++    AMBIGUOUS
+   }
+ 
+-  static QuoteMatch matchQuote(String suggestionOld, Set<String> diffLines) {
+-    List<String> quoted = normalizedLines(suggestionOld);
++  static QuoteMatch matchQuote(List<String> quoted, Set<String> diffLines) {
+     if (quoted.isEmpty()) {
+       return QuoteMatch.NO_QUOTE;
+     }
+@@ -103,39 +120,122 @@ public class FindingQuoteValidator {
+     return present == 0 ? QuoteMatch.NONE : QuoteMatch.PARTIAL;
+   }
+ 
++  /**
++   * Disambiguates a quote the {@link #matchQuote} gate already accepted as FULL. Only quotes that
++   * appear as a contiguous run over the retained (context/deleted) lines are scrutinized: additions
++   * are dropped because {@code suggestion_old} is original code, and a quote found in two or more
++   * such locations is AMBIGUOUS unless the finding's line uniquely selects one (within a 3-line
++   * tolerance). Anything not matched contiguously here stays FULL — the conservative direction.
++   */
++  private static QuoteMatch checkAmbiguity(
++      List<String> quoted, int findingLine, List<DiffLine> diffLines) {
++    List<DiffLine> filtered = retainedLines(diffLines);
++    List<Integer> matchIndices = contiguousMatchStarts(filtered, quoted);
++    if (matchIndices.size() <= 1) {
++      return QuoteMatch.FULL;
++    }
++
++    int k = quoted.size();
++    int selectedCount = 0;
++    for (int idx : matchIndices) {
++      int startLine = filtered.get(idx).rightLineNum();
++      int endLine = filtered.get(idx + k - 1).rightLineNum();
++      if (findingLine >= startLine - 3 && findingLine <= endLine + 3) {
++        selectedCount++;
++      }
++    }
++    return selectedCount == 1 ? QuoteMatch.FULL : QuoteMatch.AMBIGUOUS;
++  }
++
++  /**
++   * The diff lines that {@code suggestion_old} can match: context and deletions, never additions.
++   */
++  private static List<DiffLine> retainedLines(List<DiffLine> diffLines) {
++    var filtered = new ArrayList<DiffLine>();
++    for (DiffLine dl : diffLines) {
++      if (dl.marker() != '+') {
++        filtered.add(dl);
++      }
++    }
++    return filtered;
++  }
++
++  /** Start indices where {@code quoted} appears as a contiguous run in {@code lines}. */
++  private static List<Integer> contiguousMatchStarts(List<DiffLine> lines, List<String> quoted) {
++    var starts = new ArrayList<Integer>();
++    int k = quoted.size();
++    for (int i = 0; i <= lines.size() - k; i++) {
++      if (matchesAt(lines, i, quoted)) {
++        starts.add(i);
++      }
++    }
++    return starts;
++  }
++
++  private static boolean matchesAt(List<DiffLine> lines, int offset, List<String> quoted) {
++    for (int j = 0; j < quoted.size(); j++) {
++      if (!lines.get(offset + j).normalizedText().equals(quoted.get(j))) {
++        return false;
++      }
++    }
++    return true;
++  }
++
+   /**
+    * The diff's normalized body lines, both as one union and scoped per file. A quote is checked
+    * against its finding's own file when that file is identifiable in the diff — the same text
+    * appearing in some other file's hunk must not validate a misattributed finding. The union is the
+    * conservative fallback for findings whose file cannot be matched to a diff section.
+    */
+-  record DiffIndex(Map<String, Set<String>> byFile, Set<String> all) {
++  record DiffIndex(
++      Map<String, List<DiffLine>> fileLines,
++      List<DiffLine> allLines,
++      Map<String, Set<String>> byFile,
++      Set<String> all) {
+ 
+     Set<String> linesFor(String file) {
+-      if (file == null || file.isBlank()) {
++      var sections = sectionKeysFor(file);
++      if (sections.isEmpty()) {
+         return all;
+       }
+-      Set<String> exact = byFile.get(file);
+-      if (exact != null) {
+-        return exact;
++      var scoped = new HashSet<String>();
++      for (String section : sections) {
++        scoped.addAll(byFile.get(section));
+       }
+-      // The model sometimes shortens or expands paths; suffix matches still scope. An
+-      // ambiguous name (Handler.java in several modules) scopes to the union of its
+-      // candidates, never to the whole diff — a quote from an unrelated file must not
+-      // validate just because the finding's path was ambiguous.
+-      var candidates =
+-          byFile.keySet().stream()
+-              .filter(k -> k.endsWith("/" + file) || file.endsWith("/" + k))
+-              .toList();
+-      if (candidates.isEmpty()) {
+-        return all;
++      return scoped;
++    }
++
++    List<DiffLine> diffLinesFor(String file) {
++      var sections = sectionKeysFor(file);
++      if (sections.isEmpty()) {
++        return allLines;
+       }
+-      var scoped = new HashSet<String>();
+-      for (String candidate : candidates) {
+-        scoped.addAll(byFile.get(candidate));
++      var scoped = new ArrayList<DiffLine>();
++      for (String section : sections) {
++        scoped.addAll(fileLines.get(section));
+       }
+       return scoped;
+     }
++
++    /**
++     * The diff-section keys a finding's file resolves to, or an empty list when the file cannot be
++     * matched and the caller must fall back to the whole-diff union. An exact section match wins;
++     * otherwise the model sometimes shortens or expands paths, so suffix matches still scope. An
++     * ambiguous name (Handler.java in several modules) scopes to the union of its candidates, never
++     * to the whole diff — a quote from an unrelated file must not validate just because the
++     * finding's path was ambiguous.
++     */
++    private List<String> sectionKeysFor(String file) {
++      if (file == null || file.isBlank()) {
++        return List.of();
++      }
++      if (fileLines.containsKey(file)) {
++        return List.of(file);
++      }
++      return fileLines.keySet().stream()
++          .filter(k -> k.endsWith("/" + file) || file.endsWith("/" + k))
++          .toList();
++    }
+   }
+ 
+   /**
+@@ -146,31 +246,69 @@ public class FindingQuoteValidator {
+    * File scoping follows the formatter's "### filename (status, +A -D)" section headers.
+    */
+   static DiffIndex indexDiff(String diff) {
+-    var byFile = new HashMap<String, Set<String>>();
+-    var all = new HashSet<String>();
+-    Set<String> current = null;
++    var fileLines = new HashMap<String, List<DiffLine>>();
++    var allLines = new ArrayList<DiffLine>();
++    List<DiffLine> current = null;
++    int rightLine = 0;
++
+     for (String raw : PromptTemplateEscaper.neutralizeMarkers(diff).split("\n", -1)) {
+       if (raw.startsWith("### ")) {
+-        current = byFile.computeIfAbsent(sectionFilename(raw), k -> new HashSet<>());
++        current = fileLines.computeIfAbsent(sectionFilename(raw), k -> new ArrayList<>());
++        // A new file section restarts right-side numbering; don't carry the previous file's
++        // counter forward in case its first hunk header is missing or unparseable.
++        rightLine = 0;
++      } else if (raw.startsWith("@@")) {
++        rightLine = hunkStartLine(raw, rightLine);
+       } else if (!isDiffStructureLine(raw)) {
+-        String normalized = bodyOf(raw).strip();
+-        if (!normalized.isEmpty()) {
+-          all.add(normalized);
+-          if (current != null) {
+-            current.add(normalized);
+-          }
+-        }
++        rightLine = appendBodyLine(raw, rightLine, allLines, current);
+       }
+     }
+-    return new DiffIndex(byFile, all);
++
++    var byFile = new HashMap<String, Set<String>>();
++    fileLines.forEach((file, lines) -> byFile.put(file, textSet(lines)));
++    return new DiffIndex(fileLines, allLines, byFile, textSet(allLines));
++  }
++
++  /** The right-side start line of a hunk header, or {@code fallback} when it can't be parsed. */
++  private static int hunkStartLine(String raw, int fallback) {
++    var matcher = DiffLineResolver.HUNK_HEADER.matcher(raw);
++    return matcher.find() ? Integer.parseInt(matcher.group(1)) : fallback;
+   }
+ 
+-  /** Hunk headers, file headers, and code fences are diff plumbing, never quotable content. */
++  /**
++   * Records a normalized body line into the union and (when scoped) its file, then returns the
++   * advanced right-side line counter — additions and context advance it; deletions do not.
++   */
++  private static int appendBodyLine(
++      String raw, int rightLine, List<DiffLine> allLines, List<DiffLine> current) {
++    String normalized = bodyOf(raw).strip();
++    if (normalized.isEmpty()) {
++      return rightLine;
++    }
++    // A non-empty normalized body implies a non-empty raw line, so charAt(0) is safe.
++    char marker = raw.charAt(0);
++    var diffLine = new DiffLine(normalized, rightLine, marker);
++    allLines.add(diffLine);
++    if (current != null) {
++      current.add(diffLine);
++    }
++    return marker == '+' || marker == ' ' ? rightLine + 1 : rightLine;
++  }
++
++  private static Set<String> textSet(List<DiffLine> lines) {
++    var set = new HashSet<String>();
++    for (var dl : lines) {
++      set.add(dl.normalizedText());
++    }
++    return set;
++  }
++
++  /**
++   * File headers and code fences are diff plumbing, never quotable content. Hunk headers
++   * ({@code @@}) are intercepted earlier for line tracking, so they never reach this check.
++   */
+   private static boolean isDiffStructureLine(String raw) {
+-    return raw.startsWith("+++")
+-        || raw.startsWith("---")
+-        || raw.startsWith("@@")
+-        || raw.startsWith("```");
++    return raw.startsWith("+++") || raw.startsWith("---") || raw.startsWith("```");
+   }
+ 
+   /** The line without its unified-diff marker column (+, -, space). */
+```

--- a/src/test/resources/evalcorpus/pr100-no-newline-indicator-must-find/case.json
+++ b/src/test/resources/evalcorpus/pr100-no-newline-indicator-must-find/case.json
@@ -1,0 +1,10 @@
+{
+  "kind": "generator",
+  "sourcePr": 100,
+  "why": "Confirmed true positive from the PR #100 review: isDiffStructureLine misses the '\\ No newline at end of file' indicator, so it is indexed as quotable content. The review prompt should keep surfacing this class of bug.",
+  "expectation": "must-find",
+  "targetFile": "src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java",
+  "keywords": ["No newline", "no newline"],
+  "prTitle": "fix(review): drop suggestions and cap confidence for ambiguous quotes",
+  "prDescription": "Extends FindingQuoteValidator with line-aware ambiguity detection: a suggestion_old quote that appears in multiple diff locations is only kept when the finding's line uniquely selects one."
+}

--- a/src/test/resources/evalcorpus/pr100-no-newline-indicator-must-find/diff.txt
+++ b/src/test/resources/evalcorpus/pr100-no-newline-indicator-must-find/diff.txt
@@ -1,0 +1,286 @@
+### src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java (modified, +177 -39)
+```diff
+@@ -43,6 +43,8 @@ public class FindingQuoteValidator {
+ 
+   private static final String LOW_CONFIDENCE = "low";
+ 
++  public record DiffLine(String normalizedText, int rightLineNum, char marker) {}
++
+   /** Validates each finding's quoted code against the raw (unescaped) diff text. */
+   public ReviewResponse validate(ReviewResponse response, String diff) {
+     if (response.findings().isEmpty() || diff == null || diff.isBlank()) {
+@@ -52,7 +54,11 @@ public class FindingQuoteValidator {
+     var kept = new ArrayList<ReviewResponse.Finding>(response.findings().size());
+     var changed = false;
+     for (ReviewResponse.Finding finding : response.findings()) {
+-      QuoteMatch match = matchQuote(finding.suggestionOld(), index.linesFor(finding.file()));
++      List<String> quoted = normalizedLines(finding.suggestionOld());
++      QuoteMatch match = matchQuote(quoted, index.linesFor(finding.file()));
++      if (match == QuoteMatch.FULL) {
++        match = checkAmbiguity(quoted, finding.line(), index.diffLinesFor(finding.file()));
++      }
+       switch (match) {
+         case FULL, NO_QUOTE -> kept.add(finding);
+         case PARTIAL -> {
+@@ -63,6 +69,14 @@ public class FindingQuoteValidator {
+           kept.add(withoutSuggestion(finding));
+           changed = true;
+         }
++        case AMBIGUOUS -> {
++          Log.infof(
++              "Finding '%s' (%s:%d) quotes code that appears in multiple locations, but the finding's line is ambiguous —"
++                  + " dropping its suggestion and capping confidence",
++              finding.title(), finding.file(), finding.line());
++          kept.add(withoutSuggestion(finding));
++          changed = true;
++        }
+         case NONE -> {
+           Log.infof(
+               "Dropping finding '%s' (%s:%d) — the code it quotes does not appear in the diff",
+@@ -88,11 +102,14 @@ public class FindingQuoteValidator {
+     /** Some quoted lines are present, others are not. */
+     PARTIAL,
+     /** No quoted line is present in the diff. */
+-    NONE
++    NONE,
++    /**
++     * Quote is fully present in multiple locations, but finding line doesn't uniquely select one.
++     */
++    AMBIGUOUS
+   }
+ 
+-  static QuoteMatch matchQuote(String suggestionOld, Set<String> diffLines) {
+-    List<String> quoted = normalizedLines(suggestionOld);
++  static QuoteMatch matchQuote(List<String> quoted, Set<String> diffLines) {
+     if (quoted.isEmpty()) {
+       return QuoteMatch.NO_QUOTE;
+     }
+@@ -103,39 +120,122 @@ public class FindingQuoteValidator {
+     return present == 0 ? QuoteMatch.NONE : QuoteMatch.PARTIAL;
+   }
+ 
++  /**
++   * Disambiguates a quote the {@link #matchQuote} gate already accepted as FULL. Only quotes that
++   * appear as a contiguous run over the retained (context/deleted) lines are scrutinized: additions
++   * are dropped because {@code suggestion_old} is original code, and a quote found in two or more
++   * such locations is AMBIGUOUS unless the finding's line uniquely selects one (within a 3-line
++   * tolerance). Anything not matched contiguously here stays FULL — the conservative direction.
++   */
++  private static QuoteMatch checkAmbiguity(
++      List<String> quoted, int findingLine, List<DiffLine> diffLines) {
++    List<DiffLine> filtered = retainedLines(diffLines);
++    List<Integer> matchIndices = contiguousMatchStarts(filtered, quoted);
++    if (matchIndices.size() <= 1) {
++      return QuoteMatch.FULL;
++    }
++
++    int k = quoted.size();
++    int selectedCount = 0;
++    for (int idx : matchIndices) {
++      int startLine = filtered.get(idx).rightLineNum();
++      int endLine = filtered.get(idx + k - 1).rightLineNum();
++      if (findingLine >= startLine - 3 && findingLine <= endLine + 3) {
++        selectedCount++;
++      }
++    }
++    return selectedCount == 1 ? QuoteMatch.FULL : QuoteMatch.AMBIGUOUS;
++  }
++
++  /**
++   * The diff lines that {@code suggestion_old} can match: context and deletions, never additions.
++   */
++  private static List<DiffLine> retainedLines(List<DiffLine> diffLines) {
++    var filtered = new ArrayList<DiffLine>();
++    for (DiffLine dl : diffLines) {
++      if (dl.marker() != '+') {
++        filtered.add(dl);
++      }
++    }
++    return filtered;
++  }
++
++  /** Start indices where {@code quoted} appears as a contiguous run in {@code lines}. */
++  private static List<Integer> contiguousMatchStarts(List<DiffLine> lines, List<String> quoted) {
++    var starts = new ArrayList<Integer>();
++    int k = quoted.size();
++    for (int i = 0; i <= lines.size() - k; i++) {
++      if (matchesAt(lines, i, quoted)) {
++        starts.add(i);
++      }
++    }
++    return starts;
++  }
++
++  private static boolean matchesAt(List<DiffLine> lines, int offset, List<String> quoted) {
++    for (int j = 0; j < quoted.size(); j++) {
++      if (!lines.get(offset + j).normalizedText().equals(quoted.get(j))) {
++        return false;
++      }
++    }
++    return true;
++  }
++
+   /**
+    * The diff's normalized body lines, both as one union and scoped per file. A quote is checked
+    * against its finding's own file when that file is identifiable in the diff — the same text
+    * appearing in some other file's hunk must not validate a misattributed finding. The union is the
+    * conservative fallback for findings whose file cannot be matched to a diff section.
+    */
+-  record DiffIndex(Map<String, Set<String>> byFile, Set<String> all) {
++  record DiffIndex(
++      Map<String, List<DiffLine>> fileLines,
++      List<DiffLine> allLines,
++      Map<String, Set<String>> byFile,
++      Set<String> all) {
+ 
+     Set<String> linesFor(String file) {
+-      if (file == null || file.isBlank()) {
++      var sections = sectionKeysFor(file);
++      if (sections.isEmpty()) {
+         return all;
+       }
+-      Set<String> exact = byFile.get(file);
+-      if (exact != null) {
+-        return exact;
++      var scoped = new HashSet<String>();
++      for (String section : sections) {
++        scoped.addAll(byFile.get(section));
+       }
+-      // The model sometimes shortens or expands paths; suffix matches still scope. An
+-      // ambiguous name (Handler.java in several modules) scopes to the union of its
+-      // candidates, never to the whole diff — a quote from an unrelated file must not
+-      // validate just because the finding's path was ambiguous.
+-      var candidates =
+-          byFile.keySet().stream()
+-              .filter(k -> k.endsWith("/" + file) || file.endsWith("/" + k))
+-              .toList();
+-      if (candidates.isEmpty()) {
+-        return all;
++      return scoped;
++    }
++
++    List<DiffLine> diffLinesFor(String file) {
++      var sections = sectionKeysFor(file);
++      if (sections.isEmpty()) {
++        return allLines;
+       }
+-      var scoped = new HashSet<String>();
+-      for (String candidate : candidates) {
+-        scoped.addAll(byFile.get(candidate));
++      var scoped = new ArrayList<DiffLine>();
++      for (String section : sections) {
++        scoped.addAll(fileLines.get(section));
+       }
+       return scoped;
+     }
++
++    /**
++     * The diff-section keys a finding's file resolves to, or an empty list when the file cannot be
++     * matched and the caller must fall back to the whole-diff union. An exact section match wins;
++     * otherwise the model sometimes shortens or expands paths, so suffix matches still scope. An
++     * ambiguous name (Handler.java in several modules) scopes to the union of its candidates, never
++     * to the whole diff — a quote from an unrelated file must not validate just because the
++     * finding's path was ambiguous.
++     */
++    private List<String> sectionKeysFor(String file) {
++      if (file == null || file.isBlank()) {
++        return List.of();
++      }
++      if (fileLines.containsKey(file)) {
++        return List.of(file);
++      }
++      return fileLines.keySet().stream()
++          .filter(k -> k.endsWith("/" + file) || file.endsWith("/" + k))
++          .toList();
++    }
+   }
+ 
+   /**
+@@ -146,31 +246,69 @@ public class FindingQuoteValidator {
+    * File scoping follows the formatter's "### filename (status, +A -D)" section headers.
+    */
+   static DiffIndex indexDiff(String diff) {
+-    var byFile = new HashMap<String, Set<String>>();
+-    var all = new HashSet<String>();
+-    Set<String> current = null;
++    var fileLines = new HashMap<String, List<DiffLine>>();
++    var allLines = new ArrayList<DiffLine>();
++    List<DiffLine> current = null;
++    int rightLine = 0;
++
+     for (String raw : PromptTemplateEscaper.neutralizeMarkers(diff).split("\n", -1)) {
+       if (raw.startsWith("### ")) {
+-        current = byFile.computeIfAbsent(sectionFilename(raw), k -> new HashSet<>());
++        current = fileLines.computeIfAbsent(sectionFilename(raw), k -> new ArrayList<>());
++        // A new file section restarts right-side numbering; don't carry the previous file's
++        // counter forward in case its first hunk header is missing or unparseable.
++        rightLine = 0;
++      } else if (raw.startsWith("@@")) {
++        rightLine = hunkStartLine(raw, rightLine);
+       } else if (!isDiffStructureLine(raw)) {
+-        String normalized = bodyOf(raw).strip();
+-        if (!normalized.isEmpty()) {
+-          all.add(normalized);
+-          if (current != null) {
+-            current.add(normalized);
+-          }
+-        }
++        rightLine = appendBodyLine(raw, rightLine, allLines, current);
+       }
+     }
+-    return new DiffIndex(byFile, all);
++
++    var byFile = new HashMap<String, Set<String>>();
++    fileLines.forEach((file, lines) -> byFile.put(file, textSet(lines)));
++    return new DiffIndex(fileLines, allLines, byFile, textSet(allLines));
++  }
++
++  /** The right-side start line of a hunk header, or {@code fallback} when it can't be parsed. */
++  private static int hunkStartLine(String raw, int fallback) {
++    var matcher = DiffLineResolver.HUNK_HEADER.matcher(raw);
++    return matcher.find() ? Integer.parseInt(matcher.group(1)) : fallback;
+   }
+ 
+-  /** Hunk headers, file headers, and code fences are diff plumbing, never quotable content. */
++  /**
++   * Records a normalized body line into the union and (when scoped) its file, then returns the
++   * advanced right-side line counter — additions and context advance it; deletions do not.
++   */
++  private static int appendBodyLine(
++      String raw, int rightLine, List<DiffLine> allLines, List<DiffLine> current) {
++    String normalized = bodyOf(raw).strip();
++    if (normalized.isEmpty()) {
++      return rightLine;
++    }
++    // A non-empty normalized body implies a non-empty raw line, so charAt(0) is safe.
++    char marker = raw.charAt(0);
++    var diffLine = new DiffLine(normalized, rightLine, marker);
++    allLines.add(diffLine);
++    if (current != null) {
++      current.add(diffLine);
++    }
++    return marker == '+' || marker == ' ' ? rightLine + 1 : rightLine;
++  }
++
++  private static Set<String> textSet(List<DiffLine> lines) {
++    var set = new HashSet<String>();
++    for (var dl : lines) {
++      set.add(dl.normalizedText());
++    }
++    return set;
++  }
++
++  /**
++   * File headers and code fences are diff plumbing, never quotable content. Hunk headers
++   * ({@code @@}) are intercepted earlier for line tracking, so they never reach this check.
++   */
+   private static boolean isDiffStructureLine(String raw) {
+-    return raw.startsWith("+++")
+-        || raw.startsWith("---")
+-        || raw.startsWith("@@")
+-        || raw.startsWith("```");
++    return raw.startsWith("+++") || raw.startsWith("---") || raw.startsWith("```");
+   }
+ 
+   /** The line without its unified-diff marker column (+, -, space). */
+```

--- a/src/test/resources/evalcorpus/pr100-no-newline-indicator-true-positive/case.json
+++ b/src/test/resources/evalcorpus/pr100-no-newline-indicator-true-positive/case.json
@@ -1,0 +1,16 @@
+{
+  "kind": "verifier",
+  "sourcePr": 100,
+  "why": "Confirmed in PR #100 review thread and fixed by adding the '\\ ' prefix to isDiffStructureLine: the '\\ No newline at end of file' indicator was indexed as quotable content, enabling false quote matches.",
+  "expectedVerdicts": ["confirmed"],
+  "finding": {
+    "risk": "low",
+    "confidence": "low",
+    "file": "src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java",
+    "line": 246,
+    "title": "Unhandled \"\\ No newline\" diff indicator may pollute normalized lines",
+    "description": "The unified diff format can contain lines starting with \"\\ \" (backslash-space) to indicate a missing newline at the end of a file. These lines are not filtered out and will be treated as quotable code, which could lead to false quote matches or ambiguity false positives. Adding them to the structure line check would prevent this.",
+    "suggestion_old": "  private static boolean isDiffStructureLine(String raw) {\n    return raw.startsWith(\"+++\")\n        || raw.startsWith(\"---\")\n        || raw.startsWith(\"```\");\n  }",
+    "suggestion_new": "  private static boolean isDiffStructureLine(String raw) {\n    return raw.startsWith(\"+++\")\n        || raw.startsWith(\"---\")\n        || raw.startsWith(\"```\")\n        || raw.startsWith(\"\\\\ \");\n  }"
+  }
+}

--- a/src/test/resources/evalcorpus/pr100-no-newline-indicator-true-positive/diff.txt
+++ b/src/test/resources/evalcorpus/pr100-no-newline-indicator-true-positive/diff.txt
@@ -1,0 +1,286 @@
+### src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java (modified, +177 -39)
+```diff
+@@ -43,6 +43,8 @@ public class FindingQuoteValidator {
+ 
+   private static final String LOW_CONFIDENCE = "low";
+ 
++  public record DiffLine(String normalizedText, int rightLineNum, char marker) {}
++
+   /** Validates each finding's quoted code against the raw (unescaped) diff text. */
+   public ReviewResponse validate(ReviewResponse response, String diff) {
+     if (response.findings().isEmpty() || diff == null || diff.isBlank()) {
+@@ -52,7 +54,11 @@ public class FindingQuoteValidator {
+     var kept = new ArrayList<ReviewResponse.Finding>(response.findings().size());
+     var changed = false;
+     for (ReviewResponse.Finding finding : response.findings()) {
+-      QuoteMatch match = matchQuote(finding.suggestionOld(), index.linesFor(finding.file()));
++      List<String> quoted = normalizedLines(finding.suggestionOld());
++      QuoteMatch match = matchQuote(quoted, index.linesFor(finding.file()));
++      if (match == QuoteMatch.FULL) {
++        match = checkAmbiguity(quoted, finding.line(), index.diffLinesFor(finding.file()));
++      }
+       switch (match) {
+         case FULL, NO_QUOTE -> kept.add(finding);
+         case PARTIAL -> {
+@@ -63,6 +69,14 @@ public class FindingQuoteValidator {
+           kept.add(withoutSuggestion(finding));
+           changed = true;
+         }
++        case AMBIGUOUS -> {
++          Log.infof(
++              "Finding '%s' (%s:%d) quotes code that appears in multiple locations, but the finding's line is ambiguous —"
++                  + " dropping its suggestion and capping confidence",
++              finding.title(), finding.file(), finding.line());
++          kept.add(withoutSuggestion(finding));
++          changed = true;
++        }
+         case NONE -> {
+           Log.infof(
+               "Dropping finding '%s' (%s:%d) — the code it quotes does not appear in the diff",
+@@ -88,11 +102,14 @@ public class FindingQuoteValidator {
+     /** Some quoted lines are present, others are not. */
+     PARTIAL,
+     /** No quoted line is present in the diff. */
+-    NONE
++    NONE,
++    /**
++     * Quote is fully present in multiple locations, but finding line doesn't uniquely select one.
++     */
++    AMBIGUOUS
+   }
+ 
+-  static QuoteMatch matchQuote(String suggestionOld, Set<String> diffLines) {
+-    List<String> quoted = normalizedLines(suggestionOld);
++  static QuoteMatch matchQuote(List<String> quoted, Set<String> diffLines) {
+     if (quoted.isEmpty()) {
+       return QuoteMatch.NO_QUOTE;
+     }
+@@ -103,39 +120,122 @@ public class FindingQuoteValidator {
+     return present == 0 ? QuoteMatch.NONE : QuoteMatch.PARTIAL;
+   }
+ 
++  /**
++   * Disambiguates a quote the {@link #matchQuote} gate already accepted as FULL. Only quotes that
++   * appear as a contiguous run over the retained (context/deleted) lines are scrutinized: additions
++   * are dropped because {@code suggestion_old} is original code, and a quote found in two or more
++   * such locations is AMBIGUOUS unless the finding's line uniquely selects one (within a 3-line
++   * tolerance). Anything not matched contiguously here stays FULL — the conservative direction.
++   */
++  private static QuoteMatch checkAmbiguity(
++      List<String> quoted, int findingLine, List<DiffLine> diffLines) {
++    List<DiffLine> filtered = retainedLines(diffLines);
++    List<Integer> matchIndices = contiguousMatchStarts(filtered, quoted);
++    if (matchIndices.size() <= 1) {
++      return QuoteMatch.FULL;
++    }
++
++    int k = quoted.size();
++    int selectedCount = 0;
++    for (int idx : matchIndices) {
++      int startLine = filtered.get(idx).rightLineNum();
++      int endLine = filtered.get(idx + k - 1).rightLineNum();
++      if (findingLine >= startLine - 3 && findingLine <= endLine + 3) {
++        selectedCount++;
++      }
++    }
++    return selectedCount == 1 ? QuoteMatch.FULL : QuoteMatch.AMBIGUOUS;
++  }
++
++  /**
++   * The diff lines that {@code suggestion_old} can match: context and deletions, never additions.
++   */
++  private static List<DiffLine> retainedLines(List<DiffLine> diffLines) {
++    var filtered = new ArrayList<DiffLine>();
++    for (DiffLine dl : diffLines) {
++      if (dl.marker() != '+') {
++        filtered.add(dl);
++      }
++    }
++    return filtered;
++  }
++
++  /** Start indices where {@code quoted} appears as a contiguous run in {@code lines}. */
++  private static List<Integer> contiguousMatchStarts(List<DiffLine> lines, List<String> quoted) {
++    var starts = new ArrayList<Integer>();
++    int k = quoted.size();
++    for (int i = 0; i <= lines.size() - k; i++) {
++      if (matchesAt(lines, i, quoted)) {
++        starts.add(i);
++      }
++    }
++    return starts;
++  }
++
++  private static boolean matchesAt(List<DiffLine> lines, int offset, List<String> quoted) {
++    for (int j = 0; j < quoted.size(); j++) {
++      if (!lines.get(offset + j).normalizedText().equals(quoted.get(j))) {
++        return false;
++      }
++    }
++    return true;
++  }
++
+   /**
+    * The diff's normalized body lines, both as one union and scoped per file. A quote is checked
+    * against its finding's own file when that file is identifiable in the diff — the same text
+    * appearing in some other file's hunk must not validate a misattributed finding. The union is the
+    * conservative fallback for findings whose file cannot be matched to a diff section.
+    */
+-  record DiffIndex(Map<String, Set<String>> byFile, Set<String> all) {
++  record DiffIndex(
++      Map<String, List<DiffLine>> fileLines,
++      List<DiffLine> allLines,
++      Map<String, Set<String>> byFile,
++      Set<String> all) {
+ 
+     Set<String> linesFor(String file) {
+-      if (file == null || file.isBlank()) {
++      var sections = sectionKeysFor(file);
++      if (sections.isEmpty()) {
+         return all;
+       }
+-      Set<String> exact = byFile.get(file);
+-      if (exact != null) {
+-        return exact;
++      var scoped = new HashSet<String>();
++      for (String section : sections) {
++        scoped.addAll(byFile.get(section));
+       }
+-      // The model sometimes shortens or expands paths; suffix matches still scope. An
+-      // ambiguous name (Handler.java in several modules) scopes to the union of its
+-      // candidates, never to the whole diff — a quote from an unrelated file must not
+-      // validate just because the finding's path was ambiguous.
+-      var candidates =
+-          byFile.keySet().stream()
+-              .filter(k -> k.endsWith("/" + file) || file.endsWith("/" + k))
+-              .toList();
+-      if (candidates.isEmpty()) {
+-        return all;
++      return scoped;
++    }
++
++    List<DiffLine> diffLinesFor(String file) {
++      var sections = sectionKeysFor(file);
++      if (sections.isEmpty()) {
++        return allLines;
+       }
+-      var scoped = new HashSet<String>();
+-      for (String candidate : candidates) {
+-        scoped.addAll(byFile.get(candidate));
++      var scoped = new ArrayList<DiffLine>();
++      for (String section : sections) {
++        scoped.addAll(fileLines.get(section));
+       }
+       return scoped;
+     }
++
++    /**
++     * The diff-section keys a finding's file resolves to, or an empty list when the file cannot be
++     * matched and the caller must fall back to the whole-diff union. An exact section match wins;
++     * otherwise the model sometimes shortens or expands paths, so suffix matches still scope. An
++     * ambiguous name (Handler.java in several modules) scopes to the union of its candidates, never
++     * to the whole diff — a quote from an unrelated file must not validate just because the
++     * finding's path was ambiguous.
++     */
++    private List<String> sectionKeysFor(String file) {
++      if (file == null || file.isBlank()) {
++        return List.of();
++      }
++      if (fileLines.containsKey(file)) {
++        return List.of(file);
++      }
++      return fileLines.keySet().stream()
++          .filter(k -> k.endsWith("/" + file) || file.endsWith("/" + k))
++          .toList();
++    }
+   }
+ 
+   /**
+@@ -146,31 +246,69 @@ public class FindingQuoteValidator {
+    * File scoping follows the formatter's "### filename (status, +A -D)" section headers.
+    */
+   static DiffIndex indexDiff(String diff) {
+-    var byFile = new HashMap<String, Set<String>>();
+-    var all = new HashSet<String>();
+-    Set<String> current = null;
++    var fileLines = new HashMap<String, List<DiffLine>>();
++    var allLines = new ArrayList<DiffLine>();
++    List<DiffLine> current = null;
++    int rightLine = 0;
++
+     for (String raw : PromptTemplateEscaper.neutralizeMarkers(diff).split("\n", -1)) {
+       if (raw.startsWith("### ")) {
+-        current = byFile.computeIfAbsent(sectionFilename(raw), k -> new HashSet<>());
++        current = fileLines.computeIfAbsent(sectionFilename(raw), k -> new ArrayList<>());
++        // A new file section restarts right-side numbering; don't carry the previous file's
++        // counter forward in case its first hunk header is missing or unparseable.
++        rightLine = 0;
++      } else if (raw.startsWith("@@")) {
++        rightLine = hunkStartLine(raw, rightLine);
+       } else if (!isDiffStructureLine(raw)) {
+-        String normalized = bodyOf(raw).strip();
+-        if (!normalized.isEmpty()) {
+-          all.add(normalized);
+-          if (current != null) {
+-            current.add(normalized);
+-          }
+-        }
++        rightLine = appendBodyLine(raw, rightLine, allLines, current);
+       }
+     }
+-    return new DiffIndex(byFile, all);
++
++    var byFile = new HashMap<String, Set<String>>();
++    fileLines.forEach((file, lines) -> byFile.put(file, textSet(lines)));
++    return new DiffIndex(fileLines, allLines, byFile, textSet(allLines));
++  }
++
++  /** The right-side start line of a hunk header, or {@code fallback} when it can't be parsed. */
++  private static int hunkStartLine(String raw, int fallback) {
++    var matcher = DiffLineResolver.HUNK_HEADER.matcher(raw);
++    return matcher.find() ? Integer.parseInt(matcher.group(1)) : fallback;
+   }
+ 
+-  /** Hunk headers, file headers, and code fences are diff plumbing, never quotable content. */
++  /**
++   * Records a normalized body line into the union and (when scoped) its file, then returns the
++   * advanced right-side line counter — additions and context advance it; deletions do not.
++   */
++  private static int appendBodyLine(
++      String raw, int rightLine, List<DiffLine> allLines, List<DiffLine> current) {
++    String normalized = bodyOf(raw).strip();
++    if (normalized.isEmpty()) {
++      return rightLine;
++    }
++    // A non-empty normalized body implies a non-empty raw line, so charAt(0) is safe.
++    char marker = raw.charAt(0);
++    var diffLine = new DiffLine(normalized, rightLine, marker);
++    allLines.add(diffLine);
++    if (current != null) {
++      current.add(diffLine);
++    }
++    return marker == '+' || marker == ' ' ? rightLine + 1 : rightLine;
++  }
++
++  private static Set<String> textSet(List<DiffLine> lines) {
++    var set = new HashSet<String>();
++    for (var dl : lines) {
++      set.add(dl.normalizedText());
++    }
++    return set;
++  }
++
++  /**
++   * File headers and code fences are diff plumbing, never quotable content. Hunk headers
++   * ({@code @@}) are intercepted earlier for line tracking, so they never reach this check.
++   */
+   private static boolean isDiffStructureLine(String raw) {
+-    return raw.startsWith("+++")
+-        || raw.startsWith("---")
+-        || raw.startsWith("@@")
+-        || raw.startsWith("```");
++    return raw.startsWith("+++") || raw.startsWith("---") || raw.startsWith("```");
+   }
+ 
+   /** The line without its unified-diff marker column (+, -, space). */
+```

--- a/src/test/resources/evalcorpus/pr101-accountowner-npe-false-positive/case.json
+++ b/src/test/resources/evalcorpus/pr101-accountowner-npe-false-positive/case.json
@@ -1,0 +1,16 @@
+{
+  "kind": "verifier",
+  "sourcePr": 101,
+  "why": "Refuted in PR #101 review thread and documented in issues #106/#107: the description cites `dashboardConfig.accountOwner().orElse(null)` which exists nowhere in the codebase, and the only caller (outside the diff) guarantees a non-null owner. A parameter-nullability claim whose caller is not in the provided material is unverifiable and must not be posted.",
+  "expectedVerdicts": ["rejected"],
+  "finding": {
+    "risk": "medium",
+    "confidence": "low",
+    "file": "src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java",
+    "line": 222,
+    "title": "Potential NullPointerException when accountOwner is null in installedRepos()",
+    "description": "The new cache-hit condition calls accountOwner.equalsIgnoreCase(snapshot.owner()) without a prior null check. accountOwner is obtained from dashboardConfig.accountOwner().orElse(null) in evaluateAccess(), so it can be null. If null is passed to installedRepos(), a NullPointerException will be thrown, crashing the dashboard access check. The previous code did not call any method on accountOwner, so this is a regression introduced by the owner-aware cache. The caller's contract is not visible in the diff; verify whether accountOwner is guaranteed non-null and, if not, add an explicit null guard (e.g., Objects.requireNonNull or an early return for null).",
+    "suggestion_old": "  private RepoSnapshot installedRepos(String accountOwner) {\n    var snapshot = cachedSnapshot.get();",
+    "suggestion_new": "  private RepoSnapshot installedRepos(String accountOwner) {\n    Objects.requireNonNull(accountOwner, \"accountOwner must not be null\");\n    var snapshot = cachedSnapshot.get();"
+  }
+}

--- a/src/test/resources/evalcorpus/pr101-accountowner-npe-false-positive/diff.txt
+++ b/src/test/resources/evalcorpus/pr101-accountowner-npe-false-positive/diff.txt
@@ -1,0 +1,50 @@
+### src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java (modified, +14 -5)
+```diff
+@@ -74,13 +74,14 @@ public class DashboardAccessChecker {
+   private record OwnerCache(String owner, Instant cachedAt) {}
+ 
+   private final AtomicReference<RepoSnapshot> cachedSnapshot =
+-      new AtomicReference<>(new RepoSnapshot(List.of(), null, Instant.EPOCH));
++      new AtomicReference<>(new RepoSnapshot(null, List.of(), null, Instant.EPOCH));
+   private final AtomicReference<OwnerCache> ownerCache =
+       new AtomicReference<>(new OwnerCache(null, Instant.EPOCH));
+ 
+   static record AccessCacheEntry(boolean allowed, Instant cachedAt) {}
+ 
+-  private record RepoSnapshot(List<RepoRef> repos, String installationAuth, Instant cachedAt) {}
++  private record RepoSnapshot(
++      String owner, List<RepoRef> repos, String installationAuth, Instant cachedAt) {}
+ 
+   private record RepoRef(String owner, String name) {}
+ 
+@@ -220,7 +221,8 @@ public class DashboardAccessChecker {
+   private RepoSnapshot installedRepos(String accountOwner) {
+     var snapshot = cachedSnapshot.get();
+     if (snapshot.cachedAt().isAfter(clock.get().minus(REPO_CACHE_TTL))
+-        && snapshot.installationAuth() != null) {
++        && snapshot.installationAuth() != null
++        && accountOwner.equalsIgnoreCase(snapshot.owner())) {
+       return snapshot;
+     }
+ 
+@@ -235,10 +237,17 @@ public class DashboardAccessChecker {
+       }
+     } catch (RuntimeException e) {
+       log.warn("Failed to list installed repositories for {}: {}", accountOwner, e.getMessage());
+-      return cachedSnapshot.get();
++      // Fail closed on owner mismatch: the cached snapshot may belong to a previous owner, so
++      // returning it here would re-introduce the cross-owner reuse this cache is keyed to prevent.
++      // Only fall back to it when it was resolved for the same owner (graceful degradation during a
++      // transient GitHub outage); otherwise deny by returning an empty snapshot for this owner.
++      var previous = cachedSnapshot.get();
++      return accountOwner.equalsIgnoreCase(previous.owner())
++          ? previous
++          : new RepoSnapshot(accountOwner, List.of(), null, Instant.EPOCH);
+     }
+ 
+-    var updated = new RepoSnapshot(List.copyOf(repos), installationAuth, clock.get());
++    var updated = new RepoSnapshot(accountOwner, List.copyOf(repos), installationAuth, clock.get());
+     cachedSnapshot.set(updated);
+     log.info("Loaded {} installed repos for dashboard access control", repos.size());
+     return updated;
+```

--- a/src/test/resources/evalcorpus/pr84-omitted-lines-off-by-one-false-positive/case.json
+++ b/src/test/resources/evalcorpus/pr84-omitted-lines-off-by-one-false-positive/case.json
@@ -1,0 +1,16 @@
+{
+  "kind": "verifier",
+  "sourcePr": 84,
+  "why": "Documented in issues #96/#97: the finding hand-counted lines (7 - 3 = 4) and got it wrong — the test passes as written. Exact line-count arithmetic claims that a test in the same diff exercises must not be confirmed.",
+  "expectedVerdicts": ["rejected"],
+  "finding": {
+    "risk": "medium",
+    "confidence": "low",
+    "file": "src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java",
+    "line": 194,
+    "title": "Test assertion expects wrong number of omitted lines",
+    "description": "The test `shouldCloseDiffFenceWhenTruncatingInsidePatch` uses `maxLines=5` and a section of 7 lines. The logic will print the first 3 lines (contentLines=3), then add a closing fence and the truncation message. The truncation message will use `lines.length - contentLines = 7 - 3 = 4` omitted lines, but the assertion expects `5 lines omitted`. This mismatch will cause the test to fail.",
+    "suggestion_old": "      assertEquals(\"### a.java\\n```diff\\n@@\\n```\\n(patch truncated — 5 lines omitted)\\n\", result);",
+    "suggestion_new": "      assertEquals(\"### a.java\\n```diff\\n@@\\n```\\n(patch truncated — 4 lines omitted)\\n\", result);"
+  }
+}

--- a/src/test/resources/evalcorpus/pr84-omitted-lines-off-by-one-false-positive/diff.txt
+++ b/src/test/resources/evalcorpus/pr84-omitted-lines-off-by-one-false-positive/diff.txt
@@ -1,0 +1,70 @@
+### src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java (modified, +19 -1)
+```diff
+@@ -303,17 +303,35 @@ public class ReviewDiffFormatter {
+       return "(patch truncated)\n";
+     }
+ 
+-    var sb = new StringBuilder();
+     var contentLines = maxLines - 1;
++    if (isInsideCodeFence(lines, contentLines)) {
++      contentLines = Math.max(0, maxLines - 2);
++    }
++
++    var closesFence = isInsideCodeFence(lines, contentLines);
++    var sb = new StringBuilder();
+     for (var i = 0; i < contentLines; i++) {
+       sb.append(lines[i]).append('\n');
+     }
++    if (closesFence) {
++      sb.append("```\n");
++    }
+     sb.append("(patch truncated — ")
+         .append(lines.length - contentLines)
+         .append(" lines omitted)\n");
+     return sb.toString();
+   }
+ 
++  private static boolean isInsideCodeFence(String[] lines, int lineCount) {
++    var insideFence = false;
++    for (var i = 0; i < lineCount; i++) {
++      if (lines[i].trim().startsWith("```")) {
++        insideFence = !insideFence;
++      }
++    }
++    return insideFence;
++  }
++
+   static int lineCount(String text) {
+     if (text == null || text.isEmpty()) {
+       return 0;
+```
+
+### src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java (modified, +19 -0)
+```diff
+@@ -185,6 +185,25 @@ class ReviewDiffFormatterTest {
+       assertEquals("(patch truncated)\n", ReviewDiffFormatter.truncateSection("a\nb\nc\n", 1));
+     }
+ 
++    @Test
++    void shouldCloseDiffFenceWhenTruncatingInsidePatch() {
++      var section = "### a.java\n```diff\n@@\n+one\n+two\n```\n\n";
++
++      var result = ReviewDiffFormatter.truncateSection(section, 5);
++
++      assertEquals("### a.java\n```diff\n@@\n```\n(patch truncated — 5 lines omitted)\n", result);
++    }
++
++    @Test
++    void shouldKeepTruncatedFenceWithinLineBudget() {
++      var section = "```diff\n+one\n+two\n```\n";
++
++      var result = ReviewDiffFormatter.truncateSection(section, 2);
++
++      assertEquals("(patch truncated — 5 lines omitted)\n", result);
++      assertEquals(1, ReviewDiffFormatter.lineCount(result));
++    }
++
+     @Test
+     void shouldCountLinesForNullEmptyAndNewlineOnlyText() {
+       assertEquals(0, ReviewDiffFormatter.lineCount(null));
+```


### PR DESCRIPTION
## Summary

Implements the prompt eval/regression corpus from #113: prompt and verifier changes are no longer validated only by the next live PR review — confirmed dogfood outcomes are now pinned as labeled fixtures a suite can replay.

- **Labeled corpus** (`src/test/resources/evalcorpus/<case>/case.json` + `diff.txt`): each case pins a real, thread-resolved dogfood outcome. Diffs are reconstructed from the exact commits the bot reviewed (`original_commit_id` of each review comment) and stored in the same `### path (status, +A -D)` + fenced-patch format the pipeline sends to the model. Seeded with:
  - PR #100 refuted FP — empty-line `IndexOutOfBoundsException` (`expectedVerdicts: [rejected]`)
  - PR #100 confirmed TP — `\ No newline at end of file` indexing (`[confirmed]`)
  - PR #84 refuted FP — omitted-lines off-by-one arithmetic (#96/#97) (`[rejected]`)
  - PR #101 refuted FP — `accountOwner` NPE with caller guard outside the diff (#106/#107) (`[rejected]`)
  - Two generator-side cases over the PR #100 diff: `must-find` the no-newline bug, `must-not-find` the empty-line IOOBE claim
- **Deterministic guard** (`EvalCorpusTest`, runs in every CI build): validates corpus schema, provenance, verdict labels, and diff format — a malformed new case fails at merge time, no AI call.
- **Opt-in live suite** (`PromptEvalTest`, JUnit tag `eval`, surefire-excluded by default): verifier cases go through the production `FindingVerificationService.verify` path and classify the outcome (dropped→rejected, lowered→downgraded, unchanged→confirmed); generator cases run `PrReviewer.reviewStream` and keyword-match findings on the target file. LLM nondeterminism is absorbed by majority-over-N sampling (`-Deval.samples`, default 3) plus a tolerated-regression budget (`-Deval.tolerated`, default 0).
- **`-Peval` Maven profile** flips the surefire tag filters; CONTRIBUTING documents the workflow and how to add cases from resolved review threads.

Bugbot-comparison seeds from the issue's follow-up comment (PRs #305/#307/#308/#333) could not be extracted — those PRs have no inline review data via the API — but the corpus is append-only by design: new cases are a directory drop, no code change.

## Issue

Fixes #113

## Test plan

- [x] `EvalCorpusTest` (4 tests) passes and runs in the default build
- [x] `./mvnw test -Peval -Dtest=PromptEvalTest` wires up (skips via assumption without a provider key; live run is opt-in by design)
- [x] `./mvnw verify` passes locally — 1593 tests, Spotless, SpotBugs, JaCoCo all green
- [x] No production code changed; all new files are test-scoped or fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)