### PR TITLE
feat(review): trace a change's data structure from producer to consumer (#117)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -81,6 +81,26 @@ public final class PrReviewPrompts {
                finding or phrase a verification request only when the mock's impossibility is
                already demonstrable from what is shown. A green test whose mocks contradict the
                real collaborator is not evidence the production path works.
+            9. PRODUCER → CONSUMER CONTRACT: hunks are judged locally, so a change can be correct
+               line by line and still wrong end to end. Once per PR, for the change's PRIMARY new
+               or modified data structure — a returned collection, a flag, a computed verdict —
+               name where it is PRODUCED (the code that populates or computes it) and where it is
+               CONSUMED (the code that gates, branches, or renders on it), then check the
+               consumer's assumption against what the producer actually puts in it. (a) A value
+               whose NAME asserts a predicate — offending, invalid, failed, missing, stale,
+               duplicate — must be populated ONLY with items that satisfy it: a producer that
+               appends every item it walks, including the ones it just classified as passing,
+               contradicts its own name and every consumer that trusts the name. (b) A collection
+               consumed as a gate through isEmpty()/size()/anyMatch must hold ONLY gate-worthy
+               entries, or the gate fires on the ordinary case — the inverse of what it was added
+               for. (c) The resulting end-to-end behavior must match the PR title and description;
+               when the trace shows the opposite of the stated intent (a downgrade meant to fire
+               "only when checks are failing" also firing when every check passed), report it here
+               AND as a summary.description_gaps entry. Anchor at the producer line that breaks
+               the contract, quote it, and quote the consumer's gate line in the description; risk
+               "high" when the trace inverts the feature for its normal case. Not a finding when
+               producer and consumer agree, or when the consumer is not in the provided material —
+               say nothing rather than narrating the data flow of an ordinary local change.
 
             For each finding, provide:
             - risk: "critical" | "high" | "medium" | "low"
