### PR TITLE
feat(review): report config-key documentation that is correct but incomplete (#109)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
@@ -172,6 +172,25 @@ public final class FindingVerifierPrompts {
             confidence "low" or "medium" with the rule line quoted and the probing input named is
             the expected shape.
 
+            A config-key documentation-completeness finding — one claiming documentation for an
+            environment variable or property omits a format-critical fact (value type,
+            list/separator semantics, units, allowed values, default) — is judged against that
+            key's DEFINITION, which the review pass is handed in a section headed
+            "Config key definitions from the repository" and built from repository files outside
+            the diff. So do not reject it for quoting a definition line the diff does not contain,
+            and do not demote it as remembered framework behavior when that quoted definition
+            establishes the fact: an Optional<List<String>> @WithName mapping IS evidence the
+            value is a comma-separated list, not a recollection about the framework. Confirm it
+            when the finding quotes both the documented line and a definition establishing the
+            omitted fact while the changed documentation does not state it — the PR #104 miss, a
+            README/.env entry adding THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS with no
+            note that the value is a comma-separated list of logins, is exactly this shape and
+            must not be dropped again. Reject it when the documentation already states the fact,
+            when it names no format-critical fact (wording, tone, ordering, a missing example are
+            nitpicks), or when it quotes no definition at all. When the definition is outside YOUR
+            provided material, downgrade it to confidence "low" phrased as a verification request
+            naming the definition to check — do not reject it as unverifiable framework behavior.
+
             Severity calibration: "critical" and "high" risk require breakage demonstrable from
             the provided diff and context. A config/IaC defect whose breakage is visible in the
             manifest text in the diff — a field that fails schema validation, an over-broad RBAC
@@ -181,10 +200,15 @@ public final class FindingVerifierPrompts {
             with "low" confidence. Claims about the contents or behavior of
             artifacts not shown in the diff (base images, registries, installed packages,
             remote services) are not demonstrable here: downgrade any such finding above
-            "medium". An "undefined / unset / missing symbol" claim is demonstrable only when
-            the provided material includes the scope a definition would occupy; when that scope
-            is outside the shown context the claim is unconfirmed (the definition may sit just
-            outside the hunk), so reject the finding (per above) rather than post it. A
+            "medium". A config-key documentation-completeness claim backed by the key's quoted
+            definition is demonstrable from that definition rather than remembered framework
+            behavior, so that cap does not apply to it; leave it at the risk the omission carries
+            — normally "low", "medium" when a plausible reading of the documentation as written
+            yields a broken configuration. An "undefined / unset / missing symbol" claim is
+            demonstrable only when the provided material includes the scope a definition would
+            occupy; when that scope is outside the shown context the claim is unconfirmed (the
+            definition may sit just outside the hunk), so reject the finding (per above) rather
+            than post it. A
             parameter-nullability / precondition claim is demonstrable when the provided
             material includes the calling code that supplies the parameter, or when the changed
             signature itself declares a nullable contract for that parameter; when neither is

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -101,6 +101,28 @@ public final class PrReviewPrompts {
                "high" when the trace inverts the feature for its normal case. Not a finding when
                producer and consumer agree, or when the consumer is not in the provided material —
                say nothing rather than narrating the data flow of an ordinary local change.
+            10. CONFIG KEY DOCUMENTATION COMPLETENESS: when the diff documents a configuration key
+               — an environment variable or property named in a .md, .env* or config table — AND a
+               "Config key definitions from the repository" section supplies that key's definition,
+               read the documented description against that definition and flag it when the
+               description omits a FORMAT-CRITICAL fact an operator needs to set the value
+               correctly: the value TYPE, LIST/SEPARATOR semantics (a List-typed binding is
+               comma-separated in SmallRye/Quarkus config, so documentation that shows one value
+               and never says so leaves a maintainer to guess a space or semicolon and silently get
+               one non-matching entry), UNITS or duration format, ALLOWED VALUES of an enum-like
+               key, or the DEFAULT applied when the key is unset. Correct-but-incomplete IS a
+               finding here: this is the one documentation OMISSION the phrasing-nitpick exclusion
+               below does not swallow. Quote the documented line and the definition line that
+               establishes the missing fact, name which fact is missing, and use risk "low" — risk
+               "medium" when a plausible reading of the documentation as written produces a broken
+               configuration. Stay inside that list: wording, tone, ordering, table formatting, a
+               missing example, and any fact the definition does not establish are not findings.
+               The starkest form of the same gap counts too — a key the diff ADDS while also
+               changing a documentation/config file that lists sibling keys without listing the new
+               one is undocumented; report that here. Say nothing when the definition is not in the
+               provided material, when the documentation already states the fact anywhere in the
+               changed material, or when the diff changes no documentation/config file at all (you
+               cannot see whether documentation for the key exists elsewhere).
 
             For each finding, provide:
             - risk: "critical" | "high" | "medium" | "low"
@@ -130,7 +152,10 @@ public final class PrReviewPrompts {
               ask for that level of detail. Cosmetic phrasing nitpicks (documentation-vs-code
               wording, stylistic config formatting) with no correctness or security impact are not
               findings — but a genuine config defect, least-privilege violation, or hardening gap is
-              a real finding, not a nitpick, and belongs at its impact-based severity above.
+              a real finding, not a nitpick, and belongs at its impact-based severity above. So is
+              a config-key documentation gap under dimension 10: an omitted type, separator, unit,
+              allowed value or default is a correctness gap for whoever sets the key, not a
+              phrasing nitpick. Prose style, tone and ordering remain nitpicks.
 
             Confidence calibration:
             - confidence "high" means another reviewer could confirm the issue using only the
@@ -226,6 +251,13 @@ public final class PrReviewPrompts {
               visible, or you cannot name that case, the finding is invalid. Raise it for the
               structure the change is about, not for every local variable that crosses a hunk
               boundary.
+            - A config-key documentation-completeness claim (dimension 10) must quote the
+              documented line from the diff AND the definition line — from the diff or from the
+              config-key definitions section — that establishes the omitted fact, and name which
+              fact is missing (type, separator, units, allowed values, default). A claim that only
+              rewords the documentation, one whose missing fact the quoted definition does not
+              establish, or one about a key whose definition is not in the provided material, is
+              invalid.
             - Claims about the contents or behavior of artifacts not shown in the diff (base
               images, registries, installed packages, remote services) cannot be verified here:
               they are never "critical" or "high", and the description must be phrased as a

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.Test;
  * parameter-nullability / unseen-caller guard (#107), the in-diff-test exercise gate (a green test
  * must demonstrably hit the claimed path before it can invalidate a finding — #116), the symmetric
  * exact-arithmetic / "test fails" cap (#97), the heuristic failure-mode characterization pass with
- * its verifier exemption (#123), the producer→consumer data-flow contract dimension (#117), and the
+ * its verifier exemption (#123), the producer→consumer data-flow contract dimension (#117), the
+ * config-key documentation-completeness claim class and its narrowing guards (#109), and the
  * summary call's whole-change-set grounding (#335). These assertions are intentionally coarse —
  * they check intent survives, not exact wording; an intentional rewording should update the
  * matching anchor.
@@ -391,6 +392,103 @@ class PrReviewPromptsContentTest {
         sys,
         "not for every local variable that crosses a hunk",
         "the self-check must scope the claim to the structure the change is about");
+  }
+
+  @Test
+  void generatorPromptReportsIncompleteConfigKeyDocumentation() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "CONFIG KEY DOCUMENTATION COMPLETENESS",
+        "the config-key documentation-completeness dimension must exist (#109)");
+    assertContains(
+        sys,
+        "Config key definitions from the repository",
+        "the dimension must name the context section #108 actually renders as its evidence");
+    assertContains(
+        sys,
+        "LIST/SEPARATOR semantics",
+        "list/comma semantics must be one of the format-critical facts a doc may not omit");
+    assertContains(
+        sys,
+        "Correct-but-incomplete IS a",
+        "a documented-but-incomplete config key must be reportable, not only a contradiction");
+    assertContains(
+        sys,
+        "lists sibling keys without listing the new",
+        "a key added with no doc entry beside its siblings must be reportable too");
+  }
+
+  @Test
+  void generatorPromptCarvesConfigDocGapsOutOfThePhrasingNitpickExclusion() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "a config-key documentation gap under dimension 10",
+        "the low-severity nitpick exclusion must carve out config-key documentation gaps (#109)");
+    assertContains(
+        sys,
+        "Prose style, tone and ordering remain nitpicks",
+        "the carve-out must leave ordinary documentation prose excluded");
+  }
+
+  @Test
+  void generatorPromptKeepsTheConfigDocClaimNarrowAndEvidenced() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "wording, tone, ordering, table formatting",
+        "the dimension must exclude prose-style omissions from the carve-out");
+    assertContains(
+        sys,
+        "config-key documentation-completeness claim (dimension 10) must quote",
+        "a self-check must require both the documented line and the definition to be quoted");
+    assertContains(
+        sys,
+        "fact is missing (type, separator, units, allowed values, default)",
+        "the self-check must enumerate the format-critical facts the claim may rest on");
+  }
+
+  @Test
+  void verifierPromptDoesNotDemoteConfigDocGapsAsFrameworkBehavior() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "A config-key documentation-completeness finding",
+        "verifier must judge config-doc-completeness findings on their own terms (#109)");
+    assertContains(
+        sys,
+        "Config key definitions from the repository",
+        "verifier must know the definition comes from a section built outside the diff");
+    assertContains(
+        sys,
+        "remembered framework behavior when that quoted definition",
+        "a quoted definition must not be treated as a remembered framework claim");
+    assertContains(
+        sys,
+        "THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS",
+        "verifier must keep the PR #104 comma-separated-list regression example");
+    assertContains(
+        sys,
+        "do not reject it as unverifiable framework behavior",
+        "an unshown definition must downgrade the claim to a verification request, not drop it");
+    assertContains(
+        sys,
+        "so that cap does not apply to it",
+        "severity calibration must exempt a definition-backed config-doc claim from the cap");
+  }
+
+  @Test
+  void verifierPromptStillRejectsDocumentationPhrasingNitpicks() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "no format-critical fact (wording, tone, ordering, a missing example",
+        "the verifier carve-out must not reopen the door to documentation phrasing nitpicks");
+    assertContains(
+        sys,
+        "when the documentation already states the fact",
+        "a documentation line that already carries the fact must be rejected, not confirmed");
   }
 
   @Test

