### PR TITLE
test(webhook): remove the interrupt-test race that fails CI with UnnecessaryStubbing

### DIFF
--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/AckReactionServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/AckReactionServiceTest.java
@@ -25,6 +25,7 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubReactionClient;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -156,26 +157,46 @@ class AckReactionServiceTest {
   }
 
   @Test
-  void shouldRestoreInterruptFlagWhenInterrupted() {
-    // Block the reaction so the wait cannot return before noticing the interrupt — Future.get only
-    // throws InterruptedException when it actually has to wait, so an already-completed task would
-    // race past the interrupted path.
+  void shouldRestoreInterruptFlagWhenInterrupted() throws Exception {
+    // Interrupting before addEyes makes the stub's use a race: awaitDone throws on its first
+    // iteration while the task is still NEW, so the wait can end before the virtual thread ever
+    // calls the client, and strict stubs then fails with UnnecessaryStubbing — intermittently, and
+    // only under load, which is why it surfaced in CI and not locally. Ordering is therefore
+    // explicit: enter the stub, then interrupt, then assert.
+    var entered = new CountDownLatch(1);
     var release = new CountDownLatch(1);
     doAnswer(
             invocation -> {
+              entered.countDown();
               release.await(5, TimeUnit.SECONDS);
               return null;
             })
         .when(reactionClient)
         .createIssueCommentReaction(
             anyString(), anyString(), anyString(), anyString(), anyLong(), any());
-    Thread.currentThread().interrupt();
 
-    assertDoesNotThrow(
-        () -> service.addEyes(42L, "owner", "repo", 1001L, AckReactionService.CommentKind.ISSUE));
+    var interruptFlagAfterCall = new AtomicBoolean();
+    var returned = new CountDownLatch(1);
+    var caller =
+        new Thread(
+            () -> {
+              service.addEyes(42L, "owner", "repo", 1001L, AckReactionService.CommentKind.ISSUE);
+              interruptFlagAfterCall.set(Thread.currentThread().isInterrupted());
+              returned.countDown();
+            },
+            "ack-interrupt-caller");
+    caller.start();
 
-    // The interrupt is swallowed for the caller but must stay visible on the thread.
-    assertTrue(Thread.interrupted());
+    assertTrue(entered.await(5, TimeUnit.SECONDS), "reaction call never started");
+    caller.interrupt();
+
+    // The interrupt is swallowed for the caller — addEyes returns instead of throwing.
+    assertTrue(returned.await(5, TimeUnit.SECONDS), "addEyes never returned after the interrupt");
     release.countDown();
+    caller.join(5_000);
+
+    // Only the production catch block can have set this: the test never interrupts this thread
+    // before addEyes, so a missing Thread.currentThread().interrupt() fails here.
+    assertTrue(interruptFlagAfterCall.get(), "interrupt flag must stay visible on the caller");
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] ✅ Test

## Description

`AckReactionServiceTest.shouldRestoreInterruptFlagWhenInterrupted` intermittently fails CI with
Mockito's `UnnecessaryStubbingException`, while passing locally every time. It made PR #420's CI go
red for a change that touches only `review/`.

### Root cause

The test interrupted the calling thread **before** invoking `addEyes`:

```java
doAnswer(inv -> { release.await(5, SECONDS); return null; })   // block the reaction
    .when(reactionClient).createIssueCommentReaction(...);
Thread.currentThread().interrupt();                             // ← before the call
service.addEyes(...);
```

`addEyes` submits to a **virtual-thread-per-task executor** and then calls `reaction.get(timeout)`.
`FutureTask.awaitDone` checks task state first and the interrupt flag second, so with the flag
already set and the task still `NEW`, it throws `InterruptedException` on its *first loop iteration*
— with no dependency on whether the virtual thread has been scheduled yet.

So whether `createIssueCommentReaction` is ever called is a race the test does not control. When the
worker loses it, the `doAnswer` stub goes unused and strict stubs fails the run. `tearDown`'s
`reactionExecutor.shutdownNow()` can also interrupt the worker before it reaches the client. The
blocking stub was added to stop an already-completed task from racing past the interrupted path — it
does that, but it cannot make its own invocation happen before the wait ends.

This is load-dependent, which is exactly why it reproduces on a CI runner and not on a developer
machine.

### Evidence it is a race, not a defect

The same commit `0c9dd47` (PR #420) ran the `test` job twice:

| Job | Result |
|---|---|
| 89802238955 | `Tests run: 1803, Failures: 0, Errors: 0` |
| 89803263541 (rerun) | `Tests run: 1803, Failures: 0, Errors: 1` — this test, `» UnnecessaryStubbing` |

Identical code, identical test set.

### Fix

Make the ordering explicit instead of hoping for an interleaving:

1. The stub counts down an `entered` latch, and the test awaits it — so the stub is **always** used,
   and the wait is **always** genuinely in progress before the interrupt lands.
2. `addEyes` runs on its own named thread, interrupted only after `entered` fires — so
   `InterruptedException` from `get()` is guaranteed rather than incidental.
3. The flag is read on that thread after `addEyes` returns, via an `AtomicBoolean`.

Side benefit: the shared JUnit thread is never interrupted now. The old test relied on
`assertTrue(Thread.interrupted())` to both assert *and* clear the flag on the test-runner thread; a
future edit that reordered or short-circuited that line would have leaked an interrupt into
subsequent tests in the same thread.

No production change. `lenient()` was deliberately **not** used — it would have hidden the race
rather than removed it, and the stub genuinely should be invoked on this path.

## Related Issues

N/A — flake found while working #123 (PR #420).

Introduced by the `@InjectMocks` conversion in #410? No: the race predates it. #410 changed SUT
construction only; the pre-interrupt ordering is from #346, which added the test. Calling it out
because #410 was the last commit to touch the file and is a natural first suspect.

## How Has This Been Tested?

- [x] Unit tests

- **Mutation-verified non-vacuous**: deleting `Thread.currentThread().interrupt()` from
  `AckReactionService`'s `catch (InterruptedException)` fails the new test on
  `"interrupt flag must stay visible on the caller"`. Restored afterwards; no production diff in
  this PR. (The old test also caught that mutation — `awaitDone` clears the flag via
  `Thread.interrupted()` before throwing, so the restore was always genuinely required. The old
  assertion had teeth; only the stub's use was racy.)
- **Full suite twice under CPU saturation** (8 busy loops, to mimic a contended runner):
  `Tests run: 1783, Failures: 0, Errors: 0` both times, no `UnnecessaryStubbing`.
- `./mvnw verify` — 1783 tests, SpotBugs `BugInstance size is 0`, JaCoCo gate met.

Note: the original flake did **not** reproduce locally in 5 runs even under saturation, so the
justification rests on the `FutureTask.awaitDone` mechanics plus the same-commit CI divergence above,
not on a local repro.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code