### PR TITLE
fix(release): address v0.5.0 audit findings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ part you agree to uphold it.
 
 ## Development setup
 
-Prerequisites: **Java 25+**, **Node.js 20+** (dashboard only), **Docker** (native builds only). Maven is bundled via the wrapper.
+Prerequisites: **Java 25+**, **Node.js 22+** (dashboard only), **Docker** (native builds only). Maven is bundled via the wrapper.
 
 Follow the [README Quick Start](https://github.com/devops-thiago/ThrillhouseBot#quick-start) for cloning, credentials, dev mode, and webhook forwarding — it is the single source of truth for setup commands. Contributor-specific extras:
 

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ gh attestation verify thrillhousebot-v0.1.0-linux-amd64.tar.gz \
 
 ## Development
 
-For local development without Docker, you'll need Java 25+, Node.js 20+ (dashboard),
+For local development without Docker, you'll need Java 25+, Node.js 22+ (dashboard),
 and a [Smee.io](https://smee.io/) channel for webhook forwarding. Use `./mvnw`
 for Maven (wrapper included).
 

--- a/frontend/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/app/(dashboard)/sessions/page.test.tsx
@@ -36,12 +36,9 @@ describe('SessionsPage', () => {
 
     expect(screen.getByText('Loading...')).toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Session History' })).toBeInTheDocument();
-    });
+    await screen.findByText('#12');
 
     expect(screen.getByText('devops-thiago/ThrillhouseBot')).toBeInTheDocument();
-    expect(screen.getByText('#12')).toBeInTheDocument();
     expect(screen.getByText('deepseek-chat')).toBeInTheDocument();
   });
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,9 @@
         "jsdom": "^29.1.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -290,7 +293,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -324,6 +326,555 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1277,7 +1828,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -1765,9 +2316,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -1889,9 +2440,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -1908,7 +2459,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2057,6 +2608,69 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,9 @@
   "name": "thrillhousebot-dashboard",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "next dev",
     "dev:mock": "NEXT_PUBLIC_MOCK_API=true next dev",
@@ -18,8 +21,8 @@
     "react-dom": "^19.2.8"
   },
   "overrides": {
-    "postcss": "^8.5.10",
-    "sharp": "-"
+    "postcss": "8.5.23",
+    "sharp": "0.35.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^7.0.0",

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -148,9 +148,9 @@ public class StartupConfigValidator {
               + review.maxAiCalls());
     }
     var margin = review.tokenSafetyMargin();
-    if (margin <= 0 || margin > 1.0) {
+    if (!Double.isFinite(margin) || margin <= 0 || margin > 1.0) {
       problems.add(
-          "REVIEW_TOKEN_SAFETY_MARGIN must be in (0, 1]"
+          "REVIEW_TOKEN_SAFETY_MARGIN must be in (0, 1] and finite"
               + " (thrillhousebot.review.token-safety-margin): "
               + margin);
     }
@@ -176,56 +176,79 @@ public class StartupConfigValidator {
               .ifPresent(v -> problems.add(prefix + "output-buffer-tokens must be >= 0: " + v));
           settings
               .tokenSafetyMargin()
-              .filter(v -> v <= 0 || v > 1.0)
-              .ifPresent(v -> problems.add(prefix + "token-safety-margin must be in (0, 1]: " + v));
+              .filter(v -> !Double.isFinite(v) || v <= 0 || v > 1.0)
+              .ifPresent(
+                  v ->
+                      problems.add(
+                          prefix + "token-safety-margin must be in (0, 1] and finite: " + v));
           settings
               .temperature()
-              .filter(v -> v < 0 || v > 2.0)
-              .ifPresent(v -> problems.add(prefix + "temperature must be in [0, 2]: " + v));
+              .filter(v -> !Double.isFinite(v) || v < 0 || v > 2.0)
+              .ifPresent(
+                  v -> problems.add(prefix + "temperature must be in [0, 2] and finite: " + v));
           settings
               .topP()
-              .filter(v -> v <= 0 || v > 1.0)
-              .ifPresent(v -> problems.add(prefix + "top-p must be in (0, 1]: " + v));
+              .filter(v -> !Double.isFinite(v) || v <= 0 || v > 1.0)
+              .ifPresent(v -> problems.add(prefix + "top-p must be in (0, 1] and finite: " + v));
           settings
               .maxOutputTokens()
               .filter(v -> v < 1)
               .ifPresent(v -> problems.add(prefix + "max-output-tokens must be >= 1: " + v));
           settings
               .frequencyPenalty()
-              .filter(v -> v < -2.0 || v > 2.0)
-              .ifPresent(v -> problems.add(prefix + "frequency-penalty must be in [-2, 2]: " + v));
+              .filter(v -> !Double.isFinite(v) || v < -2.0 || v > 2.0)
+              .ifPresent(
+                  v ->
+                      problems.add(
+                          prefix + "frequency-penalty must be in [-2, 2] and finite: " + v));
           settings
               .presencePenalty()
-              .filter(v -> v < -2.0 || v > 2.0)
-              .ifPresent(v -> problems.add(prefix + "presence-penalty must be in [-2, 2]: " + v));
+              .filter(v -> !Double.isFinite(v) || v < -2.0 || v > 2.0)
+              .ifPresent(
+                  v ->
+                      problems.add(
+                          prefix + "presence-penalty must be in [-2, 2] and finite: " + v));
         });
   }
 
   /**
    * Rejects a configuration whose <em>effective</em> per-call budget for the active model is
-   * degenerate. The buffer is subtracted from the margin-scaled ceiling at runtime, so validating
-   * it against the raw max would pass configs whose effective budget is still {@code <= 0} (e.g.
-   * 48000/45000/0.9 -> -1800) — the silent-disable this validator exists to reject. Checked on the
-   * active model's resolved values (per-model overrides and input cap), because that is the
-   * combination the budgeter will actually run with — the global combination alone may be broken
-   * yet fixed by an override, or vice versa.
+   * degenerate or reserves fewer output tokens than the provider may generate. Checked on the
+   * active model's resolved values because that is the combination the budgeter actually uses.
    */
   private void validateEffectiveBudget(List<String> problems) {
     var maxInputTokens = activeModel.maxInputTokens();
     var margin = activeModel.tokenSafetyMargin();
+    var outputBuffer = activeModel.outputBufferTokens();
     if (maxInputTokens > 0
+        && Double.isFinite(margin)
         && margin > 0
         && margin <= 1.0
-        && (int) (maxInputTokens * margin) - activeModel.outputBufferTokens() <= 0) {
+        && (int) (maxInputTokens * margin) - outputBuffer <= 0) {
       problems.add(
           "the effective output buffer ("
-              + activeModel.outputBufferTokens()
+              + outputBuffer
               + ") must be less than the effective max input tokens x safety margin ("
               + (int) (maxInputTokens * margin)
               + ") for model '"
               + activeModel.modelName()
               + "' so there is budget left for the diff (thrillhousebot.review.* with"
               + " thrillhousebot.ai.models overrides)");
+    }
+    if (maxInputTokens > 0) {
+      activeModel
+          .maxOutputTokens()
+          .filter(maxOutput -> maxOutput > outputBuffer)
+          .ifPresent(
+              maxOutput ->
+                  problems.add(
+                      "the effective output buffer ("
+                          + outputBuffer
+                          + ") must be >= max-output-tokens ("
+                          + maxOutput
+                          + ") for model '"
+                          + activeModel.modelName()
+                          + "' so the token budget reserves the configured response cap"));
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessChecker.java
@@ -112,6 +112,42 @@ public class DashboardAccessChecker {
   }
 
   /**
+   * Checks access to one installed repository rather than treating access to any installation as
+   * account-wide data access. The requested repository must belong to the configured account and be
+   * present in the current installation snapshot.
+   */
+  public boolean hasRepositoryAccess(String githubLogin, String repository) {
+    if (githubLogin == null || githubLogin.isBlank() || repository == null) {
+      return false;
+    }
+    var separator = repository.indexOf('/');
+    if (separator <= 0
+        || separator != repository.lastIndexOf('/')
+        || separator == repository.length() - 1) {
+      return false;
+    }
+    var requested =
+        new RepoRef(repository.substring(0, separator), repository.substring(separator + 1));
+    var accountOwner = accountOwner();
+    if (accountOwner.isEmpty() || !accountOwner.get().equalsIgnoreCase(requested.owner())) {
+      return false;
+    }
+    var snapshot = installedRepos(accountOwner.get());
+    var installed =
+        snapshot.repos().stream()
+            .filter(
+                repo ->
+                    repo.owner().equalsIgnoreCase(requested.owner())
+                        && repo.name().equalsIgnoreCase(requested.name()))
+            .findFirst();
+    if (installed.isEmpty() || snapshot.installationAuth() == null) {
+      return false;
+    }
+    return accountOwner.get().equalsIgnoreCase(githubLogin)
+        || hasRepoAccess(snapshot.installationAuth(), installed.get(), githubLogin);
+  }
+
+  /**
    * Resolves whether {@code githubLogin} may use the dashboard. Fails closed: when no account owner
    * can be determined the result is {@link AccessDecision#NOT_CONFIGURED} (deny), never an implicit
    * grant. The underlying misconfiguration is logged once per resolution attempt in {@link

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardResource.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardResource.java
@@ -284,8 +284,14 @@ public class DashboardResource {
       return unauthorizedResponse();
     }
     if (repository != null && !repository.isBlank()) {
-      var summary = findingFeedbackService.summarize(repository.strip());
-      var recent = findingFeedbackService.listRecent(repository.strip(), 50);
+      var normalizedRepository = repository.strip();
+      if (!sessionValidator.hasRepositoryAccess(sessionToken, normalizedRepository)) {
+        return Response.status(Response.Status.FORBIDDEN)
+            .entity(Map.of(KEY_ERROR, "Repository access denied"))
+            .build();
+      }
+      var summary = findingFeedbackService.summarize(normalizedRepository);
+      var recent = findingFeedbackService.listRecent(normalizedRepository, 50);
       return Response.ok(
               Map.of(
                   "repositories",
@@ -303,7 +309,10 @@ public class DashboardResource {
                   recent))
           .build();
     }
-    var summaries = findingFeedbackService.summarizeAll();
+    var summaries =
+        findingFeedbackService.summarizeAll().stream()
+            .filter(s -> sessionValidator.hasRepositoryAccess(sessionToken, s.repository()))
+            .toList();
     var rows =
         summaries.stream()
             .map(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardSessionValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardSessionValidator.java
@@ -42,4 +42,12 @@ public class DashboardSessionValidator {
         .filter(session -> accessChecker.hasAccess(session.login()))
         .map(DashboardSessionStore.DashboardSession::login);
   }
+
+  /** Returns whether this session's login may read data for the requested installed repository. */
+  public boolean hasRepositoryAccess(String sessionId, String repository) {
+    return sessionStore
+        .findSession(sessionId)
+        .filter(session -> accessChecker.hasRepositoryAccess(session.login(), repository))
+        .isPresent();
+  }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
@@ -140,9 +140,7 @@ public class FindingFeedbackCaptureService {
                   repo,
                   prNumber,
                   rootCommentId,
-                  replyAuthorLogin,
-                  replyAuthorAssociation,
-                  replyBody);
+                  new ReviewReply(replyAuthorLogin, replyAuthorAssociation, replyBody));
             } catch (RuntimeException e) {
               log.warn(
                   "Finding feedback capture failed for {}/{} #{} comment {} (continuing)",
@@ -153,7 +151,7 @@ public class FindingFeedbackCaptureService {
                   e);
             }
           });