--- a/src/test/resources/evalcorpus/pr104-config-doc-phrasing-nitpick-false-positive/case.json
+++ b/src/test/resources/evalcorpus/pr104-config-doc-phrasing-nitpick-false-positive/case.json
@@ -1,0 +1,16 @@
+{
+  "kind": "verifier",
+  "sourcePr": 104,
+  "why": "Negative control for the #109 carve-out, over the same PR #104 doc diff. The config-key documentation-completeness class is deliberately narrow: only an omitted value type, list/separator, unit, allowed value or default is reportable. This candidate names none of them — it argues about wording and row ordering — so it is the documentation phrasing nitpick the low-severity exclusion has always dropped, and it must stay rejected. If widening the prompt for the true-positive case above lets this one through, the carve-out has reopened the nitpick door #109 promised not to.",
+  "expectedVerdicts": ["rejected"],
+  "finding": {
+    "risk": "low",
+    "confidence": "medium",
+    "file": "README.md",
+    "line": 159,
+    "title": "README wording for the manual-trigger allowlist does not match the property name",
+    "description": "The added row describes the key as an 'Allowlist of logins permitted to trigger manual `/review` without repo access', while the underlying property is named `manual-trigger-allowed-logins` and the accessor is `manualTriggerAllowedLogins`. Using 'allowed logins' in the table would match the implementation's vocabulary and read more consistently with the neighbouring rows. The row is also placed after `WEBHOOK_DEDUP_TTL` rather than in alphabetical order with the other `THRILLHOUSEBOT_*` entries.",
+    "suggestion_old": "| `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` | Allowlist of logins permitted to trigger manual `/review` without repo access | _(empty)_ |",
+    "suggestion_new": "| `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` | Allowed logins permitted to trigger manual `/review` without repo access | _(empty)_ |"
+  }
+}

