### PR TITLE
fix(review): clear the Sonar findings and coverage gaps on the release diff (#427)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureService.java
@@ -120,6 +120,9 @@ public class FindingFeedbackCaptureService {
    * Schedules best-effort capture for a review-thread reply: fetch the root body (to confirm it is
    * a bot finding), poll 👍/👎 on that root, and apply reply-body heuristics. Never blocks the
    * webhook ACK thread beyond queueing the task.
+   *
+   * <p>The reply's author and body travel as one {@link ReviewReply} — the same record the capture
+   * already used internally — rather than as three more positional parameters (java:S107).
    */
   public void scheduleCaptureOnReviewReply(
       long installationId,
@@ -127,20 +130,12 @@ public class FindingFeedbackCaptureService {
       String repo,
       int prNumber,
       long rootCommentId,
-      String replyAuthorLogin,
-      String replyAuthorAssociation,
-      String replyBody) {
+      ReviewReply reply) {
     try {
       captureExecutor.execute(
           () -> {
             try {
-              captureOnReviewReply(
-                  installationId,
-                  owner,
-                  repo,
-                  prNumber,
-                  rootCommentId,
-                  new ReviewReply(replyAuthorLogin, replyAuthorAssociation, replyBody));
+              captureOnReviewReply(installationId, owner, repo, prNumber, rootCommentId, reply);
             } catch (RuntimeException e) {
               log.warn(
                   "Finding feedback capture failed for {}/{} #{} comment {} (continuing)",
@@ -202,7 +197,7 @@ public class FindingFeedbackCaptureService {
   }
 
   /** The reply that may carry feedback: who wrote it, their author association, and its body. */
-  record ReviewReply(String authorLogin, String authorAssociation, String body) {}
+  public record ReviewReply(String authorLogin, String authorAssociation, String body) {}
 
   void captureOnReviewReply(
       long installationId,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetector.java
@@ -89,11 +89,15 @@ final class HeuristicCodeDetector {
    * {@code .} or word character immediately before it (so the receiver call {@code
    * Integer.parseInt(...)} cannot pose as a declared {@code parse} member). The member name is
    * captured; {@link #isHeuristicName(String)} decides whether it is heuristic.
+   *
+   * <p>The gap is atomic and must end on a separator, so it cannot overlap the captured name and
+   * re-split on backtracking — that overlap is what made the earlier form super-linear (java:S8786)
+   * on a long line with no {@code (}.
    */
   private static final Pattern HEURISTIC_DECLARATION =
       Pattern.compile(
           "(?i)\\b(?:private|public|protected|internal|static|final|fun|def|func|function)\\b"
-              + "[^(=\\r\\n]*(?<![.\\w])(\\w+)\\s*\\(");
+              + "(?>[^(=\\r\\n]*[^\\w.(=\\r\\n])(\\w+)\\s*\\(");
 
   /**
    * Package-private Java-style method declaration, where no visibility keyword is present. The type
@@ -127,11 +131,19 @@ final class HeuristicCodeDetector {
   private static final Pattern DECLARATION_ONLY_LINE =
       Pattern.compile("^\\+\\s*(?:import|from|package|using|#include)\\b");
 
-  /** A tolerance/window constant — the #55 three-line ambiguity window is the motivating shape. */
-  private static final Pattern THRESHOLD_CONSTANT =
-      Pattern.compile(
-          "(?i)\\b(?:static\\s+final|const|val|let|var)\\b[^=\\r\\n]*"
-              + "\\b\\w*(?:WINDOW|THRESHOLD|TOLERANCE|RADIUS|FUZZ|_LINES|LINES_)\\w*\\b[^=\\r\\n]*=");
+  /**
+   * A tolerance/window constant — the #55 three-line ambiguity window is the motivating shape. The
+   * declaration is matched structurally and the name tokens are checked in plain code, the same
+   * split as {@link #HEURISTIC_NAME_STEMS}: three unbounded runs in one expression overlapped and
+   * made it super-linear (java:S8786), and a single run terminated by {@code =} cannot.
+   */
+  private static final Pattern THRESHOLD_DECLARATION =
+      Pattern.compile("(?i)\\b(?:static\\s+final|const|val|let|var)\\b([^=\\r\\n]*)=");
+
+  /** Name fragments (lowercase) that mark a declared constant as a tolerance or window. */
+  private static final String[] THRESHOLD_NAME_TOKENS = {
+    "window", "threshold", "tolerance", "radius", "fuzz", "_lines", "lines_"
+  };
 
   /** Diff header naming the file the following hunks belong to. */
   private static final Pattern DIFF_FILE_HEADER = Pattern.compile("^\\+\\+\\+ b/(.+)$");
@@ -188,22 +200,19 @@ final class HeuristicCodeDetector {
       if (line.startsWith("+++ ")) {
         scope = FileScope.of(line);
         addedLines.clear();
-        continue;
-      }
-      // Only contiguous additions can form one declaration or construction. Context, removals,
-      // hunk headers, and ignored test-file content all terminate the bounded window.
-      if (scope.testFile() || line.isEmpty() || line.charAt(0) != '+') {
+      } else if (scope.testFile() || line.isEmpty() || line.charAt(0) != '+') {
+        // Only contiguous additions can form one declaration or construction. Context, removals,
+        // hunk headers, and ignored test-file content all terminate the bounded window.
         addedLines.clear();
-        continue;
-      }
-
-      addedLines.addLast(line);
-      if (addedLines.size() > 4) {
-        addedLines.removeFirst();
-      }
-      if (isHeuristicLine(line, scope.javaScript())
-          || isHeuristicWindow(addedLines, scope.javaScript())) {
-        return true;
+      } else {
+        addedLines.addLast(line);
+        if (addedLines.size() > 4) {
+          addedLines.removeFirst();
+        }
+        if (isHeuristicLine(line, scope.javaScript())
+            || isHeuristicWindow(addedLines, scope.javaScript())) {
+          return true;
+        }
       }
     }
     return false;
@@ -218,7 +227,21 @@ final class HeuristicCodeDetector {
         || NORMALIZATION.matcher(addedLine).find()
         || declaresHeuristicMember(addedLine, inJavaScriptFile)
         || (inJavaScriptFile && JS_REGEX_LITERAL.matcher(addedLine).find())
-        || THRESHOLD_CONSTANT.matcher(addedLine).find();
+        || declaresThresholdConstant(addedLine);
+  }
+
+  /** Whether the text declares a constant whose name carries a tolerance/window token. */
+  private static boolean declaresThresholdConstant(CharSequence text) {
+    var matcher = THRESHOLD_DECLARATION.matcher(text);
+    while (matcher.find()) {
+      var declared = matcher.group(1).toLowerCase(Locale.ROOT);
+      for (String token : THRESHOLD_NAME_TOKENS) {
+        if (declared.contains(token)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private static boolean matchesAny(List<Pattern> patterns, CharSequence text) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -498,13 +498,9 @@ public class ReviewPublisher {
       var finding = result.findings().get(i);
       if (!finding.postsInline()) {
         confidenceSkipped.add(finding);
-        continue;
-      }
-      if (posted >= maxComments) {
+      } else if (posted >= maxComments) {
         capSkipped.add(finding);
-        continue;
-      }
-      if (postFindingComment(target, finding, i + 1, lineResolver)) {
+      } else if (postFindingComment(target, finding, i + 1, lineResolver)) {
         posted++;
       } else {
         unanchored.add(finding);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookController.java
@@ -437,9 +437,8 @@ public class WebhookController {
           repo.name(),
           pr.number(),
           rootCommentId,
-          comment.user().login(),
-          comment.authorAssociation(),
-          comment.body());
+          new FindingFeedbackCaptureService.ReviewReply(
+              comment.user().login(), comment.authorAssociation(), comment.body()));
     }
 
     if (!config.review().conversationalRepliesEnabled()) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingFeedbackCaptureServiceTest.java
@@ -166,14 +166,24 @@ class FindingFeedbackCaptureServiceTest {
     try {
       for (int i = 1; i <= maxConcurrentCaptures; i++) {
         capture.scheduleCaptureOnReviewReply(
-            i, "owner", "repo", 7, 99L, "octocat", "OWNER", "not useful");
+            i,
+            "owner",
+            "repo",
+            7,
+            99L,
+            new FindingFeedbackCaptureService.ReviewReply("octocat", "OWNER", "not useful"));
       }
       assertTrue(started.await(10, TimeUnit.SECONDS), "capture workers did not all start");
 
       assertDoesNotThrow(
           () ->
               capture.scheduleCaptureOnReviewReply(
-                  99L, "owner", "repo", 7, 99L, "octocat", "OWNER", "not useful"));
+                  99L,
+                  "owner",
+                  "repo",
+                  7,
+                  99L,
+                  new FindingFeedbackCaptureService.ReviewReply("octocat", "OWNER", "not useful")));
 
       verify(authClient, times(maxConcurrentCaptures)).getAuthHeader(anyLong());
       verify(authClient, never()).getAuthHeader(99L);
@@ -575,10 +585,45 @@ class FindingFeedbackCaptureServiceTest {
             any(), any(), any(), any(), anyLong(), any(), anyInt(), anyInt()))
         .thenReturn(List.of());
 
-    capture.scheduleCaptureOnReviewReply(9L, "owner", "repo", 7, 99L, "octocat", "OWNER", "thanks");
+    capture.scheduleCaptureOnReviewReply(
+        9L,
+        "owner",
+        "repo",
+        7,
+        99L,
+        new FindingFeedbackCaptureService.ReviewReply("octocat", "OWNER", "thanks"));
     verify(authClient, timeout(2000)).getAuthHeader(9L);
     verify(reviewClient, timeout(2000))
         .getPullRequestComment(any(), any(), eq("owner"), eq("repo"), eq(99L));
+  }
+
+  @Test
+  void scheduleCaptureOnReviewReplyStopsWhenTheBotRootCarriesNoFindingMarker() {
+    // A bot comment that is not a finding — a summary or a conversational reply — has no index to
+    // attribute feedback to, so capture must stop before polling reactions.
+    when(authClient.getAuthHeader(9L)).thenReturn("Bearer t");
+    when(reviewClient.getPullRequestComment(any(), any(), eq("owner"), eq("repo"), eq(99L)))
+        .thenReturn(
+            new GitHubReviewClient.PullRequestComment(
+                99L,
+                null,
+                "Main.java",
+                "just a conversational reply, no marker",
+                new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]")));
+
+    capture.scheduleCaptureOnReviewReply(
+        9L,
+        "owner",
+        "repo",
+        7,
+        99L,
+        new FindingFeedbackCaptureService.ReviewReply("octocat", "OWNER", "not useful"));
+
+    verify(reviewClient, timeout(2000))
+        .getPullRequestComment(any(), any(), eq("owner"), eq("repo"), eq(99L));
+    verify(reactionClient, never())
+        .listReviewCommentReactions(
+            any(), any(), any(), any(), anyLong(), any(), anyInt(), anyInt());
   }
 
   @Test
@@ -609,7 +654,13 @@ class FindingFeedbackCaptureServiceTest {
   @Test
   void scheduleCaptureOnReviewReplyRunsAsyncAndSwallowsErrors() {
     when(authClient.getAuthHeader(anyLong())).thenThrow(new RuntimeException("auth fail"));
-    capture.scheduleCaptureOnReviewReply(1L, "o", "r", 1, 9L, "u", "OWNER", "not useful");
+    capture.scheduleCaptureOnReviewReply(
+        1L,
+        "o",
+        "r",
+        1,
+        9L,
+        new FindingFeedbackCaptureService.ReviewReply("u", "OWNER", "not useful"));
     verify(authClient, timeout(2000)).getAuthHeader(1L);
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -108,8 +108,13 @@ class FindingPipelineTest {
   }
 
   private static ReviewContextLoader.ReviewContext reviewContext() {
+    return reviewContext(List.of());
+  }
+
+  /** Same context with a caller-supplied changed-file list, so rename disclosure can be driven. */
+  private static ReviewContextLoader.ReviewContext reviewContext(List<FileDiff> files) {
     return new ReviewContextLoader.ReviewContext(
-        List.of(),
+        files,
         "raw legacy diff",
         "",
         0,
@@ -233,6 +238,41 @@ class FindingPipelineTest {
     var wrapped = FindingPipeline.unwrapParallelFailure(missingCause);
     assertEquals("Parallel batch review failed", wrapped.getMessage());
     assertSame(missingCause, wrapped.getCause());
+  }
+
+  @Test
+  void unwrapParallelFailurePreservesTheUnderlyingCause() {
+    // The caller distinguishes an AI failure from a wiring failure through getCause(), so the
+    // real cause must survive the IllegalStateException wrapper SpotBugs requires.
+    var cause = new IllegalArgumentException("model refused");
+    var wrapped = FindingPipeline.unwrapParallelFailure(new CompletionException(cause));
+
+    assertEquals("Parallel batch review failed", wrapped.getMessage());
+    assertSame(cause, wrapped.getCause());
+  }
+
+  @Test
+  void summaryOverviewLeadsWithThePureRenameRollup() {
+    var session = ReviewSession.create("owner/repo", 1, "Move a package", "sha");
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    var ctx =
+        reviewContext(
+            List.of(
+                new FileDiff("pkg/B.java", "renamed", 0, 0, 0, null, "pkg/A.java"),
+                new FileDiff("a.java", "modified", 3, 0, 3, "")));
+    when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
+    when(aiReviewService.summarize(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+
+    // Leading, so clamping a long overview can never drop the disclosure (#386).
+    assertTrue(
+        captor.getValue().changedFiles().startsWith("1 pure rename omitted from AI review"),
+        captor.getValue().changedFiles());
+    assertTrue(captor.getValue().changedFiles().contains("pkg/A.java → pkg/B.java"));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/HeuristicCodeDetectorTest.java
@@ -218,11 +218,13 @@ class HeuristicCodeDetectorTest {
   @Test
   void shouldNotTriggerOnRemovedHeuristicCode() {
     String removal =
-        "--- a/src/main/java/dev/thiagogonzaga/Old.java\n"
-            + "+++ b/src/main/java/dev/thiagogonzaga/Old.java\n"
-            + "@@ -1,3 +1,2 @@\n"
-            + "-  private static final Pattern P = Pattern.compile(\"x\");\n"
-            + "   int keep = 1;\n";
+        """
+        --- a/src/main/java/dev/thiagogonzaga/Old.java
+        +++ b/src/main/java/dev/thiagogonzaga/Old.java
+        @@ -1,3 +1,2 @@
+        -  private static final Pattern P = Pattern.compile("x");
+           int keep = 1;
+        """;
     assertFalse(HeuristicCodeDetector.introducesHeuristicCode(removal));
   }
 
@@ -383,9 +385,11 @@ class HeuristicCodeDetectorTest {
   void shouldNotTriggerOnDiffHeaderTextAlone() {
     assertFalse(
         HeuristicCodeDetector.introducesHeuristicCode(
-            "--- a/src/main/java/dev/thiagogonzaga/Parser.java\n"
-                + "+++ b/src/main/java/dev/thiagogonzaga/Parser.java\n"
-                + "@@ -1,2 +1,2 @@\n"
-                + "   int unchanged = 1;\n"));
+            """
+            --- a/src/main/java/dev/thiagogonzaga/Parser.java
+            +++ b/src/main/java/dev/thiagogonzaga/Parser.java
+            @@ -1,2 +1,2 @@
+               int unchanged = 1;
+            """));
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
@@ -756,5 +756,62 @@ class ReviewDiffFormatterTest {
       assertTrue(rollup.contains("o0.java → n0.java"));
       assertFalse(rollup.contains("o5.java"));
     }
+
+    @Test
+    void isPureRenameToleratesAbsentFileAndStatus() {
+      assertFalse(ReviewDiffFormatter.isPureRename(null));
+      assertFalse(
+          ReviewDiffFormatter.isPureRename(
+              new GitHubPullRequestClient.FileDiff("b.java", null, 0, 0, 0, null, "a.java")));
+    }
+
+    @Test
+    void isPureRenameRejectsARenameCarryingPatchTextWithZeroCounts() {
+      // Counts can read 0 while GitHub still ships hunks; the patch decides, so this stays
+      // reviewable rather than being silently dropped from the budget.
+      assertFalse(
+          ReviewDiffFormatter.isPureRename(
+              new GitHubPullRequestClient.FileDiff(
+                  "b.java", "renamed", 0, 0, 0, "@@ -1 +1 @@\n-a\n+b", "a.java")));
+    }
+
+    @Test
+    void pureRenameHelpersReturnEmptyForAbsentInput() {
+      assertTrue(ReviewDiffFormatter.pureRenameFiles(null).isEmpty());
+      assertTrue(ReviewDiffFormatter.pureRenameFiles(List.of()).isEmpty());
+      assertEquals("", ReviewDiffFormatter.formatPureRenameRollup(null));
+      assertEquals("", ReviewDiffFormatter.formatPureRenameRollup(List.of()));
+    }
+
+    @Test
+    void rollupFallsBackToTheNewPathWhenGitHubOmitsThePreviousFilename() {
+      var noPrevious =
+          new GitHubPullRequestClient.FileDiff("new/Only.java", "renamed", 0, 0, 0, null, null);
+      var blankPrevious =
+          new GitHubPullRequestClient.FileDiff("new/Blank.java", "renamed", 0, 0, 0, null, "  ");
+
+      var rollup = ReviewDiffFormatter.formatPureRenameRollup(List.of(noPrevious, blankPrevious));
+
+      assertTrue(rollup.contains("new/Only.java"));
+      assertTrue(rollup.contains("new/Blank.java"));
+      assertFalse(rollup.contains("→"), "no arrow without a source path: " + rollup);
+    }
+
+    @Test
+    void withPureRenamesAppendsRenamesAndReturnsTheInputWhenThereAreNone() {
+      var reviewable = List.of(file("src/App.java", "modified", 1, 0, "@@ -1 +1,2 @@\n+ok"));
+      var rename =
+          new GitHubPullRequestClient.FileDiff(
+              "pkg/B.java", "renamed", 0, 0, 0, null, "pkg/A.java");
+
+      // Identity when nothing was renamed — the caller's list is handed straight back.
+      assertSame(reviewable, ReviewDiffFormatter.withPureRenames(reviewable, reviewable));
+
+      var merged = ReviewDiffFormatter.withPureRenames(reviewable, List.of(rename));
+
+      assertEquals(2, merged.size());
+      assertEquals("src/App.java", merged.get(0).filename());
+      assertEquals("pkg/B.java", merged.get(1).filename(), "renames are appended after reviewable");
+    }
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -1088,8 +1088,11 @@ class ReviewOrchestratorTest {
                       1,
                       0,
                       1,
-                      "@@\n+doThrow(new RuntimeException(\"executor saturated\"))"
-                          + ".when(reviewDispatcher).dispatch(any());\n"))
+                      """
+                      @@
+                      +doThrow(new RuntimeException("executor saturated")).when(reviewDispatcher)\
+                      .dispatch(any());
+                      """))
               .contains("Mock Fidelity Check"));
     }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssemblerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPromptAssemblerTest.java
@@ -69,10 +69,12 @@ class ReviewPromptAssemblerTest {
     assertEquals(
         "",
         ReviewPromptAssembler.heuristicFailureModesSection(
-            "--- a/src/main/java/dev/thiagogonzaga/Service.java\n"
-                + "+++ b/src/main/java/dev/thiagogonzaga/Service.java\n"
-                + "@@ -1,2 +1,3 @@\n"
-                + "+    var trimmed = payload.trim();\n"));
+            """
+            --- a/src/main/java/dev/thiagogonzaga/Service.java
+            +++ b/src/main/java/dev/thiagogonzaga/Service.java
+            @@ -1,2 +1,3 @@
+            +    var trimmed = payload.trim();
+            """));
   }
 
   @Test
@@ -80,10 +82,12 @@ class ReviewPromptAssemblerTest {
     assertEquals(
         PrReviewPrompts.HEURISTIC_FAILURE_MODES_REQUEST,
         ReviewPromptAssembler.heuristicFailureModesSection(
-            "--- a/src/main/java/dev/thiagogonzaga/Trigger.java\n"
-                + "+++ b/src/main/java/dev/thiagogonzaga/Trigger.java\n"
-                + "@@ -1,2 +1,3 @@\n"
-                + "+  private static final Pattern P = Pattern.compile(\"/pause\");\n"));
+            """
+            --- a/src/main/java/dev/thiagogonzaga/Trigger.java
+            +++ b/src/main/java/dev/thiagogonzaga/Trigger.java
+            @@ -1,2 +1,3 @@
+            +  private static final Pattern P = Pattern.compile("/pause");
+            """));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/WebhookControllerTest.java
@@ -1184,9 +1184,8 @@ class WebhookControllerTest {
             "repo",
             42,
             99L,
-            "octocat",
-            "OWNER",
-            "@thrillhousebot why is this flagged?");
+            new FindingFeedbackCaptureService.ReviewReply(
+                "octocat", "OWNER", "@thrillhousebot why is this flagged?"));
 
     verify(replyDispatcher)
         .dispatch(
@@ -1224,7 +1223,12 @@ class WebhookControllerTest {
 
     verify(findingFeedbackCapture)
         .scheduleCaptureOnReviewReply(
-            12345L, "owner", "repo", 42, 99L, "octocat", "OWNER", "not useful");
+            12345L,
+            "owner",
+            "repo",
+            42,
+            99L,
+            new FindingFeedbackCaptureService.ReviewReply("octocat", "OWNER", "not useful"));
     verify(replyDispatcher, never()).dispatch(any(MaintainerReplyService.ReplyTask.class));
   }
 


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor
- [x] ✅ Test

## Description

Clears everything #427 (`release/v0.5.0` → `main`) reports. Opened against `release/v0.5.0` rather
than pushed to it, so it flows into #427 through the normal path.

### Sonar — 10 findings

**`java:S8786` super-linear regex ×2 (`HeuristicCodeDetector`)** — the substantive ones.

- `HEURISTIC_DECLARATION` matched `[^(=\r\n]*` and then `(\w+)\s*\(`. The gap and the name class
  overlap, so on a long line with no `(` the engine re-split at every position. The gap is now
  atomic and must end on a separator — it cannot consume the name, so there is nothing to backtrack
  into. A possessive quantifier would have been wrong here: it stops exactly the backtracking the
  name capture depends on.
- `THRESHOLD_CONSTANT` chained three unbounded runs (`[^=]* … \w*(?:ALT)\w* … [^=]*=`). Replaced by
  `THRESHOLD_DECLARATION`, one run terminated by `=`, with the name tokens checked in code — the
  same regex/code split `HEURISTIC_NAME_STEMS` already uses in this file.

**`java:S135` ×2** — the diff scan loop and `ReviewPublisher.postInlineComments` now branch with
`if/else` instead of stacked `continue`s.

**`java:S107`** — `scheduleCaptureOnReviewReply` had 8 parameters. It now takes the `ReviewReply`
record it *already* constructed internally from three of them, so the call site passes 6. The record
became `public` for the `webhook` caller.

**`java:S6126` ×5** — diff fixtures converted to text blocks.

### Codecov — three files under threshold, now fully covered

All the gaps were in the #386 pure-rename support plus two error paths, and each new test pins real
behaviour rather than just touching the line:

- `isPureRename` with an absent file/status, and a rename reporting **zero counts but carrying patch
  text** — that one stays reviewable, so a rename+edit is never silently dropped from the budget
- the rollup's fallback when GitHub omits `previous_filename` (no arrow, just the new path)
- `withPureRenames` — both the identity return and the merge path, asserting renames append *after*
  reviewable files
- the summary overview **leading** with the rename rollup, which is what stops clamping from
  dropping the disclosure on large multi-call reviews
- `unwrapParallelFailure` preserving a real cause (the null-cause side was already covered)
- a bot root comment with **no finding marker** — capture stops before polling reactions

## Related Issues

Fixes the failing `codecov/patch` and the Sonar findings on #427. No issue number — release cleanup.

## How Has This Been Tested?

- [x] Unit tests

- `./mvnw verify` — **1863 tests, 0 failures**, SpotBugs `BugInstance size is 0`, JaCoCo gate met
- JaCoCo confirms **fully covered, 0 missed instructions/branches/lines** for all five touched
  production files: `HeuristicCodeDetector`, `ReviewDiffFormatter`, `FindingPipeline`,
  `FindingFeedbackCaptureService`, `ReviewPublisher`
- The detector's 26-case suite is the guard on the two regex rewrites — behaviour is unchanged,
  including the `parseInt` exclusion and the test-path/window-constant detection those patterns drive

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code