@@ -199,6 +219,13 @@ public final class PrReviewPrompts {
               in different units, first verify the units are genuinely equivalent; when the
               other place is not visible in the provided material at all, do not claim the
               comparison.
+            - A producer→consumer contract claim (dimension 9) must quote BOTH ends from the
+              provided material — the line that populates or computes the structure and the line
+              that gates or branches on it — and name the concrete case on which they disagree
+              (an item the producer admits and the consumer mishandles). When only one end is
+              visible, or you cannot name that case, the finding is invalid. Raise it for the
+              structure the change is about, not for every local variable that crosses a hunk
+              boundary.
             - Claims about the contents or behavior of artifacts not shown in the diff (base
               images, registries, installed packages, remote services) cannot be verified here:
               they are never "critical" or "high", and the description must be phrased as a
@@ -271,8 +298,9 @@ public final class PrReviewPrompts {
               the diff itself — describe behavior, not file names
             - description_gaps: when the PR title/description is provided, an array of concrete
               mismatches between what the author claims and what the code does (claimed changes
-              that are missing, significant changes the description never mentions). Empty array
-              when there is no description or no mismatch.
+              that are missing, significant changes the description never mentions, and a
+              producer→consumer trace whose end-to-end behavior is the inverse of the stated
+              intent — dimension 9). Empty array when there is no description or no mismatch.
             - file_summaries: an array of { path, summary } objects, one per changed file, that gives
               reviewers a file-by-file walkthrough. "path" must match the file path exactly as it
               appears in the diff; "summary" is a single line (max ~100 chars) describing what

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -25,9 +25,10 @@ import org.junit.jupiter.api.Test;
  * parameter-nullability / unseen-caller guard (#107), the in-diff-test exercise gate (a green test
  * must demonstrably hit the claimed path before it can invalidate a finding — #116), the symmetric
  * exact-arithmetic / "test fails" cap (#97), the heuristic failure-mode characterization pass with
- * its verifier exemption (#123), and the summary call's whole-change-set grounding (#335). These
- * assertions are intentionally coarse — they check intent survives, not exact wording; an
- * intentional rewording should update the matching anchor.
+ * its verifier exemption (#123), the producer→consumer data-flow contract dimension (#117), and the
+ * summary call's whole-change-set grounding (#335). These assertions are intentionally coarse —
+ * they check intent survives, not exact wording; an intentional rewording should update the
+ * matching anchor.
  *
  * <p>The automated LLM eval that checks the model actually <em>acts</em> on this guidance is
  * tracked separately ({@code evalcorpus/}); this is the cheap deterministic guard.
@@ -329,6 +330,67 @@ class PrReviewPromptsContentTest {
         sys,
         "do not confirm it as a defect",
         "a contract-free heuristic claim must be downgraded to a verification request");
+  }
+
+  @Test
+  void generatorPromptTracesTheChangesStructureFromProducerToConsumer() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "PRODUCER → CONSUMER CONTRACT",
+        "the producer→consumer data-flow dimension must exist (#117)");
+    assertContains(
+        sys, "where it is PRODUCED", "the dimension must make the model name the producing end");
+    assertContains(
+        sys,
+        "CONSUMED (the code that gates, branches, or renders on it)",
+        "the dimension must name the consuming end");
+    assertContains(
+        sys,
+        "offending, invalid, failed, missing",
+        "check (a): a predicate-named value must hold only items satisfying that predicate");
+    assertContains(
+        sys,
+        "isEmpty()/size()/anyMatch must hold ONLY gate-worthy",
+        "check (b): a collection gated on emptiness/size must hold only gate-worthy entries");
+    assertContains(
+        sys,
+        "must match the PR title and description",
+        "check (c): the end-to-end behavior must be compared against the PR's stated intent");
+  }
+
+  @Test
+  void generatorPromptRoutesAnInvertedTraceIntoDescriptionGaps() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "AND as a summary.description_gaps entry",
+        "an end-to-end trace contradicting the stated intent must also become a description gap");
+    assertContains(
+        sys,
+        "producer→consumer trace whose end-to-end behavior is the inverse of the stated",
+        "the description_gaps field must name the inverted-trace case as one of its inputs");
+  }
+
+  @Test
+  void generatorPromptKeepsTheDataFlowDimensionFromFiringOnOrdinaryDiffs() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "producer and consumer agree, or when the consumer is not in the provided material",
+        "an intact producer/consumer contract must not become a finding");
+    assertContains(
+        sys,
+        "say nothing rather than narrating the data flow",
+        "an ordinary local change must not be turned into a data-flow essay");
+    assertContains(
+        sys,
+        "producer→consumer contract claim (dimension 9) must quote BOTH ends",
+        "the self-check must require both ends quoted before a contract claim is emitted");
+    assertContains(
+        sys,
+        "not for every local variable that crosses a hunk",
+        "the self-check must scope the claim to the structure the change is about");
   }
 
   @Test

--- a/src/test/resources/evalcorpus/pr99-offending-list-contract-holds-must-not-find/case.json
+++ b/src/test/resources/evalcorpus/pr99-offending-list-contract-holds-must-not-find/case.json
@@ -1,0 +1,10 @@
+{
+  "kind": "generator",
+  "sourcePr": 99,
+  "why": "Precision control for the producer→consumer contract dimension (issue #117), built from the shipped PR #99 fix: evaluateCiChecks adds an entry only when the classified status is not CI_SUCCESS, so the list the caller binds to offendingCiChecks really does hold only offending checks and the !isEmpty() gate in buildResult fires exactly when the PR says it should. Same multi-hunk producer/consumer shape as the must-find case, contract intact — the review must not manufacture a data-flow essay here.",
+  "expectation": "must-not-find",
+  "targetFile": "src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java",
+  "keywords": ["producer", "non-offending", "including passing", "contract mismatch"],
+  "prTitle": "fix(review): gate the APPROVE verdict on CI status (#95)",
+  "prDescription": "- [x] 🐛 Bug fix\n\nFixes #95\n\nThrillhouseBot could post a green APPROVE review while the PR's CI was still red or pending. This change gates the APPROVE verdict on the CI status of the head commit.\n\n- Treats a check as offending when it is failing, pending, or a required check that never reported; passing/skipped/neutral checks are excluded.\n- Downgrades a would-be APPROVE to COMMENT when any offending check exists.\n- No breaking changes; when CI is fully green the verdict is unchanged."
+}