--- a/src/test/resources/evalcorpus/pr104-config-doc-phrasing-nitpick-false-positive/diff.txt
+++ b/src/test/resources/evalcorpus/pr104-config-doc-phrasing-nitpick-false-positive/diff.txt
@@ -1,0 +1,26 @@
+### README.md (modified, +2 -0)
+```diff
+@@ -155,6 +155,8 @@ variables are the ones you will change per provider:
+ | `GITHUB_APP_ID` | GitHub App ID | _(required)_ |
+ | `GITHUB_PRIVATE_KEY` | GitHub App private key (PEM) | _(required)_ |
+ | `GITHUB_WEBHOOK_SECRET` | Webhook HMAC secret | _(required)_ |
++| `WEBHOOK_DEDUP_TTL` | Webhook deduplication time-to-live for GitHub redeliveries | `24h` |
++| `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` | Allowlist of logins permitted to trigger manual `/review` without repo access | _(empty)_ |
+ | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | OAuth credentials for dashboard login | _(required for dashboard)_ |
+ | `DASHBOARD_URL` | Public dashboard URL (OAuth callback base) | `http://localhost:8080` |
+ | `DATASOURCE_DB_KIND` | `h2` or `postgresql` | `h2` (dev), `postgresql` (`%prod`) |
+```
+
+### .env.example (modified, +4 -0)
+```diff
+@@ -5,6 +5,10 @@
+ GITHUB_APP_ID=your_app_id
+ GITHUB_WEBHOOK_SECRET=your_webhook_secret
++# Optional: webhook deduplication window for GitHub redeliveries
++#WEBHOOK_DEDUP_TTL=24h
++# Optional: allowlist of logins permitted to trigger manual /review without repo access
++#THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS=alice
+
+ # AI — any OpenAI-compatible API. Set AI_BASE_URL/AI_MODEL for your provider.
+ # Defaults below use DeepSeek; e.g. Alibaba Cloud Model Studio would be:
+```

--- a/src/test/resources/evalcorpus/pr104-config-key-doc-incomplete-true-positive/case.json
+++ b/src/test/resources/evalcorpus/pr104-config-key-doc-incomplete-true-positive/case.json
@@ -1,0 +1,16 @@
+{
+  "kind": "verifier",
+  "sourcePr": 104,
+  "why": "Dogfood miss from PR #104, recorded in issues #108 and #109: the PR documented THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS without stating that the value is a comma-separated list, and the bot returned 'No issues found'. The doc rows are reproduced here in that incomplete form. The candidate finding quotes the @WithName Optional<List<String>> definition that #108's 'Config key definitions from the repository' section supplies to the review pass; that definition lives outside the diff, so the verifier must not drop the finding as unverifiable framework behavior or as a quote absent from the diff. The verifier call is not itself handed that section (it receives findings, diff, project stack and previous findings only), so downgrading it to a confidence-'low' verification request is the honest ceiling — both non-dropping verdicts pass and 'rejected' is the regression this case exists to catch.",
+  "expectedVerdicts": ["confirmed", "downgraded"],
+  "finding": {
+    "risk": "low",
+    "confidence": "medium",
+    "file": "README.md",
+    "line": 159,
+    "title": "Documented config key omits its comma-separated list format",
+    "description": "The added README row reads `| `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` | Allowlist of logins permitted to trigger manual `/review` without repo access | _(empty)_ |` and never states the value's format. The config-key definitions section supplies the definition site: `@WithName(\"manual-trigger-allowed-logins\")` / `Optional<List<String>> manualTriggerAllowedLogins();` in ThrillhouseConfig.java — a List-typed binding, which SmallRye/Quarkus config populates by splitting the raw value on commas. The missing format-critical fact is the list separator: a maintainer reading this row can reasonably set a space- or semicolon-separated value, which binds as one entry that matches no login, and the manual `/review` stays denied with no error. The `.env.example` comment added in the same PR has the same gap.",
+    "suggestion_old": "| `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` | Allowlist of logins permitted to trigger manual `/review` without repo access | _(empty)_ |",
+    "suggestion_new": "| `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` | Comma-separated allowlist of logins permitted to trigger manual `/review` without repo access | _(empty)_ |"
+  }
+}

