### PR TITLE
test(frontend): add Vitest coverage for the overview and sessions dashboard pages (#15, #16)

### DIFF
--- a/frontend/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/app/(dashboard)/overview/page.test.tsx
@@ -1,0 +1,132 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import OverviewPage from './page';
+import { api } from '@/lib/api';
+import { useWebSocket, SessionEvent } from '@/hooks/useWebSocket';
+import { mockSummary } from '@/lib/mock-data';
+
+vi.mock('@/lib/api', () => ({
+  api: vi.fn(),
+}));
+
+vi.mock('@/hooks/useWebSocket', () => ({
+  useWebSocket: vi.fn(),
+}));
+
+function socket(events: SessionEvent[] = [], connected = true) {
+  vi.mocked(useWebSocket).mockReturnValue({ events, connected });
+}
+
+function startedEvent(overrides: Partial<SessionEvent> = {}): SessionEvent {
+  return {
+    type: 'review.started',
+    sessionId: 7,
+    repository: 'devops-thiago/ThrillhouseBot',
+    prNumber: 99,
+    prTitle: 'Live streaming PR',
+    timestamp: '2026-07-26T12:00:00Z',
+    ...overrides,
+  } as SessionEvent;
+}
+
+describe('OverviewPage', () => {
+  afterEach(() => cleanup());
+
+  beforeEach(() => {
+    socket();
+    vi.mocked(api).mockReturnValue({
+      summary: vi.fn().mockResolvedValue(mockSummary),
+    } as unknown as ReturnType<typeof api>);
+  });
+
+  it('renders summary stats once the API resolves', async () => {
+    render(<OverviewPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('42')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('heading', { name: 'Dashboard Overview' })).toBeInTheDocument();
+    expect(screen.getByText('38')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('$0.1284')).toBeInTheDocument();
+    expect(screen.getByText('deepseek-chat')).toBeInTheDocument();
+  });
+
+  it('shows placeholder values while the summary is still loading', () => {
+    // The page keeps stale data rather than swapping in a "Loading..." block, so the
+    // pre-resolve state is an em dash in every card — five cards, five placeholders.
+    vi.mocked(api).mockReturnValue({
+      summary: vi.fn().mockReturnValue(new Promise(() => {})),
+    } as unknown as ReturnType<typeof api>);
+
+    render(<OverviewPage />);
+
+    expect(screen.getAllByText('—')).toHaveLength(5);
+    expect(screen.getByRole('heading', { name: 'Dashboard Overview' })).toBeInTheDocument();
+  });
+
+  it('shows an error with retry when the summary fails, then recovers', async () => {
+    let calls = 0;
+    const summary = vi.fn().mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.reject(new Error('API error: 500'));
+      }
+      return Promise.resolve(mockSummary);
+    });
+    vi.mocked(api).mockReturnValue({ summary } as unknown as ReturnType<typeof api>);
+
+    render(<OverviewPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not load summary metrics: API error: 500/)).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+      expect(screen.getByText('42')).toBeInTheDocument();
+    });
+    expect(summary.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('reflects websocket connection state in the live output heading', async () => {
+    socket([], false);
+    render(<OverviewPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /Live Model Output 🔴/ })).toBeInTheDocument();
+    });
+  });
+
+  it('renders a live review and recent activity from a review.started event', async () => {
+    socket([startedEvent()]);
+    render(<OverviewPage />);
+
+    // One event feeds two sections, so the title appears in the live card and the activity feed.
+    await waitFor(() => {
+      expect(screen.getAllByText('Live streaming PR')).toHaveLength(2);
+    });
+
+    expect(
+      screen.getByText('devops-thiago/ThrillhouseBot#99', { selector: 'span' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Review in progress…')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No active reviews\. Open a PR to watch the model/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/No recent reviews\./)).not.toBeInTheDocument();
+  });
+
+  it('invites activity when no lifecycle events have arrived', async () => {
+    render(<OverviewPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No active reviews\./)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/No recent reviews\./)).toBeInTheDocument();
+  });
+});

