### PR TITLE
fix(test): restore release/v0.6.0 to a compiling state

### DIFF
--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrImprovementServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrImprovementServiceTest.java
@@ -803,7 +803,8 @@ class PrImprovementServiceTest {
     // covers the whole PR rather than the first max-diff-lines, a repo-ignored file is no longer
     // excluded by accident — so it has to be excluded on purpose.
     when(repoSettingsResolver.resolve(any(), any(), any(), anyLong()))
-        .thenReturn(new RepoSettings(List.of("src/Other.java"), ".github/thrillhousebot.yml"));
+        .thenReturn(
+            new RepoSettings(List.of("src/Other.java"), List.of(), ".github/thrillhousebot.yml"));
     budgetWithDiffRoom(4000);
     prWithFiles(foo(), otherFile());
     assistantReturns("{\"improvements\":[]}");
@@ -891,7 +892,8 @@ class PrImprovementServiceTest {
     // to anchor onto one either: the line map is built from the same effective file list the
     // batches are planned over, so #449's exclusion holds all the way to the committable comment.
     when(repoSettingsResolver.resolve(any(), any(), any(), anyLong()))
-        .thenReturn(new RepoSettings(List.of("src/Other.java"), ".github/thrillhousebot.yml"));
+        .thenReturn(
+            new RepoSettings(List.of("src/Other.java"), List.of(), ".github/thrillhousebot.yml"));
     prWithFiles(foo(), otherFile());
     assistantReturns(
         """


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

**`release/v0.6.0` currently does not compile.** `./mvnw clean test-compile` on `eaceafa` fails:

```
PrImprovementServiceTest.java:[806,21] constructor RepoSettings in record
  dev.thiagogonzaga.thrillhousebot.github.RepoSettings cannot be applied to given types;
  required: List<String>, List<RepoSettings.PathInstructions>, String
  found:    List<String>, String
PrImprovementServiceTest.java:[894,21]  (same)
```

Two lines, both in one test file.

### How it happened

A semantic conflict between two PRs that were each green on their own head:

- **#452** (`00cde9f`, `/improve`) added `PrImprovementServiceTest` with two-argument `RepoSettings` construction.
- **#460** (`eaceafa`, path-scoped instructions) added the `pathInstructions` component to the `RepoSettings` record.

#460's CI run predated #452 landing, so it never saw the new test file, and #452 never saw the new record component. Neither PR was wrong, and the merge of both is **textually clean** — git reports no conflict. Nothing failed until the branch itself was built, at which point every branch merging from it inherits the breakage.

Worth noting for future sequencing: a clean merge is not evidence that two feature branches compose. Only a build of the merged tree is.

### The fix

Both call sites are ignore-filter tests — `leavesFilesTheRepositoryAskedTheBotToIgnoreOutOfScope` and `neverCommitsASuggestionToAFileTheRepositoryAskedTheBotToIgnore` — and neither declares a path scope, so the new component is empty and their assertions are unchanged. No production code is touched.

### Why this is on base rather than in each PR

Every open PR against `release/v0.6.0` inherits the failure the moment it merges base. Fixing it per-branch means several independent copies of the same two-line patch, which then conflict with each other. One fix on base clears all of them at once.

## Related Issues

N/A — not an issue; a regression introduced by the interaction of #452 and #460.

Refs #316, #33.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Reproduced first, on a clean checkout of `origin/release/v0.6.0` at `eaceafa`:

```
./mvnw -B clean test-compile   →  BUILD FAILURE, the two errors quoted above
```

With this change applied, on the same tree:

```
./mvnw -B clean test spotless:check spotbugs:check
  →  Tests run: 2139, Failures: 0, Errors: 0, Skipped: 0
  →  BugInstance size is 0
  →  BUILD SUCCESS
```

So the failure is reproducible on base without the change and absent with it — the compile error is itself the red/green evidence here, and no new test is warranted for a two-line constructor-arity fix in existing tests.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Open PRs currently red for this reason and expected to go green once this lands: **#459** (which also carries its own copy of the same fix — harmless, it will resolve as identical content) and **#463**. **#461** is separately conflicted for unrelated reasons and needs its own merge.