--- a/src/test/resources/evalcorpus/pr104-config-key-doc-incomplete-true-positive/diff.txt
+++ b/src/test/resources/evalcorpus/pr104-config-key-doc-incomplete-true-positive/diff.txt
@@ -1,0 +1,26 @@
+### README.md (modified, +2 -0)
+```diff
+@@ -155,6 +155,8 @@ variables are the ones you will change per provider:
+ | `GITHUB_APP_ID` | GitHub App ID | _(required)_ |
+ | `GITHUB_PRIVATE_KEY` | GitHub App private key (PEM) | _(required)_ |
+ | `GITHUB_WEBHOOK_SECRET` | Webhook HMAC secret | _(required)_ |
++| `WEBHOOK_DEDUP_TTL` | Webhook deduplication time-to-live for GitHub redeliveries | `24h` |
++| `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` | Allowlist of logins permitted to trigger manual `/review` without repo access | _(empty)_ |
+ | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | OAuth credentials for dashboard login | _(required for dashboard)_ |
+ | `DASHBOARD_URL` | Public dashboard URL (OAuth callback base) | `http://localhost:8080` |
+ | `DATASOURCE_DB_KIND` | `h2` or `postgresql` | `h2` (dev), `postgresql` (`%prod`) |
+```
+
+### .env.example (modified, +4 -0)
+```diff
+@@ -5,6 +5,10 @@
+ GITHUB_APP_ID=your_app_id
+ GITHUB_WEBHOOK_SECRET=your_webhook_secret
++# Optional: webhook deduplication window for GitHub redeliveries
++#WEBHOOK_DEDUP_TTL=24h
++# Optional: allowlist of logins permitted to trigger manual /review without repo access
++#THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS=alice
+
+ # AI — any OpenAI-compatible API. Set AI_BASE_URL/AI_MODEL for your provider.
+ # Defaults below use DeepSeek; e.g. Alibaba Cloud Model Studio would be:
+```


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature

## Description

A documented config key whose description omits the facts an operator actually needs — value type, list/separator semantics, units, allowed values, default — was unreportable by construction:

- `PrReviewPrompts.SYSTEM` calls "documentation-vs-code wording" a cosmetic phrasing nitpick under the `"low"` severity rule, and its documentation dimensions target **contradictions** only (doc-vs-code, comment-vs-code), never **omissions** in `.md` / `.env` files.
- `FindingVerifierPrompts.SYSTEM` compounds it: a claim like "this list is comma-separated per the `Optional<List<String>>` binding" reads exactly like the remembered-framework-behavior class capped at `"medium"`, and it quotes a definition line the diff does not contain, which is a standing rejection ground.

Dogfood evidence — **PR #104**: the entry for `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` never said the value is comma-separated, and the bot returned "No issues found".

**#108 (merged) closed the evidence half**: `ConfigKeyContextResolver` resolves the keys a `*.md` / `.env*` diff names to their definition sites and renders them into the review context under `### Config key definitions from the repository`. This PR is the matching prompt half, in the generator+verifier "claim-class" shape established by #97 and #107 — a generator-only change fails, because the verifier re-applies the framework-behavior cap.

