### PR TITLE
feat(release): credit contributors automatically in the release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+# Shapes the notes GitHub generates for a release. The release workflow appends that
+# generated section after the curated CHANGELOG.md notes, so this controls the merged-PR
+# list and the "New Contributors" credit — not the hand-written part.
+#
+# Dependency bumps are excluded: they are already summarised under "Dependencies" in
+# CHANGELOG.md, and seven Dependabot PRs in one release would bury the humans in both the
+# PR list and the contributor credit.
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - dependabot[bot]
+      - github-actions
+      - github-actions[bot]
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Fixes
+      labels:
+        - bug
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,10 +286,23 @@ jobs:
             exit 1
           fi
 
+          # Curated CHANGELOG notes first, then GitHub's generated section — the merged-PR list
+          # and, the point of this, "New Contributors". Generated explicitly rather than with
+          # `gh release create --generate-notes` because `gh release edit` has no such flag: the
+          # re-run path below would otherwise overwrite the body and drop the credit. Shaped by
+          # .github/release.yml. Best-effort — a failure here must not fail the release.
+          cp release_notes.md release_body.md
+          if generated=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="$TAG" --jq .body 2>/dev/null) && [ -n "$generated" ]; then
+            printf '\n\n%s\n' "$generated" >> release_body.md
+          else
+            echo "::warning::Could not generate release notes; publishing CHANGELOG notes only"
+          fi
+
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists; uploading artifacts and refreshing notes"
             gh release upload "$TAG" "${artifacts[@]}" --clobber
-            edit_args=( "$TAG" --notes-file release_notes.md )
+            edit_args=( "$TAG" --notes-file release_body.md )
             if [ "$UPDATE_LATEST" = "true" ]; then
               edit_args+=( --latest )
             else
@@ -297,7 +310,7 @@ jobs:
             fi
             gh release edit "${edit_args[@]}"
           else
-            args=( "$TAG" --notes-file release_notes.md )
+            args=( "$TAG" --notes-file release_body.md )
             if [ "$UPDATE_LATEST" = "true" ]; then
               args+=( --latest )
             else


### PR DESCRIPTION
## What type of PR is this?

- [x] 🏗️ CI/CD

## Description

Release notes were assembled from `CHANGELOG.md` alone, so GitHub's generated **New Contributors**
section never ran and outside contributors went uncredited.

v0.5.0 has one: **@matheusandre1** wrote the wider default ignored-files patterns (#429).

### Workflow

`gh release create` gains the generated section — but not via `--generate-notes`. The existing
workflow has two paths, and `gh release edit` (the re-run path) has **no** `--generate-notes` flag,
so adding it only to `create` would mean any re-run silently overwrites the body and drops the
credit. Instead the notes are generated once through the Release Notes API and both paths publish
the same `release_body.md`:

```bash
cp release_notes.md release_body.md
if generated=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
    -f tag_name="$TAG" --jq .body 2>/dev/null) && [ -n "$generated" ]; then
  printf '\n\n%s\n' "$generated" >> release_body.md
else
  echo "::warning::Could not generate release notes; publishing CHANGELOG notes only"
fi
```

Best-effort by design: if generation fails the release still publishes with the curated notes and a
warning, rather than failing at the last step of a release.

`contents: write` and `GH_TOKEN` are already present on that step, so no permission change.

### `.github/release.yml` (new)

Shapes the generated section. Excludes `dependabot` and `github-actions`: seven Dependabot PRs
landed in v0.5.0 and would bury the humans in both the PR list and the contributor credit, and the
bumps are already summarised under **Dependencies** in the changelog.

## Related Issues

N/A — release process.

## How Has This Been Tested?

- [x] Manual testing

- `.github/release.yml` parses and carries the `changelog` root key GitHub expects
- Confirmed `gh release edit` lacks `--generate-notes` (`gh release edit --help`), which is what
  drove the generate-once approach rather than the one-flag version
- Confirmed the step already exports `GH_TOKEN` and the job holds `contents: write`, both required
  by the `generate-notes` endpoint
- Contributors verified from the branch itself: `git shortlog -sne origin/main..origin/release/v0.5.0`
  → Thiago Gonzaga (28), dependabot (7), Matheus André (1, #429)

The generated section itself can only be verified when a release is cut — the failure mode if
anything is wrong is a warning plus notes-as-before, not a broken release.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
