### PR TITLE
feat(review): flag a large PR whose review found nothing inline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,9 +69,10 @@ GITHUB_WEBHOOK_SECRET=your_webhook_secret
 #REVIEW_OUTPUT_BUFFER_TOKENS=8192
 #REVIEW_MAX_AI_CALLS=6
 #REVIEW_TOKEN_SAFETY_MARGIN=0.9
-# Optional: line cap on single-call diff renders (/describe, /changelog, /add-docs,
-# /generate-tests, replies, budgeting-disabled review). Token-budgeted reviews ignore it
-# (DiffBudgetPlanner owns coverage); 0 = off
+# Optional: line cap on single-call diff renders (/add-docs, replies, base comparison,
+# budgeting-disabled review). Token-budgeted reviews and the batched commands — /improve,
+# /describe, /changelog, /generate-tests — ignore it (DiffBudgetPlanner owns coverage by
+# tokens); 0 = off
 #REVIEW_MAX_DIFF_LINES=5000
 
 # Optional: review tuning knobs (defaults shown). Every thrillhousebot.* key can be set as an env

--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,13 @@ GITHUB_WEBHOOK_SECRET=your_webhook_secret
 # (set to true to enable); a follow-up pass with no delta still posts nothing
 #REVIEW_FOLLOW_UP_SUMMARY_ENABLED=false
 
+# Optional: note in the PR summary when a large PR's review opened no inline finding — it may be
+# genuinely clean, or the pass may have been shallow (set to true to enable). No extra AI call and
+# the verdict is unchanged. Either threshold triggers on its own; 0 switches that dimension off.
+#REVIEW_LARGE_PR_NUDGE_ENABLED=false
+#REVIEW_LARGE_PR_NUDGE_MIN_FILES=20
+#REVIEW_LARGE_PR_NUDGE_MIN_CHANGED_LINES=1000
+
 # Optional: token budgeting for whole-PR review (multi-call map-reduce); defaults shown.
 # MAX_INPUT_TOKENS=0 disables budgeting; MAX_AI_CALLS caps batch calls + the final summary call.
 # The effective budget is additionally capped by the active model's max-input-tokens entry

--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ will change per provider:
 | `REVIEW_GENERATE_TESTS_ENABLED` | Allow the on-demand `/generate-tests` command to propose unit tests for the changed code | `true` |
 | `REVIEW_DIAGRAM_ENABLED` | Include an opt-in Mermaid control-flow diagram in the PR summary | `false` |
 | `REVIEW_FOLLOW_UP_SUMMARY_ENABLED` | Post a short delta comment on follow-up reviews with the new-finding, resolved, and still-open counts. Only the first review posts the full summary; a follow-up pass with no delta (nothing new, nothing resolved) posts nothing | `false` |