**Generator (`PrReviewPrompts.SYSTEM`)**

- New review dimension **10. CONFIG KEY DOCUMENTATION COMPLETENESS**, gated on the key's definition being present in the `Config key definitions from the repository` section that #108 actually renders. Reportable: an omitted **type**, **list/separator semantics**, **units/duration format**, **allowed values**, or **default**. Risk `"low"`, or `"medium"` when a plausible reading of the doc as written produces a broken configuration.
- Per the issue thread's follow-up (the PR #164 / `MANUAL_TRIGGER_AUTH_TIMEOUT` instance), the same dimension covers the starkest form: a key the diff **adds** while also changing a doc/config file that lists sibling keys without listing the new one. When the diff changes no doc/config file at all, the model cannot see whether docs exist elsewhere and must say nothing.
- The `"low"` severity bullet now carves this out explicitly — an omitted type/separator/unit/allowed-value/default is a correctness gap for whoever sets the key, **not** a phrasing nitpick; prose style, tone and ordering remain nitpicks.
- A new self-check keeps it narrow: the claim must quote the documented line **and** the definition line that establishes the omitted fact, and name which fact is missing. A claim that only rewords the documentation, whose missing fact the quoted definition does not establish, or about a key whose definition is not in the provided material, is invalid.

**Verifier (`FindingVerifierPrompts.SYSTEM`)**