-    } catch (RejectedExecutionException e) {
+    } catch (RejectedExecutionException _) {
       log.warn(
           "Finding feedback capture at capacity for {}/{} #{} comment {}; dropping task",
           owner,
@@ -203,6 +201,9 @@ public class FindingFeedbackCaptureService {
     }
   }
 
+  /** The reply that may carry feedback: who wrote it, their author association, and its body. */
+  record ReviewReply(String authorLogin, String authorAssociation, String body) {}
+
   void captureOnReviewReply(
       long installationId,
       String owner,
@@ -212,7 +213,12 @@ public class FindingFeedbackCaptureService {
       String replyAuthorLogin,
       String replyBody) {
     captureOnReviewReply(
-        installationId, owner, repo, prNumber, rootCommentId, replyAuthorLogin, "OWNER", replyBody);
+        installationId,
+        owner,
+        repo,
+        prNumber,
+        rootCommentId,
+        new ReviewReply(replyAuthorLogin, "OWNER", replyBody));
   }
 
   void captureOnReviewReply(
@@ -221,12 +227,12 @@ public class FindingFeedbackCaptureService {
       String repo,
       int prNumber,
       long rootCommentId,
-      String replyAuthorLogin,
-      String replyAuthorAssociation,
-      String replyBody) {
+      ReviewReply reply) {
+    var replyAuthorLogin = reply.authorLogin();
+    var replyBody = reply.body();
     var auth = authClient.getAuthHeader(installationId);
     var permissionCache = new HashMap<String, Boolean>();
-    if (!mayHoldWriteAccess(replyAuthorAssociation)
+    if (!mayHoldWriteAccess(reply.authorAssociation())
         || !hasWriteAccess(auth, owner, repo, replyAuthorLogin, permissionCache)) {
       return;
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
@@ -17,16 +17,24 @@ package dev.thiagogonzaga.thrillhousebot.review;
 
 import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubInstallationClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReactionClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
@@ -48,6 +56,10 @@ public class FindingFeedbackCaptureService {
   private static final String ACCEPT = "application/vnd.github+json";
   private static final String CONTENT_PLUS_ONE = "+1";
   private static final String CONTENT_MINUS_ONE = "-1";
+  private static final int MAX_CONCURRENT_CAPTURES = 8;
+  private static final Set<String> WRITE_PERMISSIONS = Set.of("admin", "maintain", "write");
+  private static final Set<String> WRITE_CAPABLE_ASSOCIATIONS =
+      Set.of("OWNER", "MEMBER", "COLLABORATOR");
 
   /** Cap on finding threads polled during a follow-up review (package-visible for tests). */
   static final int MAX_FINDINGS_PER_CAPTURE = 40;
@@ -71,9 +83,17 @@ public class FindingFeedbackCaptureService {
   private final GitHubAuthClient authClient;
   private final GitHubReactionClient reactionClient;
   private final GitHubReviewClient reviewClient;
+  private final GitHubInstallationClient installationClient;
 
   private final ExecutorService captureExecutor =
-      Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("finding-feedback-", 0).factory());
+      new ThreadPoolExecutor(
+          0,
+          MAX_CONCURRENT_CAPTURES,
+          30,
+          TimeUnit.SECONDS,
+          new SynchronousQueue<>(),
+          Thread.ofVirtual().name("finding-feedback-", 0).factory(),
+          new ThreadPoolExecutor.AbortPolicy());
 
   @Inject
   public FindingFeedbackCaptureService(
@@ -81,12 +101,14 @@ public class FindingFeedbackCaptureService {
       BotIdentity botIdentity,
       GitHubAuthClient authClient,
       @RestClient GitHubReactionClient reactionClient,
-      @RestClient GitHubReviewClient reviewClient) {
+      @RestClient GitHubReviewClient reviewClient,
+      @RestClient GitHubInstallationClient installationClient) {
     this.feedbackService = feedbackService;
     this.botIdentity = botIdentity;
     this.authClient = authClient;
     this.reactionClient = reactionClient;
     this.reviewClient = reviewClient;
+    this.installationClient = installationClient;
   }
 
   @PreDestroy
@@ -106,22 +128,39 @@ public class FindingFeedbackCaptureService {
       int prNumber,
       long rootCommentId,
       String replyAuthorLogin,
+      String replyAuthorAssociation,
       String replyBody) {
-    captureExecutor.execute(
-        () -> {
-          try {
-            captureOnReviewReply(
-                installationId, owner, repo, prNumber, rootCommentId, replyAuthorLogin, replyBody);
-          } catch (RuntimeException e) {
-            log.warn(
-                "Finding feedback capture failed for {}/{} #{} comment {} (continuing)",
-                owner,
-                repo,
-                prNumber,
-                rootCommentId,
-                e);
-          }
-        });
+    try {
+      captureExecutor.execute(
+          () -> {
+            try {
+              captureOnReviewReply(
+                  installationId,
+                  owner,
+                  repo,
+                  prNumber,
+                  rootCommentId,
+                  replyAuthorLogin,
+                  replyAuthorAssociation,
+                  replyBody);
+            } catch (RuntimeException e) {
+              log.warn(
+                  "Finding feedback capture failed for {}/{} #{} comment {} (continuing)",
+                  owner,
+                  repo,
+                  prNumber,
+                  rootCommentId,
+                  e);
+            }
+          });
+    } catch (RejectedExecutionException e) {
+      log.warn(
+          "Finding feedback capture at capacity for {}/{} #{} comment {}; dropping task",
+          owner,
+          repo,
+          prNumber,
+          rootCommentId);
+    }
   }
 
   /**
@@ -145,11 +184,14 @@ public class FindingFeedbackCaptureService {
               .filter(c -> c != null && c.inReplyToId() == null)
               .filter(c -> c.user() != null && botIdentity.matches(c.user().login()))
               .filter(c -> SuggestionFormatter.parseFindingMarker(c.body()).isPresent())
-              .sorted(Comparator.comparingLong(GitHubReviewClient.PullRequestComment::id))
+              .sorted(
+                  Comparator.comparingLong(GitHubReviewClient.PullRequestComment::id).reversed())
               .limit(MAX_FINDINGS_PER_CAPTURE)
               .toList();
+      var permissionCache = new HashMap<String, Boolean>();
       for (var comment : candidates) {
-        captureReactions(auth, owner, repo, prNumber, comment.id(), comment.body());
+        captureReactions(
+            auth, owner, repo, prNumber, comment.id(), comment.body(), permissionCache);
       }
     } catch (RuntimeException e) {
       log.warn(
@@ -169,21 +211,42 @@ public class FindingFeedbackCaptureService {
       long rootCommentId,
       String replyAuthorLogin,
       String replyBody) {
+    captureOnReviewReply(
+        installationId, owner, repo, prNumber, rootCommentId, replyAuthorLogin, "OWNER", replyBody);
+  }
+
+  void captureOnReviewReply(
+      long installationId,
+      String owner,
+      String repo,
+      int prNumber,
+      long rootCommentId,
+      String replyAuthorLogin,
+      String replyAuthorAssociation,
+      String replyBody) {
     var auth = authClient.getAuthHeader(installationId);
-    String rootBody = fetchCommentBody(auth, owner, repo, rootCommentId);
-    OptionalInt findingIndex = SuggestionFormatter.parseFindingMarker(rootBody);
+    var permissionCache = new HashMap<String, Boolean>();
+    if (!mayHoldWriteAccess(replyAuthorAssociation)
+        || !hasWriteAccess(auth, owner, repo, replyAuthorLogin, permissionCache)) {
+      return;
+    }
+    var root = fetchRootComment(auth, owner, repo, rootCommentId);
+    if (root == null || root.user() == null || !botIdentity.matches(root.user().login())) {
+      return;
+    }
+    OptionalInt findingIndex = SuggestionFormatter.parseFindingMarker(root.body());
     if (findingIndex.isEmpty()) {
       return;
     }
-    captureReactions(auth, owner, repo, prNumber, rootCommentId, rootBody);
+    captureReactions(auth, owner, repo, prNumber, rootCommentId, root.body(), permissionCache);
     captureReplyHeuristic(
         owner, repo, prNumber, rootCommentId, findingIndex.getAsInt(), replyAuthorLogin, replyBody);
   }
 
-  private String fetchCommentBody(String auth, String owner, String repo, long commentId) {
+  private GitHubReviewClient.PullRequestComment fetchRootComment(
+      String auth, String owner, String repo, long commentId) {
     try {
-      var comment = reviewClient.getPullRequestComment(auth, ACCEPT, owner, repo, commentId);
-      return comment != null ? comment.body() : null;
+      return reviewClient.getPullRequestComment(auth, ACCEPT, owner, repo, commentId);
     } catch (RuntimeException e) {
       log.debug(
           "Failed to fetch review comment {} on {}/{} for feedback capture (continuing)",
@@ -197,13 +260,31 @@ public class FindingFeedbackCaptureService {
 
   void captureReactions(
       String auth, String owner, String repo, int prNumber, long commentId, String commentBody) {
+    captureReactions(auth, owner, repo, prNumber, commentId, commentBody, new HashMap<>());
+  }
+
+  private void captureReactions(
+      String auth,
+      String owner,
+      String repo,
+      int prNumber,
+      long commentId,
+      String commentBody,
+      Map<String, Boolean> permissionCache) {
     OptionalInt findingIndex = SuggestionFormatter.parseFindingMarker(commentBody);
     if (findingIndex.isEmpty()) {
       return;
     }
     var ctx =
         new ReactionPollContext(
-            auth, owner, repo, owner + "/" + repo, prNumber, commentId, findingIndex.getAsInt());
+            auth,
+            owner,
+            repo,
+            owner + "/" + repo,
+            prNumber,
+            commentId,
+            findingIndex.getAsInt(),
+            permissionCache);
     listAndRecord(ctx, CONTENT_PLUS_ONE);
     listAndRecord(ctx, CONTENT_MINUS_ONE);
   }
@@ -215,7 +296,8 @@ public class FindingFeedbackCaptureService {
       String repoKey,
       int prNumber,
       long commentId,
-      Integer findingIndex) {}
+      Integer findingIndex,
+      Map<String, Boolean> permissionCache) {}
 
   private void listAndRecord(ReactionPollContext ctx, String content) {
     String signal =
@@ -265,7 +347,8 @@ public class FindingFeedbackCaptureService {
       ReactionPollContext ctx, String signal, List<GitHubReactionClient.Reaction> reactions) {
     for (var reaction : reactions) {
       String login = humanReactorLogin(reaction);
-      if (login == null) {
+      if (login == null
+          || !hasWriteAccess(ctx.auth(), ctx.owner(), ctx.repo(), login, ctx.permissionCache())) {
         continue;
       }
       feedbackService.recordFeedback(
@@ -288,6 +371,37 @@ public class FindingFeedbackCaptureService {
     }
     String login = reaction.user().login();
     return botIdentity.matches(login) ? null : login;
+  }
+
+  private boolean hasWriteAccess(
+      String auth, String owner, String repo, String login, Map<String, Boolean> permissionCache) {
+    if (login == null || login.isBlank()) {
+      return false;
+    }
+    return permissionCache.computeIfAbsent(
+        login.toLowerCase(Locale.ROOT),
+        ignored -> {
+          try {
+            var permission =
+                installationClient.collaboratorPermission(auth, ACCEPT, owner, repo, login);
+            var level = permission == null ? null : permission.permission();
+            return level != null
+                && WRITE_PERMISSIONS.contains(level.strip().toLowerCase(Locale.ROOT));
+          } catch (RuntimeException e) {
+            log.debug(
+                "Failed to verify feedback actor @{} on {}/{}; ignoring signal",
+                login,
+                owner,
+                repo,
+                e);
+            return false;
+          }
+        });
+  }
+
+  private static boolean mayHoldWriteAccess(String authorAssociation) {
+    return authorAssociation != null
+        && WRITE_CAPABLE_ASSOCIATIONS.contains(authorAssociation.strip().toUpperCase(Locale.ROOT));
   }
 
   void captureReplyHeuristic(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -625,8 +625,8 @@ public class FindingPipeline {
         String fallback = lineResolver.getLineText(finding.file(), finding.line());
         if (fallback != null && !fallback.isBlank()) {
           Log.infof(
-              "Populating missing content anchor for finding '%s' (%s:%d) with: '%s'",
-              finding.title(), finding.file(), finding.line(), fallback.strip());
+              "Populating missing content anchor for finding '%s' (%s:%d)",
+              finding.title(), finding.file(), finding.line());
           adjusted.add(
               new ReviewResponse.Finding(
                   finding.risk(),

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -54,6 +54,9 @@ public class FollowUpAnalyzer {
       "The code this finding targeted is no longer in this revision's diff (removed by a"
           + " force-push or a later commit) — superseded.";
 
+  private static final String PURE_RENAME_UNRESOLVED_NOTE =
+      "The finding's file was renamed without content changes, so the finding remains unresolved.";
+
   /**
    * The only statuses the prompt contract defines for {@code previous_findings_status} ("resolved"
    * | "unresolved" | "justified"). A value outside this set does not count as the model accounting
@@ -605,6 +608,15 @@ public class FollowUpAnalyzer {
       String previousAiResponseJson,
       List<ReviewResponse.PreviousFindingStatus> statuses,
       DiffLineResolver lineResolver) {
+    return supersedeVanished(previousAiResponseJson, statuses, lineResolver, Map.of());
+  }
+
+  /** Rename-aware variant used by the review verdict path. */
+  public List<ReviewResponse.PreviousFindingStatus> supersedeVanished(
+      String previousAiResponseJson,
+      List<ReviewResponse.PreviousFindingStatus> statuses,
+      DiffLineResolver lineResolver,
+      Map<String, String> renameTargets) {
     if (statuses == null || statuses.isEmpty() || lineResolver == null) {
       return statuses == null ? List.of() : statuses;
     }
@@ -614,7 +626,7 @@ public class FollowUpAnalyzer {
     }
     var rewritten = new ArrayList<ReviewResponse.PreviousFindingStatus>(statuses.size());
     for (var status : statuses) {
-      if (hasVanished(status, previous, lineResolver)) {
+      if (hasVanished(status, previous, lineResolver, renameTargets)) {
         Log.infof(
             "Superseding unresolved previous finding #%d — its targeted code is no longer in the"
                 + " current diff",
@@ -629,10 +641,52 @@ public class FollowUpAnalyzer {
     return rewritten;
   }
 
+  /**
+   * Adds deterministic statuses when the model omits a prior finding entirely. Vanished findings
+   * become superseded; findings moved by a content-identical pure rename remain unresolved because
+   * their flagged code is unchanged. This keeps the regenerated summary and approval gate in sync
+   * even when {@code previous_findings_status} is empty.
+   */
+  public List<ReviewResponse.PreviousFindingStatus> addUnreportedVanished(
+      List<ReviewResponse.Finding> previous,
+      List<ReviewResponse.PreviousFindingStatus> statuses,
+      DiffLineResolver lineResolver,
+      Map<String, String> renameTargets) {
+    if (previous == null || previous.isEmpty() || lineResolver == null) {
+      return statuses == null ? List.of() : statuses;
+    }
+    var result = new ArrayList<>(statuses == null ? List.of() : statuses);
+    var reportedIds = new HashSet<Integer>();
+    for (var status : result) {
+      reportedIds.add(status.id());
+    }
+    for (int index = 0; index < previous.size(); index++) {
+      var id = index + 1;
+      var finding = previous.get(index);
+      if (reportedIds.contains(id) || finding.file() == null) {
+        continue;
+      }
+      var currentPath = renameTargets.getOrDefault(finding.file(), finding.file());
+      if (currentPath.isBlank()) {
+        // A content-identical rename is deliberately absent from the reviewable diff. The anchor
+        // therefore cannot be resolved at either path, but the unchanged finding must keep holding
+        // approval when the model silently omits it.
+        result.add(
+            new ReviewResponse.PreviousFindingStatus(
+                id, STATUS_UNRESOLVED, PURE_RENAME_UNRESOLVED_NOTE));
+      } else if (!lineResolver.isFindingPresent(currentPath, finding.suggestionOld())) {
+        result.add(
+            new ReviewResponse.PreviousFindingStatus(id, STATUS_SUPERSEDED, SUPERSEDED_NOTE));
+      }
+    }
+    return result;
+  }
+
   private static boolean hasVanished(
       ReviewResponse.PreviousFindingStatus status,
       List<ReviewResponse.Finding> previous,
-      DiffLineResolver lineResolver) {
+      DiffLineResolver lineResolver,
+      Map<String, String> renameTargets) {
     if (!STATUS_UNRESOLVED.equalsIgnoreCase(status.status())) {
       return false;
     }
@@ -644,7 +698,11 @@ public class FollowUpAnalyzer {
     if (finding.file() == null) {
       return false;
     }
-    return !lineResolver.isFindingPresent(finding.file(), finding.suggestionOld());
+    var currentPath = renameTargets.getOrDefault(finding.file(), finding.file());
+    if (currentPath.isBlank()) {
+      return false;
+    }
+    return !lineResolver.isFindingPresent(currentPath, finding.suggestionOld());
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
@@ -42,8 +42,8 @@ final class HeuristicCodeDetector {
   /** JavaScript/TypeScript regex literal in a value-producing position, not division or a URL. */
   private static final Pattern JS_REGEX_LITERAL =
       Pattern.compile(
-          "(?:=|\\breturn\\b|\\(|,|:)\\s*/(?:\\\\.|[^/\\\\\\r\\n])+/[dgimsuvy]*"
-              + "(?:\\s*[,;).]|\\s*$)");
+          "(?:=|\\breturn\\b|\\(|,|:)\\s*/(?:\\\\.|[^/\\\\\\r\\n])++/[dgimsuvy]*"
+              + "(?=\\s*(?:[,;).]|$))");
 
   /** Source paths where slash-delimited regex literals are language syntax. */
   private static final Pattern JS_REGEX_PATH = Pattern.compile("(?i)\\.(?:[cm]?js|jsx|tsx?)$");
@@ -83,7 +83,8 @@ final class HeuristicCodeDetector {
           "(?i)\\b(?:const|let|var)\\s+"
               + "(?:parse|validate|isValid|tokeni[sz]e|segment|normali[sz]e|canonicali[sz]e"
               + "|sanitiz|lex|scan|split)\\w*\\s*=\\s*"
-              + "(?:function\\s*\\(|(?:async\\s*)?(?:\\([^\\r\\n]*\\)|[\\w$]+)\\s*=>)");
+              + "(?:function\\s*\\(|(?:async\\s*)?"
+              + "(?:\\((?:[^()\\r\\n]++|\\([^()\\r\\n]*+\\))*+\\)|[\\w$]+)\\s*=>)");
 
   /**
    * An import/package line mentions a type without using it, so it is never itself heuristic code —

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
@@ -84,7 +84,7 @@ final class HeuristicCodeDetector {
               + "(?:parse|validate|isValid|tokeni[sz]e|segment|normali[sz]e|canonicali[sz]e"
               + "|sanitiz|lex|scan|split)\\w*\\s*=\\s*"
               + "(?:function\\s*\\(|(?:async\\s*)?"
-              + "(?:\\((?:[^()\\r\\n]++|\\([^()\\r\\n]*+\\))*+\\)|[\\w$]+)\\s*=>)");
+              + "(?:\\((?=[^\\r\\n]*\\)\\s*=>)|[\\w$]+\\s*=>))");
 
   /**
    * An import/package line mentions a type without using it, so it is never itself heuristic code —

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
@@ -16,6 +16,8 @@
 package dev.thiagogonzaga.thrillhousebot.review;
 
 import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 /**
@@ -34,10 +36,13 @@ import java.util.regex.Pattern;
 final class HeuristicCodeDetector {
 
   /** Explicit regex construction, across the languages the bot reviews. */
-  private static final Pattern REGEX_CONSTRUCTION =
-      Pattern.compile(
-          "Pattern\\s*\\.\\s*compile\\s*\\(|re\\s*\\.\\s*compile\\s*\\("
-              + "|new\\s+RegExp\\s*\\(|regexp\\s*\\.\\s*MustCompile\\s*\\(|\\bRegex\\s*\\(");
+  private static final List<Pattern> REGEX_CONSTRUCTION_PATTERNS =
+      List.of(
+          Pattern.compile("Pattern\\s*\\.\\s*compile\\s*\\("),
+          Pattern.compile("re\\s*\\.\\s*compile\\s*\\("),
+          Pattern.compile("new\\s+RegExp\\s*\\("),
+          Pattern.compile("regexp\\s*\\.\\s*MustCompile\\s*\\("),
+          Pattern.compile("\\bRegex\\s*\\("));
 
   /** JavaScript/TypeScript regex literal in a value-producing position, not division or a URL. */
   private static final Pattern JS_REGEX_LITERAL =
@@ -56,35 +61,64 @@ final class HeuristicCodeDetector {
       Pattern.compile("(?i)\\bNormalizer\\b|isWhitespace|\\bNBSP\\b|zero.?width");
 
   /**
+   * Name stems (lowercase) whose declared members carry a decision boundary. Checked in plain code
+   * against the identifier the structural patterns below capture, so no pattern repeats the
+   * alternation.
+   */
+  private static final String[] HEURISTIC_NAME_STEMS = {
+    "parse",
+    "validate",
+    "isvalid",
+    "tokenise",
+    "tokenize",
+    "segment",
+    "normalise",
+    "normalize",
+    "canonicalise",
+    "canonicalize",
+    "sanitiz",
+    "lex",
+    "scan",
+    "split"
+  };
+
+  /**
    * A <em>declared</em> parse/validate/tokenize-style member — the decision boundary lives in its
    * body. Three constraints keep ordinary calls out: a declaration keyword on the same line, no
    * {@code =} before the name (a field initializer is an assignment, not a declaration), and no
    * {@code .} or word character immediately before it (so the receiver call {@code
-   * Integer.parseInt(...)} cannot pose as a declared {@code parse} member).
+   * Integer.parseInt(...)} cannot pose as a declared {@code parse} member). The member name is
+   * captured; {@link #isHeuristicName(String)} decides whether it is heuristic.
    */
   private static final Pattern HEURISTIC_DECLARATION =
       Pattern.compile(
           "(?i)\\b(?:private|public|protected|internal|static|final|fun|def|func|function)\\b"
-              + "[^(=\\r\\n]*(?<![.\\w])"
-              + "(?:parse|validate|isValid|tokeni[sz]e|segment|normali[sz]e|canonicali[sz]e"
-              + "|sanitiz|lex|scan|split)\\w*\\s*\\(");
+              + "[^(=\\r\\n]*(?<![.\\w])(\\w+)\\s*\\(");
 
-  /** Package-private Java-style method declaration, where no visibility keyword is present. */
+  /**
+   * Package-private Java-style method declaration, where no visibility keyword is present. The type
+   * list is one character-class run instead of a repeated token group, so matching stays linear on
+   * pathological inputs, and the control-flow keywords are excluded by one lookahead apiece instead
+   * of one alternation.
+   */
   private static final Pattern PACKAGE_PRIVATE_HEURISTIC_DECLARATION =
       Pattern.compile(
-          "(?i)^\\+\\s*(?!(?:return|if|for|while|switch|throw|new)\\b)"
-              + "(?:@[\\w.]+\\s+)?(?:[\\w$<>?,.\\[\\]]+\\s+)+"
-              + "(?:parse|validate|isValid|tokeni[sz]e|segment|normali[sz]e|canonicali[sz]e"
-              + "|sanitiz|lex|scan|split)\\w*\\s*\\(");
+          "(?i)^\\+\\s*(?!return\\b)(?!if\\b)(?!for\\b)(?!while\\b)(?!switch\\b)(?!throw\\b)"
+              + "(?!new\\b)(?:@[\\w.]+\\s+)?"
+              + "[\\w$<>?,.\\[\\]][\\w$<>?,.\\[\\]\\s]*\\s(\\w+)\\s*\\(");
 
-  /** JavaScript/TypeScript parser or validator assigned to an arrow/function expression. */
-  private static final Pattern ASSIGNED_HEURISTIC_DECLARATION =
-      Pattern.compile(
-          "(?i)\\b(?:const|let|var)\\s+"
-              + "(?:parse|validate|isValid|tokeni[sz]e|segment|normali[sz]e|canonicali[sz]e"
-              + "|sanitiz|lex|scan|split)\\w*\\s*=\\s*"
-              + "(?:function\\s*\\(|(?:async\\s*)?"
-              + "(?:\\((?=[^\\r\\n]*\\)\\s*=>)|[\\w$]+\\s*=>))");
+  /**
+   * JavaScript/TypeScript parser or validator assigned to an arrow/function expression, one pattern
+   * per expression form.
+   */
+  private static final List<Pattern> ASSIGNED_HEURISTIC_DECLARATION_PATTERNS =
+      List.of(
+          Pattern.compile("(?i)\\b(?:const|let|var)\\s+(\\w+)\\s*=\\s*function\\s*\\("),
+          Pattern.compile(
+              "(?i)\\b(?:const|let|var)\\s+(\\w+)\\s*=\\s*(?:async\\s*)?"
+                  + "\\((?=[^\\r\\n]*\\)\\s*=>)"),
+          Pattern.compile(
+              "(?i)\\b(?:const|let|var)\\s+(\\w+)\\s*=\\s*(?:async\\s*)?[\\w$]+\\s*=>"));
 
   /**
    * An import/package line mentions a type without using it, so it is never itself heuristic code —
@@ -124,6 +158,20 @@ final class HeuristicCodeDetector {
         || JAVA_TEST_SUFFIX.matcher(path).find();
   }
 
+  /** Per-file scanning state derived from a {@code +++ } diff header line. */
+  private record FileScope(boolean testFile, boolean javaScript) {
+    private static final FileScope NONE = new FileScope(false, false);
+
+    private static FileScope of(String headerLine) {
+      var header = DIFF_FILE_HEADER.matcher(headerLine);
+      if (!header.matches()) {
+        return NONE;
+      }
+      var path = header.group(1);
+      return new FileScope(isTestPath(path), JS_REGEX_PATH.matcher(path).find());
+    }
+  }
+
   /**
    * Whether any added line outside a test file introduces heuristic code. Scans the unified diff in
    * one pass over text the review already holds.
@@ -132,24 +180,19 @@ final class HeuristicCodeDetector {
     if (diff == null || diff.isBlank()) {
       return false;
     }
-    var inTestFile = false;
-    var inJavaScriptFile = false;
+    var scope = FileScope.NONE;
     var addedLines = new ArrayDeque<String>(4);
     for (String line : diff.split("\n", -1)) {
       // Every "+++ " line is a header, including the "+++ /dev/null" of a deletion — consuming them
       // all here keeps file state and the multiline window from carrying into the next file.
       if (line.startsWith("+++ ")) {
-        var header = DIFF_FILE_HEADER.matcher(line);
-        var hasSourcePath = header.matches();
-        var path = hasSourcePath ? header.group(1) : "";
-        inTestFile = hasSourcePath && isTestPath(path);
-        inJavaScriptFile = hasSourcePath && JS_REGEX_PATH.matcher(path).find();
+        scope = FileScope.of(line);
         addedLines.clear();
         continue;
       }
       // Only contiguous additions can form one declaration or construction. Context, removals,
       // hunk headers, and ignored test-file content all terminate the bounded window.
-      if (inTestFile || line.isEmpty() || line.charAt(0) != '+') {
+      if (scope.testFile() || line.isEmpty() || line.charAt(0) != '+') {
         addedLines.clear();
         continue;
       }
@@ -158,8 +201,8 @@ final class HeuristicCodeDetector {
       if (addedLines.size() > 4) {
         addedLines.removeFirst();
       }
-      if (isHeuristicLine(line, inJavaScriptFile)
-          || isHeuristicWindow(addedLines, inJavaScriptFile)) {
+      if (isHeuristicLine(line, scope.javaScript())
+          || isHeuristicWindow(addedLines, scope.javaScript())) {
         return true;
       }
     }
@@ -170,15 +213,62 @@ final class HeuristicCodeDetector {
     if (DECLARATION_ONLY_LINE.matcher(addedLine).find()) {
       return false;
     }
-    return REGEX_CONSTRUCTION.matcher(addedLine).find()
+    return matchesAny(REGEX_CONSTRUCTION_PATTERNS, addedLine)
         || CHAR_SCANNING.matcher(addedLine).find()
         || NORMALIZATION.matcher(addedLine).find()
-        || HEURISTIC_DECLARATION.matcher(addedLine).find()
-        || PACKAGE_PRIVATE_HEURISTIC_DECLARATION.matcher(addedLine).find()
-        || (inJavaScriptFile
-            && (JS_REGEX_LITERAL.matcher(addedLine).find()
-                || ASSIGNED_HEURISTIC_DECLARATION.matcher(addedLine).find()))
+        || declaresHeuristicMember(addedLine, inJavaScriptFile)
+        || (inJavaScriptFile && JS_REGEX_LITERAL.matcher(addedLine).find())
         || THRESHOLD_CONSTANT.matcher(addedLine).find();
+  }
+
+  private static boolean matchesAny(List<Pattern> patterns, CharSequence text) {
+    for (Pattern pattern : patterns) {
+      if (pattern.matcher(text).find()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Whether the text declares a member whose captured name carries a heuristic stem. */
+  private static boolean declaresHeuristicMember(CharSequence text, boolean inJavaScriptFile) {
+    if (namesHeuristicMember(HEURISTIC_DECLARATION, text)
+        || namesHeuristicMember(PACKAGE_PRIVATE_HEURISTIC_DECLARATION, text)) {
+      return true;
+    }
+    if (!inJavaScriptFile) {
+      return false;
+    }
+    for (Pattern pattern : ASSIGNED_HEURISTIC_DECLARATION_PATTERNS) {
+      if (namesHeuristicMember(pattern, text)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Scans every structural match, not only the first: a line can declare a non-heuristic member
+   * before the heuristic one, and rejecting the first capture must not hide the second.
+   */
+  private static boolean namesHeuristicMember(Pattern structure, CharSequence text) {
+    var matcher = structure.matcher(text);
+    while (matcher.find()) {
+      if (isHeuristicName(matcher.group(1))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isHeuristicName(String memberName) {
+    var lower = memberName.toLowerCase(Locale.ROOT);
+    for (String stem : HEURISTIC_NAME_STEMS) {
+      if (lower.startsWith(stem)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static boolean isHeuristicWindow(
@@ -203,9 +293,7 @@ final class HeuristicCodeDetector {
 
   private static boolean hasMultilineHeuristicSignal(
       CharSequence addedLines, boolean inJavaScriptFile) {
-    return REGEX_CONSTRUCTION.matcher(addedLines).find()
-        || HEURISTIC_DECLARATION.matcher(addedLines).find()
-        || PACKAGE_PRIVATE_HEURISTIC_DECLARATION.matcher(addedLines).find()
-        || (inJavaScriptFile && ASSIGNED_HEURISTIC_DECLARATION.matcher(addedLines).find());
+    return matchesAny(REGEX_CONSTRUCTION_PATTERNS, addedLines)
+        || declaresHeuristicMember(addedLines, inJavaScriptFile);
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import java.util.ArrayDeque;
 import java.util.regex.Pattern;
 
 /**
@@ -35,7 +36,17 @@ final class HeuristicCodeDetector {
   /** Explicit regex construction, across the languages the bot reviews. */
   private static final Pattern REGEX_CONSTRUCTION =
       Pattern.compile(
-          "Pattern\\.compile\\(|re\\.compile\\(|new\\s+RegExp\\(|regexp\\.MustCompile\\(|\\bRegex\\(");
+          "Pattern\\s*\\.\\s*compile\\s*\\(|re\\s*\\.\\s*compile\\s*\\("
+              + "|new\\s+RegExp\\s*\\(|regexp\\s*\\.\\s*MustCompile\\s*\\(|\\bRegex\\s*\\(");
+
+  /** JavaScript/TypeScript regex literal in a value-producing position, not division or a URL. */
+  private static final Pattern JS_REGEX_LITERAL =
+      Pattern.compile(
+          "(?:=|\\breturn\\b|\\(|,|:)\\s*/(?:\\\\.|[^/\\\\\\r\\n])+/[dgimsuvy]*"
+              + "(?:\\s*[,;).]|\\s*$)");
+
+  /** Source paths where slash-delimited regex literals are language syntax. */
+  private static final Pattern JS_REGEX_PATH = Pattern.compile("(?i)\\.(?:[cm]?js|jsx|tsx?)$");
 
   /** Char-level scanning: a parser written by hand, where an index slips silently. */
   private static final Pattern CHAR_SCANNING = Pattern.compile("\\.charAt\\(|\\.codePointAt\\(");
@@ -53,9 +64,26 @@ final class HeuristicCodeDetector {
    */
   private static final Pattern HEURISTIC_DECLARATION =
       Pattern.compile(
-          "(?i)\\b(?:private|public|protected|internal|static|final|fun|def|func)\\b[^(=\\r\\n]*"
-              + "(?<![.\\w])(?:parse|validate|isValid|tokeni[sz]e|segment|normali[sz]e"
-              + "|canonicali[sz]e|sanitiz|lex|scan|split)\\w*\\s*\\(");
+          "(?i)\\b(?:private|public|protected|internal|static|final|fun|def|func|function)\\b"
+              + "[^(=\\r\\n]*(?<![.\\w])"
+              + "(?:parse|validate|isValid|tokeni[sz]e|segment|normali[sz]e|canonicali[sz]e"
+              + "|sanitiz|lex|scan|split)\\w*\\s*\\(");
+
+  /** Package-private Java-style method declaration, where no visibility keyword is present. */
+  private static final Pattern PACKAGE_PRIVATE_HEURISTIC_DECLARATION =
+      Pattern.compile(
+          "(?i)^\\+\\s*(?!(?:return|if|for|while|switch|throw|new)\\b)"
+              + "(?:@[\\w.]+\\s+)?(?:[\\w$<>?,.\\[\\]]+\\s+)+"
+              + "(?:parse|validate|isValid|tokeni[sz]e|segment|normali[sz]e|canonicali[sz]e"
+              + "|sanitiz|lex|scan|split)\\w*\\s*\\(");
+
+  /** JavaScript/TypeScript parser or validator assigned to an arrow/function expression. */
+  private static final Pattern ASSIGNED_HEURISTIC_DECLARATION =
+      Pattern.compile(
+          "(?i)\\b(?:const|let|var)\\s+"
+              + "(?:parse|validate|isValid|tokeni[sz]e|segment|normali[sz]e|canonicali[sz]e"
+              + "|sanitiz|lex|scan|split)\\w*\\s*=\\s*"
+              + "(?:function\\s*\\(|(?:async\\s*)?(?:\\([^\\r\\n]*\\)|[\\w$]+)\\s*=>)");
 
   /**
    * An import/package line mentions a type without using it, so it is never itself heuristic code —
@@ -104,25 +132,40 @@ final class HeuristicCodeDetector {
       return false;
     }
     var inTestFile = false;
+    var inJavaScriptFile = false;
+    var addedLines = new ArrayDeque<String>(4);
     for (String line : diff.split("\n", -1)) {
       // Every "+++ " line is a header, including the "+++ /dev/null" of a deletion — consuming them
-      // all here keeps the flag from carrying over to the next file and out of the content check.
+      // all here keeps file state and the multiline window from carrying into the next file.
       if (line.startsWith("+++ ")) {
         var header = DIFF_FILE_HEADER.matcher(line);
-        inTestFile = header.matches() && isTestPath(header.group(1));
+        var hasSourcePath = header.matches();
+        var path = hasSourcePath ? header.group(1) : "";
+        inTestFile = hasSourcePath && isTestPath(path);
+        inJavaScriptFile = hasSourcePath && JS_REGEX_PATH.matcher(path).find();
+        addedLines.clear();
         continue;
       }
-      if (inTestFile || line.length() < 2 || line.charAt(0) != '+') {
+      // Only contiguous additions can form one declaration or construction. Context, removals,
+      // hunk headers, and ignored test-file content all terminate the bounded window.
+      if (inTestFile || line.isEmpty() || line.charAt(0) != '+') {
+        addedLines.clear();
         continue;
       }
-      if (isHeuristicLine(line)) {
+
+      addedLines.addLast(line);
+      if (addedLines.size() > 4) {
+        addedLines.removeFirst();
+      }
+      if (isHeuristicLine(line, inJavaScriptFile)
+          || isHeuristicWindow(addedLines, inJavaScriptFile)) {
         return true;
       }
     }
     return false;
   }
 
-  private static boolean isHeuristicLine(String addedLine) {
+  private static boolean isHeuristicLine(String addedLine, boolean inJavaScriptFile) {
     if (DECLARATION_ONLY_LINE.matcher(addedLine).find()) {
       return false;
     }
@@ -130,6 +173,38 @@ final class HeuristicCodeDetector {
         || CHAR_SCANNING.matcher(addedLine).find()
         || NORMALIZATION.matcher(addedLine).find()
         || HEURISTIC_DECLARATION.matcher(addedLine).find()
+        || PACKAGE_PRIVATE_HEURISTIC_DECLARATION.matcher(addedLine).find()
+        || (inJavaScriptFile
+            && (JS_REGEX_LITERAL.matcher(addedLine).find()
+                || ASSIGNED_HEURISTIC_DECLARATION.matcher(addedLine).find()))
         || THRESHOLD_CONSTANT.matcher(addedLine).find();
+  }
+
+  private static boolean isHeuristicWindow(
+      ArrayDeque<String> addedLines, boolean inJavaScriptFile) {
+    if (addedLines.size() < 2) {
+      return false;
+    }
+    String[] lines = addedLines.toArray(String[]::new);
+    // Check every suffix ending at the newest line. This recognizes a declaration that starts
+    // after an unrelated addition without letting text older than four lines influence the match.
+    for (int start = 0; start < lines.length - 1; start++) {
+      var joined = new StringBuilder(lines[start]);
+      for (int index = start + 1; index < lines.length; index++) {
+        joined.append(' ').append(lines[index], 1, lines[index].length());
+      }
+      if (hasMultilineHeuristicSignal(joined, inJavaScriptFile)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasMultilineHeuristicSignal(
+      CharSequence addedLines, boolean inJavaScriptFile) {
+    return REGEX_CONSTRUCTION.matcher(addedLines).find()
+        || HEURISTIC_DECLARATION.matcher(addedLines).find()
+        || PACKAGE_PRIVATE_HEURISTIC_DECLARATION.matcher(addedLines).find()
+        || (inJavaScriptFile && ASSIGNED_HEURISTIC_DECLARATION.matcher(addedLines).find());
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
@@ -159,7 +159,7 @@ public class ReviewContextLoader {
   ReviewContext load(
       String auth, ReviewOrchestrator.ReviewRequest req, ReviewSession session, String repository) {
     var files = fetchPrFiles(auth, req.owner(), req.repo(), req.prNumber());
-    var prTotals = fetchPrTotals(auth, req.owner(), req.repo(), req.prNumber());
+    var prTotals = fetchPrTotalsForReview(auth, req);
     var reviewableFiles = diffFormatter.reviewableFiles(files);
     var tokenBudgeted = activeModel.maxInputTokens() > 0;
     var diffResult =
@@ -322,6 +322,41 @@ public class ReviewContextLoader {
     }
   }
 
+  /**
+   * Reads totals after the file list and rejects a review whose webhook SHA is no longer current.
+   * The files endpoint is keyed only by PR number, so without this check a force-push can pair the
+   * old request SHA with the new revision's files.
+   */
+  private PrTotals fetchPrTotalsForReview(String auth, ReviewOrchestrator.ReviewRequest req) {
+    try {
+      var pr = prClient.getPullRequest(auth, ACCEPT, req.owner(), req.repo(), req.prNumber());
+      var currentHead = pr != null && pr.head() != null ? pr.head().sha() : null;
+      if (currentHead == null
+          || req.commitSha() == null
+          || !currentHead.equalsIgnoreCase(req.commitSha())) {
+        throw new StaleReviewException(req.commitSha(), currentHead);
+      }
+      return new PrTotals(pr.changedFiles(), pr.additions(), pr.deletions());
+    } catch (StaleReviewException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new IllegalStateException(
+          "Unable to confirm the current PR head; refusing to review potentially mixed revisions",
+          e);
+    }
+  }
+
+  static final class StaleReviewException extends RuntimeException {
+    StaleReviewException(String expectedHead, String currentHead) {
+      super(
+          "PR head changed while loading review context (expected "
+              + expectedHead
+              + ", current "
+              + currentHead
+              + "); refusing to review mixed revisions");
+    }
+  }
+
   ReviewDiffFormatter.FormattedDiff buildBaseComparisonWithStats(
       String auth, String owner, String repo, String base, String head) {
     return buildBaseComparisonWithStats(auth, owner, repo, base, head, true);
@@ -379,15 +414,9 @@ public class ReviewContextLoader {
    * starts-with-heading check alone would miss an already-posted summary on a large PR and re-post
    * it on every re-review.
    */
-  private static boolean isBotSummaryComment(String body) {
-    if (body == null) {
-      return false;
-    }
-    if (body.stripLeading().startsWith(PrSummaryGenerator.SUMMARY_HEADING)) {
-      return true;
-    }
-    return body.lines()
-        .anyMatch(line -> line.stripLeading().startsWith(PrSummaryGenerator.SUMMARY_HEADING));
+  static boolean isBotSummaryComment(String body) {
+    return body != null
+        && body.lines().anyMatch(line -> line.strip().equals(PrSummaryGenerator.SUMMARY_HEADING));
   }
 
   List<GitHubCommentClient.IssueComment> fetchIssueComments(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -127,10 +127,7 @@ public class ReviewPublisher {
     var existing =
         commentClient.listComments(auth, ACCEPT, owner, repo, prNumber).stream()
             .filter(c -> c.user() != null && botIdentity.matches(c.user().login()))
-            .filter(
-                c ->
-                    c.body() != null
-                        && c.body().stripLeading().startsWith(PrSummaryGenerator.SUMMARY_HEADING))
+            .filter(c -> ReviewContextLoader.isBotSummaryComment(c.body()))
             .reduce((first, second) -> second);
     var request = new GitHubCommentClient.CreateCommentRequest(summaryMarkdown);
     if (existing.isPresent()) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -22,7 +22,9 @@ import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -138,11 +140,21 @@ public class VerdictBuilder {
     // Skip the DiffLineResolver when there are no statuses — first reviews and empty-status
     // paths must not pay for a patch re-parse (#135).
     var rawStatuses = aiResponse.previousFindingsStatus();
+    var currentRenameTargets = renameTargets(ctx.files());
     var effectiveStatuses =
         followUpAnalyzer.supersedeVanished(
             ctx.previousAiResponseJson(),
             rawStatuses,
-            rawStatuses.isEmpty() ? null : ctx.lineResolver());
+            rawStatuses.isEmpty() ? null : ctx.lineResolver(),
+            currentRenameTargets);
+    if (ctx.hasContext()) {
+      effectiveStatuses =
+          followUpAnalyzer.addUnreportedVanished(
+              ctx.previousFindingsList(),
+              effectiveStatuses,
+              ctx.lineResolver(),
+              currentRenameTargets);
+    }
     var effectiveResponse =
         new ReviewResponse(aiResponse.findings(), effectiveStatuses, aiResponse.summary());
     var unresolvedPrevious =
@@ -166,7 +178,9 @@ public class VerdictBuilder {
         changedFiles,
         unresolvedPrevious,
         ciEvaluation,
-        backstopUnresolved);
+        backstopUnresolved,
+        ReviewDiffFormatter.formatPureRenameRollup(
+            ReviewDiffFormatter.pureRenameFiles(ctx.files())));
   }
 
   static String conclusionForResult(ReviewResult result) {
@@ -316,6 +330,23 @@ public class VerdictBuilder {
   }
 
   /**
+   * Maps a prior path to its current rename target; blank means a content-identical pure rename.
+   */
+  static Map<String, String> renameTargets(List<GitHubPullRequestClient.FileDiff> files) {
+    var targets = new HashMap<String, String>();
+    for (var file : files) {
+      if (file != null
+          && "renamed".equalsIgnoreCase(file.status())
+          && file.previousFilename() != null
+          && !file.previousFilename().isBlank()) {
+        targets.putIfAbsent(
+            file.previousFilename(), ReviewDiffFormatter.isPureRename(file) ? "" : file.filename());
+      }
+    }
+    return targets;
+  }
+
+  /**
    * Projects the reviewed diff onto the (path, change type) rows the summary walkthrough renders.
    */
   static List<PrSummaryGenerator.ChangedFile> toChangedFiles(
@@ -333,6 +364,26 @@ public class VerdictBuilder {
       List<Finding> unresolvedPrevious,
       CiStatusEvaluator.CiEvaluation ciEvaluation,
       List<ReviewResult.PreviousFindingStatus> backstopUnresolved) {
+    return buildResult(
+        aiResponse,
+        isFirstReview,
+        diffStats,
+        changedFiles,
+        unresolvedPrevious,
+        ciEvaluation,
+        backstopUnresolved,
+        "");
+  }
+
+  private ReviewResult buildResult(
+      ReviewResponse aiResponse,
+      boolean isFirstReview,
+      DiffStats diffStats,
+      List<PrSummaryGenerator.ChangedFile> changedFiles,
+      List<Finding> unresolvedPrevious,
+      CiStatusEvaluator.CiEvaluation ciEvaluation,
+      List<ReviewResult.PreviousFindingStatus> backstopUnresolved,
+      String pureRenameRollup) {
     var offendingCiChecks = ciEvaluation.offendingChecks();
     var ciUnreadable = ciEvaluation.unreadable();
     var requiredContextsKnown = ciEvaluation.requiredContextsKnown();
@@ -384,6 +435,15 @@ public class VerdictBuilder {
                 ciUnreadable,
                 requiredContextsKnown,
                 diffStats.truncation()));
+    if (pureRenameRollup != null && !pureRenameRollup.isBlank()) {
+      summaryMarkdown =
+          summaryMarkdown.replace(
+              PrSummaryGenerator.SUMMARY_HEADING + "\n\n",
+              PrSummaryGenerator.SUMMARY_HEADING
+                  + "\n\n> **AI review scope:** "
+                  + pureRenameRollup.strip()
+                  + "\n\n");
+    }
     if (diffStats.truncated()) {
       summaryMarkdown =
           ReviewResult.truncationNotice(diffStats.omittedFiles(), diffStats.truncation())

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -175,12 +175,13 @@ public class VerdictBuilder {
         effectiveResponse,
         ctx.isFirstVisibleReview(),
         diffStats,
-        changedFiles,
+        new SummaryInputs(
+            changedFiles,
+            ReviewDiffFormatter.formatPureRenameRollup(
+                ReviewDiffFormatter.pureRenameFiles(ctx.files()))),
         unresolvedPrevious,
         ciEvaluation,
-        backstopUnresolved,
-        ReviewDiffFormatter.formatPureRenameRollup(
-            ReviewDiffFormatter.pureRenameFiles(ctx.files())));
+        backstopUnresolved);
   }
 
   static String conclusionForResult(ReviewResult result) {
@@ -356,6 +357,10 @@ public class VerdictBuilder {
         .toList();
   }
 
+  /** Inputs that only shape the summary walkthrough: the file rows and the pure-rename rollup. */
+  private record SummaryInputs(
+      List<PrSummaryGenerator.ChangedFile> changedFiles, String pureRenameRollup) {}
+
   ReviewResult buildResult(
       ReviewResponse aiResponse,
       boolean isFirstReview,
@@ -368,22 +373,22 @@ public class VerdictBuilder {
         aiResponse,
         isFirstReview,
         diffStats,
-        changedFiles,
+        new SummaryInputs(changedFiles, ""),
         unresolvedPrevious,
         ciEvaluation,
-        backstopUnresolved,
-        "");
+        backstopUnresolved);
   }
 
   private ReviewResult buildResult(
       ReviewResponse aiResponse,
       boolean isFirstReview,
       DiffStats diffStats,
-      List<PrSummaryGenerator.ChangedFile> changedFiles,
+      SummaryInputs summaryInputs,
       List<Finding> unresolvedPrevious,
       CiStatusEvaluator.CiEvaluation ciEvaluation,
-      List<ReviewResult.PreviousFindingStatus> backstopUnresolved,
-      String pureRenameRollup) {
+      List<ReviewResult.PreviousFindingStatus> backstopUnresolved) {
+    var changedFiles = summaryInputs.changedFiles();
+    var pureRenameRollup = summaryInputs.pureRenameRollup();
     var offendingCiChecks = ciEvaluation.offendingChecks();
     var ciUnreadable = ciEvaluation.unreadable();
     var requiredContextsKnown = ciEvaluation.requiredContextsKnown();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
@@ -157,13 +157,20 @@ public final class FindingVerifierPrompts {
             is the finding's own construction and is absent from the diff by definition, so the
             verbatim-quote and "unverifiable here" grounds above do not apply to it: requiring the
             input to be quoted would reject this entire class, which is exactly the blind spot the
-            characterization pass exists to cover. Confirm or downgrade it by tracing the quoted
-            rule against the named input yourself — reject it only when that trace shows the rule
-            handles the input correctly, when the rule it describes is not in the diff, or when it
-            names no concrete input at all. A silent miss (the rule accepts or skips what it
-            should catch) is a real defect even though nothing in the diff looks wrong, and being
-            unable to execute the rule here is not grounds for rejection: confidence "low" or
-            "medium" with the rule line quoted and the probing input named is the expected shape.
+            characterization pass exists to cover. Trace the quoted rule against the named input
+            yourself to establish what the rule actually does, but confirm a defect only when the
+            provided material also shows that the input belongs to the expected domain or that the
+            result violates a visible requirement, caller expectation, test, documentation, comment,
+            or API contract. Mechanics alone prove behavior, not what the rule should accept or
+            reject. When that expected-domain evidence is absent, downgrade the claim to confidence
+            "low" and phrase it as a verification request naming both the input and the missing
+            contract; do not confirm it as a defect. Otherwise, reject it when the trace shows the
+            rule handles the input correctly, when the rule it describes is not in the diff, or when
+            it names no concrete input at all. A silent miss (the rule accepts or skips what visible
+            contract evidence says it should catch) is a real defect even though nothing in the diff
+            looks wrong, and being unable to execute the rule here is not grounds for rejection:
+            confidence "low" or "medium" with the rule line quoted and the probing input named is
+            the expected shape.
 
             Severity calibration: "critical" and "high" risk require breakage demonstrable from
             the provided diff and context. A config/IaC defect whose breakage is visible in the

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
@@ -68,9 +68,9 @@ public final class FindingVerifierPrompts {
               the same diff, so you would repeat a miscount rather than catch it — which is how a
               hand-counted off-by-one ("the section is 7 lines, so 7 - 3 = 4 omitted") reached a
               PR against a test that passes as written. Reject it. Do NOT reject when the finding
-              is already phrased as a verification request naming what to run, or when an
-              execution/CI signal in the provided material shows the failure — downgrade to
-              confidence "low" instead.
+              is already phrased as a verification request naming what to run. When an
+              execution/CI signal in the provided material shows the failure, keep the finding
+              and assign the confidence justified by that evidence instead of forcing it low.
             - The flagged code does not appear in the diff as the finding describes it, or the
               code the finding quotes is not present verbatim in the diff — a
               finding built on a paraphrase of the change is invalid.
@@ -101,9 +101,10 @@ public final class FindingVerifierPrompts {
               the hunk — already guarantee a non-null owner and dereference it first). Reject
               it. Do NOT reject when (a) the material shows a caller that can pass null or
               another violating value, or (b) the changed signature itself declares a nullable
-              contract for that parameter — @Nullable / @CheckForNull, Optional, a documented
-              null-allowed Javadoc/Kotlin type, or similar — so a null-at-entry trace is
-              demonstrable from the signature without any caller hunk. Those findings stand.
+              contract for that parameter — @Nullable / @CheckForNull, a documented null-allowed
+              Javadoc/Kotlin type, or similar — so a null-at-entry trace is demonstrable from the
+              signature without any caller hunk. An Optional parameter is not itself nullable
+              unless a separate null-allowed contract says so. Those findings stand.
             - The finding misstates language semantics — for example, claiming the string
               escape "\\n" produces a literal backslash and n rather than a newline.
             - The finding claims a class is missing a required no-arg/default constructor for

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -556,6 +556,13 @@ public final class PrReviewPrompts {
             - Anchor at the new rule's line and quote that line. The synthesized input is your
               own construction and will NOT appear in the diff — say so plainly ("input not in
               the diff: ..."), and never present it as quoted material.
+            - Before treating a synthesized input as a defect, require visible evidence in the
+              provided material that the input belongs to the rule's expected domain, or that the
+              observed result violates its contract — requirements, callers, tests, documentation,
+              comments, or API contracts. The rule's mechanics can prove what it does, but mechanics
+              alone cannot prove what it should accept or reject. Without that expected-domain
+              evidence, report only a confidence "low" verification request naming the input and
+              the missing contract to check; do not call the behavior a confirmed defect.
             - Use confidence "low" or "medium" and phrase the consequence as a verification
               request naming the input to try. A limitation you cannot execute here is still worth
               reporting at that confidence; it is not a nitpick and the uncertainty is inherent to

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -147,13 +147,14 @@ public final class PrReviewPrompts {
             - The symmetric case — a claim that a test FAILS, or any claim resting on exact
               line-count, array-length, or index arithmetic you performed by counting lines or
               elements in the diff (for example "the section is 7 lines, so it prints 4") — is at
-              most confidence "low" and must be phrased as a verification request ("CI will
-              confirm this", "the test run will show which value is right"), never as settled fact
-              ("this test fails", "the assertion expects the wrong number"). Show the arithmetic
-              one step at a time from values quoted verbatim in the diff, and say in the
-              description that the test may pass as written. Counting is the least reliable thing
-              you do here and re-reading the same diff cannot check it — only an execution signal
-              or provided CI context can. Without one of those, a definitively-worded
+              most confidence "low" without an execution signal or provided CI context, and must
+              then be phrased as a verification request ("CI will confirm this", "the test run
+              will show which value is right"), never as settled fact ("this test fails", "the
+              assertion expects the wrong number"). Show the arithmetic one step at a time from
+              values quoted verbatim in the diff, and say in the description that the test may
+              pass as written. Counting is the least reliable thing you do here;
+              re-reading the same diff cannot check it. When execution or CI evidence settles the
+              result, use the confidence justified by that evidence. Without such evidence, a definitively-worded
               test-failure or off-by-one claim is invalid.
             - Re-read the flagged lines in the diff and confirm the issue exists in the code as
               written, not in a paraphrase of it. Quote the flagged lines exactly as they appear
@@ -178,7 +179,8 @@ public final class PrReviewPrompts {
               material and shown to pass such a value, or (b) the changed signature itself
               declares a nullable contract for that parameter — @Nullable / @CheckForNull,
               Optional, a documented null-allowed Javadoc/Kotlin type, or similar — so a
-              null-at-entry path is demonstrable from the signature alone. Inventing a null (or
+              null-at-entry path is demonstrable from the signature alone. An Optional parameter
+              is not itself nullable unless a separate null-allowed contract says so. Inventing a null (or
               other violating) argument at the method boundary when neither the caller nor such
               a nullable contract is in the diff does not establish the path — the caller's
               contract may already guarantee the precondition. When neither is visible, omit the

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -438,6 +438,7 @@ public class WebhookController {
           pr.number(),
           rootCommentId,
           comment.user().login(),
+          comment.authorAssociation(),
           comment.body());
     }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -295,6 +295,47 @@ class StartupConfigValidatorTest {
   }
 
   @Test
+  void failsFastWhenGlobalSafetyMarginIsNonFinite() {
+    for (var margin :
+        new double[] {Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY}) {
+      var ex = assertFailsValidation(new ConfigBuilder().tokenSafetyMargin(margin).build());
+      assertTrue(
+          ex.getMessage().contains("REVIEW_TOKEN_SAFETY_MARGIN must be in (0, 1] and finite"),
+          ex.getMessage());
+    }
+  }
+
+  @Test
+  void failsFastWhenPerModelFloatingPointSettingsAreNonFinite() {
+    var settings = emptyModelSettings();
+    lenient().when(settings.tokenSafetyMargin()).thenReturn(Optional.of(Double.NaN));
+    lenient().when(settings.temperature()).thenReturn(Optional.of(Double.POSITIVE_INFINITY));
+    lenient().when(settings.topP()).thenReturn(Optional.of(Double.NEGATIVE_INFINITY));
+    lenient().when(settings.frequencyPenalty()).thenReturn(Optional.of(Double.NaN));
+    lenient().when(settings.presencePenalty()).thenReturn(Optional.of(Double.POSITIVE_INFINITY));
+
+    var ex = assertFailsValidation(new ConfigBuilder().model("non-finite", settings).build());
+    var message = ex.getMessage();
+    assertTrue(message.contains("token-safety-margin must be in (0, 1] and finite"), message);
+    assertTrue(message.contains("temperature must be in [0, 2] and finite"), message);
+    assertTrue(message.contains("top-p must be in (0, 1] and finite"), message);
+    assertTrue(message.contains("frequency-penalty must be in [-2, 2] and finite"), message);
+    assertTrue(message.contains("presence-penalty must be in [-2, 2] and finite"), message);
+  }
+
+  @Test
+  void failsFastWhenEnabledBudgetDoesNotReserveConfiguredResponseCap() {
+    var settings = emptyModelSettings();
+    lenient().when(settings.maxOutputTokens()).thenReturn(Optional.of(8_193));
+
+    var ex = assertFailsValidation(new ConfigBuilder().model("deepseek-chat", settings).build());
+    assertTrue(
+        ex.getMessage()
+            .contains("effective output buffer (8192) must be >= max-output-tokens (8193)"),
+        ex.getMessage());
+  }
+
+  @Test
   void failsFastWhenOutputBufferLeavesNoDiffBudget() {
     var ex =
         assertFailsValidation(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -378,7 +378,7 @@ class StartupConfigValidatorTest {
     lenient().when(settings.tokenSafetyMargin()).thenReturn(Optional.of(0.8));
     lenient().when(settings.temperature()).thenReturn(Optional.of(0.2));
     lenient().when(settings.topP()).thenReturn(Optional.of(0.95));
-    lenient().when(settings.maxOutputTokens()).thenReturn(Optional.of(8_192));
+    lenient().when(settings.maxOutputTokens()).thenReturn(Optional.of(4_096));
     lenient().when(settings.frequencyPenalty()).thenReturn(Optional.of(-2.0));
     lenient().when(settings.presencePenalty()).thenReturn(Optional.of(2.0));
     lenient().when(settings.seed()).thenReturn(Optional.of(42));
@@ -410,8 +410,16 @@ class StartupConfigValidatorTest {
 
   @Test
   void allowsTokenBudgetingDisabledWithZeroInputTokens() {
-    // 0 input tokens disables budgeting (single call); the output-buffer cross-check is skipped.
-    new ConfigBuilder().maxInputTokens(0).build().validate();
+    // 0 input tokens disables budgeting (single call); neither output-buffer cross-check applies,
+    // even when the provider response cap is larger than the otherwise-unused buffer.
+    var settings = emptyModelSettings();
+    lenient().when(settings.maxOutputTokens()).thenReturn(Optional.of(8_192));
+    new ConfigBuilder()
+        .maxInputTokens(0)
+        .outputBufferTokens(4_096)
+        .model("deepseek-chat", settings)
+        .build()
+        .validate();
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
@@ -109,6 +109,31 @@ class DashboardAccessCheckerTest {
         .checkCollaborator(anyString(), anyString(), anyString(), anyString(), anyString());
   }
 
+  @SuppressWarnings("unchecked")
+  @Test
+  void shouldIgnoreForeignRepositoryEntriesInCachedSnapshot() throws ReflectiveOperationException {
+    var repoRefClass = Class.forName(DashboardAccessChecker.class.getName() + "$RepoRef");
+    var repoRefConstructor = repoRefClass.getDeclaredConstructor(String.class, String.class);
+    repoRefConstructor.setAccessible(true);
+    var foreignRepo = repoRefConstructor.newInstance("other-owner", "demo");
+
+    var snapshotClass = Class.forName(DashboardAccessChecker.class.getName() + "$RepoSnapshot");
+    var snapshotConstructor =
+        snapshotClass.getDeclaredConstructor(
+            String.class, List.class, String.class, java.time.Instant.class);
+    snapshotConstructor.setAccessible(true);
+    var snapshot =
+        snapshotConstructor.newInstance("myowner", List.of(foreignRepo), "Bearer token", now.get());
+    var cacheField = DashboardAccessChecker.class.getDeclaredField("cachedSnapshot");
+    cacheField.setAccessible(true);
+    var cache = (java.util.concurrent.atomic.AtomicReference<Object>) cacheField.get(checker);
+    cache.set(snapshot);
+
+    assertFalse(checker.hasRepositoryAccess("myowner", "myowner/demo"));
+    verify(installationClient, never())
+        .checkCollaborator(anyString(), anyString(), anyString(), anyString(), anyString());
+  }
+
   @Test
   void shouldAllowCollaboratorAccessToInstalledRepository() {
     stubInstalledRepo("myowner", "demo");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardAccessCheckerTest.java
@@ -100,6 +100,101 @@ class DashboardAccessCheckerTest {
   }
 
   @Test
+  void shouldAllowOwnerAccessToInstalledRepositoryCaseInsensitively() {
+    stubInstalledRepo("myowner", "demo");
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+
+    assertTrue(checker.hasRepositoryAccess("MYOWNER", "MyOwner/DEMO"));
+    verify(installationClient, never())
+        .checkCollaborator(anyString(), anyString(), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void shouldAllowCollaboratorAccessToInstalledRepository() {
+    stubInstalledRepo("myowner", "demo");
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+    Response collaboratorResponse = mock(Response.class);
+    when(collaboratorResponse.getStatus()).thenReturn(204);
+    when(installationClient.checkCollaborator(
+            eq("Bearer inst-token"), anyString(), eq("myowner"), eq("demo"), eq("collab")))
+        .thenReturn(collaboratorResponse);
+
+    assertTrue(checker.hasRepositoryAccess("collab", "myowner/demo"));
+  }
+
+  @Test
+  void shouldDenyNonCollaboratorAccessToInstalledRepository() {
+    stubInstalledRepo("myowner", "demo");
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+    Response notCollaborator = mock(Response.class);
+    when(notCollaborator.getStatus()).thenReturn(404);
+    when(installationClient.checkCollaborator(
+            eq("Bearer inst-token"), anyString(), eq("myowner"), eq("demo"), eq("outsider")))
+        .thenReturn(notCollaborator);
+
+    assertFalse(checker.hasRepositoryAccess("outsider", "myowner/demo"));
+  }
+
+  @Test
+  void shouldDenyMissingAndForeignRepositoriesWithoutCheckingCollaborator() {
+    stubInstalledRepo("myowner", "demo");
+    when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");
+
+    assertFalse(checker.hasRepositoryAccess("myowner", "myowner/missing"));
+    assertFalse(checker.hasRepositoryAccess("myowner", "other-owner/demo"));
+    verify(installationClient, never())
+        .checkCollaborator(anyString(), anyString(), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void shouldDenyMalformedRepositoryAccessInputs() {
+    assertAll(
+        () -> assertFalse(checker.hasRepositoryAccess(null, "myowner/demo")),
+        () -> assertFalse(checker.hasRepositoryAccess("   ", "myowner/demo")),
+        () -> assertFalse(checker.hasRepositoryAccess("myowner", null)),
+        () -> assertFalse(checker.hasRepositoryAccess("myowner", "   ")),
+        () -> assertFalse(checker.hasRepositoryAccess("myowner", "demo")),
+        () -> assertFalse(checker.hasRepositoryAccess("myowner", "/demo")),
+        () -> assertFalse(checker.hasRepositoryAccess("myowner", "myowner/")),
+        () -> assertFalse(checker.hasRepositoryAccess("myowner", "myowner/demo/extra")));
+    verifyNoInteractions(authClient, installationClient);
+  }
+
+  @Test
+  void shouldDenyRepositoryAccessWhenInstallationIsMissing() {
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
+        .thenReturn(List.of());
+
+    assertFalse(checker.hasRepositoryAccess("myowner", "myowner/demo"));
+    verify(authClient, never()).getAuthHeader(anyLong());
+  }
+
+  @Test
+  void shouldDenyRepositoryAccessWhenInstallationAuthIsMissing() {
+    when(installationClient.listInstallations(eq("Bearer jwt"), anyString(), eq(100), eq(1)))
+        .thenReturn(List.of(installationFor("myowner", 99L)));
+    when(authClient.getAuthHeader(99L)).thenReturn(null);
+    when(installationClient.listInstallationRepositories(isNull(), anyString(), eq(100), eq(1)))
+        .thenReturn(
+            new GitHubInstallationClient.InstallationRepositoriesResponse(
+                1, ownerRepos("myowner", "demo")));
+
+    assertFalse(checker.hasRepositoryAccess("myowner", "myowner/demo"));
+    verify(installationClient, never())
+        .checkCollaborator(anyString(), anyString(), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void shouldDenyRepositoryAccessWhenOwnerCannotBeResolved() {
+    when(installationClient.getApp(anyString(), anyString()))
+        .thenThrow(new RuntimeException("GitHub App unavailable"));
+
+    assertFalse(checker.hasRepositoryAccess("myowner", "myowner/demo"));
+    verify(installationClient, never())
+        .listInstallations(anyString(), anyString(), anyInt(), anyInt());
+  }
+
+  @Test
   void shouldDenyUserWhoIsNotCollaborator() {
     stubInstalledRepo("myowner", "demo");
     when(authClient.getAuthHeader(99L)).thenReturn("Bearer inst-token");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardResourceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardResourceTest.java
@@ -49,6 +49,7 @@ class DashboardResourceTest extends ReviewSessionTestSupport {
   void setUp() {
     when(sessionValidator.isValidSession(anyString())).thenReturn(true);
     when(sessionValidator.isValidSession(isNull())).thenReturn(false);
+    when(sessionValidator.hasRepositoryAccess(anyString(), anyString())).thenReturn(true);
   }
 
   @AfterEach
@@ -154,6 +155,54 @@ class DashboardResourceTest extends ReviewSessionTestSupport {
         .then()
         .statusCode(200)
         .body("repositories", not(empty()));
+  }
+
+  @Test
+  void shouldRejectFeedbackForAnInaccessibleRepository() {
+    when(sessionValidator.hasRepositoryAccess(VALID_TOKEN, "private/repo")).thenReturn(false);
+
+    given()
+        .cookie(COOKIE_NAME, VALID_TOKEN)
+        .queryParam("repository", "private/repo")
+        .when()
+        .get("/feedback")
+        .then()
+        .statusCode(403)
+        .body("error", equalTo("Repository access denied"));
+  }
+
+  @Test
+  void shouldFilterInaccessibleRepositoriesFromFeedbackAggregates() {
+    findingFeedbackService.recordFeedback(
+        new FindingFeedbackService.FeedbackInput(
+            "allowed/repo",
+            1,
+            10L,
+            1,
+            FindingFeedback.SIGNAL_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "octocat",
+            201L));
+    findingFeedbackService.recordFeedback(
+        new FindingFeedbackService.FeedbackInput(
+            "private/repo",
+            2,
+            20L,
+            1,
+            FindingFeedback.SIGNAL_NOT_USEFUL,
+            FindingFeedback.SOURCE_REACTION,
+            "alice",
+            202L));
+    when(sessionValidator.hasRepositoryAccess(VALID_TOKEN, "private/repo")).thenReturn(false);
+
+    given()
+        .cookie(COOKIE_NAME, VALID_TOKEN)
+        .when()
+        .get("/feedback")
+        .then()
+        .statusCode(200)
+        .body("repositories", hasSize(1))
+        .body("repositories[0].repository", equalTo("allowed/repo"));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardSessionValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/dashboard/DashboardSessionValidatorTest.java
@@ -86,4 +86,28 @@ class DashboardSessionValidatorTest {
 
     assertTrue(validator.resolveLogin(sessionId).isEmpty());
   }
+
+  @Test
+  void shouldDelegateAllowedRepositoryAccessForKnownSession() {
+    var sessionId = sessionStore.createSession("octocat", "gho_secret", "https://a.co", "Octocat");
+    when(accessChecker.hasRepositoryAccess("octocat", "owner/repo")).thenReturn(true);
+
+    assertTrue(validator.hasRepositoryAccess(sessionId, "owner/repo"));
+    verify(accessChecker).hasRepositoryAccess("octocat", "owner/repo");
+  }
+
+  @Test
+  void shouldDelegateDeniedRepositoryAccessForKnownSession() {
+    var sessionId = sessionStore.createSession("outsider", "gho_secret", "https://a.co", "Out");
+    when(accessChecker.hasRepositoryAccess("outsider", "owner/repo")).thenReturn(false);
+
+    assertFalse(validator.hasRepositoryAccess(sessionId, "owner/repo"));
+    verify(accessChecker).hasRepositoryAccess("outsider", "owner/repo");
+  }
+
+  @Test
+  void shouldRejectRepositoryAccessForUnknownSessionWithoutDelegating() {
+    assertFalse(validator.hasRepositoryAccess("unknown", "owner/repo"));
+    verify(accessChecker, never()).hasRepositoryAccess(anyString(), anyString());
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 
 import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubInstallationClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReactionClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import java.util.List;
@@ -35,19 +36,26 @@ class FindingFeedbackCaptureServiceTest {
   @Mock private GitHubAuthClient authClient;
   @Mock private GitHubReactionClient reactionClient;
   @Mock private GitHubReviewClient reviewClient;
+  @Mock private GitHubInstallationClient installationClient;
 
   private FindingFeedbackCaptureService capture;
 
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
+    lenient()
+        .when(
+            installationClient.collaboratorPermission(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(new GitHubInstallationClient.CollaboratorPermission("write", "write"));
     capture =
         new FindingFeedbackCaptureService(
             feedbackService,
             BotIdentity.of("thrillhousebot[bot]"),
             authClient,
             reactionClient,
-            reviewClient);
+            reviewClient,
+            installationClient);
   }
 
   @Test
@@ -97,6 +105,47 @@ class FindingFeedbackCaptureServiceTest {
                 3L));
     verify(feedbackService, never())
         .recordFeedback(argThat(in -> "thrillhousebot[bot]".equals(in.reactorLogin())));
+  }
+
+  @Test
+  void captureReactionsIgnoresReadOnlyCollaborators() {
+    when(installationClient.collaboratorPermission(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq("octocat")))
+        .thenReturn(new GitHubInstallationClient.CollaboratorPermission("read", "read"));
+    when(reactionClient.listReviewCommentReactions(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L), eq("+1"), eq(100), eq(1)))
+        .thenReturn(
+            List.of(
+                new GitHubReactionClient.Reaction(
+                    1L, "+1", new GitHubReactionClient.Reaction.User("octocat", 1), "t")));
+
+    capture.captureReactions(
+        "Bearer t", "owner", "repo", 7, 99L, SuggestionFormatter.findingMarker(2));
+
+    verifyNoInteractions(feedbackService);
+  }
+
+  @Test
+  void captureOnReviewReplyRejectsNonMaintainerAssociationBeforeFetchingRoot() {
+    when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
+
+    capture.captureOnReviewReply(
+        9L, "owner", "repo", 7, 99L, "external-contributor", "CONTRIBUTOR", "false positive");
+
+    verifyNoInteractions(reviewClient, reactionClient, installationClient, feedbackService);
+  }
+
+  @Test
+  void captureOnReviewReplyRejectsReadOnlyCollaboratorBeforeFetchingRoot() {
+    when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
+    when(installationClient.collaboratorPermission(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq("octocat")))
+        .thenReturn(new GitHubInstallationClient.CollaboratorPermission("read", "read"));
+
+    capture.captureOnReviewReply(
+        9L, "owner", "repo", 7, 99L, "octocat", "MEMBER", "false positive");
+
+    verifyNoInteractions(reviewClient, reactionClient, feedbackService);
   }
 
   @Test
@@ -329,8 +378,8 @@ class FindingFeedbackCaptureServiceTest {
   void captureOnPriorFindingsStopsAtMaxFindingsInDeterministicIdOrder() {
     var comments = new java.util.ArrayList<GitHubReviewClient.PullRequestComment>();
     int max = FindingFeedbackCaptureService.MAX_FINDINGS_PER_CAPTURE;
-    // Insert higher ids first so insertion order would prefer them; we must still poll the
-    // lowest comment ids and skip the highest.
+    // Insert higher ids first; newest roots are polled so recently added reaction-only feedback is
+    // not starved behind the oldest roots forever.
     for (int i = max + 2; i >= 1; i--) {
       long id = 1000L + i;
       comments.add(
@@ -357,21 +406,19 @@ class FindingFeedbackCaptureServiceTest {
             anyString(),
             eq(100),
             anyInt());
-    long skippedLow = 1000L + max + 1;
-    long skippedHigh = 1000L + max + 2;
     verify(reactionClient, never())
         .listReviewCommentReactions(
-            any(), any(), any(), any(), eq(skippedLow), anyString(), anyInt(), anyInt());
+            any(), any(), any(), any(), eq(1001L), anyString(), anyInt(), anyInt());
     verify(reactionClient, never())
         .listReviewCommentReactions(
-            any(), any(), any(), any(), eq(skippedHigh), anyString(), anyInt(), anyInt());
+            any(), any(), any(), any(), eq(1002L), anyString(), anyInt(), anyInt());
     verify(reactionClient, times(2))
         .listReviewCommentReactions(
             eq("Bearer t"),
             anyString(),
             eq("owner"),
             eq("repo"),
-            eq(1001L),
+            eq(1000L + max + 2),
             anyString(),
             eq(100),
             anyInt());
@@ -392,7 +439,7 @@ class FindingFeedbackCaptureServiceTest {
             any(), any(), any(), any(), anyLong(), any(), anyInt(), anyInt()))
         .thenReturn(List.of());
 
-    capture.scheduleCaptureOnReviewReply(9L, "owner", "repo", 7, 99L, "octocat", "thanks");
+    capture.scheduleCaptureOnReviewReply(9L, "owner", "repo", 7, 99L, "octocat", "OWNER", "thanks");
     verify(authClient, timeout(2000)).getAuthHeader(9L);
     verify(reviewClient, timeout(2000))
         .getPullRequestComment(any(), any(), eq("owner"), eq("repo"), eq(99L));
@@ -426,7 +473,7 @@ class FindingFeedbackCaptureServiceTest {
   @Test
   void scheduleCaptureOnReviewReplyRunsAsyncAndSwallowsErrors() {
     when(authClient.getAuthHeader(anyLong())).thenThrow(new RuntimeException("auth fail"));
-    capture.scheduleCaptureOnReviewReply(1L, "o", "r", 1, 9L, "u", "not useful");
+    capture.scheduleCaptureOnReviewReply(1L, "o", "r", 1, 9L, "u", "OWNER", "not useful");
     verify(authClient, timeout(2000)).getAuthHeader(1L);
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -66,12 +66,17 @@ class FindingFeedbackCaptureServiceTest {
     capture.shutdown();
   }
 
+  /** An OWNER-association reply, the common case in these tests. */
+  private static FindingFeedbackCaptureService.ReviewReply reply(String authorLogin, String body) {
+    return new FindingFeedbackCaptureService.ReviewReply(authorLogin, "OWNER", body);
+  }
+
   @Test
   void captureOnReviewReplyRejectsNullOrBlankActorBeforePermissionLookup() {
     when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
 
-    capture.captureOnReviewReply(9L, "owner", "repo", 7, 99L, null, "OWNER", "false positive");
-    capture.captureOnReviewReply(9L, "owner", "repo", 7, 99L, "   ", "OWNER", "false positive");
+    capture.captureOnReviewReply(9L, "owner", "repo", 7, 99L, reply(null, "false positive"));
+    capture.captureOnReviewReply(9L, "owner", "repo", 7, 99L, reply("   ", "false positive"));
 
     verifyNoInteractions(installationClient, reviewClient, reactionClient, feedbackService);
   }
@@ -80,7 +85,13 @@ class FindingFeedbackCaptureServiceTest {
   void captureOnReviewReplyRejectsNullAssociationBeforePermissionLookup() {
     when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
 
-    capture.captureOnReviewReply(9L, "owner", "repo", 7, 99L, "octocat", null, "false positive");
+    capture.captureOnReviewReply(
+        9L,
+        "owner",
+        "repo",
+        7,
+        99L,
+        new FindingFeedbackCaptureService.ReviewReply("octocat", null, "false positive"));
 
     verifyNoInteractions(installationClient, reviewClient, reactionClient, feedbackService);
   }
@@ -96,9 +107,9 @@ class FindingFeedbackCaptureServiceTest {
         .thenReturn(new GitHubInstallationClient.CollaboratorPermission(null, null));
 
     capture.captureOnReviewReply(
-        9L, "owner", "repo", 7, 99L, "null-response", "OWNER", "false positive");
+        9L, "owner", "repo", 7, 99L, reply("null-response", "false positive"));
     capture.captureOnReviewReply(
-        9L, "owner", "repo", 7, 99L, "null-level", "OWNER", "false positive");
+        9L, "owner", "repo", 7, 99L, reply("null-level", "false positive"));
 
     verifyNoInteractions(reviewClient, reactionClient, feedbackService);
   }
@@ -113,7 +124,7 @@ class FindingFeedbackCaptureServiceTest {
     assertDoesNotThrow(
         () ->
             capture.captureOnReviewReply(
-                9L, "owner", "repo", 7, 99L, "octocat", "OWNER", "false positive"));
+                9L, "owner", "repo", 7, 99L, reply("octocat", "false positive")));
 
     verifyNoInteractions(reviewClient, reactionClient, feedbackService);
   }
@@ -244,7 +255,13 @@ class FindingFeedbackCaptureServiceTest {
     when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
 
     capture.captureOnReviewReply(
-        9L, "owner", "repo", 7, 99L, "external-contributor", "CONTRIBUTOR", "false positive");
+        9L,
+        "owner",
+        "repo",
+        7,
+        99L,
+        new FindingFeedbackCaptureService.ReviewReply(
+            "external-contributor", "CONTRIBUTOR", "false positive"));
 
     verifyNoInteractions(reviewClient, reactionClient, installationClient, feedbackService);
   }
@@ -257,7 +274,12 @@ class FindingFeedbackCaptureServiceTest {
         .thenReturn(new GitHubInstallationClient.CollaboratorPermission("read", "read"));
 
     capture.captureOnReviewReply(
-        9L, "owner", "repo", 7, 99L, "octocat", "MEMBER", "false positive");
+        9L,
+        "owner",
+        "repo",
+        7,
+        99L,
+        new FindingFeedbackCaptureService.ReviewReply("octocat", "MEMBER", "false positive"));
 
     verifyNoInteractions(reviewClient, reactionClient, feedbackService);
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -25,6 +25,9 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubInstallationClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReactionClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -56,6 +59,117 @@ class FindingFeedbackCaptureServiceTest {
             reactionClient,
             reviewClient,
             installationClient);
+  }
+
+  @AfterEach
+  void tearDown() {
+    capture.shutdown();
+  }
+
+  @Test
+  void captureOnReviewReplyRejectsNullOrBlankActorBeforePermissionLookup() {
+    when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
+
+    capture.captureOnReviewReply(9L, "owner", "repo", 7, 99L, null, "OWNER", "false positive");
+    capture.captureOnReviewReply(9L, "owner", "repo", 7, 99L, "   ", "OWNER", "false positive");
+
+    verifyNoInteractions(installationClient, reviewClient, reactionClient, feedbackService);
+  }
+
+  @Test
+  void captureOnReviewReplyRejectsNullAssociationBeforePermissionLookup() {
+    when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
+
+    capture.captureOnReviewReply(9L, "owner", "repo", 7, 99L, "octocat", null, "false positive");
+
+    verifyNoInteractions(installationClient, reviewClient, reactionClient, feedbackService);
+  }
+
+  @Test
+  void captureOnReviewReplyRejectsMissingPermissionResponseOrLevel() {
+    when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
+    when(installationClient.collaboratorPermission(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq("null-response")))
+        .thenReturn(null);
+    when(installationClient.collaboratorPermission(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq("null-level")))
+        .thenReturn(new GitHubInstallationClient.CollaboratorPermission(null, null));
+
+    capture.captureOnReviewReply(
+        9L, "owner", "repo", 7, 99L, "null-response", "OWNER", "false positive");
+    capture.captureOnReviewReply(
+        9L, "owner", "repo", 7, 99L, "null-level", "OWNER", "false positive");
+
+    verifyNoInteractions(reviewClient, reactionClient, feedbackService);
+  }
+
+  @Test
+  void captureOnReviewReplyIgnoresPermissionApiException() {
+    when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
+    when(installationClient.collaboratorPermission(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq("octocat")))
+        .thenThrow(new RuntimeException("api down"));
+
+    assertDoesNotThrow(
+        () ->
+            capture.captureOnReviewReply(
+                9L, "owner", "repo", 7, 99L, "octocat", "OWNER", "false positive"));
+
+    verifyNoInteractions(reviewClient, reactionClient, feedbackService);
+  }
+
+  @Test
+  void captureOnReviewReplySkipsRootCommentWithNullUser() {
+    when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
+    when(reviewClient.getPullRequestComment(
+            anyString(), anyString(), eq("owner"), eq("repo"), eq(99L)))
+        .thenReturn(
+            new GitHubReviewClient.PullRequestComment(
+                99L, null, "Main.java", "finding\n" + SuggestionFormatter.findingMarker(1), null));
+
+    capture.captureOnReviewReply(9L, "owner", "repo", 7, 99L, "octocat", "not useful");
+
+    verifyNoInteractions(reactionClient, feedbackService);
+  }
+
+  @Test
+  void scheduleCaptureOnReviewReplyDropsTaskWhenExecutorIsAtCapacity() throws InterruptedException {
+    int maxConcurrentCaptures = 8;
+    var started = new CountDownLatch(maxConcurrentCaptures);
+    var release = new CountDownLatch(1);
+    var completed = new CountDownLatch(maxConcurrentCaptures);
+    when(authClient.getAuthHeader(anyLong()))
+        .thenAnswer(
+            ignored -> {
+              started.countDown();
+              release.await();
+              return "Bearer t";
+            });
+    when(reviewClient.getPullRequestComment(any(), any(), any(), any(), anyLong()))
+        .thenAnswer(
+            ignored -> {
+              completed.countDown();
+              return null;
+            });
+
+    try {
+      for (int i = 1; i <= maxConcurrentCaptures; i++) {
+        capture.scheduleCaptureOnReviewReply(
+            i, "owner", "repo", 7, 99L, "octocat", "OWNER", "not useful");
+      }
+      assertTrue(started.await(10, TimeUnit.SECONDS), "capture workers did not all start");
+
+      assertDoesNotThrow(
+          () ->
+              capture.scheduleCaptureOnReviewReply(
+                  99L, "owner", "repo", 7, 99L, "octocat", "OWNER", "not useful"));
+
+      verify(authClient, times(maxConcurrentCaptures)).getAuthHeader(anyLong());
+      verify(authClient, never()).getAuthHeader(99L);
+    } finally {
+      release.countDown();
+    }
+    assertTrue(completed.await(10, TimeUnit.SECONDS), "accepted capture tasks did not complete");
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -869,6 +869,22 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void unreportedPureRenameShouldRemainUnresolved() {
+    var previous =
+        List.of(
+            new ReviewResponse.Finding(
+                "medium", "old/A.java", 10, "Finding", "description", "flagged()", null));
+
+    var statuses =
+        analyzer.addUnreportedVanished(
+            previous, List.of(), new DiffLineResolver(Map.of()), Map.of("old/A.java", ""));
+
+    assertEquals(1, statuses.size());
+    assertEquals("unresolved", statuses.get(0).status());
+    assertTrue(statuses.get(0).note().contains("renamed without content changes"));
+  }
+
+  @Test
   void toStatusesShouldKeepTheSyntheticSupersededStatus() {
     var statuses =
         analyzer.toStatuses(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -878,6 +878,7 @@ class FollowUpAnalyzerTest {
                 "medium", "src/A.java", 1, "Finding", "description", "flagged()", null));
 
     assertEquals(reported, analyzer.addUnreportedVanished(null, reported, resolver, Map.of()));
+    assertTrue(analyzer.addUnreportedVanished(null, null, resolver, Map.of()).isEmpty());
     assertEquals(reported, analyzer.addUnreportedVanished(List.of(), reported, resolver, Map.of()));
     assertEquals(reported, analyzer.addUnreportedVanished(previous, reported, null, Map.of()));
     assertTrue(analyzer.addUnreportedVanished(previous, null, resolver, Map.of()).isEmpty());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -869,6 +869,70 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void addUnreportedVanishedShouldPassThroughGuardInputsAndAcceptNullStatuses() {
+    var resolver = new DiffLineResolver(Map.of("src/A.java", "@@ -1,1 +1,1 @@\n-old\n+flagged()"));
+    var reported = List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed"));
+    var previous =
+        List.of(
+            new ReviewResponse.Finding(
+                "medium", "src/A.java", 1, "Finding", "description", "flagged()", null));
+
+    assertEquals(reported, analyzer.addUnreportedVanished(null, reported, resolver, Map.of()));
+    assertEquals(reported, analyzer.addUnreportedVanished(List.of(), reported, resolver, Map.of()));
+    assertEquals(reported, analyzer.addUnreportedVanished(previous, reported, null, Map.of()));
+    assertTrue(analyzer.addUnreportedVanished(previous, null, resolver, Map.of()).isEmpty());
+  }
+
+  @Test
+  void addUnreportedVanishedShouldHandleReportedUnplaceablePresentVanishedAndRenamedFindings() {
+    var previous =
+        List.of(
+            new ReviewResponse.Finding(
+                "medium", "src/Reported.java", 1, "Reported", "d", "reported()", null),
+            new ReviewResponse.Finding("medium", null, 2, "No file", "d", "unplaceable()", null),
+            new ReviewResponse.Finding(
+                "medium", "src/Still.java", 3, "Still", "d", "stillFlagged()", null),
+            new ReviewResponse.Finding(
+                "medium", "src/Gone.java", 4, "Gone", "d", "goneFlagged()", null),
+            new ReviewResponse.Finding(
+                "medium", "old/Moved.java", 5, "Moved", "d", "movedFlagged()", null),
+            new ReviewResponse.Finding(
+                "medium", "old/Gone.java", 6, "Moved then gone", "d", "goneAgain()", null),
+            new ReviewResponse.Finding(
+                "medium", "old/Pure.java", 7, "Pure rename", "d", "unchanged()", null));
+    var reported = List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed"));
+    var resolver =
+        new DiffLineResolver(
+            Map.of(
+                "src/Still.java", "@@ -3,1 +3,1 @@\n-old\n+stillFlagged()",
+                "new/Moved.java", "@@ -5,1 +5,1 @@\n-old\n+movedFlagged()"));
+    var renameTargets =
+        Map.of(
+            "old/Moved.java", "new/Moved.java",
+            "old/Gone.java", "new/Gone.java",
+            "old/Pure.java", "");
+
+    var statuses = analyzer.addUnreportedVanished(previous, reported, resolver, renameTargets);
+
+    assertEquals(List.of(1, 4, 6, 7), statuses.stream().map(s -> s.id()).toList());
+    assertEquals("superseded", statuses.get(1).status());
+    assertEquals("superseded", statuses.get(2).status());
+    assertEquals("unresolved", statuses.get(3).status());
+    assertTrue(statuses.get(3).note().contains("renamed without content changes"));
+  }
+
+  @Test
+  void supersedeVanishedShouldKeepUnresolvedAcrossPureRename() {
+    var statuses = List.of(new ReviewResponse.PreviousFindingStatus(1, "unresolved", "still"));
+
+    var rewritten =
+        analyzer.supersedeVanished(
+            PREVIOUS_JSON, statuses, new DiffLineResolver(Map.of()), Map.of("src/A.java", ""));
+
+    assertEquals(statuses, rewritten);
+  }
+
+  @Test
   void unreportedPureRenameShouldRemainUnresolved() {
     var previous =
         List.of(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
@@ -179,6 +179,20 @@ class HeuristicCodeDetectorTest {
   }
 
   @Test
+  void shouldNotTriggerOnDeclaredMembersWithoutAHeuristicName() {
+    // These carry the full declaration shape, so rejection happens on the captured member name.
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/Service.java",
+                "  public String renderTitle(String raw) {",
+                "  Token renderToken(String raw) {")));
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("frontend/src/render.ts", "const renderToken = (value: string) => value;")));
+  }
+
+  @Test
   void shouldNotTriggerOnImportOrPackageLines() {
     assertFalse(
         HeuristicCodeDetector.introducesHeuristicCode(
@@ -347,12 +361,14 @@ class HeuristicCodeDetectorTest {
                 "      .compile(\"too-far-away\");")));
 
     String interrupted =
-        "--- a/src/main/java/dev/thiagogonzaga/Interrupted.java\n"
-            + "+++ b/src/main/java/dev/thiagogonzaga/Interrupted.java\n"
-            + "@@ -1,2 +1,4 @@\n"
-            + "+  Pattern\n"
-            + "   String context = value;\n"
-            + "+      .compile(\"after-context\");\n";
+        """
+        --- a/src/main/java/dev/thiagogonzaga/Interrupted.java
+        +++ b/src/main/java/dev/thiagogonzaga/Interrupted.java
+        @@ -1,2 +1,4 @@
+        +  Pattern
+           String context = value;
+        +      .compile("after-context");
+        """;
     assertFalse(HeuristicCodeDetector.introducesHeuristicCode(interrupted));
 
     String files =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
@@ -100,6 +100,12 @@ class HeuristicCodeDetectorTest {
             diff(
                 "src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java",
                 "  private void validateAppId(String appId) {")));
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java",
+                "  private boolean",
+                "      validateInstallation(long installationId) {")));
   }
 
   @Test
@@ -221,6 +227,117 @@ class HeuristicCodeDetectorTest {
             + "-  int gone = 1;\n"
             + diff("src/main/java/dev/thiagogonzaga/Kept.java", "  int i = s.charAt(2);");
     assertTrue(HeuristicCodeDetector.introducesHeuristicCode(combined));
+  }
+
+  @Test
+  void shouldTriggerOnJavaScriptAndTypeScriptRegexLiterals() {
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("frontend/src/version.js", "const VERSION = /^v[0-9]+$/i;")));
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("frontend/src/version.tsx", "return /^(?:major|minor|patch)$/;")));
+  }
+
+  @Test
+  void shouldTriggerOnJavaScriptFunctionAndArrowValidatorDeclarations() {
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("frontend/src/validate.ts", "function validateTag(value: string) {")));
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "frontend/src/validate.ts",
+                "const validateTag = (value: string) => value.length > 0;")));
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "frontend/src/parse.ts",
+                "const parseTag =",
+                "    (value: string) => value.split(':');")));
+  }
+
+  @Test
+  void shouldTriggerOnPackagePrivateJavaHeuristicDeclaration() {
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/TagParser.java",
+                "  Optional<Tag> parseTag(String raw) {")));
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/TagParser.java",
+                "  Optional<Tag>",
+                "      parseMultilineTag(String raw) {")));
+  }
+
+  @Test
+  void shouldTriggerOnMultilineRegexConstruction() {
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/TagParser.java",
+                "  private static final Pattern TAG = Pattern",
+                "      .compile(\"^v[0-9]+$\");")));
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("frontend/src/parse.ts", "const tag = new RegExp", "    ('^v[0-9]+$', 'i');")));
+  }
+
+  @Test
+  void shouldRestrictRegexLiteralsAndAssignedHeuristicsToJavaScriptSources() {
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/Math.java",
+                "  var ratio = total / count;",
+                "  var url = \"https://example.test/path\";",
+                "  var matcher = /^v[0-9]+$/;",
+                "  const validateTag = (value) => true;")));
+  }
+
+  @Test
+  void shouldNotMistakeJavaScriptDivisionUrlsCallsOrAssignmentsForHeuristicCode() {
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "frontend/src/service.ts",
+                "const ratio = total / count;",
+                "const endpoint = 'https://example.test/path';",
+                "const result = validator.validate(input);",
+                "const validateResult = existingValidator;",
+                "const parser = service.parse(input);")));
+  }
+
+  @Test
+  void shouldBoundAndResetTheMultilineDetectionWindow() {
+    assertFalse(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "src/main/java/dev/thiagogonzaga/Separated.java",
+                "  Pattern",
+                "  int one = 1;",
+                "  int two = 2;",
+                "  int three = 3;",
+                "  int four = 4;",
+                "      .compile(\"too-far-away\");")));
+
+    String interrupted =
+        "--- a/src/main/java/dev/thiagogonzaga/Interrupted.java\n"
+            + "+++ b/src/main/java/dev/thiagogonzaga/Interrupted.java\n"
+            + "@@ -1,2 +1,4 @@\n"
+            + "+  Pattern\n"
+            + "   String context = value;\n"
+            + "+      .compile(\"after-context\");\n";
+    assertFalse(HeuristicCodeDetector.introducesHeuristicCode(interrupted));
+
+    String files =
+        diff("src/main/java/dev/thiagogonzaga/First.java", "  Pattern")
+            + diff("src/main/java/dev/thiagogonzaga/Second.java", "      .compile(\"x\");")
+            + diff("src/test/java/dev/thiagogonzaga/FixtureTest.java", "  Pattern")
+            + diff("src/main/java/dev/thiagogonzaga/Third.java", "      .compile(\"y\");");
+    assertFalse(HeuristicCodeDetector.introducesHeuristicCode(files));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
@@ -237,6 +237,21 @@ class HeuristicCodeDetectorTest {
     assertTrue(
         HeuristicCodeDetector.introducesHeuristicCode(
             diff("frontend/src/version.tsx", "return /^(?:major|minor|patch)$/;")));
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("frontend/src/path.ts", "const PATH = /^\\/api\\/v[0-9]+$/;")));
+  }
+
+  @Test
+  void shouldHandleLargeRegexAndArrowBodiesWithoutBacktrackingOverflow() {
+    var longToken = "x".repeat(100_000);
+
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("frontend/src/version.ts", "const VERSION = /" + longToken + "/;")));
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("frontend/src/validate.ts", "const validateTag = (" + longToken + ") => true;")));
   }
 
   @Test
@@ -249,6 +264,14 @@ class HeuristicCodeDetectorTest {
             diff(
                 "frontend/src/validate.ts",
                 "const validateTag = (value: string) => value.length > 0;")));
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff("frontend/src/parse.ts", "const parseTag = value => value.split(':');")));
+    assertTrue(
+        HeuristicCodeDetector.introducesHeuristicCode(
+            diff(
+                "frontend/src/validate.ts",
+                "const validateTag = (predicate: (value: string) => boolean) => predicate('v1');")));
     assertTrue(
         HeuristicCodeDetector.introducesHeuristicCode(
             diff(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
@@ -388,8 +388,12 @@ class ReviewContextLoaderTest {
   class StaleHeadValidation {
 
     private ReviewOrchestrator.ReviewRequest request() {
+      return request("expected-sha");
+    }
+
+    private ReviewOrchestrator.ReviewRequest request(String commitSha) {
       return new ReviewOrchestrator.ReviewRequest(
-          "owner", "repo", 42, "expected-sha", "Title", "", "base-sha", "main", 9L, false);
+          "owner", "repo", 42, commitSha, "Title", "", "base-sha", "main", 9L, false);
     }
 
     private ReviewSession session() {
@@ -416,6 +420,50 @@ class ReviewContextLoaderTest {
               () -> loader.load("auth", request(), session(), "owner/repo"));
 
       assertTrue(error.getMessage().contains("expected expected-sha, current new-sha"));
+    }
+
+    @Test
+    void shouldRejectNullPullRequestHeadAndCurrentSha() {
+      when(prClient.getPullRequestFiles(any(), any(), eq("owner"), eq("repo"), eq(42)))
+          .thenReturn(List.of());
+      when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(42)))
+          .thenReturn(
+              null,
+              new GitHubPullRequestClient.PullRequestDetails(
+                  "Title", "", null, new GitHubPullRequestClient.Ref("base-sha")),
+              new GitHubPullRequestClient.PullRequestDetails(
+                  "Title",
+                  "",
+                  new GitHubPullRequestClient.Ref(null),
+                  new GitHubPullRequestClient.Ref("base-sha")));
+
+      for (var ignored = 0; ignored < 3; ignored++) {
+        var error =
+            assertThrows(
+                ReviewContextLoader.StaleReviewException.class,
+                () -> loader.load("auth", request(), session(), "owner/repo"));
+        assertTrue(error.getMessage().contains("current null"));
+      }
+    }
+
+    @Test
+    void shouldRejectNullRequestedSha() {
+      when(prClient.getPullRequestFiles(any(), any(), eq("owner"), eq("repo"), eq(42)))
+          .thenReturn(List.of());
+      when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(42)))
+          .thenReturn(
+              new GitHubPullRequestClient.PullRequestDetails(
+                  "Title",
+                  "",
+                  new GitHubPullRequestClient.Ref("current-sha"),
+                  new GitHubPullRequestClient.Ref("base-sha")));
+
+      var error =
+          assertThrows(
+              ReviewContextLoader.StaleReviewException.class,
+              () -> loader.load("auth", request(null), session(), "owner/repo"));
+
+      assertTrue(error.getMessage().contains("expected null, current current-sha"));
     }
 
     @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
@@ -385,6 +385,56 @@ class ReviewContextLoaderTest {
   }
 
   @Nested
+  class StaleHeadValidation {
+
+    private ReviewOrchestrator.ReviewRequest request() {
+      return new ReviewOrchestrator.ReviewRequest(
+          "owner", "repo", 42, "expected-sha", "Title", "", "base-sha", "main", 9L, false);
+    }
+
+    private ReviewSession session() {
+      var session = ReviewSession.create("owner/repo", 42, "Title", "expected-sha");
+      session.id = 1L;
+      return session;
+    }
+
+    @Test
+    void shouldRejectWhenHeadChangesAfterFilesAreFetched() {
+      when(prClient.getPullRequestFiles(any(), any(), eq("owner"), eq("repo"), eq(42)))
+          .thenReturn(List.of());
+      when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(42)))
+          .thenReturn(
+              new GitHubPullRequestClient.PullRequestDetails(
+                  "Title",
+                  "",
+                  new GitHubPullRequestClient.Ref("new-sha"),
+                  new GitHubPullRequestClient.Ref("base-sha")));
+
+      var error =
+          assertThrows(
+              ReviewContextLoader.StaleReviewException.class,
+              () -> loader.load("auth", request(), session(), "owner/repo"));
+
+      assertTrue(error.getMessage().contains("expected expected-sha, current new-sha"));
+    }
+
+    @Test
+    void shouldFailClosedWhenCurrentHeadCannotBeRead() {
+      when(prClient.getPullRequestFiles(any(), any(), eq("owner"), eq("repo"), eq(42)))
+          .thenReturn(List.of());
+      when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(42)))
+          .thenThrow(new RuntimeException("GitHub unavailable"));
+
+      var error =
+          assertThrows(
+              IllegalStateException.class,
+              () -> loader.load("auth", request(), session(), "owner/repo"));
+
+      assertTrue(error.getMessage().contains("refusing to review potentially mixed revisions"));
+    }
+  }
+
+  @Nested
   class FetchPrFiles {
 
     @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
@@ -473,10 +473,12 @@ class ReviewContextLoaderTest {
       when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(42)))
           .thenThrow(new RuntimeException("GitHub unavailable"));
 
