### PR TITLE
fix(review): ground the PR summary in the whole change set (#335)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -599,12 +599,15 @@ public class FindingPipeline {
       deletions += file.deletions();
     }
     var totals = ctx.prTotals();
-    var filesChanged = totals != null ? totals.filesChanged() : files.size();
-    if (totals != null) {
+    // A non-positive file count means the totals carry nothing usable: fall back to the
+    // diff-derived counts rather than announcing a zero-file PR over a non-empty file list.
+    var authoritative = totals != null && totals.filesChanged() > 0;
+    var filesChanged = authoritative ? totals.filesChanged() : files.size();
+    if (authoritative) {
       additions = totals.additions();
       deletions = totals.deletions();
     }
-    if (filesChanged <= 0 && files.isEmpty()) {
+    if (filesChanged <= 0) {
       return "";
     }
     var sb = new StringBuilder();
@@ -656,11 +659,12 @@ public class FindingPipeline {
     }
   }
 
-  /** The file's parent directory, or a stable label for files at the repository root. */
+  /**
+   * The file's parent directory, or a stable label for a path carrying no directory component —
+   * which also covers a blank one. A null path is not guarded here: the per-file loop above already
+   * dereferences the same name against an immutable set, so it could never reach this point.
+   */
   private static String directoryOf(String path) {
-    if (path == null || path.isBlank()) {
-      return "(repository root)";
-    }
     var slash = path.lastIndexOf('/');
     return slash <= 0 ? "(repository root)" : path.substring(0, slash);
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewService;
 import dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService;
@@ -49,6 +50,9 @@ import java.util.stream.IntStream;
  */
 @ApplicationScoped
 public class FindingPipeline {
+
+  /** Directory rows listed in the scope header before the remainder is rolled up by count. */
+  private static final int MAX_SCOPE_DIRECTORIES = 10;
 
   private record BatchOutcome(
       int index,
@@ -551,6 +555,8 @@ public class FindingPipeline {
     if (!pureRenames.isEmpty()) {
       sb.append(ReviewDiffFormatter.formatPureRenameRollup(pureRenames));
     }
+    // Scope totals next, ahead of the per-file rows, for the same reason: clamping drops the tail.
+    sb.append(changeScopeSummary(ctx));
     var omitted = Set.copyOf(plan.omittedFiles());
     var clipped = Set.copyOf(plan.clippedFiles());
     for (var file : ctx.reviewableFiles()) {
@@ -574,6 +580,89 @@ public class FindingPipeline {
       sb.append(name).append(" (omitted — exceeded the review call budget; not analyzed)\n");
     }
     return sb.toString();
+  }
+
+  /**
+   * PR-level scope header for the summary call: the authoritative file/line totals (GitHub's, the
+   * same numbers the rendered Changes Overview reports — #298) plus how the change is spread across
+   * directories. The summary call never sees the diff, so without these the only cue for how big
+   * the change is is a file list the input budget may have clamped — which is how a multi-file
+   * decompose got described as one extracted class (#335). Rendered as data, ahead of the per-file
+   * rows, so clamping can only take the tail.
+   */
+  private static String changeScopeSummary(ReviewContextLoader.ReviewContext ctx) {
+    var files = VerdictBuilder.overviewFiles(ctx);
+    var additions = 0;
+    var deletions = 0;
+    for (var file : files) {
+      additions += file.additions();
+      deletions += file.deletions();
+    }
+    var totals = ctx.prTotals();
+    var filesChanged = totals != null ? totals.filesChanged() : files.size();
+    if (totals != null) {
+      additions = totals.additions();
+      deletions = totals.deletions();
+    }
+    if (filesChanged <= 0 && files.isEmpty()) {
+      return "";
+    }
+    var sb = new StringBuilder();
+    sb.append("PR scope (whole pull request): ")
+        .append(filesChanged)
+        .append(filesChanged == 1 ? " file changed, +" : " files changed, +")
+        .append(additions)
+        .append(" -")
+        .append(deletions)
+        .append("\n");
+    appendDirectoryBreakdown(sb, files);
+    return sb.toString();
+  }
+
+  /**
+   * "directory: N files (+a -d)" rows, most files first, so a change spread over several packages
+   * cannot read as a single-file edit. Bounded so a wide PR cannot crowd out the file list.
+   */
+  private static void appendDirectoryBreakdown(
+      StringBuilder sb, List<GitHubPullRequestClient.FileDiff> files) {
+    if (files.isEmpty()) {
+      return;
+    }
+    var byDirectory = new LinkedHashMap<String, int[]>();
+    for (var file : files) {
+      var stats = byDirectory.computeIfAbsent(directoryOf(file.filename()), key -> new int[3]);
+      stats[0]++;
+      stats[1] += file.additions();
+      stats[2] += file.deletions();
+    }
+    var rows = new ArrayList<>(byDirectory.entrySet());
+    rows.sort(
+        Comparator.<Map.Entry<String, int[]>>comparingInt(e -> -e.getValue()[0])
+            .thenComparing(Map.Entry::getKey));
+    sb.append("Directories touched: ").append(byDirectory.size()).append("\n");
+    for (var row : rows.subList(0, Math.min(rows.size(), MAX_SCOPE_DIRECTORIES))) {
+      sb.append("- ")
+          .append(row.getKey())
+          .append(": ")
+          .append(row.getValue()[0])
+          .append(row.getValue()[0] == 1 ? " file (+" : " files (+")
+          .append(row.getValue()[1])
+          .append(" -")
+          .append(row.getValue()[2])
+          .append(")\n");
+    }
+    if (rows.size() > MAX_SCOPE_DIRECTORIES) {
+      sb.append("- (+").append(rows.size() - MAX_SCOPE_DIRECTORIES).append(" more directories)\n");
+    }
+  }
+
+  /** The file's parent directory, or a stable label for files at the repository root. */
+  private static String directoryOf(String path) {
+    if (path == null || path.isBlank()) {
+      return "(repository root)";
+    }
+    var slash = path.lastIndexOf('/');
+    return slash <= 0 ? "(repository root)" : path.substring(0, slash);
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -357,16 +357,25 @@ public final class PrReviewPrompts {
             - Base summary.total_findings and the per-severity counts on the findings provided
               below — unless a "(+N more findings not shown …)" note follows the array; use that
               note's stated true totals then, since the list was truncated to fit your input.
-            - overall_assessment and pr_purpose must be consistent with those findings and the
-              changed-files list; do not contradict them.
+            - overall_assessment and pr_purpose must be consistent with those findings, with the PR
+              scope totals, and with the changed-files list; do not contradict them. A summary whose
+              scope is narrower than the stated PR scope is wrong: few or no findings means the
+              reviewed code looked fine, never that the change was small or touched one file.
 
             The "summary" object must include:
             - total_findings, critical, high, medium, low: counts of the findings provided below
             - overall_assessment: one-sentence verdict on the change
-            - pr_purpose: 1-3 sentences on what this change does, derived from the changed files and
-              findings — describe behavior, not file names
+            - pr_purpose: 1-3 sentences on what the WHOLE change set does. You do not see the diff,
+              so ground it in the PR title and description (the author's stated intent) together
+              with the PR scope totals and the changed-file list below, which are computed from the
+              diff and are authoritative. Cover the change set as a whole: when it spans many files
+              or several directories, say so and name the main areas it touches. Never present one
+              extracted class, one file, or the one component that happens to carry findings as if
+              it were the whole pull request. Describe behavior, not a file listing.
             - description_gaps: when a PR description is provided, an array of concrete mismatches
-              between what the author claims and what the change does. Empty array otherwise.
+              between what the author claims and what the change does — including a description
+              whose scope is narrower than the change itself (it covers one component, or far fewer
+              files than the PR scope totals report). Empty array otherwise.
             - file_summaries: an array of { path, summary } objects giving a file-by-file
               walkthrough. "path" must match a changed-file path exactly; "summary" is a single line
               (max ~100 chars) on what changed in that file. Most impactful first, cap at 15.
@@ -396,7 +405,9 @@ public final class PrReviewPrompts {
             ## Findings already computed for this PR (final — summarize, do not change)
             {{findings}}
 
-            ## Changed files
+            ## PR scope and changed files (computed from the diff — authoritative)
+            Everything listed here belongs to this pull request; the purpose you write must
+            account for all of it, not just the entries with findings.
             {{changedFiles}}
 
             {{#if previousFindings}}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -359,6 +359,64 @@ class FindingPipelineTest {
   }
 
   @Test
+  void summaryOverviewScopeFallsBackToDiffCountsWhenPrTotalsAreEmpty() {
+    // A zero file count means the totals carry nothing usable; announcing a zero-file PR over a
+    // non-empty file list would contradict the very list printed below it.
+    var session = ReviewSession.create("owner/repo", 1, "Totals unavailable", "sha");
+    var reviewable =
+        List.of(
+            new FileDiff("a.java", "modified", 3, 0, 3, ""),
+            new FileDiff("b.java", "modified", 2, 0, 2, ""));
+    var ctx = reviewContext(List.of(), reviewable, new ReviewContextLoader.PrTotals(0, 0, 0));
+
+    var overview = captureSummaryChangedFiles(session, ctx);
+
+    assertTrue(
+        overview.contains("PR scope (whole pull request): 2 files changed, +5 -0"), overview);
+  }
+
+  @Test
+  void summaryOverviewOmitsTheScopeBlockWhenNothingIsInTheChangeSet() {
+    // Nothing reviewable and no PR totals: emit no scope header at all rather than "0 files".
+    var session = ReviewSession.create("owner/repo", 1, "Everything ignored", "sha");
+
+    var overview = captureSummaryChangedFiles(session, reviewContext(List.of(), List.of(), null));
+
+    assertEquals("", overview);
+  }
+
+  @Test
+  void summaryOverviewScopeKeepsTotalsWhenNoFileSurvivesTheIgnoreGlob() {
+    // GitHub still reports the PR's real size when the ignore-glob drops every changed file, so
+    // the header stands on its own — with no directory breakdown, which would have to be empty.
+    var session = ReviewSession.create("owner/repo", 1, "All ignored", "sha");
+    var ctx = reviewContext(List.of(), List.of(), new ReviewContextLoader.PrTotals(23, 1612, 240));
+
+    var overview = captureSummaryChangedFiles(session, ctx);
+
+    assertEquals("PR scope (whole pull request): 23 files changed, +1612 -240\n", overview);
+  }
+
+  @Test
+  void summaryOverviewScopeBucketsAPathWithNoDirectoryAtTheRoot() {
+    // A name carrying no directory component — a blank one included — buckets at the root instead
+    // of opening a directory row named after it.
+    var session = ReviewSession.create("owner/repo", 1, "Odd payload", "sha");
+    var files =
+        List.of(
+            new FileDiff("  ", "modified", 2, 0, 2, ""),
+            new FileDiff("src/app/A.java", "modified", 4, 1, 5, ""));
+
+    var overview = captureSummaryChangedFiles(session, reviewContext(files, files, null));
+
+    assertTrue(
+        overview.contains("PR scope (whole pull request): 2 files changed, +6 -1"), overview);
+    assertTrue(overview.contains("Directories touched: 2"), overview);
+    assertTrue(overview.contains("- (repository root): 1 file (+2 -0)"), overview);
+    assertTrue(overview.contains("- src/app: 1 file (+4 -1)"), overview);
+  }
+
+  @Test
   void summaryOverviewRollsUpDirectoriesBeyondTheCap() {
     var session = ReviewSession.create("owner/repo", 1, "Wide PR", "sha");
     var files = new ArrayList<FileDiff>();

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -42,6 +42,7 @@ import dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService;
 import dev.thiagogonzaga.thrillhousebot.review.ai.PrReviewPrompts;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import dev.thiagogonzaga.thrillhousebot.review.ai.TokenCounter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
@@ -113,6 +114,17 @@ class FindingPipelineTest {
 
   /** Same context with a caller-supplied changed-file list, so rename disclosure can be driven. */
   private static ReviewContextLoader.ReviewContext reviewContext(List<FileDiff> files) {
+    return reviewContext(
+        files,
+        List.of(
+            new FileDiff("a.java", "modified", 3, 0, 3, ""),
+            new FileDiff("b.java", "modified", 2, 0, 2, "")),
+        null);
+  }
+
+  /** Same context with an explicit reviewable-file set and GitHub's PR totals (may be null). */
+  private static ReviewContextLoader.ReviewContext reviewContext(
+      List<FileDiff> files, List<FileDiff> reviewableFiles, ReviewContextLoader.PrTotals prTotals) {
     return new ReviewContextLoader.ReviewContext(
         files,
         "raw legacy diff",
@@ -130,11 +142,9 @@ class FindingPipelineTest {
         List.of(),
         "",
         "",
-        List.of(
-            new FileDiff("a.java", "modified", 3, 0, 3, ""),
-            new FileDiff("b.java", "modified", 2, 0, 2, "")),
+        reviewableFiles,
         () -> new DiffLineResolver(Map.of()),
-        null);
+        prTotals);
   }
 
   private static DiffBudgetPlanner.BudgetPlan multiBatchPlan() {
@@ -273,6 +283,92 @@ class FindingPipelineTest {
         captor.getValue().changedFiles().startsWith("1 pure rename omitted from AI review"),
         captor.getValue().changedFiles());
     assertTrue(captor.getValue().changedFiles().contains("pkg/A.java → pkg/B.java"));
+  }
+
+  /** Runs the multi-call path and returns the changed-files section the summary call received. */
+  private String captureSummaryChangedFiles(
+      ReviewSession session, ReviewContextLoader.ReviewContext ctx) {
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
+    when(aiReviewService.summarize(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+
+    return captor.getValue().changedFiles();
+  }
+
+  @Test
+  void summaryOverviewStatesTheWholePrScopeForAMultiFileRefactor() {
+    // The #335 fixture: a decompose whose title/body announce the full scope, but whose summary
+    // call sees no diff — without these totals nothing tells it the change is more than one class.
+    var session = ReviewSession.create("owner/repo", 1, "Decompose the orchestrator", "sha");
+    var files =
+        List.of(
+            new FileDiff(
+                "src/main/java/app/review/Orchestrator.java", "modified", 40, 900, 940, ""),
+            new FileDiff(
+                "src/main/java/app/review/CiStatusEvaluator.java", "added", 120, 0, 120, ""),
+            new FileDiff("src/main/java/app/review/FindingPipeline.java", "added", 300, 0, 300, ""),
+            new FileDiff("src/test/java/app/review/PipelineTest.java", "added", 200, 0, 200, ""),
+            new FileDiff("README.md", "modified", 4, 2, 6, ""));
+    var overview = captureSummaryChangedFiles(session, reviewContext(files, files, null));
+
+    assertTrue(
+        overview.contains("PR scope (whole pull request): 5 files changed, +664 -902"), overview);
+    assertTrue(overview.contains("Directories touched: 3"), overview);
+    assertTrue(overview.contains("- src/main/java/app/review: 3 files (+460 -900)"), overview);
+    assertTrue(overview.contains("- src/test/java/app/review: 1 file (+200 -0)"), overview);
+    assertTrue(overview.contains("- (repository root): 1 file (+4 -2)"), overview);
+    // Ahead of the per-file rows, so clamping a long overview can only drop the tail.
+    assertTrue(
+        overview.indexOf("PR scope (whole pull request)") < overview.indexOf("README.md (modified"),
+        overview);
+  }
+
+  @Test
+  void summaryOverviewScopeUsesGitHubsAuthoritativeTotalsWhenAvailable() {
+    // Same totals the rendered Changes Overview reports (#298), so the prose cannot contradict it.
+    var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
+    var reviewable =
+        List.of(
+            new FileDiff("a.java", "modified", 3, 0, 3, ""),
+            new FileDiff("b.java", "modified", 2, 0, 2, ""));
+    var ctx = reviewContext(List.of(), reviewable, new ReviewContextLoader.PrTotals(23, 1612, 240));
+
+    var overview = captureSummaryChangedFiles(session, ctx);
+
+    assertTrue(
+        overview.contains("PR scope (whole pull request): 23 files changed, +1612 -240"), overview);
+  }
+
+  @Test
+  void summaryOverviewScopeStaysSingularForASingleFilePr() {
+    // No regression on small single-purpose PRs: no multi-file or multi-directory language.
+    var session = ReviewSession.create("owner/repo", 1, "Fix a typo", "sha");
+    var files = List.of(new FileDiff("src/main/java/app/Tiny.java", "modified", 3, 1, 4, ""));
+    var overview = captureSummaryChangedFiles(session, reviewContext(files, files, null));
+
+    assertTrue(overview.contains("PR scope (whole pull request): 1 file changed, +3 -1"), overview);
+    assertTrue(overview.contains("Directories touched: 1"), overview);
+    assertTrue(overview.contains("- src/main/java/app: 1 file (+3 -1)"), overview);
+    assertFalse(overview.contains("files changed"), overview);
+    assertFalse(overview.contains("more directories"), overview);
+  }
+
+  @Test
+  void summaryOverviewRollsUpDirectoriesBeyondTheCap() {
+    var session = ReviewSession.create("owner/repo", 1, "Wide PR", "sha");
+    var files = new ArrayList<FileDiff>();
+    for (var i = 0; i < 12; i++) {
+      files.add(new FileDiff("pkg" + i + "/File.java", "modified", 1, 0, 1, ""));
+    }
+    var overview = captureSummaryChangedFiles(session, reviewContext(files, files, null));
+
+    assertTrue(overview.contains("Directories touched: 12"), overview);
+    assertTrue(overview.contains("- (+2 more directories)"), overview);
   }
 
   @Test
@@ -500,13 +596,26 @@ class FindingPipelineTest {
     var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
     var ctx = reviewContext();
     var template = new AiReviewService.PromptInputs("d", "d", "", "", "", "", "");
-    var high = new ReviewResponse.Finding("high", "high", "a.java", 1, "H", "d", "o", "n");
-    var medium = new ReviewResponse.Finding("medium", "high", "a.java", 3, "M", "d", "o", "n");
-    var nullRisk = new ReviewResponse.Finding(null, "high", "a.java", 2, "N", "d", "o", "n");
-    var critical = new ReviewResponse.Finding("critical", "high", "b.java", 1, "C", "d", "o", "n");
+    // Descriptions long enough that one finding outweighs the changed-files overview: the budget
+    // below leaves room for exactly one, and the overview keeps its own (larger) share unclamped.
+    var desc =
+        "this description exists to make one serialized finding the dominant cost ".repeat(3);
+    var high = new ReviewResponse.Finding("high", "high", "a.java", 1, "H", desc, "o", "n");
+    var medium = new ReviewResponse.Finding("medium", "high", "a.java", 3, "M", desc, "o", "n");
+    var nullRisk = new ReviewResponse.Finding(null, "high", "a.java", 2, "N", desc, "o", "n");
+    var critical = new ReviewResponse.Finding("critical", "high", "b.java", 1, "C", desc, "o", "n");
 
     var tokenCounter = new TokenCounter();
-    var overview = "a.java (modified, +3 -0)\nb.java (modified, +2 -0)\n";
+    // The overview the pipeline will build (scope header + per-file rows), so the budget below is
+    // calibrated against the same fixed sections the production code measures.
+    var overview =
+        """
+        PR scope (whole pull request): 2 files changed, +5 -0
+        Directories touched: 1
+        - (repository root): 2 files (+5 -0)
+        a.java (modified, +3 -0)
+        b.java (modified, +2 -0)
+        """;
     var fixedSections =
         PrReviewPrompts.SUMMARY_SYSTEM + PrReviewPrompts.SUMMARY_USER + "d" + overview;
     var criticalJson = new ObjectMapper().writeValueAsString(List.of(critical));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -24,9 +24,10 @@ import org.junit.jupiter.api.Test;
  * config/IaC severity recalibration (so declarative findings are not suppressed), the
  * parameter-nullability / unseen-caller guard (#107), the in-diff-test exercise gate (a green test
  * must demonstrably hit the claimed path before it can invalidate a finding — #116), the symmetric
- * exact-arithmetic / "test fails" cap (#97), and the heuristic failure-mode characterization pass
- * with its verifier exemption (#123). These assertions are intentionally coarse — they check intent
- * survives, not exact wording; an intentional rewording should update the matching anchor.
+ * exact-arithmetic / "test fails" cap (#97), the heuristic failure-mode characterization pass with
+ * its verifier exemption (#123), and the summary call's whole-change-set grounding (#335). These
+ * assertions are intentionally coarse — they check intent survives, not exact wording; an
+ * intentional rewording should update the matching anchor.
  *
  * <p>The automated LLM eval that checks the model actually <em>acts</em> on this guidance is
  * tracked separately ({@code evalcorpus/}); this is the cheap deterministic guard.
@@ -360,5 +361,57 @@ class PrReviewPromptsContentTest {
         req,
         "participant O as ReviewOrchestrator",
         "the diagram prompt must include a correct sequence-diagram example");
+  }
+
+  @Test
+  void summaryPromptGroundsThePurposeInTheWholeChangeSet() {
+    String sys = PrReviewPrompts.SUMMARY_SYSTEM;
+    assertContains(
+        sys,
+        "what the WHOLE change set does",
+        "pr_purpose must be scoped to the whole change set, not one file (#335)");
+    assertContains(
+        sys,
+        "PR title and description (the author's stated intent)",
+        "pr_purpose must be grounded in the PR title/description");
+    assertContains(
+        sys,
+        "PR scope totals and the changed-file list",
+        "pr_purpose must be grounded in the authoritative scope totals");
+    assertContains(
+        sys,
+        "extracted class, one file, or the one component that happens to carry findings",
+        "the summary must not present one extracted class as the whole PR (#335)");
+  }
+
+  @Test
+  void summaryPromptRejectsASummaryNarrowerThanThePrScope() {
+    String sys = PrReviewPrompts.SUMMARY_SYSTEM;
+    assertContains(
+        sys,
+        "scope is narrower than the stated PR scope is wrong",
+        "a summary whose scope is a subset of the diff's must be called out as wrong (#335)");
+    assertContains(
+        sys,
+        "never that the change was small or touched one file",
+        "zero findings must not be read as a small change");
+    assertContains(
+        sys,
+        "whose scope is narrower than the change itself",
+        "description_gaps must cover a description that covers only part of the change (#335)");
+  }
+
+  @Test
+  void summaryUserPromptFramesTheFileListAsAuthoritativeScope() {
+    String user = PrReviewPrompts.SUMMARY_USER;
+    assertContains(
+        user,
+        "## PR scope and changed files (computed from the diff — authoritative)",
+        "the summary user prompt must present the scope block as authoritative");
+    assertContains(
+        user,
+        "account for all of it",
+        "the summary user prompt must require the purpose to cover every listed entry");
+    assertContains(user, "{{changedFiles}}", "the changed-files slot must survive the rewording");
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Dogfooding turned up a summary that described a full multi-collaborator decompose (~1.6k LOC, 7 new collaborators) as "extracts CI-status evaluation" — the prose named one class while the diff was the whole refactor.

**Diagnosis.** On a large PR the summary comes from a separate model call (`AiReviewService.summarize` → `PrReviewer.summarizeStream`, driven by `PrReviewPrompts.SUMMARY_SYSTEM` / `SUMMARY_USER`), and that call never sees the diff. The PR title and description were already reaching it through the `prContext` slot, so the gap was not the metadata — it was that:

1. `SUMMARY_SYSTEM` told the model to derive `pr_purpose` "from the changed files and findings" and never mentioned the author's stated intent or the size of the change; and
2. nothing in the prompt stated how big the change actually is. The only breadth signal was a changed-file list that `clampOverview` may truncate on exactly the large PRs where this matters.

**Fix.**

- `FindingPipeline` now renders a deterministic PR-scope block at the head of the changed-files section: `PR scope (whole pull request): N files changed, +A -D`, then a per-directory breakdown (`- src/main/java/...: 3 files (+460 -900)`), capped at 10 directories with a rollup for the rest. The totals are GitHub's authoritative PR totals (`ctx.prTotals()`, the same numbers the rendered Changes Overview reports since #298), falling back to the diff-derived counts when the fetch failed. It sits ahead of the per-file rows so budget clamping can only drop the tail, the same reason the pure-rename rollup leads.
- `SUMMARY_SYSTEM` now requires `pr_purpose` to describe the WHOLE change set, grounded in the PR title/description *and* the scope totals, and explicitly forbids presenting one extracted class, one file, or the one component carrying findings as if it were the whole PR. It also states that a summary narrower than the stated PR scope is wrong and that few/no findings never means the change was small.
- `description_gaps` now covers the qualitative case this issue is about: a description whose scope is narrower than the change itself.
- `SUMMARY_USER` renames the file-list section to `## PR scope and changed files (computed from the diff — authoritative)` and states the purpose must account for all of it.

Everything new is data derived from the diff and file list; the untrusted prose (title/body) keeps going through the existing escaped `prContext` slot.

**Deliberately not implemented** (both optional in the issue):

- *The "mentions fewer files than changedFiles.size()" guard.* `pr_purpose` is prose that the prompt explicitly asks to "describe behavior, not a file listing", so a well-written summary mentions no file paths at all. A mention-count threshold would append "(partial — see walkthrough)" to correct summaries, which erodes trust in the other direction. The deterministic effort went into making the scope authoritative and unclampable instead.
- *A "Description vs PR metadata" pass in `FindingVerifierPrompts.SYSTEM`.* That verifier audits individual candidate findings and runs per batch, before the summary exists — it has no summary to check. The equivalent signal is instead encoded where the summary is produced (`description_gaps`, already rendered by `PrSummaryGenerator.appendDescriptionGaps` as "⚠️ Description vs. Implementation"), with no extra AI call.

No new config keys, so no README/`.env.example` changes.

## Related Issues

Fixes #335

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Red/green validated per test: with the production change stashed (`git stash push -- src/main/java`) and the tests kept, all seven new assertions fail; with it restored they pass.

Red phase (`./mvnw -B test -Dtest='FindingPipelineTest,PrReviewPromptsContentTest'` → `Tests run: 47, Failures: 7`):

```
FindingPipelineTest.summaryOverviewStatesTheWholePrScopeForAMultiFileRefactor
  src/main/java/app/review/Orchestrator.java (modified, +40 -900)
  ... ==> expected: <true> but was: <false>
FindingPipelineTest.summaryOverviewScopeUsesGitHubsAuthoritativeTotalsWhenAvailable
  a.java (modified, +3 -0) ... ==> expected: <true> but was: <false>
FindingPipelineTest.summaryOverviewScopeStaysSingularForASingleFilePr
  src/main/java/app/Tiny.java (modified, +3 -1) ==> expected: <true> but was: <false>
FindingPipelineTest.summaryOverviewRollsUpDirectoriesBeyondTheCap
  pkg0/File.java (modified, +1 -0) ... ==> expected: <true> but was: <false>
PrReviewPromptsContentTest.summaryPromptGroundsThePurposeInTheWholeChangeSet
  pr_purpose must be scoped to the whole change set, not one file (#335)
  — missing marker: "what the WHOLE change set does" ==> expected: <true> but was: <false>
PrReviewPromptsContentTest.summaryPromptRejectsASummaryNarrowerThanThePrScope
  a summary whose scope is a subset of the diff's must be called out as wrong (#335)
  — missing marker: "scope is narrower than the stated PR scope is wrong"
PrReviewPromptsContentTest.summaryUserPromptFramesTheFileListAsAuthoritativeScope
  the summary user prompt must present the scope block as authoritative
  — missing marker: "## PR scope and changed files (computed from the diff — authoritative)"
```

(The assertion message on the pipeline tests is the captured `SummaryInputs.changedFiles()` value, i.e. the file list with no scope header.)

Green phase: same command, `Tests run: 47, Failures: 0`.

Coverage of the acceptance criteria:

- *Summary reflects multi-file refactors* — `summaryOverviewStatesTheWholePrScopeForAMultiFileRefactor` drives the multi-file fixture (5 files over 3 directories, title/body announcing the full scope) through the map-reduce path and asserts the summary call receives the totals, the per-directory breakdown, and that they precede the per-file rows. The prompt-side half is pinned by the `PrReviewPromptsContentTest` cases.
- *Regression test with a multi-file fixture* — the same test, plus `summaryOverviewScopeUsesGitHubsAuthoritativeTotalsWhenAvailable` (GitHub totals win over diff-derived counts) and `summaryOverviewRollsUpDirectoriesBeyondTheCap` (the breakdown stays bounded).
- *No regression on small single-purpose PRs* — `summaryOverviewScopeStaysSingularForASingleFilePr` asserts a one-file PR renders singular scope text with no multi-file or multi-directory language, and the single-call review path (which is what small PRs use) is untouched.

Also run: `./mvnw -B spotless:apply`, `./mvnw -B clean compile spotbugs:check spotless:check` (BugInstance size is 0, BUILD SUCCESS), `./mvnw -B clean test` (full suite: `Tests run: 1884, Failures: 0, Errors: 0, Skipped: 0`).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

The block the summary call now receives ahead of the file list, for a decompose-shaped PR:

```
PR scope (whole pull request): 5 files changed, +664 -902
Directories touched: 3
- src/main/java/app/review: 3 files (+460 -900)
- src/test/java/app/review: 1 file (+200 -0)
- (repository root): 1 file (+4 -2)
src/main/java/app/review/Orchestrator.java (modified, +40 -900)
...
```

## Additional Notes

`summaryFindingsJsonIsClampedToThePerCallBudget` calibrates a per-call budget against the exact fixed prompt sections, so it needed its expected overview updated for the new scope block and slightly longer finding descriptions to keep the findings share dominant; its assertions are unchanged.