- New claim-class paragraph, alongside the existing bug-fix-efficacy / mock-fidelity / heuristic-limitation ones: the definition is repository material the review pass was handed from **outside the diff**, so the finding is neither rejected for quoting an unshown line nor demoted as remembered framework behavior — an `Optional<List<String>>` `@WithName` mapping *is* evidence, not a recollection. The PR #104 miss is embedded as the inline regression example.
- The same paragraph keeps the door shut: reject when the documentation already states the fact, when the finding names no format-critical fact (wording, tone, ordering, a missing example), or when it quotes no definition at all.
- Severity calibration exempts a definition-backed claim from the "unverifiable framework behavior → at most medium" cap.

### What is now reportable that was not

Exactly one thing: a config key documented in the diff whose description omits its **type, list/comma separator, units, allowed values, or default**, where the key's **definition is in the provided material** and the documentation does not state that fact anywhere in the changed material — plus the degenerate case of a key added with no entry beside its siblings in a doc file the same diff touches. Everything else about documentation prose — wording, tone, ordering, table formatting, missing examples, and any fact the definition does not establish — remains excluded, in both prompts.

## ⚠️ Known limitation: the verifier is not given the config-key context

**`FindingVerifier.verify(...)` receives `findings`, `diff`, `projectStack` and `previousFindings` — and no `configKeyContext`.** The section #108 builds is threaded only through `ReviewContextLoader` → `ReviewPromptAssembler` → the **generator** call. The verifier never sees it.

The practical consequence, stated plainly:

- **Docs-only PR (the PR #104 shape).** The key's definition is in the generator's material but *not* the verifier's. The best available verdict is a **downgrade to a confidence-`"low"` verification request, not a confirmation**. The prompt says exactly that, so the finding survives to the summary instead of being dropped — which is the actual behavioral change here — but it will not post as a confirmed inline finding.
- **PR that adds the key and documents it together** (what this repo's own guidance requires). The definition is in the diff, so the verifier can confirm outright and the rule works end to end.

**Full parity needs `configKeyContext` threaded through `FindingVerifier` → `FindingVerificationService` → `FindingPipeline`** (a new `@V` slot on the AI-service interface, a matching section in `FindingVerifierPrompts.USER`, an extra parameter on `FindingVerificationService.verify`, and the value carried to both `FindingPipeline` call sites). That is production plumbing, deliberately out of scope for a prompt-scoped issue whose stated files are the two prompt constants — but it is the follow-up this change wants, and it is why the true-positive eval case below accepts two verdicts rather than one.

## Related Issues

Fixes #109

Depends on #108 (merged) for the implementation evidence the rule refers to.

## How Has This Been Tested?

- [x] Unit tests

Five new coarse content anchors in `PrReviewPromptsContentTest` (35 tests in the class), following the convention #117 and #335 used there:

- `generatorPromptReportsIncompleteConfigKeyDocumentation`
- `generatorPromptCarvesConfigDocGapsOutOfThePhrasingNitpickExclusion`
- `generatorPromptKeepsTheConfigDocClaimNarrowAndEvidenced`
- `verifierPromptDoesNotDemoteConfigDocGapsAsFrameworkBehavior`
- `verifierPromptStillRejectsDocumentationPhrasingNitpicks`

Red/green validation — with the two prompt files reverted (`git stash push -- src/main/java`) and the tests kept, all five fail:

```
[ERROR] Tests run: 30, Failures: 5, Errors: 0, Skipped: 0 -- in PrReviewPromptsContentTest
generatorPromptReportsIncompleteConfigKeyDocumentation
  the config-key documentation-completeness dimension must exist (#109) — missing marker:
  "CONFIG KEY DOCUMENTATION COMPLETENESS" ==> expected: <true> but was: <false>
generatorPromptCarvesConfigDocGapsOutOfThePhrasingNitpickExclusion
  the low-severity nitpick exclusion must carve out config-key documentation gaps (#109) —
  missing marker: "a config-key documentation gap under dimension 10" ==> expected: <true> but was: <false>
generatorPromptKeepsTheConfigDocClaimNarrowAndEvidenced
  the dimension must exclude prose-style omissions from the carve-out — missing marker:
  "wording, tone, ordering, table formatting" ==> expected: <true> but was: <false>
verifierPromptDoesNotDemoteConfigDocGapsAsFrameworkBehavior
  verifier must judge config-doc-completeness findings on their own terms (#109) — missing marker:
  "A config-key documentation-completeness finding" ==> expected: <true> but was: <false>
verifierPromptStillRejectsDocumentationPhrasingNitpicks
  the verifier carve-out must not reopen the door to documentation phrasing nitpicks — missing
  marker: "no format-critical fact (wording, tone, ordering, a missing example" ==> expected: <true> but was: <false>
```

With the prompt change restored, all five pass. These anchors prove the guidance is present and guard against silent reversion; they prove nothing about model behavior.

Local gates (Java 25):

- `./mvnw -B spotless:apply` + `./mvnw -B clean compile spotbugs:check spotless:check` — BUILD SUCCESS
- `./mvnw -B clean test` — **2201 tests, 0 failures, 0 errors**

### 🚨 The eval-corpus cases in this PR have NOT been executed

Two new eval-corpus **verifier** cases derived from the PR #104 miss are added, and `EvalCorpusTest` validates their well-formedness in every build — but that is a fixture check, not a behavioral one:

- `evalcorpus/pr104-config-key-doc-incomplete-true-positive` — the incomplete README/`.env` entry, with a candidate finding quoting the `@WithName` `Optional<List<String>>` definition. `expectedVerdicts: ["confirmed", "downgraded"]` — the labelled property is **"must not be dropped"**, and two verdicts are accepted precisely because of the verifier-plumbing gap above.
- `evalcorpus/pr104-config-doc-phrasing-nitpick-false-positive` — a wording/ordering nitpick over the same diff. `expectedVerdicts: ["rejected"]`, the negative control for "the carve-out did not reopen the nitpick door".

**Neither case has been run.** `PromptEvalTest` is tagged `eval` and needs a live provider key; **no provider key exists in the environment this was developed in**, so both labels are **expected outcomes I reasoned to, not measured results**. Nothing in this PR demonstrates that a model actually acts on the new guidance, and no false-positive rate has been measured.

**`PromptEvalTest -Peval` should be run against a live provider before this ships:**

```bash
QUARKUS_LANGCHAIN4J_OPENAI_API_KEY=... ./mvnw test -Peval -Dtest=PromptEvalTest
```

**If the true-positive case comes back `rejected`, the verifier-plumbing gap above is the first thing to look at** — the verifier cannot see the definition on a docs-only diff, so a rejection there is the expected symptom of that missing context rather than a prompt-wording problem.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors

## Additional Notes

No production logic changed — prompt text, its deterministic content anchors, and eval fixtures only.

No CHANGELOG entry, matching #117 and #108 in this milestone: the wave branches all edit the same `[Unreleased]` block and the entry is better written once at release assembly.