--- a/src/test/resources/evalcorpus/pr99-offending-list-contract-holds-must-not-find/diff.txt
+++ b/src/test/resources/evalcorpus/pr99-offending-list-contract-holds-must-not-find/diff.txt
@@ -1,0 +1,83 @@
+### src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java (modified, +60 -3)
+```diff
+@@ -251,11 +251,20 @@ public void review(ReviewRequest request) {
+               aiResponse, priorAiResponseJsons, inlineComments, BOT_LOGIN);
+       persistAiResponse(session, aiResponse);
+
++      List<String> requiredContexts = resolveRequiredContexts(auth, req).orElse(null);
++
++      List<ReviewResult.CiCheck> offendingCiChecks =
++          evaluateCiChecks(auth, req.owner(), req.repo(), req.commitSha(), requiredContexts);
++
+       DiffStats diffStats = DiffStats.fromFiles(diffFormatter.reviewableFiles(files));
+       var unresolvedPrevious =
+           followUpAnalyzer.unresolvedFindings(
+               previousAiResponseJson, aiResponse.previousFindingsStatus());
+-      var result = buildResult(aiResponse, isFirstReview, diffStats, unresolvedPrevious);
++      var result =
++          buildResult(aiResponse, isFirstReview, diffStats, unresolvedPrevious, offendingCiChecks);
+
+       // Finalize check run before posting PR review — avoid approving then failing later
+       String conclusion = conclusionForResult(result);
+@@ -727,6 +751,11 @@ ReviewResult buildResult(
+       state = ReviewState.COMMENT;
+     }
+
++    // Gating approval verdict on CI status:
++    if (state == ReviewState.APPROVE && !offendingCiChecks.isEmpty()) {
++      state = ReviewState.COMMENT;
++    }
++
+     // The summary is generated for clean reviews too: a zero-findings result still reports the
+     // change overview and carries the celebration line inside the same comment
+     var summaryMarkdown =
+@@ -946,4 +1003,45 @@ void createReviewWithFallback(
+       reviewClient.createReview(auth, ACCEPT, owner, repo, prNumber, fallback);
+     }
+   }
++
++  /**
++   * Returns only the <em>offending</em> CI checks on {@code commitSha} — those that are pending,
++   * failing, or (when required) missing entirely. Passing checks are deliberately excluded so the
++   * caller can gate APPROVE on a non-empty result; a successful required check is recorded in
++   * {@code seen} so it is not later mistaken for a missing one.
++   */
++  List<ReviewResult.CiCheck> evaluateCiChecks(
++      String auth, String owner, String repo, String commitSha, List<String> requiredContexts) {
++    var offending = new ArrayList<ReviewResult.CiCheck>();
++    var seen = new HashSet<String>();
++
++    try {
++      for (var run : checkRunClient.getAllCheckRuns(auth, ACCEPT, owner, repo, commitSha)) {
++        if (isThrillhouseBotCheck(run.name(), run.app())
++            || isNotRequired(run.name(), requiredContexts)) {
++          continue;
++        }
++        seen.add(run.name());
++        String ciStatus = classifyCheckRun(run.status(), run.conclusion());
++        if (!CI_SUCCESS.equals(ciStatus)) {
++          offending.add(
++              new ReviewResult.CiCheck(run.name(), "check-run", ciStatus, run.conclusion()));
++        }
++      }
++    } catch (Exception e) {
++      Log.warnf(e, "Failed to fetch check runs for commit %s", commitSha);
++    }
++
++    addMissingRequiredChecks(requiredContexts, seen, offending);
++    return offending;
++  }
++
++  /** Required contexts that never reported are implicitly pending. */
++  private void addMissingRequiredChecks(
++      List<String> requiredContexts, Set<String> seen, List<ReviewResult.CiCheck> offending) {
++    if (requiredContexts == null) {
++      return;
++    }
++    for (String required : requiredContexts) {
++      if (!isThrillhouseBotCheck(required, null) && seen.add(required)) {
++        offending.add(new ReviewResult.CiCheck(required, "missing", CI_PENDING, null));
++      }
++    }
++  }
+```

