### PR TITLE
test(review): drive the real backstop computation through review() (#136)

### DIFF
--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -4637,6 +4637,73 @@ class ReviewOrchestratorTest {
       }
     }
 
+    /**
+     * End-to-end guard for #136(c): every other backstop test stubs {@code
+     * unreportedUnresolvedStatusesFromParsed} to a canned list, so only the gate wiring (backstop
+     * list → previousStatuses → hasUnresolved → COMMENT) is exercised. Here the real analyzer runs
+     * inside {@code review()}, so a break anywhere along parse prior JSON → presence check →
+     * maintainer-reply check → 1-based id mapping fails this test.
+     */
+    @Test
+    void shouldHoldApproveViaTheRealBackstopComputationThroughReview() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = followUpSession();
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+        delegateStatusGate();
+        delegateBackstopComputation();
+        // The prior finding's line must still be in the diff, or presence correctly clears it.
+        when(prClient.getPullRequestFiles(
+                anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(List.of(fileDiffWithLine("src/Main.java", 10)));
+        // Only the bot has spoken on the thread — no maintainer reply to justify dropping it.
+        when(reviewClient.listPullRequestComments(
+                anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(
+                List.of(
+                    new GitHubReviewClient.PullRequestComment(
+                        1L,
+                        null,
+                        "src/Main.java",
+                        "body",
+                        new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]"))));
+        when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
+            .thenReturn(List.of(PRIOR_FINDING_JSON));
+        when(followUpAnalyzer.buildPreviousFindingsContext(
+                anyList(), any(), any(), any(), eq(BOT_ID)))
+            .thenReturn("1. [MEDIUM] src/Main.java:10 — Dropped finding");
+        // The silent drop: this round reports neither the finding nor a status for it.
+        when(aiReviewService.review(any(ReviewSession.class), any()))
+            .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+        orchestrator.review(followUpRequest());
+
+        var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+        verify(reviewClient)
+            .createReview(
+                anyString(), anyString(), anyString(), anyString(), anyInt(), captor.capture());
+        assertEquals("COMMENT", captor.getValue().event());
+        assertTrue(captor.getValue().body().contains("remain unresolved"));
+      }
+    }
+
+    /** Runs the real parse + backstop computation instead of a canned status list. */
+    private void delegateBackstopComputation() {
+      when(followUpAnalyzer.parsePreviousResponses(any()))
+          .thenAnswer(invocation -> realAnalyzer.parsePreviousResponses(invocation.getArgument(0)));
+      when(followUpAnalyzer.unreportedUnresolvedStatusesFromParsed(
+              any(), any(), any(), any(), eq(BOT_ID)))
+          .thenAnswer(
+              invocation ->
+                  realAnalyzer.unreportedUnresolvedStatusesFromParsed(
+                      invocation.getArgument(0),
+                      invocation.getArgument(1),
+                      invocation.getArgument(2),
+                      invocation.getArgument(3),
+                      invocation.getArgument(4)));
+    }
+
     private static final String PRIOR_FINDING_JSON =
         "{\"findings\":[{\"risk\":\"medium\",\"file\":\"src/Main.java\",\"line\":10,"
             + "\"title\":\"Dropped finding\",\"description\":\"d\"}]}";


### PR DESCRIPTION
## What type of PR is this?

- [x] ✅ Test

## Description

Scoped to **part (c)** of #136 — the other two parts are already done, which I confirmed against
current `main` and [recorded on the issue](https://github.com/devops-thiago/ThrillhouseBot/issues/136):

| Part | Status |
|---|---|
| (a) presence edge cases | Done by #139 |
| (b) vacuous follow-up assertion | Done by #147, unrecorded — it replaced the test with `shouldPostSummaryOnPersistedButUnreviewedPr`, which overrides the global blank-summary stub and asserts `createComment` **is** called |
| (c) end-to-end backstop | **This PR** |

Part (b) also can't be done as originally written: #147 is titled *"decouple first-review UX from
persistence context"*, so the persistence-aware `isFirstReview` behaviour that (b) wanted a regression
guard for was deliberately redesigned. A guard written to the original wording would pin behaviour
that was intentionally changed.

### What (c) needed

`followUpAnalyzer` is a `@Mock`, and every backstop test stubs
`unreportedUnresolvedStatusesFromParsed` to a canned list. That exercises only the gate wiring —
backstop list → `previousStatuses` → `hasUnresolved` → COMMENT. The computation the backstop actually
depends on (parse prior JSON → presence check → maintainer-reply check → 1-based id mapping) never ran
in a `review()` flow.

`shouldHoldApproveViaTheRealBackstopComputationThroughReview` closes that. Rather than rebuilding the
SUT with a real analyzer — which would have meant duplicating the 14-argument wiring — it follows the
idiom already in the file: `ApproveBackstop` keeps a `realAnalyzer` and a `delegateStatusGate()`
helper that routes specific methods to real logic. The new `delegateBackstopComputation()` does the
same for `parsePreviousResponses` and `unreportedUnresolvedStatusesFromParsed`, with a real diff from
`prClient` anchoring the prior finding and a bot-only comment thread so nothing justifies dropping it.

## Related Issues

Fixes #136

Taken over from @Jk2006k, who picked it up in June; noted on the issue with the reduced scope.

## How Has This Been Tested?

- [x] Unit tests

**Mutation-verified.** Stubbing `unreportedUnresolvedStatusesFromParsed` to return no statuses:

- the new test **fails** — `expected: <COMMENT> but was: <APPROVE>`
- the other **eight** `ApproveBackstop` tests still **pass**

That contrast is the point: the existing tests are blind to the real computation breaking, which is
exactly what #136(c) reported. Production restored afterwards; no production diff in this PR.

Local gates:

- `./mvnw spotless:apply` + `verify` — **1805 tests, 0 failures**, SpotBugs `BugInstance size is 0`,
  JaCoCo gate met

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code