+      var reviewRequest = request();
+      var reviewSession = session();
       var error =
           assertThrows(
               IllegalStateException.class,
-              () -> loader.load("auth", request(), session(), "owner/repo"));
+              () -> loader.load("auth", reviewRequest, reviewSession, "owner/repo"));
 
       assertTrue(error.getMessage().contains("refusing to review potentially mixed revisions"));
     }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -4652,8 +4652,8 @@ class ReviewOrchestratorTest {
      * End-to-end guard for #136(c): every other backstop test stubs {@code
      * unreportedUnresolvedStatusesFromParsed} to a canned list, so only the gate wiring (backstop
      * list → previousStatuses → hasUnresolved → COMMENT) is exercised. Here the real analyzer runs
-     * inside {@code review()}, so a break anywhere along parse prior JSON → presence check →
-     * maintainer-reply check → 1-based id mapping fails this test.
+     * inside {@code review()}, so a break anywhere along parse prior JSON → anchored presence check
+     * → maintainer-reply check → 1-based id mapping fails this test.
      */
     @Test
     void shouldHoldApproveViaTheRealBackstopComputationThroughReview() {
@@ -4664,11 +4664,11 @@ class ReviewOrchestratorTest {
             .thenReturn(session);
         delegateStatusGate();
         delegateBackstopComputation();
-        // The prior finding's line must still be in the diff, or presence correctly clears it.
+        // The persisted "new" anchor must remain in the diff, or presence correctly clears it.
         when(prClient.getPullRequestFiles(
                 anyString(), anyString(), anyString(), anyString(), anyInt()))
             .thenReturn(List.of(fileDiffWithLine("src/Main.java", 10)));
-        // Only the bot has spoken on the thread — no maintainer reply to justify dropping it.
+        // A matchable bot root exists, but no maintainer replied to justify dropping the finding.
         when(reviewClient.listPullRequestComments(
                 anyString(), anyString(), anyString(), anyString(), anyInt()))
             .thenReturn(
@@ -4677,7 +4677,8 @@ class ReviewOrchestratorTest {
                         1L,
                         null,
                         "src/Main.java",
-                        "body",
+                        "**🟡 MEDIUM — Dropped finding**\n\nd\n\n"
+                            + SuggestionFormatter.findingMarker(1),
                         new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]"))));
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
@@ -4690,12 +4691,24 @@ class ReviewOrchestratorTest {
 
         orchestrator.review(followUpRequest());
 
-        var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+        var reviewCaptor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
         verify(reviewClient)
             .createReview(
-                anyString(), anyString(), anyString(), anyString(), anyInt(), captor.capture());
-        assertEquals("COMMENT", captor.getValue().event());
-        assertTrue(captor.getValue().body().contains("remain unresolved"));
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyInt(),
+                reviewCaptor.capture());
+        assertEquals("COMMENT", reviewCaptor.getValue().event());
+        assertTrue(reviewCaptor.getValue().body().contains("remain unresolved"));
+
+        var resultCaptor = ArgumentCaptor.forClass(ReviewResult.class);
+        verify(summaryGenerator)
+            .generate(anyInt(), anyInt(), anyInt(), any(), any(), resultCaptor.capture());
+        var previousStatuses = resultCaptor.getValue().previousStatuses();
+        assertEquals(1, previousStatuses.size());
+        assertEquals(1, previousStatuses.get(0).id());
       }
     }
 
@@ -4717,7 +4730,8 @@ class ReviewOrchestratorTest {
 
     private static final String PRIOR_FINDING_JSON =
         "{\"findings\":[{\"risk\":\"medium\",\"file\":\"src/Main.java\",\"line\":10,"
-            + "\"title\":\"Dropped finding\",\"description\":\"d\"}]}";
+            + "\"title\":\"Dropped finding\",\"description\":\"d\","
+            + "\"suggestion_old\":\"new\"}]}";
 
     private ReviewSession followUpSession() {
       var session = mock(ReviewSession.class);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -155,6 +155,17 @@ class ReviewOrchestratorTest {
     lenient()
         .when(checkRunClient.getAllCombinedStatus(any(), any(), any(), any(), any()))
         .thenReturn(List.of());
+    lenient()
+        .when(prClient.getPullRequest(any(), any(), any(), any(), anyInt()))
+        .thenReturn(
+            new GitHubPullRequestClient.PullRequestDetails(
+                "Test PR",
+                "",
+                new GitHubPullRequestClient.Ref("abcdefgh"),
+                new GitHubPullRequestClient.Ref("base-sha"),
+                1,
+                1,
+                1));
     diagramConfig = mock(ThrillhouseConfig.DiagramConfig.class);
     when(reviewConfig.diagram()).thenReturn(diagramConfig);
     doAnswer(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssemblerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssemblerTest.java
@@ -89,33 +89,45 @@ class ReviewPromptAssemblerTest {
   @Test
   void shouldEmitHeuristicSectionForEverySupportedDeclarationAndRegexForm() {
     String[] diffs = {
-      "--- a/frontend/src/validate.ts\n"
-          + "+++ b/frontend/src/validate.ts\n"
-          + "@@ -1 +1 @@\n"
-          + "+const TOKEN = /^[a-z]+$/i;\n",
-      "--- a/frontend/src/validate.js\n"
-          + "+++ b/frontend/src/validate.js\n"
-          + "@@ -1 +1 @@\n"
-          + "+function validateToken(value) {\n",
-      "--- a/frontend/src/parse.ts\n"
-          + "+++ b/frontend/src/parse.ts\n"
-          + "@@ -1 +1,2 @@\n"
-          + "+const parseToken =\n"
-          + "+    (value: string) => value.split(':');\n",
-      "--- a/src/main/java/dev/thiagogonzaga/Parser.java\n"
-          + "+++ b/src/main/java/dev/thiagogonzaga/Parser.java\n"
-          + "@@ -1 +1 @@\n"
-          + "+  Token parseToken(String raw) {\n",
-      "--- a/src/main/java/dev/thiagogonzaga/Parser.java\n"
-          + "+++ b/src/main/java/dev/thiagogonzaga/Parser.java\n"
-          + "@@ -1 +1,2 @@\n"
-          + "+  private static final Pattern TOKEN = Pattern\n"
-          + "+      .compile(\"^[a-z]+$\");\n",
-      "--- a/frontend/src/parse.ts\n"
-          + "+++ b/frontend/src/parse.ts\n"
-          + "@@ -1 +1,2 @@\n"
-          + "+const token = new RegExp\n"
-          + "+    ('^[a-z]+$', 'i');\n"
+      """
+      --- a/frontend/src/validate.ts
+      +++ b/frontend/src/validate.ts
+      @@ -1 +1 @@
+      +const TOKEN = /^[a-z]+$/i;
+      """,
+      """
+      --- a/frontend/src/validate.js
+      +++ b/frontend/src/validate.js
+      @@ -1 +1 @@
+      +function validateToken(value) {
+      """,
+      """
+      --- a/frontend/src/parse.ts
+      +++ b/frontend/src/parse.ts
+      @@ -1 +1,2 @@
+      +const parseToken =
+      +    (value: string) => value.split(':');
+      """,
+      """
+      --- a/src/main/java/dev/thiagogonzaga/Parser.java
+      +++ b/src/main/java/dev/thiagogonzaga/Parser.java
+      @@ -1 +1 @@
+      +  Token parseToken(String raw) {
+      """,
+      """
+      --- a/src/main/java/dev/thiagogonzaga/Parser.java
+      +++ b/src/main/java/dev/thiagogonzaga/Parser.java
+      @@ -1 +1,2 @@
+      +  private static final Pattern TOKEN = Pattern
+      +      .compile("^[a-z]+$");
+      """,
+      """
+      --- a/frontend/src/parse.ts
+      +++ b/frontend/src/parse.ts
+      @@ -1 +1,2 @@
+      +const token = new RegExp
+      +    ('^[a-z]+$', 'i');
+      """
     };
 
     for (String diff : diffs) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssemblerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssemblerTest.java
@@ -87,6 +87,45 @@ class ReviewPromptAssemblerTest {
   }
 
   @Test
+  void shouldEmitHeuristicSectionForEverySupportedDeclarationAndRegexForm() {
+    String[] diffs = {
+      "--- a/frontend/src/validate.ts\n"
+          + "+++ b/frontend/src/validate.ts\n"
+          + "@@ -1 +1 @@\n"
+          + "+const TOKEN = /^[a-z]+$/i;\n",
+      "--- a/frontend/src/validate.js\n"
+          + "+++ b/frontend/src/validate.js\n"
+          + "@@ -1 +1 @@\n"
+          + "+function validateToken(value) {\n",
+      "--- a/frontend/src/parse.ts\n"
+          + "+++ b/frontend/src/parse.ts\n"
+          + "@@ -1 +1,2 @@\n"
+          + "+const parseToken =\n"
+          + "+    (value: string) => value.split(':');\n",
+      "--- a/src/main/java/dev/thiagogonzaga/Parser.java\n"
+          + "+++ b/src/main/java/dev/thiagogonzaga/Parser.java\n"
+          + "@@ -1 +1 @@\n"
+          + "+  Token parseToken(String raw) {\n",
+      "--- a/src/main/java/dev/thiagogonzaga/Parser.java\n"
+          + "+++ b/src/main/java/dev/thiagogonzaga/Parser.java\n"
+          + "@@ -1 +1,2 @@\n"
+          + "+  private static final Pattern TOKEN = Pattern\n"
+          + "+      .compile(\"^[a-z]+$\");\n",
+      "--- a/frontend/src/parse.ts\n"
+          + "+++ b/frontend/src/parse.ts\n"
+          + "@@ -1 +1,2 @@\n"
+          + "+const token = new RegExp\n"
+          + "+    ('^[a-z]+$', 'i');\n"
+    };
+
+    for (String diff : diffs) {
+      assertEquals(
+          PrReviewPrompts.HEURISTIC_FAILURE_MODES_REQUEST,
+          ReviewPromptAssembler.heuristicFailureModesSection(diff));
+    }
+  }
+
+  @Test
   void shouldOmitBugFixSectionWhenPrIsNotABugFix() {
     assertEquals("", ReviewPromptAssembler.bugFixEfficacySection("Adds a new feature", "ctx"));
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisherTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisherTest.java
@@ -79,6 +79,33 @@ class ReviewPublisherTest {
   }
 
   @Test
+  void followUpWithSupersededFindingIgnoresNewerConversationalHeadingReference() {
+    var bot = new GitHubReviewClient.ReviewResponse.User("thrillhousebot");
+    when(commentClient.listComments(anyString(), anyString(), anyString(), anyString(), anyInt()))
+        .thenReturn(
+            List.of(
+                new GitHubCommentClient.IssueComment(
+                    66L,
+                    ReviewResult.truncationNotice(2)
+                        + PrSummaryGenerator.SUMMARY_HEADING
+                        + "\n\nstale",
+                    bot),
+                new GitHubCommentClient.IssueComment(
+                    77L,
+                    "As noted in the "
+                        + PrSummaryGenerator.SUMMARY_HEADING
+                        + ", this was reviewed.",
+                    bot)));
+
+    assertTrue(publisher.publishSummary("auth", "o", "r", 1, SUPERSEDED_RESULT, false));
+
+    verify(commentClient)
+        .updateComment(anyString(), anyString(), anyString(), anyString(), eq(66L), any());
+    verify(commentClient, never())
+        .updateComment(anyString(), anyString(), anyString(), anyString(), eq(77L), any());
+  }
+
+  @Test
   void followUpWithSupersededFindingPostsANewSummaryWhenNoneExists() {
     // None of these is the bot's summary: no author, another author, no body, unrelated body.
     var bot = new GitHubReviewClient.ReviewResponse.User("thrillhousebot");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -562,6 +562,72 @@ class VerdictBuilderTest {
   }
 
   @Test
+  void renameTargetsFiltersMixedInputsAndDistinguishesPureFromContentRenames() {
+    var targets =
+        VerdictBuilder.renameTargets(
+            java.util.Arrays.asList(
+                null,
+                new FileDiff("src/Modified.java", "modified", 1, 0, 1, "+change", "old.java"),
+                new FileDiff("src/NoPrevious.java", "renamed", 0, 0, 0, null, null),
+                new FileDiff("src/BlankPrevious.java", "renamed", 0, 0, 0, "", "  "),
+                new FileDiff("new/Pure.java", "RENAMED", 0, 0, 0, "  ", "old/Pure.java"),
+                new FileDiff(
+                    "new/Edited.java",
+                    "renamed",
+                    1,
+                    0,
+                    1,
+                    "@@ -1 +1 @@\n-old\n+new",
+                    "old/Edited.java")));
+
+    assertEquals(Map.of("old/Pure.java", "", "old/Edited.java", "new/Edited.java"), targets);
+  }
+
+  @Test
+  void pureRenameRollupIsInsertedIntoPositiveSummaryAsAiReviewScope() {
+    var pureRename = new FileDiff("new/Pure.java", "renamed", 0, 0, 0, null, "old/Pure.java");
+    var ctx =
+        new ReviewContextLoader.ReviewContext(
+            List.of(pureRename),
+            "diff",
+            "",
+            0,
+            List.of(),
+            List.of(),
+            List.of(),
+            true,
+            false,
+            null,
+            List.of(),
+            "",
+            new InstructionsResolver.ResolvedInstructions("", ""),
+            List.of(),
+            "",
+            "",
+            List.of(),
+            () -> new DiffLineResolver(Map.of()),
+            null);
+    var realSummaryBuilder =
+        new VerdictBuilder(
+            new PrSummaryGenerator(false),
+            followUpAnalyzer,
+            BotIdentity.from(List.of("thrillhousebot[bot]")),
+            BlockingStrictness.BALANCED);
+
+    var result = realSummaryBuilder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, FULL_COVERAGE);
+
+    assertEquals(ReviewState.APPROVE, result.reviewState());
+    assertTrue(
+        result
+            .summaryMarkdown()
+            .startsWith(
+                PrSummaryGenerator.SUMMARY_HEADING
+                    + "\n\n> **AI review scope:** 1 pure rename omitted from AI review "
+                    + "(old/Pure.java → new/Pure.java)\n\n"),
+        result.summaryMarkdown());
+  }
+
+  @Test
   void nullStrictnessInTestConstructorFallsBackToBalanced() {
     var nullModeBuilder =
         new VerdictBuilder(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -21,8 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -625,6 +627,18 @@ class VerdictBuilderTest {
                     + "\n\n> **AI review scope:** 1 pure rename omitted from AI review "
                     + "(old/Pure.java → new/Pure.java)\n\n"),
         result.summaryMarkdown());
+  }
+
+  @Test
+  void nullPureRenameRollupIsIgnored() {
+    try (var formatter = mockStatic(ReviewDiffFormatter.class, CALLS_REAL_METHODS)) {
+      formatter.when(() -> ReviewDiffFormatter.formatPureRenameRollup(List.of())).thenReturn(null);
+
+      var result =
+          builder.build(contextWithLineCapOmissions(0), CLEAN_RESPONSE, CI_CLEAR, FULL_COVERAGE);
+
+      assertEquals("", result.summaryMarkdown());
+    }
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -64,7 +64,14 @@ class VerdictBuilderTest {
                 any()))
         .thenReturn(List.of());
     lenient()
-        .when(followUpAnalyzer.supersedeVanished(any(), any(), any()))
+        .when(followUpAnalyzer.supersedeVanished(any(), any(), any(), any()))
+        .thenAnswer(
+            inv -> {
+              List<?> statuses = inv.getArgument(1);
+              return statuses == null ? List.of() : statuses;
+            });
+    lenient()
+        .when(followUpAnalyzer.addUnreportedVanished(any(), any(), any(), any()))
         .thenAnswer(
             inv -> {
               List<?> statuses = inv.getArgument(1);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -297,6 +297,40 @@ class PrReviewPromptsContentTest {
   }
 
   @Test
+  void heuristicRequestRequiresVisibleContractBeforeCallingBehaviorDefective() {
+    String req = PrReviewPrompts.HEURISTIC_FAILURE_MODES_REQUEST;
+    assertContains(
+        req,
+        "input belongs to the rule's expected domain",
+        "mechanical edge probing must be tied to visible expected-domain evidence");
+    assertContains(
+        req,
+        "alone cannot prove what it should accept or reject",
+        "the generator must distinguish observed mechanics from contract violation");
+    assertContains(
+        req,
+        "do not call the behavior a confirmed defect",
+        "contract-free probes must remain low-confidence verification requests");
+  }
+
+  @Test
+  void verifierRequiresVisibleContractForHeuristicLimitations() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "input belongs to the expected domain",
+        "the verifier must require expected-domain evidence before confirmation");
+    assertContains(
+        sys,
+        "Mechanics alone prove behavior",
+        "the verifier must not infer the intended contract from mechanics alone");
+    assertContains(
+        sys,
+        "do not confirm it as a defect",
+        "a contract-free heuristic claim must be downgraded to a verification request");
+  }
+
+  @Test
   void diagramRequestRequiresQuotedNodeLabels() {
     String req = PrReviewPrompts.DIAGRAM_REQUEST;
     assertContains(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -1179,7 +1179,14 @@ class WebhookControllerTest {
 
     verify(findingFeedbackCapture)
         .scheduleCaptureOnReviewReply(
-            12345L, "owner", "repo", 42, 99L, "octocat", "@thrillhousebot why is this flagged?");
+            12345L,
+            "owner",
+            "repo",
+            42,
+            99L,
+            "octocat",
+            "OWNER",
+            "@thrillhousebot why is this flagged?");
 
     verify(replyDispatcher)
         .dispatch(
@@ -1216,7 +1223,8 @@ class WebhookControllerTest {
     assertEquals(200, response.getStatus());
 
     verify(findingFeedbackCapture)
-        .scheduleCaptureOnReviewReply(12345L, "owner", "repo", 42, 99L, "octocat", "not useful");
+        .scheduleCaptureOnReviewReply(
+            12345L, "owner", "repo", 42, 99L, "octocat", "OWNER", "not useful");
     verify(replyDispatcher, never()).dispatch(any(MaintainerReplyService.ReplyTask.class));
   }
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19,6 +19,9 @@
       },
       "devDependencies": {
         "unist-util-visit": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -6462,9 +6465,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -6750,9 +6753,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6769,7 +6772,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/website/package.json
+++ b/website/package.json
@@ -2,6 +2,9 @@
   "name": "website",
   "version": "1.0.0",
   "description": "",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
@@ -21,6 +24,9 @@
     "sharp": "^0.35.3",
     "starlight-links-validator": "^0.25.2",
     "starlight-versions": "^0.9.1"
+  },
+  "overrides": {
+    "postcss": "8.5.23"
   },
   "devDependencies": {
     "unist-util-visit": "^5.1.0"


### PR DESCRIPTION
## What type of PR is this?
- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [x] 📝 Documentation
- [x] 🔧 Refactor
- [x] 🚀 Performance
- [x] ✅ Test
- [x] 🔒 Security
- [x] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description
Audits every change added to `release/v0.5.0` since its branch point and fixes the release-blocking correctness, security, concurrency, configuration, dependency, and test-reliability issues found.

Key fixes:
- Scope dashboard feedback reads to repositories the authenticated user can access.
- Accept feedback only from verified write-capable collaborators on bot-authored finding threads; bound capture concurrency and prioritize newer findings.
- Reject mixed-revision reviews after force-pushes; preserve/supersede previous findings correctly across rename+edit, pure rename, and model omission cases.
- Refresh only genuine bot summary comments and recognize truncation-prefixed summaries safely.
- Reject non-finite numeric configuration, reserve configured output capacity only when budgeting is enabled, and retain evidence-appropriate finding confidence.
- Remove source-line contents from INFO logs and clarify pure-rename AI review scope.
- Correct `Optional<T>` prompt guidance and execution-backed arithmetic/test-failure confidence guidance.
- Detect JS/TS regex literals, function/arrow validators, package-private Java declarations, and multiline regex construction using a bounded, file-reset-aware window.
- Require visible expected-domain or contract evidence before confirming synthesized heuristic failures; contract-free probes remain low-confidence verification requests.
- Make the sessions page test await resolved API row data instead of an always-present heading.
- Require Node 22, pin PostCSS 8.5.23, and pin Sharp 0.35.3 so clean npm 11 installs work without known high-severity advisories.
- Add focused regression coverage for every executable production line and branch introduced by the audit.

Newly audited after rebasing through `eb69d3a`:
- `16daeb0` / #420: adversarial parser/regex/validator review support — fixed detector recall and verifier precision gaps.
- `77910ed` / #421: webhook interrupt-race test fix — verified correct; no production, security, or resource-leak regression found.
- `58b0cae` / #422: frontend dashboard coverage — fixed the sessions API-resolution race.
- `eb69d3a` / #424: real backstop integration coverage — corrected the anchor/thread fixtures and explicitly pinned 1-based status mapping.

Coverage remediation:
- `74ceb46`: exercises dashboard repository authorization, feedback rejection/saturation, non-finite and output-budget validation, follow-up rename/vanished handling, stale-head nulls, and verdict rename rollups.
- `c03685d`: covers the final three branch-partial lines reported by Codecov without changing production behavior.
- `89066f8`: makes heuristic regex matching stack-safe with possessive repetition and an explicit regex-literal terminator lookahead, with regression coverage for escaped literals, nested TypeScript arrows, and 100k-character inputs.
- Local changed-code intersection against `origin/release/v0.5.0`: 222/222 executable production lines (100%) and 216/216 changed branches (100%).

## Related Issues
Follow-up audit for #64, #334, #342, #323, #324, #337, #336, #341, #110, #113, #322, #135, #105, #111, #107, #116, #386, #97, #123, #15, #16, and #136; reviewed the corresponding release PRs #389–#424.

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

- `./mvnw spotless:apply`
- Focused coverage suite — 295 tests passed
- Focused remaining-branch suite — 173 tests passed
- `./mvnw verify` — 1,854 tests passed; SpotBugs clean; all JaCoCo checks met
- `HeuristicCodeDetector` — 315/315 instructions, 74/74 branches, 74/74 lines, 7/7 methods
- `LANG=en_US.UTF-8 npm run test -- --run` in `frontend` — 22 tests passed
- `npm run build` in `frontend` — production build passed
- `npm run build` in `website` — 56 pages built; all internal links valid
- `npm audit` in both npm projects — 0 vulnerabilities
- `git diff --check` and IDE diagnostics for all edited files — clean

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes
The requested `release/0.5.0` ref does not exist, so this PR targets the existing `release/v0.5.0` branch.

Repository rulesets were intentionally not changed. The live required-check ruleset currently omits `release/**`, and required check contexts are not source/integration-bound; those repository-security changes require explicit owner confirmation and remain release follow-ups.

Other audited follow-ups not included here: GitHub publication body-size budgets, framework-filter false-negative risk, remaining #135 lazy/parse-once opportunities, feedback retention/purge policy, and dispatcher coalescing observability.
