### PR TITLE
feat(review): gate inline posting on confidence (#105)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/Finding.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/Finding.java
@@ -64,4 +64,13 @@ public record Finding(
         && suggestionNew != null
         && !suggestionNew.isBlank();
   }
+
+  /**
+   * Whether this finding should open an inline review thread. Low-confidence findings at medium/low
+   * risk are routed to the PR summary instead; critical/high risk stays inline even when confidence
+   * is low so severe-but-uncertain items remain visible on the diff.
+   */
+  public boolean postsInline() {
+    return confidence != Confidence.LOW || risk == RiskLevel.CRITICAL || risk == RiskLevel.HIGH;
+  }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -123,6 +123,7 @@ public class PrSummaryGenerator {
 
     appendPreviousFindings(sb, result);
     appendFindingsOrCelebration(sb, result);
+    appendDoubleCheckFindings(sb, result);
     appendCiChecks(sb, result);
 
     sb.append("---\n");
@@ -158,19 +159,22 @@ public class PrSummaryGenerator {
 
   private static void appendFindingsOrCelebration(StringBuilder sb, ReviewResult result) {
     if (result.hasIssues()) {
-      sb.append("### Key Findings\n");
-      for (Finding f : result.keyFindings()) {
-        sb.append("- **")
-            .append(f.risk().name())
-            .append(":** ")
-            .append(f.title())
-            .append(" (`")
-            .append(f.file())
-            .append(":")
-            .append(f.line())
-            .append("`)\n");
+      var keyFindings = result.keyFindings();
+      if (!keyFindings.isEmpty()) {
+        sb.append("### Key Findings\n");
+        for (Finding f : keyFindings) {
+          sb.append("- **")
+              .append(f.risk().name())
+              .append(":** ")
+              .append(f.title())
+              .append(" (`")
+              .append(f.file())
+              .append(":")
+              .append(f.line())
+              .append("`)\n");
+        }
+        sb.append("\n");
       }
-      sb.append("\n");
     } else if (hasNoUnresolvedPrevious(result)) {
       if (result.ciHoldsApproval()) {
         appendCiHold(sb, result);
@@ -181,6 +185,42 @@ public class PrSummaryGenerator {
         sb.append(ZERO_ISSUES_MESSAGE).append("\n\n");
       }
     }
+  }
+
+  /**
+   * Collapsed section for low-confidence medium/low findings that were withheld from inline
+   * threads. Keeps the signal visible and clearly non-blocking without opening a review thread that
+   * maintainers must triage and resolve.
+   */
+  private static void appendDoubleCheckFindings(StringBuilder sb, ReviewResult result) {
+    var findings = result.doubleCheckFindings();
+    if (findings.isEmpty()) {
+      return;
+    }
+    sb.append("### Things to double-check\n");
+    sb.append("<details>\n");
+    sb.append("<summary>")
+        .append(findings.size())
+        .append(" lower-confidence finding")
+        .append(findings.size() == 1 ? "" : "s")
+        .append("</summary>\n\n");
+    for (Finding f : findings) {
+      sb.append("- **")
+          .append(f.risk().name())
+          .append(":** ")
+          .append(f.title())
+          .append(" (`")
+          .append(f.file())
+          .append(":")
+          .append(f.line())
+          .append("`)");
+      String disclaimer = SuggestionFormatter.confidenceDisclaimer(f.confidence());
+      if (!disclaimer.isEmpty()) {
+        sb.append(' ').append(disclaimer);
+      }
+      sb.append("\n");
+    }
+    sb.append("\n</details>\n\n");
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -205,6 +205,7 @@ public class PrSummaryGenerator {
         .append(findings.size() == 1 ? "" : "s")
         .append("</summary>\n\n");
     for (Finding f : findings) {
+      // By construction these findings are confidence LOW, so the disclaimer is always present.
       sb.append("- **")
           .append(f.risk().name())
           .append(":** ")
@@ -213,12 +214,9 @@ public class PrSummaryGenerator {
           .append(f.file())
           .append(":")
           .append(f.line())
-          .append("`)");
-      String disclaimer = SuggestionFormatter.confidenceDisclaimer(f.confidence());
-      if (!disclaimer.isEmpty()) {
-        sb.append(' ').append(disclaimer);
-      }
-      sb.append("\n");
+          .append("`) ")
+          .append(SuggestionFormatter.confidenceDisclaimer(Confidence.LOW))
+          .append("\n");
     }
     sb.append("\n</details>\n\n");
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -217,11 +217,18 @@ public class ReviewPublisher {
         result.reviewState() == ReviewState.REQUEST_CHANGES ? EVENT_REQUEST_CHANGES : EVENT_COMMENT;
 
     if (inline.posted() == 0) {
-      // Inline anchoring failed for every finding (e.g. all lines fell outside the diff after a
-      // force-push); surface them in the review body instead.
-      Log.warnf(
-          "No inline comments posted for %s/%s #%d — surfacing findings in the review body",
-          owner, repo, prNumber);
+      // Nothing landed inline: either anchoring failed, the comment cap skipped everything, or
+      // every finding was routed to the summary as lower-confidence. Surface them in the review
+      // body so follow-ups (which do not re-post the summary) still carry the signal.
+      if (!inline.unanchored().isEmpty() || !inline.capSkipped().isEmpty()) {
+        Log.warnf(
+            "No inline comments posted for %s/%s #%d — surfacing findings in the review body",
+            owner, repo, prNumber);
+      } else {
+        Log.infof(
+            "No inline comments for %s/%s #%d — lower-confidence findings routed to the summary",
+            owner, repo, prNumber);
+      }
       var fallbackParts = new ArrayList<>(skippedFindingsBodyParts(inline));
       appendTruncationNotice(fallbackParts, result);
       createReviewWithFallback(
@@ -264,7 +271,10 @@ public class ReviewPublisher {
     }
   }
 
-  /** Review-body sections for findings not posted inline — un-anchored and/or cap-skipped. */
+  /**
+   * Review-body sections for findings not posted inline — un-anchored, cap-skipped, and/or
+   * confidence-routed to the summary's "Things to double-check" section.
+   */
   private static List<String> skippedFindingsBodyParts(InlineCommentResult inline) {
     var parts = new ArrayList<String>();
     if (!inline.unanchored().isEmpty()) {
@@ -272,6 +282,9 @@ public class ReviewPublisher {
     }
     if (!inline.capSkipped().isEmpty()) {
       parts.add(capSkippedFindingsBody(inline.capSkipped()));
+    }
+    if (!inline.confidenceSkipped().isEmpty()) {
+      parts.add(confidenceSkippedFindingsBody(inline.confidenceSkipped()));
     }
     return parts;
   }
@@ -293,6 +306,20 @@ public class ReviewPublisher {
             """
              issue(s) not posted inline because the per-run comment cap was reached — re-run \
             `/review` or raise the comment cap:
+
+            """);
+    appendFindingList(sb, findings);
+    return sb.toString();
+  }
+
+  private static String confidenceSkippedFindingsBody(List<Finding> findings) {
+    var sb = new StringBuilder();
+    sb.append("ThrillhouseBot noted ")
+        .append(findings.size())
+        .append(
+            """
+             lower-confidence item(s) under **Things to double-check** in the PR summary \
+            (not posted as inline threads):
 
             """);
     appendFindingList(sb, findings);
@@ -390,16 +417,22 @@ public class ReviewPublisher {
   }
 
   /**
-   * How many findings anchored as inline comments, the ones that could not be anchored, and the
-   * ones skipped because {@code maxReviewComments} was reached (never tried for anchoring).
+   * How many findings anchored as inline comments, the ones that could not be anchored, the ones
+   * skipped because {@code maxReviewComments} was reached (never tried for anchoring), and the ones
+   * withheld because confidence is low (routed to the summary instead).
    */
-  record InlineCommentResult(int posted, List<Finding> unanchored, List<Finding> capSkipped) {}
+  record InlineCommentResult(
+      int posted,
+      List<Finding> unanchored,
+      List<Finding> capSkipped,
+      List<Finding> confidenceSkipped) {}
 
   /**
    * Posts each finding as its own pull request review comment on the diff. Individual comments
    * survive 422s that would reject an entire batched review. Findings whose line falls outside the
    * diff (or are otherwise rejected) are returned as {@code unanchored} so the caller can still
-   * report them in the review body rather than dropping them.
+   * report them in the review body rather than dropping them. Low-confidence medium/low findings
+   * are skipped here and surfaced in the PR summary's "Things to double-check" section instead.
    */
   InlineCommentResult postInlineComments(
       String auth,
@@ -413,11 +446,16 @@ public class ReviewPublisher {
     var posted = 0;
     var unanchored = new ArrayList<Finding>();
     var capSkipped = new ArrayList<Finding>();
+    var confidenceSkipped = new ArrayList<Finding>();
     var maxComments = config.review().maxReviewComments();
     for (var i = 0; i < result.findings().size(); i++) {
       // The 1-based index doubles as the finding's id in the persisted response and the hidden
       // comment marker, keeping thread matching deterministic on follow-up reviews.
       var finding = result.findings().get(i);
+      if (!finding.postsInline()) {
+        confidenceSkipped.add(finding);
+        continue;
+      }
       if (posted >= maxComments) {
         capSkipped.add(finding);
         continue;
@@ -428,7 +466,8 @@ public class ReviewPublisher {
         unanchored.add(finding);
       }
     }
-    return new InlineCommentResult(posted, List.copyOf(unanchored), List.copyOf(capSkipped));
+    return new InlineCommentResult(
+        posted, List.copyOf(unanchored), List.copyOf(capSkipped), List.copyOf(confidenceSkipped));
   }
 
   /** PR coordinates shared by every inline comment of one review. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -147,14 +147,24 @@ public record ReviewResult(
 
   /**
    * The highest-risk findings the first-review summary comment lists under "Key Findings" (top
-   * {@value #KEY_FINDINGS_COUNT} by risk). Used by {@code PrSummaryGenerator} to render that
-   * section.
+   * {@value #KEY_FINDINGS_COUNT} by risk among findings that post inline). Used by {@code
+   * PrSummaryGenerator} to render that section. Low-confidence medium/low findings are listed under
+   * "Things to double-check" instead ({@link #doubleCheckFindings()}).
    */
   public List<Finding> keyFindings() {
     return findings.stream()
+        .filter(Finding::postsInline)
         .sorted((a, b) -> a.risk().compareTo(b.risk()))
         .limit(KEY_FINDINGS_COUNT)
         .toList();
+  }
+
+  /**
+   * Findings withheld from inline threads because confidence is low and risk is below high — shown
+   * in the PR summary's collapsed "Things to double-check" section instead.
+   */
+  public List<Finding> doubleCheckFindings() {
+    return findings.stream().filter(f -> !f.postsInline()).toList();
   }
 
   /** True when CI holds approval back: a required check is offending, or CI could not be read. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatter.java
@@ -79,6 +79,19 @@ public class SuggestionFormatter {
   }
 
   /**
+   * Italic disclaimer appended when confidence is below high, so readers know to verify before
+   * acting. Empty for {@link Confidence#HIGH}.
+   */
+  public static String confidenceDisclaimer(Confidence confidence) {
+    if (confidence == null || confidence == Confidence.HIGH) {
+      return "";
+    }
+    return "_("
+        + confidence.name().toLowerCase(Locale.ROOT)
+        + " confidence — verify before acting)_";
+  }
+
+  /**
    * Builds a full review comment body for a single finding. Includes the risk emoji, title,
    * description, and suggestion block (if applicable).
    */
@@ -101,10 +114,9 @@ public class SuggestionFormatter {
         .append(" — ")
         .append(finding.title())
         .append("**");
-    if (finding.confidence() != Confidence.HIGH) {
-      sb.append(" _(")
-          .append(finding.confidence().name().toLowerCase(Locale.ROOT))
-          .append(" confidence — verify before acting)_");
+    String disclaimer = confidenceDisclaimer(finding.confidence());
+    if (!disclaimer.isEmpty()) {
+      sb.append(' ').append(disclaimer);
     }
     sb.append("\n\n");
     sb.append(finding.description()).append("\n");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingTest.java
@@ -120,4 +120,32 @@ class FindingTest {
 
     assertFalse(finding.hasSuggestion());
   }
+
+  @Test
+  void postsInlineShouldBeFalseForLowConfidenceMediumRisk() {
+    var finding = new Finding(RiskLevel.MEDIUM, Confidence.LOW, "f", 1, "t", "d", null, null);
+
+    assertFalse(finding.postsInline());
+  }
+
+  @Test
+  void postsInlineShouldBeTrueForMediumConfidence() {
+    var finding = new Finding(RiskLevel.MEDIUM, Confidence.MEDIUM, "f", 1, "t", "d", null, null);
+
+    assertTrue(finding.postsInline());
+  }
+
+  @Test
+  void postsInlineShouldBeTrueForHighRiskEvenAtLowConfidence() {
+    var finding = new Finding(RiskLevel.HIGH, Confidence.LOW, "f", 1, "t", "d", null, null);
+
+    assertTrue(finding.postsInline());
+  }
+
+  @Test
+  void postsInlineShouldBeTrueForCriticalRiskEvenAtLowConfidence() {
+    var finding = new Finding(RiskLevel.CRITICAL, Confidence.LOW, "f", 1, "t", "d", null, null);
+
+    assertTrue(finding.postsInline());
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -122,6 +122,35 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
+  void shouldPluralizeDoubleCheckSummaryWhenMultipleLowConfidenceFindings() {
+    var findings =
+        List.of(
+            new Finding(RiskLevel.MEDIUM, Confidence.LOW, "a.java", 1, "One", "d", null, null),
+            new Finding(RiskLevel.LOW, Confidence.LOW, "b.java", 2, "Two", "d", null, null));
+    var result =
+        new ReviewResult(
+            findings,
+            0,
+            0,
+            1,
+            1,
+            RiskLevel.MEDIUM,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
+
+    var summary = generator.generate(2, 1, 0, List.of(), null, result);
+
+    assertTrue(summary.contains("2 lower-confidence findings"));
+    assertFalse(summary.contains("### Key Findings"));
+    assertTrue(summary.contains("One"));
+    assertTrue(summary.contains("Two"));
+  }
+
+  @Test
   void shouldRenderPrPurposeAndDescriptionGaps() {
     var aiSummary =
         new ReviewResponse.Summary(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -83,6 +83,45 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
+  void shouldRouteLowConfidenceFindingsToDoubleCheckSectionNotKeyFindings() {
+    var inline =
+        new Finding(
+            RiskLevel.HIGH, Confidence.HIGH, "src/A.java", 1, "Real bug", "desc", null, null);
+    var lowConfidence =
+        new Finding(
+            RiskLevel.MEDIUM, Confidence.LOW, "src/B.java", 22, "Possible NPE", "desc", null, null);
+    var result =
+        new ReviewResult(
+            List.of(inline, lowConfidence),
+            0,
+            1,
+            1,
+            0,
+            RiskLevel.HIGH,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
+
+    var summary = generator.generate(2, 10, 2, List.of(), null, result);
+
+    assertTrue(summary.contains("### Key Findings"));
+    assertTrue(summary.contains("Real bug"));
+    assertTrue(summary.contains("### Things to double-check"));
+    assertTrue(summary.contains("1 lower-confidence finding"));
+    assertTrue(summary.contains("Possible NPE"));
+    assertTrue(summary.contains("`src/B.java:22`"));
+    assertTrue(summary.contains("_(low confidence — verify before acting)_"));
+    // Low-confidence item must not also appear under Key Findings.
+    int keyIdx = summary.indexOf("### Key Findings");
+    int doubleCheckIdx = summary.indexOf("### Things to double-check");
+    assertTrue(keyIdx >= 0 && doubleCheckIdx > keyIdx);
+    assertFalse(summary.substring(keyIdx, doubleCheckIdx).contains("Possible NPE"));
+  }
+
+  @Test
   void shouldRenderPrPurposeAndDescriptionGaps() {
     var aiSummary =
         new ReviewResponse.Summary(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2960,6 +2960,43 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void shouldWarnWhenCommentCapSkipsEveryInlineEligibleFinding() {
+      when(reviewConfig.maxReviewComments()).thenReturn(0);
+      var finding =
+          new Finding(
+              RiskLevel.MEDIUM,
+              Confidence.HIGH,
+              "src/Main.java",
+              10,
+              "Real smell",
+              "desc",
+              null,
+              null);
+      var result = resultWithFinding(finding, ReviewState.COMMENT);
+      var resolver =
+          new DiffLineResolver(
+              Map.of("src/Main.java", fileDiffWithLine("src/Main.java", 10).patch()));
+
+      reviewPublisher.postReview("Bearer tok", "owner", "repo", 7, "sha", result, resolver);
+
+      verify(reviewClient, never())
+          .createPullRequestComment(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+      verify(reviewClient)
+          .createReview(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(
+                  req ->
+                      req.body().contains("comment cap was reached")
+                          && req.body().contains("Real smell")
+                          && !req.body().contains("Things to double-check")));
+    }
+
+    @Test
     void shouldDiscloseConfidenceSkippedFindingsInReviewBodyWhenNonePostInline() {
       var finding =
           new Finding(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2960,6 +2960,107 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void shouldDiscloseConfidenceSkippedFindingsInReviewBodyWhenNonePostInline() {
+      var finding =
+          new Finding(
+              RiskLevel.MEDIUM,
+              Confidence.LOW,
+              "src/Main.java",
+              10,
+              "Possible NPE",
+              "verify the caller",
+              null,
+              null);
+      var result = resultWithFinding(finding, ReviewState.COMMENT);
+      var resolver =
+          new DiffLineResolver(
+              Map.of("src/Main.java", fileDiffWithLine("src/Main.java", 10).patch()));
+
+      reviewPublisher.postReview("Bearer tok", "owner", "repo", 7, "sha", result, resolver);
+
+      verify(reviewClient, never())
+          .createPullRequestComment(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+      verify(reviewClient)
+          .createReview(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(
+                  req ->
+                      "COMMENT".equals(req.event())
+                          && req.body().contains("Things to double-check")
+                          && req.body().contains("Possible NPE")
+                          && req.body().contains("verify the caller")
+                          && req.body().contains("lower-confidence")));
+    }
+
+    @Test
+    void shouldDiscloseConfidenceSkippedFindingsAlongsideInlineComments() {
+      var lowConfidence =
+          new Finding(
+              RiskLevel.LOW,
+              Confidence.LOW,
+              "src/Skip.java",
+              20,
+              "Maybe nit",
+              "double-check this",
+              null,
+              null);
+      var inline =
+          new Finding(
+              RiskLevel.MEDIUM,
+              Confidence.HIGH,
+              "src/Main.java",
+              10,
+              "Real smell",
+              "desc",
+              null,
+              null);
+      var result =
+          new ReviewResult(
+              List.of(lowConfidence, inline),
+              0,
+              0,
+              1,
+              1,
+              RiskLevel.MEDIUM,
+              ReviewState.COMMENT,
+              true,
+              "",
+              List.of(),
+              List.of(),
+              0);
+      var resolver =
+          new DiffLineResolver(
+              Map.of(
+                  "src/Main.java", fileDiffWithLine("src/Main.java", 10).patch(),
+                  "src/Skip.java", fileDiffWithLine("src/Skip.java", 20).patch()));
+      when(suggestionFormatter.formatReviewComment(any(), anyBoolean(), anyInt()))
+          .thenReturn("body");
+
+      reviewPublisher.postReview("Bearer tok", "owner", "repo", 7, "sha", result, resolver);
+
+      verify(reviewClient, times(1))
+          .createPullRequestComment(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+      verify(reviewClient)
+          .createReview(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(
+                  req ->
+                      req.body().contains("Things to double-check")
+                          && req.body().contains("Maybe nit")
+                          && !req.body().contains("could not be anchored")));
+    }
+
+    @Test
     void shouldRespectMaxReviewCommentsLimit() {
       when(reviewConfig.maxReviewComments()).thenReturn(1);
       var first = new Finding(RiskLevel.MEDIUM, "src/A.java", 10, "One", "desc", null, null);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2875,6 +2875,91 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void shouldExcludeLowConfidenceFindingsFromInlineSet() {
+      var lowConfidence =
+          new Finding(
+              RiskLevel.MEDIUM,
+              Confidence.LOW,
+              "src/Main.java",
+              10,
+              "Possible NPE",
+              "desc",
+              null,
+              null);
+      var mediumConfidence =
+          new Finding(
+              RiskLevel.MEDIUM,
+              Confidence.MEDIUM,
+              "src/Other.java",
+              20,
+              "Real smell",
+              "desc",
+              null,
+              null);
+      var result =
+          new ReviewResult(
+              List.of(lowConfidence, mediumConfidence),
+              0,
+              0,
+              2,
+              0,
+              RiskLevel.MEDIUM,
+              ReviewState.COMMENT,
+              true,
+              "",
+              List.of(),
+              List.of(),
+              0);
+      var resolver =
+          new DiffLineResolver(
+              Map.of(
+                  "src/Main.java", fileDiffWithLine("src/Main.java", 10).patch(),
+                  "src/Other.java", fileDiffWithLine("src/Other.java", 20).patch()));
+      when(suggestionFormatter.formatReviewComment(any(), anyBoolean(), anyInt()))
+          .thenReturn("body");
+
+      var inline =
+          reviewPublisher.postInlineComments(
+              "Bearer tok", "owner", "repo", 7, "sha", result, resolver);
+
+      assertEquals(1, inline.posted());
+      assertEquals(1, inline.confidenceSkipped().size());
+      assertEquals("Possible NPE", inline.confidenceSkipped().get(0).title());
+      assertTrue(inline.unanchored().isEmpty());
+      assertTrue(inline.capSkipped().isEmpty());
+      verify(reviewClient, times(1))
+          .createPullRequestComment(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+    }
+
+    @Test
+    void shouldKeepLowConfidenceHighRiskFindingsInline() {
+      var finding =
+          new Finding(
+              RiskLevel.HIGH,
+              Confidence.LOW,
+              "src/Main.java",
+              10,
+              "Severe but uncertain",
+              "desc",
+              null,
+              null);
+      var result = resultWithFinding(finding, ReviewState.COMMENT);
+      var resolver =
+          new DiffLineResolver(
+              Map.of("src/Main.java", fileDiffWithLine("src/Main.java", 10).patch()));
+      when(suggestionFormatter.formatReviewComment(any(), anyBoolean(), anyInt()))
+          .thenReturn("body");
+
+      var inline =
+          reviewPublisher.postInlineComments(
+              "Bearer tok", "owner", "repo", 7, "sha", result, resolver);
+
+      assertEquals(1, inline.posted());
+      assertTrue(inline.confidenceSkipped().isEmpty());
+    }
+
+    @Test
     void shouldRespectMaxReviewCommentsLimit() {
       when(reviewConfig.maxReviewComments()).thenReturn(1);
       var first = new Finding(RiskLevel.MEDIUM, "src/A.java", 10, "One", "desc", null, null);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -55,6 +55,30 @@ class ReviewResultTest {
   }
 
   @Test
+  void keyFindingsShouldExcludeLowConfidenceFindingsRoutedToDoubleCheck() {
+    var inline = new Finding(RiskLevel.HIGH, Confidence.HIGH, "a", 1, "Inline", "", null, null);
+    var summaryOnly =
+        new Finding(RiskLevel.MEDIUM, Confidence.LOW, "b", 2, "Double-check", "", null, null);
+    var result =
+        new ReviewResult(
+            List.of(inline, summaryOnly),
+            0,
+            1,
+            1,
+            0,
+            RiskLevel.HIGH,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
+
+    assertEquals(List.of(inline), result.keyFindings());
+    assertEquals(List.of(summaryOnly), result.doubleCheckFindings());
+  }
+
+  @Test
   void totalFindingsShouldReturnListSize() {
     var findings =
         List.of(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SuggestionFormatterTest.java
@@ -107,6 +107,15 @@ class SuggestionFormatterTest {
   }
 
   @Test
+  void confidenceDisclaimerShouldBeEmptyForNullOrHighConfidence() {
+    assertEquals("", SuggestionFormatter.confidenceDisclaimer(null));
+    assertEquals("", SuggestionFormatter.confidenceDisclaimer(Confidence.HIGH));
+    assertEquals(
+        "_(low confidence — verify before acting)_",
+        SuggestionFormatter.confidenceDisclaimer(Confidence.LOW));
+  }
+
+  @Test
   void shouldFormatDocCommentWithSymbolAndSuggestionBlock() {
     var comment =
         formatter.formatDocComment(


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Confidence already drove the review verdict but not comment placement, so low-confidence findings still opened inline threads that maintainers had to triage (dogfood: PR #101 NPE false positive at low confidence).

This gates inline posting:

- **Inline** when `confidence >= MEDIUM`, or when `risk >= HIGH` (severe-but-uncertain stays visible on the diff)
- **Summary** otherwise: collapsed **Things to double-check** section with file/line and the existing confidence disclaimer
- `ReviewState` / blocking logic unchanged

Also surfaces confidence-routed findings in the review body so follow-up reviews (which do not re-post the summary) still carry the signal.

## Related Issues

Fixes #105

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- `Finding.postsInline` / `ReviewResult.keyFindings` + `doubleCheckFindings`
- `ReviewPublisher.postInlineComments` excludes low-confidence medium findings and keeps low-confidence high-risk inline
- `PrSummaryGenerator` renders **Things to double-check** and keeps those titles out of **Key Findings**
- `./mvnw spotless:check spotbugs:check verify` passed locally

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Part of the confidence-capping multiplier for #106/#107/#98 — capping to low now actually moves findings out of the inline stream.

Made with [Cursor](https://cursor.com)