--- a/src/test/resources/evalcorpus/pr99-offending-list-holds-passing-checks-must-find/case.json
+++ b/src/test/resources/evalcorpus/pr99-offending-list-holds-passing-checks-must-find/case.json
@@ -1,0 +1,10 @@
+{
+  "kind": "generator",
+  "sourcePr": 99,
+  "why": "Dogfood miss from PR #99 / issue #117: evaluateCiChecks appends EVERY check it walks, including the ones it classifies ciStatus = \"success\", but the caller binds the result to offendingCiChecks and buildResult downgrades APPROVE on !offendingCiChecks.isEmpty(). Producer and consumer sit in different hunks and each is locally valid; only the end-to-end trace shows that a PR with fully green CI is never approved — the inverse of the PR's stated intent (\"downgrades a would-be APPROVE to COMMENT when any offending check exists\"). The review prompt must trace the structure from producer to consumer and flag the contract mismatch.",
+  "expectation": "must-find",
+  "targetFile": "src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java",
+  "keywords": ["passing", "success", "green", "non-offending", "never approve"],
+  "prTitle": "fix(review): gate the APPROVE verdict on CI status (#95)",
+  "prDescription": "- [x] 🐛 Bug fix\n\nFixes #95\n\nThrillhouseBot could post a green APPROVE review while the PR's CI was still red or pending. This change gates the APPROVE verdict on the CI status of the head commit.\n\n- Treats a check as offending when it is failing, pending, or a required check that never reported; passing/skipped/neutral checks are excluded.\n- Downgrades a would-be APPROVE to COMMENT when any offending check exists.\n- No breaking changes; when CI is fully green the verdict is unchanged."
+}

--- a/src/test/resources/evalcorpus/pr99-offending-list-holds-passing-checks-must-find/diff.txt
+++ b/src/test/resources/evalcorpus/pr99-offending-list-holds-passing-checks-must-find/diff.txt
@@ -1,0 +1,133 @@
+### src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java (modified, +96 -3)
+```diff
+@@ -251,11 +251,20 @@ public void review(ReviewRequest request) {
+               aiResponse, priorAiResponseJsons, inlineComments, BOT_LOGIN);
+       persistAiResponse(session, aiResponse);
+
++      List<String> requiredContexts = resolveRequiredContexts(auth, req);
++
++      List<ReviewResult.CiCheck> offendingCiChecks =
++          evaluateCiChecks(auth, req.owner(), req.repo(), req.commitSha(), requiredContexts);
++
+       DiffStats diffStats = DiffStats.fromFiles(diffFormatter.reviewableFiles(files));
+       var unresolvedPrevious =
+           followUpAnalyzer.unresolvedFindings(
+               previousAiResponseJson, aiResponse.previousFindingsStatus());
+-      var result = buildResult(aiResponse, isFirstReview, diffStats, unresolvedPrevious);
++      var result =
++          buildResult(aiResponse, isFirstReview, diffStats, unresolvedPrevious, offendingCiChecks);
+
+       // Finalize check run before posting PR review — avoid approving then failing later
+       String conclusion = conclusionForResult(result);
+@@ -691,7 +714,8 @@ ReviewResult buildResult(
+       ReviewResponse aiResponse,
+       boolean isFirstReview,
+       DiffStats diffStats,
+-      List<Finding> unresolvedPrevious) {
++      List<Finding> unresolvedPrevious,
++      List<ReviewResult.CiCheck> offendingCiChecks) {
+     var findings = new ArrayList<Finding>();
+     var critical = 0;
+     var high = 0;
+@@ -727,6 +751,11 @@ ReviewResult buildResult(
+       state = ReviewState.COMMENT;
+     }
+
++    // Gating approval verdict on CI status:
++    if (state == ReviewState.APPROVE && !offendingCiChecks.isEmpty()) {
++      state = ReviewState.COMMENT;
++    }
++
+     // The summary is generated for clean reviews too: a zero-findings result still reports the
+     // change overview and carries the celebration line inside the same comment
+     var summaryMarkdown =
+@@ -946,4 +1003,66 @@ void createReviewWithFallback(
+       reviewClient.createReview(auth, ACCEPT, owner, repo, prNumber, fallback);
+     }
+   }
++
++  List<ReviewResult.CiCheck> evaluateCiChecks(
++      String auth, String owner, String repo, String commitSha, List<String> requiredContexts) {
++    List<ReviewResult.CiCheck> checks = new ArrayList<>();
++
++    // 1. Get Check Runs
++    try {
++      var checkRunsResponse = checkRunClient.getCheckRuns(auth, ACCEPT, owner, repo, commitSha);
++      if (checkRunsResponse != null && checkRunsResponse.checkRuns() != null) {
++        for (var run : checkRunsResponse.checkRuns()) {
++          // Ignore ThrillhouseBot's own check runs
++          if (isThrillhouseBotCheck(run.name(), run.app())) {
++            continue;
++          }
++
++          // If requiredContexts is provided, check if this run is in it
++          if (requiredContexts != null && !requiredContexts.contains(run.name())) {
++            continue;
++          }
++
++          String ciStatus = "success";
++          if (!"completed".equalsIgnoreCase(run.status())) {
++            ciStatus = "pending";
++          } else if (run.conclusion() == null
++              || !List.of("success", "skipped", "neutral")
++                  .contains(run.conclusion().toLowerCase(Locale.ROOT))) {
++            ciStatus = "failing";
++          }
++
++          checks.add(new ReviewResult.CiCheck(run.name(), "check-run", ciStatus, run.conclusion()));
++        }
++      }
++    } catch (Exception e) {
++      Log.warnf(e, "Failed to fetch check runs for commit %s", commitSha);
++    }
++
++    // 2. Get Combined Statuses
++    try {
++      var combinedStatus = checkRunClient.getCombinedStatus(auth, ACCEPT, owner, repo, commitSha);
++      if (combinedStatus != null && combinedStatus.statuses() != null) {
++        for (var status : combinedStatus.statuses()) {
++          if (isThrillhouseBotCheck(status.context(), null)) {
++            continue;
++          }
++
++          if (requiredContexts != null && !requiredContexts.contains(status.context())) {
++            continue;
++          }
++
++          String ciStatus = "success";
++          if ("pending".equalsIgnoreCase(status.state())) {
++            ciStatus = "pending";
++          } else if ("failure".equalsIgnoreCase(status.state())
++              || "error".equalsIgnoreCase(status.state())) {
++            ciStatus = "failing";
++          }
++
++          checks.add(new ReviewResult.CiCheck(status.context(), "status", ciStatus, status.state()));
++        }
++      }
++    } catch (Exception e) {
++      Log.warnf(e, "Failed to fetch combined status for commit %s", commitSha);
++    }
++
++    return checks;
++  }
+```
+
+### src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java (modified, +14 -1)
+```diff
+@@ -30,7 +30,20 @@ public record ReviewResult(
+     ReviewState reviewState,
+     boolean isFirstReview,
+     String summaryMarkdown,
+-    List<PreviousFindingStatus> previousStatuses) {
++    List<PreviousFindingStatus> previousStatuses,
++    List<CiCheck> offendingCiChecks) {
++
++  /** One CI check that is holding the APPROVE verdict back: failing, pending, or never reported. */
++  public record CiCheck(String name, String type, String status, String rawConclusion) {
++
++    public boolean isFailing() {
++      return "failing".equals(status);
++    }
++  }
+```


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

