### PR TITLE
feat(review): downgrade exact-arithmetic claims and add a symmetric "test fails" self-check (#97)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
@@ -60,6 +60,17 @@ public final class FindingVerifierPrompts {
               exists but may not exercise this path. Do not apply this rejection when the
               test's mocks or stubs contradict the real collaborator's contract — that test
               does not faithfully exercise the production path.
+            - The finding rests on exact line-count, array-length, or index arithmetic (counting
+              lines or elements in the diff to derive a number), or claims a specific test fails,
+              AND states it as settled fact ("this test fails", "the assertion expects the wrong
+              number") with no execution signal or provided CI context behind it. You cannot
+              settle such a claim by recounting: you are the same modality as its author reading
+              the same diff, so you would repeat a miscount rather than catch it — which is how a
+              hand-counted off-by-one ("the section is 7 lines, so 7 - 3 = 4 omitted") reached a
+              PR against a test that passes as written. Reject it. Do NOT reject when the finding
+              is already phrased as a verification request naming what to run, or when an
+              execution/CI signal in the provided material shows the failure — downgrade to
+              confidence "low" instead.
             - The flagged code does not appear in the diff as the finding describes it, or the
               code the finding quotes is not present verbatim in the diff — a
               finding built on a paraphrase of the change is invalid.
@@ -156,7 +167,9 @@ public final class FindingVerifierPrompts {
             material includes the calling code that supplies the parameter, or when the changed
             signature itself declares a nullable contract for that parameter; when neither is
             shown the nullability is unestablished, so reject the finding (per above) rather
-            than post it.
+            than post it. An exact-arithmetic or test-failure claim is demonstrable only when an
+            execution signal or provided CI context settles it; on the strength of counting alone
+            it is never "confirmed" and never above confidence "low".
 
             Also audit each finding's suggested fix: when the underlying issue is real but
             suggestion_new is incorrect, incomplete, or would introduce a new defect, return

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -144,6 +144,17 @@ public final class PrReviewPrompts {
               description that a test exists but may not exercise this path. A green test
               whose mocks contradict the real collaborator also does not suppress a finding —
               that test does not exercise the production path it claims to cover.
+            - The symmetric case — a claim that a test FAILS, or any claim resting on exact
+              line-count, array-length, or index arithmetic you performed by counting lines or
+              elements in the diff (for example "the section is 7 lines, so it prints 4") — is at
+              most confidence "low" and must be phrased as a verification request ("CI will
+              confirm this", "the test run will show which value is right"), never as settled fact
+              ("this test fails", "the assertion expects the wrong number"). Show the arithmetic
+              one step at a time from values quoted verbatim in the diff, and say in the
+              description that the test may pass as written. Counting is the least reliable thing
+              you do here and re-reading the same diff cannot check it — only an execution signal
+              or provided CI context can. Without one of those, a definitively-worded
+              test-failure or off-by-one claim is invalid.
             - Re-read the flagged lines in the diff and confirm the issue exists in the code as
               written, not in a paraphrase of it. Quote the flagged lines exactly as they appear
               in the diff; if the exact text you are about to quote cannot be found
@@ -297,7 +308,10 @@ public final class PrReviewPrompts {
             that leaves a collaborator on the path unmocked so a default bypasses it, or that
             mocks a collaborator to throw or return something the real method cannot, is
             not such evidence — lower confidence and note that rather than treating the test
-            as disproof.
+            as disproof. The reverse claim — that one of these tests itself fails, an assertion
+            expecting the wrong value or an off-by-one in an expected count — rests on arithmetic
+            that no amount of re-reading can check: keep it at confidence "low", phrase it as
+            "CI will confirm", and never state the failure as settled fact.
             {{relatedTests}}
             {{/if}}
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -22,10 +22,11 @@ import org.junit.jupiter.api.Test;
 /**
  * Pins review/verifier prompt guidance so a future edit cannot silently revert it. Covers the
  * config/IaC severity recalibration (so declarative findings are not suppressed), the
- * parameter-nullability / unseen-caller guard (#107), and the in-diff-test exercise gate (a green
- * test must demonstrably hit the claimed path before it can invalidate a finding — #116). These
- * assertions are intentionally coarse — they check intent survives, not exact wording; an
- * intentional rewording should update the matching anchor.
+ * parameter-nullability / unseen-caller guard (#107), the in-diff-test exercise gate (a green test
+ * must demonstrably hit the claimed path before it can invalidate a finding — #116), and the
+ * symmetric exact-arithmetic / "test fails" cap (#97). These assertions are intentionally coarse —
+ * they check intent survives, not exact wording; an intentional rewording should update the
+ * matching anchor.
  *
  * <p>The automated LLM eval that checks the model actually <em>acts</em> on this guidance is
  * tracked separately ({@code evalcorpus/}); this is the cheap deterministic guard.
@@ -146,6 +147,65 @@ class PrReviewPromptsContentTest {
         sys,
         "may not exercise this path",
         "verifier downgrade reason must name that the test may not exercise the path");
+  }
+
+  @Test
+  void generatorPromptCapsExactArithmeticAndTestFailureClaims() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "a claim that a test FAILS",
+        "generator must carry the symmetric guard for the test-failure direction");
+    assertContains(
+        sys,
+        "line-count, array-length, or index arithmetic",
+        "generator must name exact-arithmetic claims as the capped category");
+    assertContains(
+        sys,
+        "never as settled fact",
+        "an arithmetic/test-failure claim must be phrased as a verification request");
+    assertContains(
+        sys,
+        "re-reading the same diff cannot check it",
+        "generator must say why a second reading cannot validate counting");
+  }
+
+  @Test
+  void generatorUserPromptHedgesClaimsThatAnInDiffTestItselfFails() {
+    String user = PrReviewPrompts.USER;
+    assertContains(
+        user,
+        "that one of these tests itself fails",
+        "related-tests guidance must cover the reverse claim that a provided test fails");
+    assertContains(
+        user,
+        "CI will confirm",
+        "a test-failure claim must be phrased as awaiting CI, not asserted");
+  }
+
+  @Test
+  void verifierPromptRejectsRecountedArithmeticAndTestFailureClaims() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "claims a specific test fails",
+        "verifier must have a rejection ground for definitive test-failure claims");
+    assertContains(
+        sys,
+        "settle such a claim by recounting",
+        "verifier must state that same-modality recounting cannot validate arithmetic");
+    assertContains(
+        sys,
+        "7 - 3 = 4 omitted",
+        "verifier must keep the PR #84 hand-counted off-by-one regression example");
+    assertContains(
+        sys,
+        "phrased as a verification request naming what to run",
+        "a properly hedged arithmetic claim must be downgraded rather than rejected");
+    assertContains(
+        sys,
+        "exact-arithmetic or test-failure claim is demonstrable only when",
+        "verifier severity calibration must cap arithmetic claims without an execution signal");
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature

## Description

The review and verifier prompts guarded against **fabrication** but not **miscalculation**. The only
test-related self-check was the *inverse* of the PR #84 failure — "if a test in this same diff
exercises the path you claim is broken, explain why it would still pass". Nothing guarded the
opposite direction: a claim that a test *fails*, or a finding resting on exact line-count /
array-length arithmetic the model performed by hand.

That gap is what produced the #84 miss: a MEDIUM, definitively-worded off-by-one ("Test assertion
expects wrong number of omitted lines") pinned to `ReviewDiffFormatterTest.java:194`, against a test
that passes as written. `FindingVerifier` is the same modality over the same diff, so it re-did the
same `7 - 3 = 4` count and **agreed** instead of catching it — the finding was already labelled "low
confidence" and still surfaced as settled fact.

This adds the symmetric rule to both prompts:

- **`PrReviewPrompts.SYSTEM`** — a new self-check bullet, placed next to its existing mirror image:
  a claim that a test FAILS, or one resting on line-count / array-length / index arithmetic, is at
  most confidence `"low"`, must show the arithmetic step by step from values quoted verbatim in the
  diff, must state that the test may pass as written, and must be phrased as a verification request
  ("CI will confirm this") — never as settled fact. Without an execution or CI signal, a
  definitively-worded test-failure claim is invalid.
- **`PrReviewPrompts.USER`** — the *Tests changed in this PR* section now covers the reverse claim
  too. This is where the model reads the test files, and #84's finding was *on* a test file.
- **`FindingVerifierPrompts.SYSTEM`** — a new rejection ground plus a severity-calibration cap. The
  verifier is told explicitly that it *cannot* settle such a claim by recounting, because it shares
  the author's modality and diff, and it keeps the `7 - 3 = 4` case as a regression example. Hedged
  claims are downgraded to `"low"`; claims asserted as fact with no execution signal are rejected.

The confidence cap has real teeth now that #105 (merged) routes low-confidence findings to the
summary instead of posting them inline.

Follows the shape established by #107 (reject bullet + calibration sentence) rather than inventing a
new prompt structure. No production logic changed — prompt text and its deterministic guards only.

## Related Issues

Fixes #97

Groundwork already in place: #113 added the eval corpus case
`evalcorpus/pr84-omitted-lines-off-by-one-false-positive` with `expectedVerdicts: ["rejected"]` and a
`why` citing this issue — this PR is what makes the prompts produce that verdict. Complements #96
(execution oracle, now unscheduled) and #59 (CI context), either of which would supply the execution
signal this rule defers to.

## How Has This Been Tested?

- [x] Unit tests

Three new tests in `PrReviewPromptsContentTest` (15 total in the class, all green), pinning each half
of the guard so a future prompt edit cannot silently revert it:

- `generatorPromptCapsExactArithmeticAndTestFailureClaims`
- `generatorUserPromptHedgesClaimsThatAnInDiffTestItselfFails`
- `verifierPromptRejectsRecountedArithmeticAndTestFailureClaims`

Markers are deliberately coarse and single-line, matching the file's stated convention (check intent
survives, not exact wording).

Local gates, all green:

- `./mvnw spotless:apply` + `spotless:check`
- `./mvnw verify` — **1783 tests, 0 failures**, SpotBugs clean, JaCoCo gate met

The LLM eval that checks the model *acts* on this guidance is the `eval`-tagged `PromptEvalTest`,
excluded from the default surefire run by design.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code