### PR TITLE
fix(config): warn when a per-model env var maps to nothing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,7 +98,11 @@ AI_TIMEOUT=300s
 # presence-penalty, and seed are sent on every chat call when set (no top_k on the
 # OpenAI-compatible wire). A low temperature (e.g. 0.2) makes reviews more deterministic.
 #
-# Env form (hyphen-only keys → single underscores; dotted keys → double underscores around key):
+# Env form: the underscores depend on whether the key needs quoting in application.properties.
+# A hyphen-only key (deepseek-v4-pro) is unquoted there and takes SINGLE underscores; a key with a
+# dot (gpt-5.5) is quoted and takes DOUBLE underscores either side. The wrong form resolves to
+# nothing and the setting silently never applies, so the bot warns at startup naming the spelling
+# that works — check the boot log if a tuning value seems ignored.
 #   THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_PRO_MAX_INPUT_TOKENS=1000000
 #   THRILLHOUSEBOT_AI_MODELS__GPT_5_5__MAX_INPUT_TOKENS=256000
 #   THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_CHAT_TEMPERATURE=0.2

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -22,8 +22,10 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,6 +104,7 @@ public class StartupConfigValidator {
     logReasoningStatus();
     logCiGatingStatus();
     logActiveModelStatus();
+    warnUnmappedModelEnvVars(System.getenv());
     log.info(
         "Configuration validated: GitHub App id, private key, webhook secret, and AI API key are"
             + " present.");
@@ -345,6 +348,91 @@ public class StartupConfigValidator {
    * deliberately), and logs the active generation parameters so a tuning entry that targets the
    * wrong model name is visible immediately.
    */
+  /** Env-var prefix every per-model setting shares. */
+  private static final String MODEL_ENV_PREFIX = "THRILLHOUSEBOT_AI_MODELS_";
+
+  /** The per-model setting names, in env-var form. */
+  private static final List<String> MODEL_SETTING_SUFFIXES =
+      List.of(
+          "MAX_INPUT_TOKENS",
+          "OUTPUT_BUFFER_TOKENS",
+          "TOKEN_SAFETY_MARGIN",
+          "MAX_OUTPUT_TOKENS",
+          "FREQUENCY_PENALTY",
+          "PRESENCE_PENALTY",
+          "TEMPERATURE",
+          "TOP_P",
+          "SEED");
+
+  /**
+   * The env-var prefix SmallRye actually reads for a model key. A key that needs quoting in the
+   * properties file because it contains a dot ({@code "gpt-5.5"}) maps with a doubled underscore
+   * either side of the key; a hyphen-only key ({@code deepseek-v4-pro}) maps with single ones.
+   */
+  static String modelEnvPrefix(String model) {
+    var upper = model.toUpperCase(Locale.ROOT).replace('-', '_').replace('.', '_');
+    return model.indexOf('.') >= 0
+        ? MODEL_ENV_PREFIX + "_" + upper + "__"
+        : MODEL_ENV_PREFIX + upper + "_";
+  }
+
+  /** Separator-insensitive form, so both underscore spellings of one key compare equal. */
+  private static String separatorInsensitive(String value) {
+    return value.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]", "");
+  }
+
+  /**
+   * Warns about {@code THRILLHOUSEBOT_AI_MODELS_*} variables that map to no configured model.
+   * Choosing the wrong underscore spelling resolves to nothing and the tuning silently never
+   * applies — the model keeps its default cap, and the only downstream signal is a budget that
+   * looks inexplicably small. Package-private so tests can drive an environment map.
+   */
+  void warnUnmappedModelEnvVars(Map<String, String> environment) {
+    unmappedModelEnvWarnings(config.ai().models().keySet(), environment).forEach(log::warn);
+  }
+
+  /**
+   * The warnings {@link #warnUnmappedModelEnvVars} emits, as plain strings so the rule is testable
+   * without a log appender. Sorted so the output is stable across environment iteration order.
+   */
+  static List<String> unmappedModelEnvWarnings(
+      Set<String> configuredModels, Map<String, String> environment) {
+    var warnings = new ArrayList<String>();
+    for (var name : environment.keySet()) {
+      if (!name.startsWith(MODEL_ENV_PREFIX)
+          || configuredModels.stream().anyMatch(model -> name.startsWith(modelEnvPrefix(model)))) {
+        continue;
+      }
+      var intended =
+          configuredModels.stream()
+              .filter(
+                  model ->
+                      separatorInsensitive(name)
+                          .startsWith(separatorInsensitive(modelEnvPrefix(model))))
+              .findFirst();
+      var setting = MODEL_SETTING_SUFFIXES.stream().filter(name::endsWith).findFirst();
+      if (intended.isPresent() && setting.isPresent()) {
+        warnings.add(
+            name
+                + " does not map to any model setting and is being ignored — model '"
+                + intended.get()
+                + "' is read as "
+                + modelEnvPrefix(intended.get())
+                + setting.get()
+                + ". Fix the underscores or the setting will silently never apply.");
+      } else {
+        warnings.add(
+            name
+                + " does not map to any configured model and is being ignored. Known models: "
+                + configuredModels
+                + ". An unlisted model needs an empty stub"
+                + " (thrillhousebot.ai.models.\"<model>\".max-input-tokens=) so its key exists.");
+      }
+    }
+    warnings.sort(String::compareTo);
+    return List.copyOf(warnings);
+  }
+
   private void logActiveModelStatus() {
     if (config.review().maxInputTokens() > 0 && activeModel.budgetClampedByModelCap()) {
       log.warn(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -348,6 +348,42 @@ public class StartupConfigValidator {
    * deliberately), and logs the active generation parameters so a tuning entry that targets the
    * wrong model name is visible immediately.
    */
+  private void logActiveModelStatus() {
+    if (config.review().maxInputTokens() > 0 && activeModel.budgetClampedByModelCap()) {
+      log.warn(
+          "REVIEW_MAX_INPUT_TOKENS ({}) exceeds the input cap of model '{}' ({}); using {}. Raise"
+              + " thrillhousebot.ai.models.\"{}\".max-input-tokens if the model's context window"
+              + " allows it.",
+          config.review().maxInputTokens(),
+          activeModel.modelName(),
+          activeModel.modelInputCap(),
+          activeModel.maxInputTokens(),
+          activeModel.modelName());
+    }
+    if (config.ai().models().containsKey(activeModel.modelName())) {
+      var temperature = orProviderDefault(activeModel.temperature());
+      var topP = orProviderDefault(activeModel.topP());
+      var maxOutputTokens = orProviderDefault(activeModel.maxOutputTokens());
+      var frequencyPenalty = orProviderDefault(activeModel.frequencyPenalty());
+      var presencePenalty = orProviderDefault(activeModel.presencePenalty());
+      var seed = activeModel.seed().map(String::valueOf).orElse("none");
+      log.info(
+          "Per-model AI settings active for '{}': max-input-tokens={}, output-buffer-tokens={},"
+              + " token-safety-margin={}, temperature={}, top-p={}, max-output-tokens={},"
+              + " frequency-penalty={}, presence-penalty={}, seed={}",
+          activeModel.modelName(),
+          activeModel.maxInputTokens(),
+          activeModel.outputBufferTokens(),
+          activeModel.tokenSafetyMargin(),
+          temperature,
+          topP,
+          maxOutputTokens,
+          frequencyPenalty,
+          presencePenalty,
+          seed);
+    }
+  }
+
   /** Env-var prefix every per-model setting shares. */
   private static final String MODEL_ENV_PREFIX = "THRILLHOUSEBOT_AI_MODELS_";
 
@@ -431,42 +467,6 @@ public class StartupConfigValidator {
     }
     warnings.sort(String::compareTo);
     return List.copyOf(warnings);
-  }
-
-  private void logActiveModelStatus() {
-    if (config.review().maxInputTokens() > 0 && activeModel.budgetClampedByModelCap()) {
-      log.warn(
-          "REVIEW_MAX_INPUT_TOKENS ({}) exceeds the input cap of model '{}' ({}); using {}. Raise"
-              + " thrillhousebot.ai.models.\"{}\".max-input-tokens if the model's context window"
-              + " allows it.",
-          config.review().maxInputTokens(),
-          activeModel.modelName(),
-          activeModel.modelInputCap(),
-          activeModel.maxInputTokens(),
-          activeModel.modelName());
-    }
-    if (config.ai().models().containsKey(activeModel.modelName())) {
-      var temperature = orProviderDefault(activeModel.temperature());
-      var topP = orProviderDefault(activeModel.topP());
-      var maxOutputTokens = orProviderDefault(activeModel.maxOutputTokens());
-      var frequencyPenalty = orProviderDefault(activeModel.frequencyPenalty());
-      var presencePenalty = orProviderDefault(activeModel.presencePenalty());
-      var seed = activeModel.seed().map(String::valueOf).orElse("none");
-      log.info(
-          "Per-model AI settings active for '{}': max-input-tokens={}, output-buffer-tokens={},"
-              + " token-safety-margin={}, temperature={}, top-p={}, max-output-tokens={},"
-              + " frequency-penalty={}, presence-penalty={}, seed={}",
-          activeModel.modelName(),
-          activeModel.maxInputTokens(),
-          activeModel.outputBufferTokens(),
-          activeModel.tokenSafetyMargin(),
-          temperature,
-          topP,
-          maxOutputTokens,
-          frequencyPenalty,
-          presencePenalty,
-          seed);
-    }
   }
 
   private static String orProviderDefault(Optional<? extends Number> value) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class StartupConfigValidatorTest {
@@ -578,5 +580,81 @@ class StartupConfigValidatorTest {
     assertEquals(
         StartupConfigValidator.DashboardOauthStatus.PARTIAL,
         StartupConfigValidator.dashboardOauthStatus(false, true));
+  }
+
+  @Nested
+  class ModelEnvVarMapping {
+
+    /** The properties key is unquoted (hyphens only), so SmallRye reads single underscores. */
+    @Test
+    void shouldUseSingleUnderscoresForAHyphenOnlyModelKey() {
+      assertEquals(
+          "THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_PRO_",
+          StartupConfigValidator.modelEnvPrefix("deepseek-v4-pro"));
+    }
+
+    /**
+     * A dotted key needs quoting in the properties file and doubles the surrounding underscores.
+     */
+    @Test
+    void shouldUseDoubledUnderscoresForADottedModelKey() {
+      assertEquals(
+          "THRILLHOUSEBOT_AI_MODELS__GPT_5_5__", StartupConfigValidator.modelEnvPrefix("gpt-5.5"));
+    }
+
+    @Test
+    void shouldWarnWhenTheWrongUnderscoreFormIsUsedForAKnownModel() {
+      // The doubled form belongs to dotted keys; on a hyphen-only key it resolves to nothing and
+      // the model silently keeps its default cap.
+      var warnings =
+          StartupConfigValidator.unmappedModelEnvWarnings(
+              Set.of("deepseek-v4-pro"),
+              Map.of("THRILLHOUSEBOT_AI_MODELS__DEEPSEEK_V4_PRO__MAX_INPUT_TOKENS", "1000000"));
+
+      assertEquals(1, warnings.size(), warnings.toString());
+      assertTrue(warnings.get(0).contains("does not map to any model setting"), warnings.get(0));
+      assertTrue(
+          warnings.get(0).contains("THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_PRO_MAX_INPUT_TOKENS"),
+          "must name the spelling that actually works: " + warnings.get(0));
+    }
+
+    @Test
+    void shouldStaySilentWhenTheFormIsCorrect() {
+      assertTrue(
+          StartupConfigValidator.unmappedModelEnvWarnings(
+                  Set.of("deepseek-v4-pro"),
+                  Map.of("THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_PRO_MAX_INPUT_TOKENS", "1000000"))
+              .isEmpty());
+    }
+
+    @Test
+    void shouldStaySilentForACorrectlySpelledDottedKey() {
+      assertTrue(
+          StartupConfigValidator.unmappedModelEnvWarnings(
+                  Set.of("gpt-5.5"),
+                  Map.of("THRILLHOUSEBOT_AI_MODELS__GPT_5_5__MAX_INPUT_TOKENS", "256000"))
+              .isEmpty());
+    }
+
+    @Test
+    void shouldWarnWhenTheModelHasNoConfiguredStubAtAll() {
+      var warnings =
+          StartupConfigValidator.unmappedModelEnvWarnings(
+              Set.of("deepseek-v4-pro"),
+              Map.of("THRILLHOUSEBOT_AI_MODELS_LLAMA_9_MAX_INPUT_TOKENS", "8000"));
+
+      assertEquals(1, warnings.size(), warnings.toString());
+      assertTrue(warnings.get(0).contains("does not map to any configured model"), warnings.get(0));
+      assertTrue(warnings.get(0).contains("empty stub"), warnings.get(0));
+    }
+
+    @Test
+    void shouldIgnoreUnrelatedEnvironmentVariables() {
+      assertTrue(
+          StartupConfigValidator.unmappedModelEnvWarnings(
+                  Set.of("deepseek-v4-pro"),
+                  Map.of("PATH", "/usr/bin", "REVIEW_MAX_INPUT_TOKENS", "900000"))
+              .isEmpty());
+    }
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -649,6 +649,19 @@ class StartupConfigValidatorTest {
     }
 
     @Test
+    void shouldFallBackToTheGenericWarningWhenTheSettingNameIsNotRecognised() {
+      // Right model, wrong setting: naming a spelling would be misleading when the suffix itself
+      // is not a real per-model setting, so this takes the generic branch.
+      var warnings =
+          StartupConfigValidator.unmappedModelEnvWarnings(
+              Set.of("deepseek-v4-pro"),
+              Map.of("THRILLHOUSEBOT_AI_MODELS__DEEPSEEK_V4_PRO__CONTEXT_SIZE", "1000000"));
+
+      assertEquals(1, warnings.size(), warnings.toString());
+      assertTrue(warnings.get(0).contains("does not map to any configured model"), warnings.get(0));
+    }
+
+    @Test
     void shouldIgnoreUnrelatedEnvironmentVariables() {
       assertTrue(
           StartupConfigValidator.unmappedModelEnvWarnings(


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Found by reading the running test instance's logs.

```
WARN StartupConfigValidator: REVIEW_MAX_INPUT_TOKENS (900000) exceeds the input cap of
model 'deepseek-v4-pro' (128000); using 128000.
```

The deployment had set `THRILLHOUSEBOT_AI_MODELS__DEEPSEEK_V4_PRO__MAX_INPUT_TOKENS=1000000`, which
looks right and resolves to nothing. The doubled underscores belong to keys that need **quoting** in
`application.properties` (`"gpt-5.5"`, because of the dot); a hyphen-only key like `deepseek-v4-pro`
is unquoted and takes **single** underscores.

So the model stayed on its 128 000 default — **12.8% of the configured 1M context** — and the only
signal was a cap warning that never said why the cap was low. In that instance it meant a 143-file
diff was batched against a window 8× smaller than intended: 25 sessions, 3.95M tokens, $7.07 in about
an hour.

### The fix

Startup scans `THRILLHOUSEBOT_AI_MODELS_*` and warns for any variable that matches no configured
model:

- when the intended model is recognisable (separator-insensitive match), it names the spelling that
  actually works — `THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_PRO_MAX_INPUT_TOKENS`
- otherwise it lists the known models and points at the empty-stub requirement for an unlisted one

**Warn, not fail.** A leftover variable for a model no longer in use shouldn't stop a boot, and this
is a class of typo where the operator's intent is clear but the cost of a hard failure is a broken
deployment.

The rule is a pure function (`unmappedModelEnvWarnings`) returning the messages, so it is tested
directly. Log-appender capture was the first approach and doesn't work here — Quarkus runs JBoss
LogManager, not Logback — and the pure function is the better shape regardless.

`.env.example` now explains *why* the two forms differ rather than just listing them, and points at
the boot log.

## Related Issues

N/A — found in the v0.5.0 test deployment.

## How Has This Been Tested?

- [x] Unit tests

Six new cases in `StartupConfigValidatorTest.ModelEnvVarMapping`, including the exact variable from
the live deployment:

- both prefix spellings (`deepseek-v4-pro` → single, `gpt-5.5` → double)
- the wrong form on a known model warns **and names the working spelling**
- correct forms — hyphen-only and dotted — stay silent
- an unknown model warns about the missing stub
- unrelated variables (`PATH`, `REVIEW_MAX_INPUT_TOKENS`) are ignored

`./mvnw verify` — **1876 tests, 0 failures**, SpotBugs `BugInstance size is 0`, JaCoCo gate met.

### Not fixed here

Two other things the same logs turned up, both out of scope for this PR:

1. An unhandled SSE exception escaping to the Vert.x event loop on every streaming review
   (`MismatchedInputException: No content to map due to end-of-input` via
   `OpenAiRestApiReaderInterceptor`). Non-fatal — reviews complete and every batch persists — but it
   logs at ERROR and will trip alerting. Worth its own issue.
2. `deepseek-v4-pro`'s shipped stub is empty, so the conservative 128 000 default applies. Filling in
   1M was tempting but wrong: some providers serve V4 Pro at 512K, and a too-high default would
   over-budget and fail their calls. The operator setting it explicitly is correct.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code