The reviewer judges hunks **locally**. Nothing asks whether a change actually does what its title claims by following its central data structure from where it is *produced* to where it is *consumed*, so a producer/consumer contract mismatch spanning two individually-valid hunks slips through.

The dogfood case is PR #99 (Fixes #95): `evaluateCiChecks` appended **every** check it walked — including the ones it had just classified `"success"` — the caller bound the result to `offendingCiChecks`, and `buildResult` downgraded `APPROVE` on `!offendingCiChecks.isEmpty()`. Both hunks read fine in isolation; the net effect was that a PR with fully green CI could never be approved, the inverse of the PR's stated intent ("downgrades a would-be APPROVE to COMMENT when any offending check exists").

**`PrReviewPrompts.SYSTEM`** gains review dimension 9, `PRODUCER → CONSUMER CONTRACT`:

- Name where the change's **primary** new/modified data structure is PRODUCED (the code that populates or computes it) and where it is CONSUMED (the code that gates, branches, or renders on it), then check the consumer's assumption against what the producer actually puts in it.
- Three concrete checks: **(a)** a value whose name asserts a predicate — `offending`, `invalid`, `failed`, `missing`, `stale`, `duplicate` — must be populated only with items satisfying it; **(b)** a collection consumed as a gate through `isEmpty()`/`size()`/`anyMatch` must hold only gate-worthy entries; **(c)** the resulting end-to-end behavior must match the PR title and description.
- When the trace shows the opposite of the stated intent, it is reported as a finding **and** as a `summary.description_gaps` entry — the `description_gaps` field description now names the inverted trace as one of its inputs.