--- a/frontend/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/app/(dashboard)/sessions/page.test.tsx
@@ -1,0 +1,184 @@
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import SessionsPage from './page';
+import { api } from '@/lib/api';
+import { mockSessionDetail, mockSessions } from '@/lib/mock-data';
+
+vi.mock('@/lib/api', () => ({
+  api: vi.fn(),
+}));
+
+function listPage(overrides: Partial<{ total: number; page: number }> = {}) {
+  return {
+    sessions: mockSessions,
+    total: overrides.total ?? mockSessions.length,
+    page: overrides.page ?? 0,
+    size: 20,
+  };
+}
+
+describe('SessionsPage', () => {
+  afterEach(() => {
+    cleanup();
+    window.history.replaceState(null, '', '/');
+  });
+
+  beforeEach(() => {
+    vi.mocked(api).mockReturnValue({
+      sessions: vi.fn().mockResolvedValue(listPage()),
+      session: vi.fn().mockResolvedValue(mockSessionDetail),
+    } as unknown as ReturnType<typeof api>);
+  });
+
+  it('renders session rows once the list API resolves', async () => {
+    render(<SessionsPage />);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Session History' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('devops-thiago/ThrillhouseBot')).toBeInTheDocument();
+    expect(screen.getByText('#12')).toBeInTheDocument();
+    expect(screen.getByText('deepseek-chat')).toBeInTheDocument();
+  });
+
+  it('shows an error with retry when the list API fails, then recovers', async () => {
+    let calls = 0;
+    const sessions = vi.fn().mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.reject(new Error('API error: 500'));
+      }
+      return Promise.resolve(listPage());
+    });
+    vi.mocked(api).mockReturnValue({
+      sessions,
+      session: vi.fn().mockResolvedValue(mockSessionDetail),
+    } as unknown as ReturnType<typeof api>);
+
+    render(<SessionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/API error: 500/)).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+      expect(screen.getByText('#12')).toBeInTheDocument();
+    });
+    expect(sessions.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('loads session detail when a row is selected and reflects it in the URL', async () => {
+    const session = vi.fn().mockResolvedValue(mockSessionDetail);
+    vi.mocked(api).mockReturnValue({
+      sessions: vi.fn().mockResolvedValue(listPage()),
+      session,
+    } as unknown as ReturnType<typeof api>);
+
+    render(<SessionsPage />);
+    await waitFor(() => {
+      expect(screen.getByText('#12')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'View' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Session #1' })).toBeInTheDocument();
+    });
+    expect(session).toHaveBeenCalledWith(1);
+    // Selecting deep-links the row so the panel survives a reload/share.
+    expect(new URLSearchParams(window.location.search).get('id')).toBe('1');
+
+    const panel = screen.getByRole('heading', { name: 'Session #1' }).parentElement!.parentElement!;
+    expect(within(panel).getByText('abc1234')).toBeInTheDocument();
+  });
+
+  it('opens the detail panel straight from an ?id= deep link', async () => {
+    window.history.replaceState(null, '', '/?id=1');
+    const session = vi.fn().mockResolvedValue(mockSessionDetail);
+    vi.mocked(api).mockReturnValue({
+      sessions: vi.fn().mockResolvedValue(listPage()),
+      session,
+    } as unknown as ReturnType<typeof api>);
+
+    render(<SessionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Session #1' })).toBeInTheDocument();
+    });
+    expect(session).toHaveBeenCalledWith(1);
+  });
+
+  it('ignores a non-numeric ?id= rather than requesting it', async () => {
+    window.history.replaceState(null, '', '/?id=not-a-number');
+    const session = vi.fn().mockResolvedValue(mockSessionDetail);
+    vi.mocked(api).mockReturnValue({
+      sessions: vi.fn().mockResolvedValue(listPage()),
+      session,
+    } as unknown as ReturnType<typeof api>);
+
+    render(<SessionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('#12')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('heading', { name: /^Session #/ })).not.toBeInTheDocument();
+    expect(session).not.toHaveBeenCalled();
+  });
+
+  it('reports a detail fetch failure inside the panel', async () => {
+    vi.mocked(api).mockReturnValue({
+      sessions: vi.fn().mockResolvedValue(listPage()),
+      session: vi.fn().mockRejectedValue(new Error('detail boom')),
+    } as unknown as ReturnType<typeof api>);
+
+    render(<SessionsPage />);
+    await waitFor(() => {
+      expect(screen.getByText('#12')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'View' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Could not load session details.')).toBeInTheDocument();
+    });
+  });
+
+  it('pages forward when the total exceeds one page', async () => {
+    const sessions = vi.fn().mockResolvedValue(listPage({ total: 45 }));
+    vi.mocked(api).mockReturnValue({
+      sessions,
+      session: vi.fn().mockResolvedValue(mockSessionDetail),
+    } as unknown as ReturnType<typeof api>);
+
+    render(<SessionsPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Page 1 of 3')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: '← Previous' })).toBeDisabled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Next →' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Page 2 of 3')).toBeInTheDocument();
+    });
+    expect(sessions).toHaveBeenLastCalledWith(1);
+  });
+
+  it('disables paging when a single page holds every session', async () => {
+    render(<SessionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Page 1 of 1')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: '← Previous' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Next →' })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## What type of PR is this?

- [x] ✅ Test

## Description

`costs` and `tokens` had Vitest coverage; `overview` and `sessions` — the two most interactive
screens — had none. Adds both, following the `costs/page.test.tsx` pattern (mock `@/lib/api`, drive
fixtures from `@/lib/mock-data`).

**Two issues, one PR, one commit each.** They are sibling pages, test-only, touch no shared file, and
SonarCloud's quality gate is timing out on every PR today — so one CI cycle instead of two. Trivial to
split if you'd rather merge them separately.

### `overview/page.test.tsx` (#15) — 6 tests

Summary render from `mockSummary`; placeholder state before the API resolves; error + **Retry** and
recovery; websocket connection state in the *Live Model Output* heading; a `review.started` event
driving the live-review card and activity feed; and the empty-state copy when no events have arrived.

`@/hooks/useWebSocket` is mocked with controllable `events`/`connected`, per the issue.

### `sessions/page.test.tsx` (#16) — 8 tests

List render; error + **Retry** and recovery; row selection loading detail *and* deep-linking `?id=`;
restoring the panel straight from an `?id=` link; ignoring a non-numeric `?id=` without requesting it;
the detail-failure message; and pagination both when `total > size` and when it is not.

### Two places the issues' suggested assertions did not match the pages

Called out because the issue text would mislead the next reader:

1. **#15 asks for a "loading state"** — the overview page has no `Loading...` block. It uses
   `useDashboardFetch` with `keepStaleWhileLoading: true`, so the pre-resolve state is an em dash in
   each of the five cards. The test asserts that instead. (The page also has *two* distinct error
   states — a hard error and a stale-refresh banner; the test covers the hard one, which is the path
   the issue describes.)
2. **#16 suggests asserting/clicking the PR title** — the sessions table never renders `prTitle`. Its
   columns are Repo, PR, Model, Status, Tokens, Cost, Findings, Time, and a **View** button. Rows are
   identified by `#12` and selection goes through the View button.

`window.history.replaceState` is used to set and reset the URL rather than stubbing it, so the
deep-link assertions exercise the page's real `URLSearchParams` reads.

## Related Issues

Fixes #15
Fixes #16

## How Has This Been Tested?

- [x] Unit tests

- `npm run test` — **6 files, 22 tests, all passing** (up from 4 files / 8 tests)
- `npm run build` — succeeds; CI runs this too

Note for anyone reproducing locally: `npm ci` fails here with `Missing: sharp@ from lock file` on
npm 11.17.0 / node 26.5.0, because of how that npm version reconciles the intentional
`"overrides": { "sharp": "-" }` in `frontend/package.json` against the lockfile. CI's
`npm ci --ignore-scripts` passes, and the entry predates today's dependency bumps (it is on `main`
too), so nothing here is broken — but `npm install --no-save --ignore-scripts` is the local
workaround. No lockfile change is included in this PR.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code