### PR TITLE
feat(review): adversarially stress-test newly-added parsers/regex/validators for their own failure modes (#123)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
@@ -75,7 +75,7 @@ final class HeuristicCodeDetector {
 
   private static final Pattern TEST_PATH =
       Pattern.compile(
-          "(?i)(?:^|/)(?:test|tests|spec|__tests__)/|[._-](?:test|spec)\\.|Test\\.java$");
+          "(?i)(?:(?:^|/)(?:test|tests|spec|__tests__)/|[._-](?:test|spec)\\.|Test\\.java$)");
 
   private HeuristicCodeDetector() {}
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import java.util.regex.Pattern;
+
+/**
+ * Detects that a diff introduces parsing / regex / validation / heuristic code, so the review
+ * prompt can switch those hunks into failure-mode characterization instead of happy-path reading
+ * (issue #123). Such code is a function whose decision boundary must be probed with inputs the diff
+ * does not contain by definition, so re-reading the added lines cannot reveal a silent miss.
+ *
+ * <p>Detection is textual and deliberately narrow: only added lines count, test files are ignored
+ * (a regex there is usually a fixture, not new production logic), and every signal names
+ * construction or char-level scanning rather than mere use. Ubiquitous calls — {@code substring},
+ * {@code indexOf}, {@code trim}, {@code matches}, {@code parseInt} — are excluded on purpose: they
+ * appear in most diffs, and a trigger that fires on most diffs spends prompt budget without adding
+ * an angle. A missed trigger costs one unprompted review; an over-eager one taxes every review.
+ */
+final class HeuristicCodeDetector {
+
+  /** Explicit regex construction, across the languages the bot reviews. */
+  private static final Pattern REGEX_CONSTRUCTION =
+      Pattern.compile(
+          "Pattern\\.compile\\(|re\\.compile\\(|new\\s+RegExp\\(|regexp\\.MustCompile\\(|\\bRegex\\(");
+
+  /** Char-level scanning: a parser written by hand, where an index slips silently. */
+  private static final Pattern CHAR_SCANNING = Pattern.compile("\\.charAt\\(|\\.codePointAt\\(");
+
+  /** Unicode / whitespace normalization, where an NBSP or zero-width char is the classic miss. */
+  private static final Pattern NORMALIZATION =
+      Pattern.compile("(?i)\\bNormalizer\\b|isWhitespace|\\bNBSP\\b|zero.?width");
+
+  /**
+   * A <em>declared</em> parse/validate/tokenize-style member — the decision boundary lives in its
+   * body. Requires a declaration keyword on the same line so a call like {@code parseInt(...)} does
+   * not trigger.
+   */
+  private static final Pattern HEURISTIC_DECLARATION =
+      Pattern.compile(
+          "(?i)\\b(?:private|public|protected|internal|static|final|fun|def|func)\\b[^(\\r\\n]*"
+              + "\\b(?:parse|validate|isValid|tokeni[sz]e|segment|normali[sz]e|canonicali[sz]e"
+              + "|sanitiz|lex|scan|split)\\w*\\s*\\(");
+
+  /** A tolerance/window constant — the #55 three-line ambiguity window is the motivating shape. */
+  private static final Pattern THRESHOLD_CONSTANT =
+      Pattern.compile(
+          "(?i)\\b(?:static\\s+final|const|val|let|var)\\b[^=\\r\\n]*"
+              + "\\b\\w*(?:WINDOW|THRESHOLD|TOLERANCE|RADIUS|FUZZ|_LINES|LINES_)\\w*\\b[^=\\r\\n]*=");
+
+  /** Diff header naming the file the following hunks belong to. */
+  private static final Pattern DIFF_FILE_HEADER = Pattern.compile("^\\+\\+\\+ b/(.+)$");
+
+  private static final Pattern TEST_PATH =
+      Pattern.compile(
+          "(?i)(?:^|/)(?:test|tests|spec|__tests__)/|[._-](?:test|spec)\\.|Test\\.java$");
+
+  private HeuristicCodeDetector() {}
+
+  /**
+   * Whether any added line outside a test file introduces heuristic code. Scans the unified diff in
+   * one pass over text the review already holds.
+   */
+  static boolean introducesHeuristicCode(String diff) {
+    if (diff == null || diff.isBlank()) {
+      return false;
+    }
+    var inTestFile = false;
+    for (String line : diff.split("\n", -1)) {
+      // Every "+++ " line is a header, including the "+++ /dev/null" of a deletion — consuming them
+      // all here keeps the flag from carrying over to the next file and out of the content check.
+      if (line.startsWith("+++ ")) {
+        var header = DIFF_FILE_HEADER.matcher(line);
+        inTestFile = header.matches() && TEST_PATH.matcher(header.group(1)).find();
+        continue;
+      }
+      if (inTestFile || line.length() < 2 || line.charAt(0) != '+') {
+        continue;
+      }
+      if (isHeuristicLine(line)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isHeuristicLine(String addedLine) {
+    return REGEX_CONSTRUCTION.matcher(addedLine).find()
+        || CHAR_SCANNING.matcher(addedLine).find()
+        || NORMALIZATION.matcher(addedLine).find()
+        || HEURISTIC_DECLARATION.matcher(addedLine).find()
+        || THRESHOLD_CONSTANT.matcher(addedLine).find();
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
@@ -73,11 +73,27 @@ final class HeuristicCodeDetector {
   /** Diff header naming the file the following hunks belong to. */
   private static final Pattern DIFF_FILE_HEADER = Pattern.compile("^\\+\\+\\+ b/(.+)$");
 
-  private static final Pattern TEST_PATH =
-      Pattern.compile(
-          "(?i)(?:(?:^|/)(?:test|tests|spec|__tests__)/|[._-](?:test|spec)\\.|Test\\.java$)");
+  /**
+   * Test-path recognition, split across three patterns rather than one alternation: an anchor
+   * sitting in one branch of a top-level alternation leaves its scope implicit (java:S5850), and
+   * each of these carries at most one anchor and no competing branch.
+   */
+  private static final Pattern TEST_DIRECTORY_SEGMENT =
+      Pattern.compile("(?i)(?:^|/)(?:test|tests|spec|__tests__)/");
+
+  /** A {@code .test.} / {@code _spec.} style marker in the file name. */
+  private static final Pattern TEST_FILENAME_MARKER = Pattern.compile("(?i)[._-](?:test|spec)\\.");
+
+  /** The Java convention, which only counts at the end of the path. */
+  private static final Pattern JAVA_TEST_SUFFIX = Pattern.compile("Test\\.java$");
 
   private HeuristicCodeDetector() {}
+
+  private static boolean isTestPath(String path) {
+    return TEST_DIRECTORY_SEGMENT.matcher(path).find()
+        || TEST_FILENAME_MARKER.matcher(path).find()
+        || JAVA_TEST_SUFFIX.matcher(path).find();
+  }
 
   /**
    * Whether any added line outside a test file introduces heuristic code. Scans the unified diff in
@@ -93,7 +109,7 @@ final class HeuristicCodeDetector {
       // all here keeps the flag from carrying over to the next file and out of the content check.
       if (line.startsWith("+++ ")) {
         var header = DIFF_FILE_HEADER.matcher(line);
-        inTestFile = header.matches() && TEST_PATH.matcher(header.group(1)).find();
+        inTestFile = header.matches() && isTestPath(header.group(1));
         continue;
       }
       if (inTestFile || line.length() < 2 || line.charAt(0) != '+') {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
@@ -46,14 +46,23 @@ final class HeuristicCodeDetector {
 
   /**
    * A <em>declared</em> parse/validate/tokenize-style member — the decision boundary lives in its
-   * body. Requires a declaration keyword on the same line so a call like {@code parseInt(...)} does
-   * not trigger.
+   * body. Three constraints keep ordinary calls out: a declaration keyword on the same line, no
+   * {@code =} before the name (a field initializer is an assignment, not a declaration), and no
+   * {@code .} or word character immediately before it (so the receiver call {@code
+   * Integer.parseInt(...)} cannot pose as a declared {@code parse} member).
    */
   private static final Pattern HEURISTIC_DECLARATION =
       Pattern.compile(
-          "(?i)\\b(?:private|public|protected|internal|static|final|fun|def|func)\\b[^(\\r\\n]*"
-              + "\\b(?:parse|validate|isValid|tokeni[sz]e|segment|normali[sz]e|canonicali[sz]e"
-              + "|sanitiz|lex|scan|split)\\w*\\s*\\(");
+          "(?i)\\b(?:private|public|protected|internal|static|final|fun|def|func)\\b[^(=\\r\\n]*"
+              + "(?<![.\\w])(?:parse|validate|isValid|tokeni[sz]e|segment|normali[sz]e"
+              + "|canonicali[sz]e|sanitiz|lex|scan|split)\\w*\\s*\\(");
+
+  /**
+   * An import/package line mentions a type without using it, so it is never itself heuristic code —
+   * {@code import java.text.Normalizer;} must not stand in for normalization logic.
+   */
+  private static final Pattern DECLARATION_ONLY_LINE =
+      Pattern.compile("^\\+\\s*(?:import|from|package|using|#include)\\b");
 
   /** A tolerance/window constant — the #55 three-line ambiguity window is the motivating shape. */
   private static final Pattern THRESHOLD_CONSTANT =
@@ -98,6 +107,9 @@ final class HeuristicCodeDetector {
   }
 
   private static boolean isHeuristicLine(String addedLine) {
+    if (DECLARATION_ONLY_LINE.matcher(addedLine).find()) {
+      return false;
+    }
     return REGEX_CONSTRUCTION.matcher(addedLine).find()
         || CHAR_SCANNING.matcher(addedLine).find()
         || NORMALIZATION.matcher(addedLine).find()

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssembler.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssembler.java
@@ -68,10 +68,14 @@ public class ReviewPromptAssembler {
             combineSections(
                 combineSections(
                     combineSections(
-                        labelGuidance.isBlank() ? "" : PromptTemplateEscaper.escape(labelGuidance),
-                        diagramGuidance),
-                    mockFidelitySection(relatedTests)),
-                bugFixEfficacySection(req.prDescription(), ctx.linkedIssuesContext())),
+                        combineSections(
+                            labelGuidance.isBlank()
+                                ? ""
+                                : PromptTemplateEscaper.escape(labelGuidance),
+                            diagramGuidance),
+                        mockFidelitySection(relatedTests)),
+                    bugFixEfficacySection(req.prDescription(), ctx.linkedIssuesContext())),
+                heuristicFailureModesSection(ctx.diff())),
             PromptSections.instructionsSection(ctx.instructions(), INSTRUCTIONS_GUIDANCE));
     return new AiReviewService.PromptInputs(
         fencedDiff,
@@ -93,6 +97,18 @@ public class ReviewPromptAssembler {
       return "";
     }
     return PrReviewPrompts.MOCK_FIDELITY_REQUEST;
+  }
+
+  /**
+   * Failure-mode characterization guidance — empty unless the diff introduces parsing / regex /
+   * validation / heuristic code, whose defects need synthesized inputs rather than closer reading
+   * (issue #123).
+   */
+  static String heuristicFailureModesSection(String diff) {
+    if (!HeuristicCodeDetector.introducesHeuristicCode(diff)) {
+      return "";
+    }
+    return PrReviewPrompts.HEURISTIC_FAILURE_MODES_REQUEST;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
@@ -150,6 +150,20 @@ public final class FindingVerifierPrompts {
             line and contradicting real-method line named is the expected shape — downgrade
             inflated severity at most; do not reject as unverifiable when both sides are shown.
 
+            A heuristic-limitation finding — one claiming a newly-added regex, parser, tokenizer,
+            normalizer, validator, or scope/threshold rule mishandles an input — is judged on the
+            rule's mechanics, NOT on whether the input appears in the diff. The triggering input
+            is the finding's own construction and is absent from the diff by definition, so the
+            verbatim-quote and "unverifiable here" grounds above do not apply to it: requiring the
+            input to be quoted would reject this entire class, which is exactly the blind spot the
+            characterization pass exists to cover. Confirm or downgrade it by tracing the quoted
+            rule against the named input yourself — reject it only when that trace shows the rule
+            handles the input correctly, when the rule it describes is not in the diff, or when it
+            names no concrete input at all. A silent miss (the rule accepts or skips what it
+            should catch) is a real defect even though nothing in the diff looks wrong, and being
+            unable to execute the rule here is not grounds for rejection: confidence "low" or
+            "medium" with the rule line quoted and the probing input named is the expected shape.
+
             Severity calibration: "critical" and "high" risk require breakage demonstrable from
             the provided diff and context. A config/IaC defect whose breakage is visible in the
             manifest text in the diff — a field that fails schema validation, an over-broad RBAC

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -528,5 +528,39 @@ public final class PrReviewPrompts {
             - A faithful stub that matches the real contract is not a finding."""
           .stripIndent();
 
+  public static final String HEURISTIC_FAILURE_MODES_REQUEST =
+      """
+            ## Heuristic Failure-Mode Characterization
+            This PR introduces parsing, regex, validation, or heuristic code. Do not grade it the
+            way you grade a null check. It is a function whose decision boundary you must
+            characterize, and the input that breaks it is by definition NOT in the diff — so
+            re-reading the added lines cannot find the defect. For those hunks only:
+            - Identify each new decision rule: a regex or `Pattern.compile`, a tokenizer or
+              segmenter, a normalize/compact step, a matching or scoping rule, a threshold or
+              window constant.
+            - For each, SYNTHESIZE the inputs that probe its edges and name them literally in the
+              description. Work from the rule's own mechanics, for example: a paren-counting
+              regex meets a lambda or a nested call; an ASCII whitespace class meets a non-breaking
+              space, a zero-width joiner, or a line-wrapped string; a line-oriented rule meets a
+              CRLF file or a line with no trailing newline; a scope window meets an occurrence one
+              line outside it; a "starts with" check meets the token inside a fenced code block or
+              a blockquote; a presence check meets a value that is present but the wrong shape
+              (non-numeric where a number is required).
+            - Report BOTH directions, and weight the one the code cannot tell you about: a false
+              positive (it matches what it should not) is visible when you read the rule; a false
+              NEGATIVE (it silently misses, mis-segments, or accepts) is the defect class this
+              section exists for. "Handles the shown cases correctly" is not a conclusion — say
+              which inputs you probed and which the rule mishandles.
+            - Anchor at the new rule's line and quote that line. The synthesized input is your
+              own construction and will NOT appear in the diff — say so plainly ("input not in
+              the diff: ..."), and never present it as quoted material.
+            - Use confidence "low" or "medium" and phrase the consequence as a verification
+              request naming the input to try. A limitation you cannot execute here is still worth
+              reporting at that confidence; it is not a nitpick and the uncertainty is inherent to
+              the claim, not a reason to omit it.
+            - A rule whose edges you probed and found sound is not a finding. Say nothing rather
+              than manufacturing a limitation."""
+          .stripIndent();
+
   private PrReviewPrompts() {}
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the #123 trigger in both directions. Recall matters (a missed regex means the review never
+ * characterizes it) but so does precision: the guidance costs prompt budget on every PR it fires
+ * for, so ordinary string handling must not trigger it.
+ */
+class HeuristicCodeDetectorTest {
+
+  private static String diff(String path, String... addedLines) {
+    var sb = new StringBuilder("diff --git a/").append(path).append(" b/").append(path);
+    sb.append("\n--- a/")
+        .append(path)
+        .append("\n+++ b/")
+        .append(path)
+        .append("\n@@ -1,3 +1,6 @@\n");
+    for (String line : addedLines) {
+      sb.append('+').append(line).append('\n');
+    }
+    return sb.toString();
+  }
+
+  @Test
+  void shouldNotTriggerOnAbsentOrEmptyDiff() {
+    assertFalse(HeuristicCodeDetector.introducesHeuristicCode(null));
+    assertFalse(HeuristicCodeDetector.introducesHeuristicCode(""));
+    assertFalse(HeuristicCodeDetector.introducesHeuristicCode("   "));
+  }
+
+  @Test
+  void shouldTriggerOnNewCompiledRegex() {
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java",
+                "  private static final Pattern PAUSE ="
+                    + " Pattern.compile(\".*(?:^|\\\\s)/pause(?:\\\\s|$).*\", Pattern.DOTALL);")));
+  }
+
+  @Test
+  void shouldTriggerOnRegexConstructionInOtherLanguages() {
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("frontend/src/parse.ts", "const RE = new RegExp('^v[0-9]+');")));
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("scripts/check.py", "TAG = re.compile(r'^v\\\\d+')")));
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("cmd/main.go", "var tag = regexp.MustCompile(`^v\\\\d+`)")));
+  }
+
+  @Test
+  void shouldTriggerOnCharLevelScanning() {
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/Formatter.java",
+                "    if (raw.charAt(0) == '@') {")));
+  }
+
+  @Test
+  void shouldTriggerOnUnicodeOrWhitespaceNormalization() {
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/Compact.java",
+                "    return Normalizer.normalize(in, Normalizer.Form.NFKC);")));
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/Compact.java",
+                "    while (Character.isWhitespace(c)) {")));
+  }
+
+  @Test
+  void shouldTriggerOnDeclaredValidatorSoPresenceOnlyChecksGetProbed() {
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java",
+                "  private void validateAppId(String appId) {")));
+  }
+
+  @Test
+  void shouldTriggerOnWindowOrThresholdConstant() {
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java",
+                "  private static final int AMBIGUITY_WINDOW_LINES = 3;")));
+  }
+
+  @Test
+  void shouldIgnoreHeuristicCodeAddedOnlyInTestFiles() {
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/test/java/dev/thiagogonzaga/thrillhousebot/review/SomethingTest.java",
+                "    var re = Pattern.compile(\"^fixture$\");")));
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("frontend/src/__tests__/page.spec.ts", "const RE = new RegExp('fixture');")));
+  }
+
+  @Test
+  void shouldStillTriggerWhenProductionAndTestFilesBothChange() {
+    String combined =
+        diff("src/test/java/dev/thiagogonzaga/FooTest.java", "    var re = Pattern.compile(\"x\");")
+            + diff("src/main/java/dev/thiagogonzaga/Foo.java", "  int i = s.charAt(2);");
+    assertTrue(HeuristicCodeDetector.introducesHeuristicCode(combined));
+  }
+
+  @Test
+  void shouldNotTriggerOnOrdinaryStringHandling() {
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/Service.java",
+                "    var name = payload.trim();",
+                "    if (body.indexOf(\"x\") > 0) {",
+                "    var head = body.substring(0, 10);",
+                "    int id = Integer.parseInt(raw);",
+                "    if (path.matches(other)) {")));
+  }
+
+  @Test
+  void shouldNotTriggerOnRemovedHeuristicCode() {
+    String removal =
+        "--- a/src/main/java/dev/thiagogonzaga/Old.java\n"
+            + "+++ b/src/main/java/dev/thiagogonzaga/Old.java\n"
+            + "@@ -1,3 +1,2 @@\n"
+            + "-  private static final Pattern P = Pattern.compile(\"x\");\n"
+            + "   int keep = 1;\n";
+    assertFalse(HeuristicCodeDetector.introducesHeuristicCode(removal));
+  }
+
+  @Test
+  void shouldNotCarryTheTestFileFlagPastADeletedFile() {
+    // A deletion's "+++ /dev/null" must reset the flag, or the production file that follows a
+    // deleted test file would inherit inTestFile and go unscanned.
+    String combined =
+        "--- a/src/test/java/dev/thiagogonzaga/GoneTest.java\n"
+            + "+++ b/src/test/java/dev/thiagogonzaga/GoneTest.java\n"
+            + "@@ -1,2 +1,3 @@\n"
+            + "+    var re = Pattern.compile(\"fixture\");\n"
+            + "--- a/src/main/java/dev/thiagogonzaga/Dropped.java\n"
+            + "+++ /dev/null\n"
+            + "@@ -1,2 +0,0 @@\n"
+            + "-  int gone = 1;\n"
+            + diff("src/main/java/dev/thiagogonzaga/Kept.java", "  int i = s.charAt(2);");
+    assertTrue(HeuristicCodeDetector.introducesHeuristicCode(combined));
+  }
+
+  @Test
+  void shouldNotTriggerOnDiffHeaderTextAlone() {
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            "--- a/src/main/java/dev/thiagogonzaga/Parser.java\n"
+                + "+++ b/src/main/java/dev/thiagogonzaga/Parser.java\n"
+                + "@@ -1,2 +1,2 @@\n"
+                + "   int unchanged = 1;\n"));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
@@ -145,6 +145,42 @@ class HeuristicCodeDetectorTest {
   }
 
   @Test
+  void shouldNotTriggerOnReceiverCallsThatMerelyStartWithAHeuristicName() {
+    // A declaration keyword plus Integer.parseInt(...) is an assignment, not a declared parser.
+    // The earlier ordinary-string-handling case used no declaration keyword and so missed this.
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/Service.java",
+                "  private int id = Integer.parseInt(raw);",
+                "  private static final long WAIT = Long.parseLong(env);",
+                "  public boolean ok = validator.validate(input);")));
+  }
+
+  @Test
+  void shouldNotTriggerOnImportOrPackageLines() {
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/Service.java",
+                "import java.text.Normalizer;",
+                "import java.util.regex.Pattern;")));
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("scripts/tool.py", "from re import compile")));
+  }
+
+  @Test
+  void shouldStillTriggerWhenTheImportIsAccompaniedByRealUse() {
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/Compact.java",
+                "import java.text.Normalizer;",
+                "    return Normalizer.normalize(in, Normalizer.Form.NFKC);")));
+  }
+
+  @Test
   void shouldNotTriggerOnRemovedHeuristicCode() {
     String removal =
         "--- a/src/main/java/dev/thiagogonzaga/Old.java\n"

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
@@ -124,6 +124,21 @@ class HeuristicCodeDetectorTest {
   }
 
   @Test
+  void shouldIgnoreTestFilesRecognisedByFilenameRatherThanDirectory() {
+    // No test directory in either path, so these reach the filename marker and the Java suffix —
+    // the two checks a path like src/test/java/... short-circuits past.
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("frontend/src/page.spec.ts", "const RE = new RegExp('fixture');")));
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("frontend/src/parse.test.ts", "const RE = new RegExp('fixture');")));
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("app/src/FindingQuoteValidatorTest.java", "    if (raw.charAt(0) == '@') {")));
+  }
+
+  @Test
   void shouldStillTriggerWhenProductionAndTestFilesBothChange() {
     String combined =
         diff("src/test/java/dev/thiagogonzaga/FooTest.java", "    var re = Pattern.compile(\"x\");")

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssemblerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssemblerTest.java
@@ -63,6 +63,30 @@ class ReviewPromptAssemblerTest {
   }
 
   @Test
+  void shouldOmitHeuristicSectionWhenDiffAddsNoHeuristicCode() {
+    assertEquals("", ReviewPromptAssembler.heuristicFailureModesSection(null));
+    assertEquals("", ReviewPromptAssembler.heuristicFailureModesSection(""));
+    assertEquals(
+        "",
+        ReviewPromptAssembler.heuristicFailureModesSection(
+            "--- a/src/main/java/dev/thiagogonzaga/Service.java\n"
+                + "+++ b/src/main/java/dev/thiagogonzaga/Service.java\n"
+                + "@@ -1,2 +1,3 @@\n"
+                + "+    var trimmed = payload.trim();\n"));
+  }
+
+  @Test
+  void shouldEmitHeuristicSectionWhenDiffAddsARegex() {
+    assertEquals(
+        PrReviewPrompts.HEURISTIC_FAILURE_MODES_REQUEST,
+        ReviewPromptAssembler.heuristicFailureModesSection(
+            "--- a/src/main/java/dev/thiagogonzaga/Trigger.java\n"
+                + "+++ b/src/main/java/dev/thiagogonzaga/Trigger.java\n"
+                + "@@ -1,2 +1,3 @@\n"
+                + "+  private static final Pattern P = Pattern.compile(\"/pause\");\n"));
+  }
+
+  @Test
   void shouldOmitBugFixSectionWhenPrIsNotABugFix() {
     assertEquals("", ReviewPromptAssembler.bugFixEfficacySection("Adds a new feature", "ctx"));
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -23,10 +23,10 @@ import org.junit.jupiter.api.Test;
  * Pins review/verifier prompt guidance so a future edit cannot silently revert it. Covers the
  * config/IaC severity recalibration (so declarative findings are not suppressed), the
  * parameter-nullability / unseen-caller guard (#107), the in-diff-test exercise gate (a green test
- * must demonstrably hit the claimed path before it can invalidate a finding — #116), and the
- * symmetric exact-arithmetic / "test fails" cap (#97). These assertions are intentionally coarse —
- * they check intent survives, not exact wording; an intentional rewording should update the
- * matching anchor.
+ * must demonstrably hit the claimed path before it can invalidate a finding — #116), the symmetric
+ * exact-arithmetic / "test fails" cap (#97), and the heuristic failure-mode characterization pass
+ * with its verifier exemption (#123). These assertions are intentionally coarse — they check intent
+ * survives, not exact wording; an intentional rewording should update the matching anchor.
  *
  * <p>The automated LLM eval that checks the model actually <em>acts</em> on this guidance is
  * tracked separately ({@code evalcorpus/}); this is the cheap deterministic guard.
@@ -252,6 +252,48 @@ class PrReviewPromptsContentTest {
         sys,
         "parameter-nullability / precondition claim is demonstrable when",
         "verifier severity calibration must reject unseen-caller precondition claims");
+  }
+
+  @Test
+  void heuristicRequestDemandsSynthesizedInputsAndFalseNegativeReporting() {
+    String req = PrReviewPrompts.HEURISTIC_FAILURE_MODES_REQUEST;
+    assertContains(
+        req,
+        "SYNTHESIZE",
+        "the characterization pass must instruct the model to invent probing inputs");
+    assertContains(
+        req,
+        "NEGATIVE (it silently misses",
+        "the pass must weight silent misses, not only visible false positives");
+    assertContains(
+        req,
+        "never present it as quoted material",
+        "a synthesized input must be labelled as absent from the diff, not quoted as material");
+    assertContains(
+        req,
+        "not a nitpick",
+        "an unexecutable heuristic limitation must not be omitted as uncertain");
+  }
+
+  @Test
+  void verifierPromptExemptsHeuristicLimitationsFromTheQuotedInputRule() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "A heuristic-limitation finding",
+        "verifier must judge heuristic-limitation findings on their own terms");
+    assertContains(
+        sys,
+        "absent from the diff by definition",
+        "verifier must accept that the triggering input cannot appear in the diff");
+    assertContains(
+        sys,
+        "would reject this entire class",
+        "verifier must be told the quote rule would otherwise erase the whole finding class");
+    assertContains(
+        sys,
+        "not grounds for rejection",
+        "inability to execute the rule must not become a rejection ground");
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature

## Description

When a diff introduces parsing / regex / validation / heuristic code, the pipeline graded it the way
it grades a null check — re-reading the added lines for happy-path correctness. It never treated the
new code as **a function whose decision boundary must be characterized**. Confirming a defect there
requires *inventing an input the diff does not contain by definition*, and both prompts feed only
diff text, so the bot's own three review rounds on PR #114 returned "No issues found" while human
review found ~10 precision/recall defects in that very code.

Three changes:

**1. A new conditional section, `PrReviewPrompts.HEURISTIC_FAILURE_MODES_REQUEST`.** It instructs the
reviewer to identify each new decision rule, *synthesize* the inputs that probe its edges and name
them literally, and report **both** directions — weighting the false negative, since a rule that
silently misses looks correct on the page while a false positive is visible on reading. The
synthesized input must be labelled as absent from the diff ("input not in the diff: …") so it is
never presented as quoted material. Concrete probes are seeded from the shapes in the issue and its
comments: a paren-counting regex meeting a lambda, an ASCII whitespace class meeting an NBSP or
zero-width joiner, a scope window meeting an occurrence one line outside it, a "starts with" check
meeting the token inside a fenced code block (the #160 `/pause` case), and a presence check meeting a
present-but-wrong-shape value (the #157 non-numeric `GITHUB_APP_ID` case).

**2. `HeuristicCodeDetector`** gates it, following `bugFixEfficacySection`'s precedent — the section
is empty unless the diff actually adds such code. Signals: regex construction (Java/JS/Python/Go/
Kotlin), char-level scanning, Unicode/whitespace normalization, a *declared* parse/validate/tokenize
member, and window/threshold constants.

**3. A verifier exemption in `FindingVerifierPrompts.SYSTEM`.** This is the load-bearing part. A
heuristic-limitation finding is *about* an input that cannot appear in the diff, so the existing
verbatim-quote and "unverifiable here" rejection grounds would erase the entire class this capability
generates. The verifier is now told to judge such findings on the rule's mechanics — trace the quoted
rule against the named input — and that inability to execute the rule is not grounds for rejection.

**Deliberately out of scope:** executing the synthesized inputs. That is #96 (unscheduled), which the
issue notes must be extended to accept synthesized inputs rather than only running the diff's
existing tests. This PR delivers generation and reporting, not proof — so findings land at
confidence "low"/"medium" as verification requests.

### Precision over recall on the trigger

The detector deliberately excludes `substring`, `indexOf`, `trim`, `matches` and `parseInt`. They
appear in most diffs, and a trigger that fires on most diffs spends prompt budget on every review
without adding an angle. `parse`/`validate`-style names count only as **declarations**: a declaration keyword on the
same line, no `=` before the name, and no `.` or word char immediately before it — so neither a bare
`parseInt(...)` call nor `private int id = Integer.parseInt(raw)` triggers. Import/package lines are
skipped too, so `import java.text.Normalizer;` cannot stand in for normalization logic. Test files are
skipped — a regex there is usually a fixture. `shouldNotTriggerOnOrdinaryStringHandling` pins this.

### Note on the hedging demotion

The issue lists the `\b(may|might|could...)\b` demotion in `FindingVerificationService` as a force
that scrubs these inherently-probabilistic findings, deferring the fix to #105. That turned out not
to need changing: the demotion drops a hedged blocking finding to *medium confidence*, not to
dropped — it still posts. So no change there, keeping this diff focused.

## Related Issues

Fixes #123

Motivating dogfood case: PR #114 / `FindingQuoteValidator`. Recall seeds named in the issue comments:
#160 (`/pause` inside a code fence), #157 (non-numeric `GITHUB_APP_ID`) — both good candidates to add
to #113's corpus as a follow-up. #63 remains the natural host if this becomes a dedicated agent role.

## How Has This Been Tested?

- [x] Unit tests

- **`HeuristicCodeDetectorTest`** (13 tests, new) — triggers for each signal class in both directions,
  including the two recall seeds, test-file exclusion, removed-heuristic code, and a deleted-file
  hunk.
- **`ReviewPromptAssemblerTest`** (+2) — section empty on ordinary string handling, emitted on a new
  regex.
- **`PrReviewPromptsContentTest`** (+2) — anchors on the request text and the verifier exemption.

Local gates, all green:

- `./mvnw spotless:apply` + `spotless:check`
- `./mvnw verify` — **1800 tests, 0 failures**, SpotBugs `BugInstance size is 0`, JaCoCo gate met
- JaCoCo on the new class: **fully covered**, 0 missed instructions/branches/lines

Coverage-chasing on the last uncovered branch surfaced a real defect, now fixed and pinned by
`shouldNotCarryTheTestFileFlagPastADeletedFile`: a deletion emits `+++ /dev/null`, which the header
regex does not match, so `inTestFile` carried over from the previous file. All `+++ ` lines are now
consumed in one place, which resets the flag and removes a redundant guard.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code