Precision is guarded from both sides so ordinary single-hunk diffs do not turn into data-flow essays: the dimension is scoped to the change's primary structure, is explicitly not a finding when producer and consumer agree or when the consumer is not in the provided material, and a new self-check bullet invalidates a contract claim that cannot quote **both** ends and name the concrete case on which they disagree.

Two generator cases are added to the eval corpus, both derived from PR #99 and sharing the same producer/consumer shape:

- `pr99-offending-list-holds-passing-checks-must-find` — the buggy revision (commit `7f38487`), `must-find`.
- `pr99-offending-list-contract-holds-must-not-find` — the shipped fix (commit `1e9ee8f`) with the contract intact, `must-not-find`.

Having both means the rule can be measured for recall and for false positives on the same code rather than only for recall.

Note: this is the contract **rule**. It is most reliable once both ends of the data flow are in context (#55, not implemented here) but is deliberately written to be useful on multi-hunk diffs alone. `SUMMARY_SYSTEM` / `SUMMARY_USER` are untouched.

## Related Issues

Fixes #117

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Three new coarse content-anchor cases in `PrReviewPromptsContentTest`, following the convention the file already uses for prompt guidance:

- `generatorPromptTracesTheChangesStructureFromProducerToConsumer`
- `generatorPromptRoutesAnInvertedTraceIntoDescriptionGaps`
- `generatorPromptKeepsTheDataFlowDimensionFromFiringOnOrdinaryDiffs`

**Red/green validation.** With the tests in place and the prompt change stashed (`git stash push -- src/main/java`), the three cases fail:

```
[ERROR] Tests run: 25, Failures: 3, Errors: 0, Skipped: 0 -- in PrReviewPromptsContentTest

PrReviewPromptsContentTest.generatorPromptTracesTheChangesStructureFromProducerToConsumer
org.opentest4j.AssertionFailedError: the producer→consumer data-flow dimension must exist (#117)
  — missing marker: "PRODUCER → CONSUMER CONTRACT" ==> expected: <true> but was: <false>

PrReviewPromptsContentTest.generatorPromptRoutesAnInvertedTraceIntoDescriptionGaps
org.opentest4j.AssertionFailedError: an end-to-end trace contradicting the stated intent must also
  become a description gap — missing marker: "AND as a summary.description_gaps entry"
  ==> expected: <true> but was: <false>

PrReviewPromptsContentTest.generatorPromptKeepsTheDataFlowDimensionFromFiringOnOrdinaryDiffs
org.opentest4j.AssertionFailedError: an intact producer/consumer contract must not become a finding
  — missing marker: "producer and consumer agree, or when the consumer is not in the provided
  material" ==> expected: <true> but was: <false>
```

With the prompt change restored: `Tests run: 25, Failures: 0` (`PrReviewPromptsContentTest`) and `Tests run: 4, Failures: 0` (`EvalCorpusTest`, which parses and well-formedness-checks the two new fixtures on every build).

Full local run: `./mvnw -B spotless:apply`, `./mvnw -B clean compile spotbugs:check spotless:check`, and `./mvnw -B clean test` (2047 tests) all green.

### What is not verified

- The content anchors prove the prompt text is present and guard against a future edit silently reverting it. They prove nothing about model behaviour.
- The two eval-corpus cases are the real evidence for this change, and they were **not executed**. No AI provider key exists in the environment this was built in. `must-find` and `must-not-find` are therefore expected outcomes recorded as corpus labels, not measured results.
- A reviewer should run the eval before merging:

  ```
  QUARKUS_LANGCHAIN4J_OPENAI_API_KEY=... ./mvnw test -Peval -Dtest=PromptEvalTest
  ```

  That run also re-checks the six pre-existing corpus cases. Those six are the actual regression guard against dimension 9 adding noise elsewhere in the review.
- The `must-not-find` control trips only on the keywords `["producer", "non-offending", "including passing", "contract mismatch"]`. A false positive worded differently would slip past it, so a clean `must-not-find` result is weaker evidence of precision than it looks.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A — prompt-text change; the deterministic evidence is the red/green output above.

## Additional Notes

- No new config key, so no README / `.env.example` entry is required.
- The new dimension adds no template variable, so the assistant interface, `PromptInputs`, and the assembler are unchanged.
- #55 (cross-file producer/consumer context) is deliberately out of scope; the rule is written to work on multi-hunk diffs alone and will get stronger when #55 lands.