+| `REVIEW_LARGE_PR_NUDGE_ENABLED` | Add a note to the PR summary when a large PR's review opened **no inline finding** — it may be genuinely clean, or the pass may have been shallow — pointing at `/review` and `/improve`. Costs no extra AI call and never changes the verdict; a PR under both thresholds below is unaffected | `false` |
+| `REVIEW_LARGE_PR_NUDGE_MIN_FILES` | Changed files at or above which the nudge applies (PR-level total, so ignored files still count). `0` switches this dimension off | `20` |
+| `REVIEW_LARGE_PR_NUDGE_MIN_CHANGED_LINES` | Changed lines (additions + deletions) at or above which the nudge applies; either dimension triggers it on its own. `0` switches this dimension off — with both at `0` the nudge never fires | `1000` |
 | `REVIEW_MAX_INPUT_TOKENS` | Per-call input-token budget for review and `/improve` calls; large PRs are split into batches that each fit it. Bounded by the active model's input cap (see [Per-model AI settings](#per-model-ai-settings)). `0` disables token budgeting | `48000` |
 | `REVIEW_OUTPUT_BUFFER_TOKENS` | Tokens reserved out of the input budget for the model's response | `8192` |
 | `REVIEW_MAX_AI_CALLS` | Cap on AI calls per review (batch calls plus the final summary call) and per `/improve` run (batch calls only — its summary is assembled locally); files that still don't fit are reported by name as omitted | `6` |

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -359,6 +359,44 @@ public interface ThrillhouseConfig {
 
     @WithName("follow-up-summary")
     FollowUpSummaryConfig followUpSummary();
+
+    @WithName("large-pr-nudge")
+    LargePrNudgeConfig largePrNudge();
+  }
+
+  /**
+   * Opt-in maintainer nudge for a large pull request the review came back clean on. A big refactor
+   * that produces no inline finding is either genuinely clean or a shallow pass, and the summary
+   * alone cannot tell those apart — so when a PR is over the size thresholds below and no finding
+   * opened an inline thread, the summary comment says so and points at {@code /review} and {@code
+   * /improve}. Purely advisory: it spends no extra AI call and never changes the verdict.
+   *
+   * <p>Off by default, like every other feature that adds content to the summary comment ({@link
+   * DiagramConfig}, {@link LabelsConfig}, {@link FollowUpSummaryConfig}) — the quiet summary is the
+   * released behaviour, and a heuristic that fires on the largest PRs is the operator's call.
+   */
+  interface LargePrNudgeConfig {
+    /** Master switch — nothing is evaluated or rendered unless this is {@code true}. */
+    @WithDefault("false")
+    boolean enabled();
+
+    /**
+     * Changed-file count at or above which a finding-free review earns the nudge. Read from the
+     * PR-level total the summary's "Changes Overview" reports, so files the ignore globs dropped
+     * still count toward how big the change is. {@code 0} switches the file dimension off.
+     */
+    @WithName("min-files")
+    @WithDefault("20")
+    int minFiles();
+
+    /**
+     * Changed lines (additions + deletions) at or above which a finding-free review earns the nudge
+     * — a handful of files can still be a large change. Either dimension on its own triggers it.
+     * {@code 0} switches the line dimension off; with both at {@code 0} the nudge never fires.
+     */
+    @WithName("min-changed-lines")
+    @WithDefault("1000")
+    int minChangedLines();
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LargePrNudge.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LargePrNudge.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import java.util.Optional;
+
+/**
+ * The opt-in "large PR, nothing inline" note the summary comment carries when {@code
+ * thrillhousebot.review.large-pr-nudge.enabled} is on.
+ *
+ * <p>A large refactor that comes back with no inline finding is either genuinely clean or a shallow
+ * pass, and nothing else in the summary distinguishes them: the Risk Assessment table shows four
+ * zeroes and the celebration reads as a clean bill of health either way. This renders the
+ * distinction the bot cannot make itself, and hands it to the maintainer.
+ *
+ * <p><b>Why a note and not a second model pass.</b> The two deeper modes the original request
+ * imagined already run or already exist as their own command: a large PR is reviewed as
+ * token-budgeted batches by {@link DiffBudgetPlanner} plus {@link FindingPipeline}, so map-reduce
+ * is the <em>first</em> mode, not an escalation from it, and {@code /improve} is an on-demand
+ * whole-PR pass a maintainer can run in one comment. What is left to "escalate" into is a re-run of
+ * the same batches against the same model — which would double the AI spend on exactly the largest
+ * PRs (up to {@code max-ai-calls} extra calls each) for sampling variance, and would have to push
+ * past the verifier, quote validator and hedge demotion that exist to keep false positives out. Two
+ * lines of prose cost nothing and put the judgement where it belongs.
+ *
+ * <p><b>What "no findings" means here.</b> The trigger is "no finding opened an inline thread" —
+ * {@link Finding#postsInline()} false for every finding in the built {@link ReviewResult}, which is
+ * the set surviving quote validation, the framework filter, dedupe, the verifier and the
+ * replied-duplicate drop. That covers both halves of the reported symptom at once: zero findings,
+ * and the "all low confidence" round where every finding was routed to "Things to double-check" and
+ * the diff itself still shows nothing.
+ *
+ * <p>Deliberately keyed off <em>this</em> round's findings only, never the previous-findings
+ * statuses or the unresolved count. Issue #455 records that a round returning zero findings
+ * corrupts the previous-findings context — the bot's own review body is fed back as a pseudo
+ * finding and the unresolved count drifts upward — and a zero-finding round is precisely the round
+ * this heuristic fires on. Reading either signal here would make the nudge appear or vanish on a
+ * phantom. The findings list carries no such defect: it is rebuilt from this round's model calls.
+ *
+ * <p>Advisory only. The APPROVE gates in {@link VerdictBuilder} are untouched: holding a merge on
+ * the suspicion that a clean review might be wrong would block every large PR that really is clean,
+ * and the heuristic is nowhere near good enough to earn that.
+ *
+ * @param enabled master switch
+ * @param minFiles changed-file count at or above which the nudge applies; {@code 0} disables this
+ *     dimension
+ * @param minChangedLines additions + deletions at or above which the nudge applies; {@code 0}
+ *     disables this dimension
+ */
+record LargePrNudge(boolean enabled, int minFiles, int minChangedLines) {
+
+  /** The off switch, used by callers that have no configuration to read (tests, defaults). */
+  static final LargePrNudge DISABLED = new LargePrNudge(false, 0, 0);
+
+  /** Section heading of the rendered note; also the marker tests and callers match on. */
+  static final String NUDGE_HEADING = "### ⚠️ Large PR — no inline findings";
+
+  static LargePrNudge from(ThrillhouseConfig.LargePrNudgeConfig config) {
+    return new LargePrNudge(config.enabled(), config.minFiles(), config.minChangedLines());
+  }
+
+  /**
+   * The note for this review, or {@link Optional#empty()} when it does not apply — the feature is
+   * off, the PR is under both thresholds, or at least one finding opened an inline thread.
+   *
+   * <p>{@code filesChanged}/{@code additions}/{@code deletions} are the PR-level totals the summary
+   * already renders under "Changes Overview" (GitHub's own, or the diff-derived fallback), so the
+   * size test and the size the note quotes are the same numbers a reader sees above it.
+   */
+  Optional<String> render(int filesChanged, int additions, int deletions, ReviewResult result) {
+    if (!enabled
+        || !overThreshold(filesChanged, additions, deletions)
+        || opensInlineThread(result)) {
+      return Optional.empty();
+    }
+    var sb = new StringBuilder();
+    sb.append(NUDGE_HEADING).append("\n\n");
+    sb.append("This review opened no inline findings across ")
+        .append(filesChanged)
+        .append(filesChanged == 1 ? " changed file (+" : " changed files (+")
+        .append(additions)
+        .append(" -")
+        .append(deletions)
+        .append(").");
+    var lowerConfidence = result.doubleCheckFindings().size();
+    if (lowerConfidence > 0) {
+      sb.append(" The ")
+          .append(lowerConfidence)
+          .append(
+              lowerConfidence == 1 ? " finding it did raise was" : " findings it did raise were")
+          .append(
+              " too low-confidence to post on the diff (see \"Things to double-check\" above).");
+    }
+    sb.append(
+        " A change this size coming back clean is worth a second look: it may genuinely be"
+            + " clean, but it is also what a shallow pass looks like.\n\n");
+    sb.append(
+        "Re-run `/review` for a fresh pass, or `/improve` for a whole-PR improvement pass, before"
+            + " treating this as a clean bill of health. This note is advisory — it does not hold"
+            + " approval.\n\n");
+    return Optional.of(sb.toString());
+  }
+
+  /**
+   * Whether the PR is large enough to expect a review to find something. Either dimension suffices
+   * — a wide change touching many small files and a narrow change rewriting one huge file are both
+   * the shape this heuristic is for — and a non-positive bound switches its dimension off rather
+   * than matching every PR.
+   */
+  private boolean overThreshold(int filesChanged, int additions, int deletions) {
+    return (minFiles > 0 && filesChanged >= minFiles)
+        || (minChangedLines > 0 && additions + deletions >= minChangedLines);
+  }
+
+  /**
+   * Whether any finding opened an inline review thread. A finding that only reached the summary's
+   * "Things to double-check" section left the diff itself unmarked, which is the reported symptom
+   * ("0–1 inline findings on a large refactor"), so it does not suppress the nudge.
+   */
+  private static boolean opensInlineThread(ReviewResult result) {
+    return result.findings().stream().anyMatch(Finding::postsInline);
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -32,14 +32,23 @@ public class PrSummaryGenerator {
   // unrequested walkthrough_diagram.
   private final boolean diagramEnabled;
 
+  // Opt-in "large PR, nothing inline" note; carries its own thresholds and off switch.
+  private final LargePrNudge largePrNudge;
+
   @Inject
   public PrSummaryGenerator(ThrillhouseConfig config) {
-    this(config.review().diagram().enabled());
+    this(config.review().diagram().enabled(), LargePrNudge.from(config.review().largePrNudge()));
   }
 
-  /** Visible for tests. */
+  /** Visible for tests; the large-PR nudge stays off, matching its shipped default. */
   PrSummaryGenerator(boolean diagramEnabled) {
+    this(diagramEnabled, LargePrNudge.DISABLED);
+  }
+
+  /** Visible for tests: pins the diagram switch and the large-PR nudge policy together. */
+  PrSummaryGenerator(boolean diagramEnabled, LargePrNudge largePrNudge) {
     this.diagramEnabled = diagramEnabled;
+    this.largePrNudge = largePrNudge;
   }
 
   /** The clean-review celebration; rendered inside the summary, never as a separate comment. */
@@ -124,6 +133,9 @@ public class PrSummaryGenerator {
     appendPreviousFindings(sb, result);
     appendFindingsOrCelebration(sb, result);
     appendDoubleCheckFindings(sb, result);
+    // After the findings sections so the note can refer back to them, and so a reader meets the
+    // celebration (or the double-check list) before the caveat about how much to trust it.
+    largePrNudge.render(filesChanged, additions, deletions, result).ifPresent(sb::append);
     appendCiChecks(sb, result);
 
     sb.append("---\n");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -186,6 +186,14 @@ thrillhousebot.review.diagram.enabled=${REVIEW_DIAGRAM_ENABLED:false}
 # new-finding, resolved, and still-open counts. A pass with no delta posts nothing.
 thrillhousebot.review.follow-up-summary.enabled=${REVIEW_FOLLOW_UP_SUMMARY_ENABLED:false}
 
+# Maintainer nudge on a large PR the review came back clean on (opt-in). When enabled, a PR at or
+# over either threshold whose review opened no inline finding gets a note in the summary comment
+# pointing at /review and /improve. No extra AI call, and the verdict is unchanged. Either
+# threshold triggers on its own; 0 switches that dimension off.
+thrillhousebot.review.large-pr-nudge.enabled=${REVIEW_LARGE_PR_NUDGE_ENABLED:false}
+thrillhousebot.review.large-pr-nudge.min-files=${REVIEW_LARGE_PR_NUDGE_MIN_FILES:20}
+thrillhousebot.review.large-pr-nudge.min-changed-lines=${REVIEW_LARGE_PR_NUDGE_MIN_CHANGED_LINES:1000}
+
 # Database (H2 for dev, PostgreSQL for prod)
 quarkus.datasource.db-kind=${DATASOURCE_DB_KIND:h2}
 quarkus.datasource.jdbc.url=jdbc:h2:mem:thrillhouse;DB_CLOSE_DELAY=-1

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/LargePrNudgeDefaultsTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/LargePrNudgeDefaultsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Default profile: the large-PR nudge is off, so an untouched deployment renders exactly the
+ * summary comment it renders today even on a huge finding-free PR. Its thresholds still resolve, so
+ * an operator who flips the one switch gets the documented 20 files / 1000 changed lines without
+ * setting anything else. Asserted through the resolved configuration rather than the
+ * {@code @WithDefault} annotations, so the {@code thrillhousebot.review.large-pr-nudge.*} property
+ * wiring in {@code application.properties} is covered too.
+ */
+@QuarkusTest
+class LargePrNudgeDefaultsTest {
+
+  @Inject ThrillhouseConfig config;
+
+  @Test
+  void largePrNudgeIsOffByDefault() {
+    assertFalse(config.review().largePrNudge().enabled());
+  }
+
+  @Test
+  void largePrNudgeThresholdsMatchTheDocumentedDefaults() {
+    assertEquals(20, config.review().largePrNudge().minFiles());
+    assertEquals(1000, config.review().largePrNudge().minChangedLines());
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/LargePrNudgeTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/LargePrNudgeTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link LargePrNudge}'s trigger conditions and rendered note. */
+class LargePrNudgeTest {
+
+  /** The shipped thresholds, enabled: 20 files or 1000 changed lines. */
+  private static final LargePrNudge ENABLED = new LargePrNudge(true, 20, 1000);
+
+  private static ReviewResult resultWith(List<Finding> findings) {
+    return new ReviewResult(
+        findings, 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
+  }
+
+  private static ReviewResult clean() {
+    return resultWith(List.of());
+  }
+
+  private static Finding inlineFinding() {
+    return new Finding(
+        RiskLevel.MEDIUM, Confidence.HIGH, "src/A.java", 12, "Real bug", "desc", null, null);
+  }
+
+  private static Finding doubleCheckFinding(String file) {
+    return new Finding(
+        RiskLevel.MEDIUM, Confidence.LOW, file, 7, "Possible NPE", "desc", null, null);
+  }
+
+  @Test
+  void firesOnALargeFileCountWithNoFindings() {
+    var note = ENABLED.render(42, 3102, 876, clean()).orElseThrow();
+
+    assertTrue(note.startsWith(LargePrNudge.NUDGE_HEADING));
+    assertTrue(note.contains("no inline findings across 42 changed files (+3102 -876)"));
+    assertTrue(note.contains("`/review`"));
+    assertTrue(note.contains("`/improve`"));
+    assertTrue(note.contains("advisory"));
+  }
+
+  @Test
+  void firesOnTheLineThresholdEvenWhenFewFilesChanged() {
+    // A narrow-but-huge change is the same shape of risk as a wide one: either dimension is
+    // enough on its own.
+    var note = ENABLED.render(2, 900, 150, clean()).orElseThrow();
+
+    assertTrue(note.contains("no inline findings across 2 changed files (+900 -150)"));
+  }
+
+  @Test
+  void staysSilentOnASmallCleanPr() {
+    // The "small PRs unchanged — no false escalation noise" criterion: 5 files / 120 lines is
+    // under both bounds, so a clean review reads exactly as it does today.
+    assertEquals(Optional.empty(), ENABLED.render(5, 100, 20, clean()));
+  }
+
+  @Test
+  void staysSilentJustUnderBothThresholds() {
+    // Boundary: the bounds are inclusive, so 19 files / 999 lines must not fire while 20 does.
+    assertEquals(Optional.empty(), ENABLED.render(19, 500, 499, clean()));
+    assertTrue(ENABLED.render(20, 500, 499, clean()).isPresent());
+    assertTrue(ENABLED.render(19, 500, 500, clean()).isPresent());
+  }
+
+  @Test
+  void staysSilentWhenAFindingOpenedAnInlineThread() {
+    // The review already marked the diff, so there is nothing suspicious about the quiet.
+    assertEquals(
+        Optional.empty(), ENABLED.render(42, 3102, 876, resultWith(List.of(inlineFinding()))));
+  }
+
+  @Test
+  void firesWhenEveryFindingWasTooLowConfidenceToPostInline() {
+    // The issue's "or all low confidence" half: the diff itself still carries no thread, so the
+    // note applies — and says how many findings were held back.
+    var result =
+        resultWith(List.of(doubleCheckFinding("src/A.java"), doubleCheckFinding("src/B.java")));
+
+    var note = ENABLED.render(30, 2000, 400, result).orElseThrow();
+
+    assertTrue(note.contains("The 2 findings it did raise were too low-confidence"));
+    assertTrue(note.contains("Things to double-check"));
+  }
+
+  @Test
+  void singularWordingForOneHeldBackFinding() {
+    var result = resultWith(List.of(doubleCheckFinding("src/A.java")));
+
+    var note = ENABLED.render(30, 2000, 400, result).orElseThrow();
+
+    assertTrue(note.contains("The 1 finding it did raise was too low-confidence"));
+  }
+
+  @Test
+  void singularWordingForASingleHugeFile() {
+    var note = ENABLED.render(1, 1200, 300, clean()).orElseThrow();
+
+    assertTrue(note.contains("across 1 changed file (+1200 -300)"));
+  }
+
+  @Test
+  void staysSilentWhenDisabled() {
+    var off = new LargePrNudge(false, 20, 1000);
+
+    assertEquals(Optional.empty(), off.render(500, 90000, 40000, clean()));
+    assertEquals(Optional.empty(), LargePrNudge.DISABLED.render(500, 90000, 40000, clean()));
+  }
+
+  @Test
+  void aZeroBoundSwitchesOnlyItsOwnDimensionOff() {
+    var linesOnly = new LargePrNudge(true, 0, 1000);
+    assertEquals(Optional.empty(), linesOnly.render(500, 10, 10, clean()));
+    assertTrue(linesOnly.render(1, 1000, 0, clean()).isPresent());
+
+    var filesOnly = new LargePrNudge(true, 20, 0);
+    assertEquals(Optional.empty(), filesOnly.render(1, 90000, 40000, clean()));
+    assertTrue(filesOnly.render(20, 1, 0, clean()).isPresent());
+  }
+
+  @Test
+  void bothBoundsZeroNeverFires() {
+    var neither = new LargePrNudge(true, 0, 0);
+
+    assertEquals(Optional.empty(), neither.render(5000, 900000, 400000, clean()));
+  }
+
+  @Test
+  void readsItsPolicyFromConfig() {
+    var config = mock(ThrillhouseConfig.LargePrNudgeConfig.class);
+    when(config.enabled()).thenReturn(true);
+    when(config.minFiles()).thenReturn(7);
+    when(config.minChangedLines()).thenReturn(0);
+
+    var nudge = LargePrNudge.from(config);
+
+    assertEquals(new LargePrNudge(true, 7, 0), nudge);
+    assertTrue(nudge.render(7, 10, 10, clean()).isPresent());
+  }
+
+  @Test
+  void theNoteNeverClaimsToHoldApproval() {
+    // The verdict gates in VerdictBuilder are deliberately untouched; the copy must not imply
+    // otherwise, or a maintainer will wait for a block that never comes.
+    var note = ENABLED.render(42, 3102, 876, clean()).orElseThrow();
+
+    assertTrue(note.contains("it does not hold approval"));
+    assertFalse(note.contains("blocked"));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -29,13 +29,18 @@ class PrSummaryGeneratorTest {
   private final PrSummaryGenerator generator = new PrSummaryGenerator(true);
 
   @Test
-  void injectConstructorReadsDiagramEnabledFromConfig() {
+  void injectConstructorReadsDiagramEnabledAndLargePrNudgeFromConfig() {
     var config = mock(ThrillhouseConfig.class);
     var review = mock(ThrillhouseConfig.ReviewConfig.class);
     var diagram = mock(ThrillhouseConfig.DiagramConfig.class);
+    var nudge = mock(ThrillhouseConfig.LargePrNudgeConfig.class);
     when(config.review()).thenReturn(review);
     when(review.diagram()).thenReturn(diagram);
     when(diagram.enabled()).thenReturn(true);
+    when(review.largePrNudge()).thenReturn(nudge);
+    when(nudge.enabled()).thenReturn(true);
+    when(nudge.minFiles()).thenReturn(20);
+    when(nudge.minChangedLines()).thenReturn(1000);
 
     var fromConfig = new PrSummaryGenerator(config);
     var result =
@@ -47,6 +52,12 @@ class PrSummaryGeneratorTest {
             1, 5, 0, List.of(), summaryWithDiagram("flowchart TD\n  A --> B"), result);
 
     assertTrue(summary.contains("### Control-Flow Diagram"));
+    // The same config wiring carries the nudge policy; this 1-file PR is under both bounds.
+    assertFalse(summary.contains(LargePrNudge.NUDGE_HEADING), summary);
+    assertTrue(
+        fromConfig
+            .generate(42, 3102, 876, List.of(), null, result)
+            .contains(LargePrNudge.NUDGE_HEADING));
   }
 
   @Test
@@ -992,6 +1003,55 @@ class PrSummaryGeneratorTest {
 
     assertTrue(summary.contains("### Control-Flow Diagram"));
     assertTrue(summary.contains("A[\"call foo()\"] --> B{\"ready?\"}"));
+  }
+
+  @Test
+  void shouldRenderLargePrNudgeAfterTheCelebrationWhenEnabledAndNothingPostedInline() {
+    // The #343 fixture: a PR well over the file threshold whose review produced no findings at
+    // all. The celebration still renders — the review really did find nothing — but the summary
+    // now also says that on a change this size, that is worth checking by hand.
+    var nudging = new PrSummaryGenerator(false, new LargePrNudge(true, 20, 1000));
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
+
+    var summary = nudging.generate(42, 3102, 876, List.of(), null, result);
+
+    assertTrue(summary.contains(PrSummaryGenerator.ZERO_ISSUES_MESSAGE), summary);
+    assertTrue(summary.contains(LargePrNudge.NUDGE_HEADING), summary);
+    assertTrue(
+        summary.contains("no inline findings across 42 changed files (+3102 -876)"), summary);
+    // Ordering: the caveat reads after the celebration it qualifies.
+    assertTrue(
+        summary.indexOf(LargePrNudge.NUDGE_HEADING)
+            > summary.indexOf(PrSummaryGenerator.ZERO_ISSUES_MESSAGE),
+        summary);
+  }
+
+  @Test
+  void shouldNotRenderLargePrNudgeOnASmallCleanPr() {
+    var nudging = new PrSummaryGenerator(false, new LargePrNudge(true, 20, 1000));
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
+
+    var summary = nudging.generate(3, 120, 45, List.of(), null, result);
+
+    assertTrue(summary.contains(PrSummaryGenerator.ZERO_ISSUES_MESSAGE), summary);
+    assertFalse(summary.contains(LargePrNudge.NUDGE_HEADING), summary);
+  }
+
+  @Test
+  void shouldNotRenderLargePrNudgeWhenTheFeatureIsOff() {
+    // The shipped default: the test-visible single-arg constructor leaves the nudge disabled, so
+    // even a huge finding-free PR renders exactly the summary it renders today.
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
+
+    var summary = generator.generate(120, 20000, 9000, List.of(), null, result);
+
+    assertFalse(summary.contains(LargePrNudge.NUDGE_HEADING), summary);
   }
 
   private static ReviewResponse.Summary summaryWithDiagram(String diagram) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [x] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Dogfooding the v0.3.0 meta-PRs showed the bot posting 0–1 inline findings on refactors a
maintainer review found ~25 issues in. Nothing in the summary comment distinguishes *"this
change really is clean"* from *"this pass was shallow"*: the Risk Assessment table shows four
zeroes and the celebration reads as a clean bill of health either way.

This adds an **opt-in note in the PR summary** when a change over a configurable size produced
no inline finding, pointing the maintainer at `/review` and `/improve`:

> ### ⚠️ Large PR — no inline findings
>
> This review opened no inline findings across 42 changed files (+3102 -876). A change this
> size coming back clean is worth a second look: it may genuinely be clean, but it is also what
> a shallow pass looks like.
>
> Re-run `/review` for a fresh pass, or `/improve` for a whole-PR improvement pass, before
> treating this as a clean bill of health. This note is advisory — it does not hold approval.

---

### Read this first: why there is no second model pass

A reviewer coming from #343 will expect a deeper second pass. **All three escalation targets the
issue named have collapsed since it was written**, so please read the code rather than the issue:

1. **Map-reduce is now the *first* mode, not an escalation from it.** #53 landed:
   `ReviewOrchestrator` already calls `budgetPlanner.plan(ctx.reviewableFiles(), promptInputs)`,
   and `FindingPipeline.runMultiCall` reviews a large PR as N parallel token-budgeted batches, N
   per-batch verifier calls, and a summary call. There is nothing left to escalate *into*.
2. **`/improve` is already a separate on-demand command** (#316), which a maintainer can run in
   one comment — which is exactly what the nudge tells them to do.
3. **Option 3 in the issue — "lower the inline confidence threshold" — does not do what it says.**
   This is a correction to the issue's premise, not just its plan. The confidence gate does not
   *drop* findings, it **routes** them: `Finding.postsInline()` sends low-confidence medium/low
   findings to `ReviewResult.doubleCheckFindings()`, which `PrSummaryGenerator` renders under
   "Things to double-check". They are already surfaced. Lowering the gate would move
   already-visible findings onto the diff as inline threads; it would not surface a single new
   one. (Findings are genuinely dropped by the *verifier* — a different mechanism, and one whose
   whole job is suppressing false positives.)

**What that leaves, and the cost I declined.** The only real "deeper pass" available is re-running
the same batches against the same model. That costs **up to `max-ai-calls` (default 6) additional
calls on exactly the largest PRs — roughly double the review bill — bought in exchange for
sampling variance.** Any "push harder" prompt variant would additionally have to fight the
verifier, quote validator, framework filter and hedge demotion that exist precisely to keep false
positives out; making it find more means making those gates find less.

The acceptance criteria explicitly permit "a measurably deeper second pass **OR** an explicit
maintainer nudge". I built the nudge: **zero extra AI calls, zero extra tokens**, a deterministic
render off numbers the summary already holds. It puts a judgement the bot cannot make in front of
the person who can. If dogfooding shows it firing constantly on PRs that really are clean, that is
cheap evidence to act on before anyone spends money on a second pass.

### Read this second: the #455 interaction

**The trigger deliberately reads only *this round's* findings.** #455 (open, unfixed) corrupts the
*previous-findings* context on a zero-finding round: `FollowUpAnalyzer.buildPreviousFindingsContext`
takes its fallback on `structured.isEmpty()`, which is also true for a persisted response that
legitimately contained zero findings, so the bot's own review body is fed back as a pseudo finding
and the unresolved count drifts upward across rounds.

That is **the same round this heuristic fires on**. So the trigger reads only
`ReviewResult.findings()` — never `previousStatuses()` or `unresolvedPreviousCount()`, both of
which #455 can inflate with a phantom. Reading either would make the note appear or vanish on a
finding that was never posted anywhere. Nothing here touches that defect or changes its blast
radius; the reasoning is recorded in `LargePrNudge`'s javadoc so a future #455 fix cannot silently
couple the two.

### Read this third: why this can never become per-push noise

The note rides the **summary comment**, and `ReviewPublisher.publishSummary` posts that only on the
**first user-visible review**, on a forced `/summary` re-run, or on a superseded-finding refresh.
Follow-up rounds post no summary, so they render no nudge. A large PR that stays finding-free
across ten pushes gets the note **once**, not ten times.

---

**Precise trigger.** "No finding opened an inline thread" — `Finding.postsInline()` false for every
finding in the built `ReviewResult`, i.e. after quote validation, the framework filter, dedupe, the
verifier and the replied-duplicate drop. That covers both halves of the reported symptom at once:
the zero-finding round, and the "all low confidence" round where the diff itself still carries no
thread (the note then says how many findings were held back).

**Deliberately not changed: the APPROVE gates in `VerdictBuilder`.** Holding a merge on the
suspicion that a clean review *might* be wrong would block every large PR that really is clean, and
this heuristic is nowhere near good enough to earn that. `VerdictBuilder` is not in the diff at all.

**Default.** Off, like every other feature that adds content to the summary comment (`diagram`,
`labels`, `follow-up-summary`): the quiet summary is the released behaviour, and a heuristic that
fires on the largest PRs is the operator's call to switch on.

**Files:**
- `review/LargePrNudge.java` (new) — the policy (thresholds + trigger) and the rendered note.
- `review/PrSummaryGenerator.java` — holds the policy and renders the note after the findings
  sections; it already receives the PR-level file/line totals and the `ReviewResult`, so no new
  plumbing was needed through `ReviewOrchestrator` or `VerdictBuilder`.
- `config/ThrillhouseConfig.java` — `thrillhousebot.review.large-pr-nudge.{enabled,min-files,min-changed-lines}`.
- `application.properties`, `README.md`, `.env.example` — key wiring and documentation.

## Related Issues

Fixes #343

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

New: `LargePrNudgeTest` (13 tests — thresholds, both boundary directions, the inline-thread
suppression, the all-low-confidence case, singular/plural wording, disabled, per-dimension `0`),
`LargePrNudgeDefaultsTest` (`@QuarkusTest`, resolved config so the property wiring is covered),
plus three cases in `PrSummaryGeneratorTest` for the rendered summary.

Each behaviour was proved load-bearing by mutating the production code and confirming the tests go
red. *(JUnit prints its values inside angle brackets; they are omitted from the quotes below
because GitHub strips angle-bracketed text from a PR body. Everything else is verbatim.)*

**1. `overThreshold(...)` → `return true;`** (every PR counts as "large") — 6 failures:

```
LargePrNudgeTest.staysSilentOnASmallCleanPr:78 expected: Optional.empty but was: Optional[### Large PR - no inline findings
LargePrNudgeTest.staysSilentJustUnderBothThresholds:84 expected: Optional.empty but was: Optional[### Large PR - no inline findings
LargePrNudgeTest.bothBoundsZeroNeverFires:148 expected: Optional.empty but was: Optional[### Large PR - no inline findings
LargePrNudgeTest.aZeroBoundSwitchesOnlyItsOwnDimensionOff:136 expected: Optional.empty but was: Optional[### Large PR - no inline findings
PrSummaryGeneratorTest.shouldNotRenderLargePrNudgeOnASmallCleanPr:1041 expected: false but was: true
```

**2. `render(...)` → always `Optional.empty()`** — 11 failures:

```
LargePrNudgeTest.firesOnALargeFileCountWithNoFindings:56 » NoSuchElement No value present
LargePrNudgeTest.firesOnTheLineThresholdEvenWhenFewFilesChanged:69 » NoSuchElement No value present
LargePrNudgeTest.firesWhenEveryFindingWasTooLowConfidenceToPostInline:103 » NoSuchElement No value present
LargePrNudgeTest.singularWordingForOneHeldBackFinding:113 » NoSuchElement No value present
LargePrNudgeTest.singularWordingForASingleHugeFile:120 » NoSuchElement No value present
LargePrNudgeTest.theNoteNeverClaimsToHoldApproval:168 » NoSuchElement No value present
LargePrNudgeTest.readsItsPolicyFromConfig:161 expected: true but was: false
LargePrNudgeTest.staysSilentJustUnderBothThresholds:85 expected: true but was: false
```

**3. `opensInlineThread(...)` → `return false;`** (an inline finding no longer suppresses the note):

```
LargePrNudgeTest.staysSilentWhenAFindingOpenedAnInlineThread:92 expected: Optional.empty but was: Optional[### Large PR - no inline findings
```

**4. Removed the `largePrNudge.render(...).ifPresent(sb::append)` line from `PrSummaryGenerator`:**

```
PrSummaryGeneratorTest.shouldRenderLargePrNudgeAfterTheCelebrationWhenEnabledAndNothingPostedInline:1021 expected: true but was: false
PrSummaryGeneratorTest.injectConstructorReadsDiagramEnabledAndLargePrNudgeFromConfig:57 expected: true but was: false
```

**5. Flipped the `application.properties` defaults (`enabled` → `true`, `min-files` → `5`):**

```
LargePrNudgeDefaultsTest.largePrNudgeIsOffByDefault:40 expected: false but was: true
LargePrNudgeDefaultsTest.largePrNudgeThresholdsMatchTheDocumentedDefaults:45 expected: 20 but was: 5
```

Each mutation was reverted and the tests confirmed green again.

**Gates, run on the merged tree (Java 25).** This branch has been merged with `release/v0.6.0` at
`d53d438` (picking up #463 and #465), and the gates were re-run on the *merged* result rather than
on the branch head alone — a textually clean merge has hidden a compile break in this milestone
before:

```
./mvnw -B clean test spotless:check spotbugs:check
  Tests run: 2249, Failures: 0, Errors: 0, Skipped: 0
  BUILD SUCCESS
```

(The pre-merge branch head was separately green at 2214 tests, plus
`clean compile spotbugs:check spotless:check`.)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

### Static analysis: two `java:S6126` findings are deliberate

Sonar raises two MAJOR `S6126` ("use a text block") findings on the two rendered paragraphs in
`LargePrNudge.render(...)`. **They are being carried, not fixed.** Each string is a *single* flowing
sentence terminated by a paragraph break, so expressing it as a text block means using a multi-line
construct for something that must contain no internal newline: every content line has to end in a
`\` continuation to suppress the newline, and the sentence-joining leading space has to be written
`\s`. The trailing `\n\n` stops being two visible escapes and becomes a blank line above the closing
delimiter, which a future editor can silently delete while tidying whitespace. That trades a style
smell for a fragility in user-facing output, so the concatenation stays.

The conversion was implemented and verified before being declined, and the verification is worth
recording because it caught a real defect:

- A scratch harness dumped `LargePrNudge.render(...)` across all three branches — no findings, one
  held-back low-confidence finding, two — before and after the change. The final candidate was
  byte-identical: 1570 bytes,
  sha256 `689fa14f6c96f485048eb33f8fa7da487113d8dcecc9e966d579c550add61dd8` both ways.
- **The first candidate was not.** It rendered **two** leading spaces instead of one — 138
  characters against the original's 137 — because `\s` followed by a literal space is two spaces.
  Had that gone straight into the file, `LargePrNudgeTest` would have gone red on one assertion, and
  "fixing" the expectation would have shipped an extra space into every nudge the bot ever posts.
  Comparing real rendered output is what caught it; a green suite would not have.

The lesson generalises past this particular refactor: for a constant that *is* user-visible output,
"the tests still pass" is not evidence a mechanical rewrite preserved it — the tests are exactly
what a wrong rewrite teaches you to adjust.

### The extra commit after the merge

The branch carries three commits: the feature, the merge with `release/v0.6.0`, and one follow-up
that is **not part of the nudge feature**, isolated to a single file so it can be cherry-picked or
dropped independently.

**`docs(config)` — corrects an `.env.example` comment #463 left stale.** #463 moved `/describe`,
`/changelog` and `/generate-tests` onto token-budgeted batching and updated the README's
`REVIEW_MAX_DIFF_LINES` row, but did not update `.env.example`, which still described all three as
line-capped single-call renders. The two files have contradicted each other on the release branch
since that merge, and the stale copy points an operator at the wrong knob: someone reading
`.env.example` to widen `/describe` coverage on a large PR would raise `REVIEW_MAX_DIFF_LINES` and
observe no change at all, because the batched commands ignore the cap — `DiffBudgetPlanner` owns
their coverage by tokens. The comment now matches the README's wording exactly. It rides along here
only because this branch already modifies `.env.example`; a standalone PR for a four-line comment
would cost a full CI cycle for less benefit.

Worth noting what this is an instance of: **a config key documented correctly in one place and
stalely in another is precisely the "correct but incomplete" gap the `CONFIG KEY DOCUMENTATION
COMPLETENESS` dimension from #465 was just built to catch.** If the bot flags it on this very PR,
that is a good dogfood signal for #109's dimension rather than a false positive.

### Merge with the new base

The only conflict was the README config table, where #463 rewrote the `REVIEW_MAX_INPUT_TOKENS` row
while my three `REVIEW_LARGE_PR_NUDGE_*` rows landed immediately above it. Resolved additively: my
three rows plus #463's updated row. No source file collided — #463 and #465 touched the on-request
command classes and the prompt constants, none of which this PR goes near, and `Inputs.omittedFiles`
(removed by #463) was never referenced here.

### Acceptance criteria

- *Configurable threshold (files and/or LOC)* — `min-files` (20) and `min-changed-lines` (1000);
  either fires on its own, `0` switches a dimension off, both at `0` disables the heuristic.
- *Zero-finding large PR gets a deeper pass **or** an explicit maintainer nudge* — the nudge, for
  the cost reasons above.
- *Small PRs unchanged* — under both thresholds nothing renders, and the whole feature is off by
  default; covered by `staysSilentOnASmallCleanPr`, `staysSilentJustUnderBothThresholds` and
  `shouldNotRenderLargePrNudgeWhenTheFeatureIsOff`.
- *Tests with a fixture PR over threshold + empty findings* —
  `shouldRenderLargePrNudgeAfterTheCelebrationWhenEnabledAndNothingPostedInline` (42 files,
  +3102 −876, zero findings) and `firesOnALargeFileCountWithNoFindings`.
- *Documented in README config* — three rows in the config table, plus `.env.example`.

The versioned docs under `website/src/content/docs/` were left alone: they are release-time
snapshots and carry none of the other v0.6.0 keys (`REVIEW_IMPROVE_ENABLED`,
`REVIEW_GENERATE_TESTS_ENABLED`, `REVIEW_FOLLOW_UP_SUMMARY_ENABLED`) either.

One pre-existing hazard noticed while reading, not touched here and already recorded on #455:
`FindingPipeline` builds `Set.copyOf(plan.omittedFiles())` and calls `.contains(file.filename())`,
which throws `NullPointerException` on a null filename, while `ReviewDiffFormatter.isIgnored`
guards the same input.