### PR TITLE
fix(review): move /add-docs onto the shared generator seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,9 +297,9 @@ will change per provider:
 | `REVIEW_LARGE_PR_NUDGE_MIN_CHANGED_LINES` | Changed lines (additions + deletions) at or above which the nudge applies; either dimension triggers it on its own. `0` switches this dimension off — with both at `0` the nudge never fires | `1000` |
 | `REVIEW_MAX_INPUT_TOKENS` | Per-call input-token budget for review, `/improve`, `/describe` and `/changelog` calls; large PRs are split into batches that each fit it. Bounded by the active model's input cap (see [Per-model AI settings](#per-model-ai-settings)). `0` disables token budgeting | `48000` |
 | `REVIEW_OUTPUT_BUFFER_TOKENS` | Tokens reserved out of the input budget for the model's response | `8192` |
-| `REVIEW_MAX_AI_CALLS` | Cap on AI calls per review (batch calls plus the final summary call), per `/describe` and `/changelog` run (batch calls plus one reduce call, spent only when the PR needed more than one batch), and per `/improve` run (batch calls only — its summary is assembled locally); files that still don't fit are reported by name as omitted | `6` |
+| `REVIEW_MAX_AI_CALLS` | Cap on AI calls per review (batch calls plus the final summary call), per `/describe` and `/changelog` run (batch calls plus one reduce call, spent only when the PR needed more than one batch), and per `/improve`, `/generate-tests` or `/add-docs` run (batch calls only — their results are merged locally); files that still don't fit are reported by name as omitted | `6` |
 | `REVIEW_TOKEN_SAFETY_MARGIN` | Fraction of the input budget actually used, absorbing token-estimate error | `0.9` |
-| `REVIEW_MAX_DIFF_LINES` | Line cap on single-call diff renders (`/add-docs`, replies, base comparison, budgeting-disabled review). Token-budgeted reviews and the batched commands — `/improve`, `/describe`, `/changelog`, `/generate-tests` — ignore it (the planner owns coverage by tokens); `0` disables the cap | `5000` |
+| `REVIEW_MAX_DIFF_LINES` | Line cap on single-call diff renders (replies, base comparison, budgeting-disabled review). Token-budgeted reviews and the batched commands — `/improve`, `/describe`, `/changelog`, `/generate-tests`, `/add-docs` — ignore it (the planner owns coverage by tokens); `0` disables the cap | `5000` |
 | `THRILLHOUSEBOT_REVIEW_MAX_REVIEW_COMMENTS` | Maximum inline comments posted per review; findings over the cap are surfaced in the summary instead of dropped | `50` |
 | `THRILLHOUSEBOT_REVIEW_MAX_AI_RETRIES` | Attempts per failed AI call before the review errors out | `5` |
 | `THRILLHOUSEBOT_REVIEW_AI_RETRY_BASE_DELAY_MS` | Base delay of the exponential retry backoff, in milliseconds | `2000` |
@@ -692,10 +692,10 @@ This is still an early-stage project; the current constraints are:
   split into up to `REVIEW_MAX_AI_CALLS - 1` batched review calls, and files that still
   don't fit are disclosed by name instead of silently dropped. `/improve` batches the same
   way (up to `REVIEW_MAX_AI_CALLS` calls, since it makes no summary call), as does
-  `/generate-tests` (its per-batch test files are unioned locally). `/describe` and
-  `/changelog` batch up to `REVIEW_MAX_AI_CALLS - 1` calls, reserving one for the step that
-  reduces the per-batch results to a single answer. Only `/add-docs` still sends the diff in
-  a single call without batching.
+  `/generate-tests` (its per-batch test files are unioned locally) and `/add-docs` (its
+  per-batch doc suggestions are merged locally). `/describe` and `/changelog` batch up to
+  `REVIEW_MAX_AI_CALLS - 1` calls, reserving one for the step that reduces the per-batch
+  results to a single answer.
 - **Pure renames** — files GitHub reports as `renamed` with zero additions/deletions and
   no patch are omitted from AI review input (they have nothing to review). The summary
   overview still lists a short rollup (`N pure renames omitted…`). Rename-plus-edit

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import dev.thiagogonzaga.thrillhousebot.config.ActiveModelSettings;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
@@ -22,13 +23,17 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.github.InstructionsResolver;
 import dev.thiagogonzaga.thrillhousebot.github.ProjectStackResolver;
+import dev.thiagogonzaga.thrillhousebot.github.RepoSettingsResolver;
 import dev.thiagogonzaga.thrillhousebot.review.ai.DocGenerationParser;
 import dev.thiagogonzaga.thrillhousebot.review.ai.DocGenerationResponse;
 import dev.thiagogonzaga.thrillhousebot.review.ai.DocGenerator;
+import dev.thiagogonzaga.thrillhousebot.review.ai.DocGeneratorPrompts;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -43,9 +48,27 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
  * as an inline {@code ```suggestion} comment on the symbol's declaration line. Authorization, the
  * pause check and the {@code add-docs-enabled} kill switch are enforced by the caller before this
  * runs.
+ *
+ * <p>Coverage and scoping come from {@link AbstractPrSuggestionGenerator}, the same seam the other
+ * on-request commands use. Two things follow from that, and both matter more here than anywhere
+ * else because this command posts committable edits:
+ *
+ * <ul>
+ *   <li>The file list is narrowed by the repository's own ignore globs on top of the
+ *       deployment-wide ones, so a path a maintainer told the bot to leave alone is never handed
+ *       back as a one-click commit button.
+ *   <li>The pass is planned as token-budgeted batches over the whole change set rather than one
+ *       call over a {@code max-diff-lines} render, so a large PR no longer has only its first N
+ *       lines documented with a footnote about the rest.
+ * </ul>
+ *
+ * <p>Unlike its siblings this command loads the PR itself rather than through {@link
+ * AbstractPrSuggestionGenerator#loadInputs}: it distinguishes "the PR could not be loaded" from
+ * "the PR has nothing reviewable to document" in what it posts back, and it needs the head SHA
+ * before doing any work at all, since without one no suggestion can be anchored.
  */
 @ApplicationScoped
-public class DocGenerationService {
+public class DocGenerationService extends AbstractPrSuggestionGenerator {
 
   private static final String ACCEPT = "application/vnd.github+json";
   private static final String COMMAND = "/add-docs";
@@ -64,17 +87,27 @@ public class DocGenerationService {
       "📝 ThrillhouseBot generated documentation but could not anchor it to the current diff. "
           + "This usually happens after a force-push — try `/add-docs` again.";
 
+  /**
+   * Posted when the plan covered nothing: every changed file overflowed even a single-file batch.
+   * {@link #NOTHING_TO_DOCUMENT} here would be a verdict on code the model never read, so this
+   * names the budget as the cause instead.
+   */
+  static final String NOT_COVERED =
+      "📝 ThrillhouseBot could not fit any part of this PR into the per-call input-token budget, so"
+          + " it has nothing to document. Raise the input-token budget and re-run `/add-docs`.";
+
+  /** The summary is assembled locally, so the whole max-ai-calls allowance goes to batch calls. */
+  private static final int REDUCE_CALLS = 0;
+
   private final GitHubAuthClient authClient;
   private final GitHubPullRequestClient prClient;
   private final GitHubReviewClient reviewClient;
   private final GitHubCommentClient commentClient;
-  private final ReviewDiffFormatter diffFormatter;
   private final SuggestionFormatter suggestionFormatter;
   private final InstructionsResolver instructionsResolver;
   private final ProjectStackResolver projectStackResolver;
   private final DocGenerator docGenerator;
   private final DocGenerationParser parser;
-  private final ThrillhouseConfig config;
 
   @Inject
   public DocGenerationService(
@@ -88,18 +121,27 @@ public class DocGenerationService {
       ProjectStackResolver projectStackResolver,
       DocGenerator docGenerator,
       DocGenerationParser parser,
+      RepoSettingsResolver repoSettingsResolver,
+      DiffBudgetPlanner budgetPlanner,
+      ActiveModelSettings activeModel,
       ThrillhouseConfig config) {
+    super(
+        prClient,
+        diffFormatter,
+        instructionsResolver,
+        repoSettingsResolver,
+        budgetPlanner,
+        activeModel,
+        config);
     this.authClient = authClient;
     this.prClient = prClient;
     this.reviewClient = reviewClient;
     this.commentClient = commentClient;
-    this.diffFormatter = diffFormatter;
     this.suggestionFormatter = suggestionFormatter;
     this.instructionsResolver = instructionsResolver;
     this.projectStackResolver = projectStackResolver;
     this.docGenerator = docGenerator;
     this.parser = parser;
-    this.config = config;
   }
 
   /**
@@ -107,7 +149,12 @@ public class DocGenerationService {
    * asynchronously.
    */
   public record DocTask(
-      String owner, String repo, int prNumber, String defaultBranch, long installationId) {}
+      String owner, String repo, int prNumber, String defaultBranch, long installationId) {
+
+    CommandTarget target() {
+      return new CommandTarget(owner, repo, defaultBranch, installationId);
+    }
+  }
 
   /** Generates and posts the documentation suggestions. Swallows every failure after logging it. */
   @ActivateRequestContext
@@ -124,49 +171,94 @@ public class DocGenerationService {
 
       var files =
           SoftLoaders.files(prClient, auth, task.owner(), task.repo(), task.prNumber(), COMMAND);
-      var reviewable = diffFormatter.reviewableFiles(files);
+      // Resolved once and threaded downstream: the batches and the line map must agree on which
+      // files are in scope. This command posts committable suggestions, so a file the repository
+      // asked the bot to leave alone must reach neither a batch nor the anchor resolver.
+      var reviewable =
+          respectPerRepoIgnores(task.target(), COMMAND, diffFormatter().reviewableFiles(files));
       if (reviewable.isEmpty()) {
         postComment(auth, task, NO_FILES);
         return;
       }
 
-      var generated = generateOrReportFailure(auth, task, files, reviewable, pr);
-      if (generated == null) {
+      var planned = planOrReportFailure(auth, task, pr, reviewable);
+      if (planned == null) {
+        return;
+      }
+      if (planned.plan().batches().isEmpty()) {
+        Log.debugf(
+            "No file of %s/%s #%d fit an /add-docs batch",
+            task.owner(), task.repo(), task.prNumber());
+        postComment(auth, task, NOT_COVERED + disclosure(planned.plan()));
         return;
       }
 
-      var outcome = postSuggestions(auth, task, pr.head().sha(), reviewable, generated.response());
-      postComment(
-          auth, task, summaryMessage(generated.response(), outcome, generated.omittedFiles()));
+      var generated = generateEachBatch(planned);
+      if (generated == null) {
+        postComment(auth, task, GENERATION_FAILED);
+        return;
+      }
+      var outcome = postSuggestions(auth, task, pr.head().sha(), reviewable, generated.docs());
+      postComment(auth, task, summaryMessage(generated, outcome, planned.plan()));
       Log.infof(
-          "/add-docs posted %d suggestion(s) and %d note(s) on %s/%s #%d",
-          outcome.suggestions(), outcome.notes(), task.owner(), task.repo(), task.prNumber());
+          "/add-docs posted %d suggestion(s) and %d note(s) from %d batch(es) on %s/%s #%d",
+          outcome.suggestions(),
+          outcome.notes(),
+          planned.plan().batches().size(),
+          task.owner(),
+          task.repo(),
+          task.prNumber());
     } catch (RuntimeException e) {
       Log.warnf(
           e, "Failed to handle /add-docs on %s/%s #%d", task.owner(), task.repo(), task.prNumber());
     }
   }
 
-  /** Parsed documentation plus how many files the diff line budget omitted. */
-  private record GeneratedDocs(DocGenerationResponse response, int omittedFiles) {}
+  /** One run's prompt inputs, its resolved project stack, and the batch plan built from them. */
+  private record PlannedRun(Inputs inputs, String stack, DiffBudgetPlanner.BudgetPlan plan) {}
 
   /**
-   * Builds the diff, runs generation, and returns the parsed docs plus the omitted-file count —
-   * posting the failure notice and returning {@code null} when the diff build, model call, or parse
-   * throws, so the caller can bail without a nested try. The diff build stays inside this handler
-   * on purpose: a formatter failure must still surface {@code GENERATION_FAILED} to the user rather
-   * than be swallowed by {@link #handle}'s outer catch with only a log line.
+   * Resolves the per-call context and plans the token-budgeted batches, posting the failure notice
+   * and returning {@code null} when planning throws — so the caller can bail without a nested try.
+   * Planning stays inside this handler on purpose: a planner failure must still surface {@code
+   * GENERATION_FAILED} to the user rather than be swallowed by {@link #handle}'s outer catch with
+   * only a log line.
    */
-  private GeneratedDocs generateOrReportFailure(
+  private PlannedRun planOrReportFailure(
       String auth,
       DocTask task,
-      List<GitHubPullRequestClient.FileDiff> files,
-      List<GitHubPullRequestClient.FileDiff> reviewable,
-      GitHubPullRequestClient.PullRequestDetails pr) {
+      GitHubPullRequestClient.PullRequestDetails pr,
+      List<GitHubPullRequestClient.FileDiff> reviewable) {
     try {
-      var formatted = diffFormatter.buildDiffStringWithStats(files, reviewable);
-      var response = generate(task, formatted.text(), pr);
-      return new GeneratedDocs(response, formatted.omittedFiles());
+      String stack =
+          SoftLoaders.projectStack(
+              projectStackResolver,
+              task.owner(),
+              task.repo(),
+              task.defaultBranch(),
+              task.installationId(),
+              COMMAND);
+      // The whole-PR render is deliberately absent: nothing is sent to a model from it, and this
+      // command establishes "is there anything to work from" from the reviewable file list above.
+      var inputs =
+          new Inputs(
+              "",
+              orEmpty(pr.title()),
+              orEmpty(pr.body()),
+              buildInstructionsSection(task),
+              pr.head().sha(),
+              reviewable);
+      // The project stack rides on every batch call, so it has to be part of the overhead the
+      // planner subtracts before sizing batches — see the six-argument planBatches.
+      var plan =
+          planBatches(
+              reviewable,
+              inputs,
+              DocGeneratorPrompts.systemPrompt(),
+              DocGeneratorPrompts.userPrompt(),
+              PromptTemplateEscaper.escape(stack),
+              REDUCE_CALLS);
+      return new PlannedRun(inputs, stack, plan);
     } catch (RuntimeException e) {
       Log.warnf(
           e, "Doc generation failed for %s/%s #%d", task.owner(), task.repo(), task.prNumber());
@@ -175,26 +267,66 @@ public class DocGenerationService {
     }
   }
 
-  private DocGenerationResponse generate(
-      DocTask task, String diff, GitHubPullRequestClient.PullRequestDetails pr) {
-    String prContext = PromptSections.prContext(pr.title(), pr.body());
-    String stack =
-        SoftLoaders.projectStack(
-            projectStackResolver,
-            task.owner(),
-            task.repo(),
-            task.defaultBranch(),
-            task.installationId(),
-            COMMAND);
-    String instructions = buildInstructionsSection(task);
+  /** The docs merged across every batch, plus how many batch calls failed outright. */
+  private record Generated(List<DocGenerationResponse.DocSuggestion> docs, int failedBatches) {}
 
+  /**
+   * The map step plus the local union reduce: one call per batch, docs merged in batch order. A
+   * batch whose call fails or whose response will not parse is skipped rather than failing the run
+   * — the other batches still cover most of the PR — and the count is disclosed. Returns {@code
+   * null} only when every batch failed, which is the case that warrants the failure notice.
+   */
+  private Generated generateEachBatch(PlannedRun planned) {
+    var merged = new ArrayList<DocGenerationResponse.DocSuggestion>();
+    var seen = new HashSet<String>();
+    int failed = 0;
+    for (var batch : planned.plan().batches()) {
+      var response = generateOne(planned, batch);
+      if (response == null) {
+        failed++;
+        continue;
+      }
+      for (var doc : response.docs()) {
+        // Batches hold disjoint files, but a model can still quote a file it saw named in another
+        // batch's context — two comments on one declaration line would be noise on the PR.
+        if (seen.add(doc.file().strip() + ":" + doc.line())) {
+          merged.add(doc);
+        }
+      }
+    }
+    if (failed == planned.plan().batches().size()) {
+      Log.debugf("Every /add-docs batch failed — reporting the failure");
+      return null;
+    }
+    return new Generated(List.copyOf(merged), failed);
+  }
+
+  /** One batch's assistant call and parse, or {@code null} when either step fails. */
+  private DocGenerationResponse generateOne(PlannedRun planned, DiffBudgetPlanner.DiffBatch batch) {
     String raw =
-        docGenerator.generate(
-            PromptTemplateEscaper.fence(diff),
-            PromptTemplateEscaper.escape(prContext),
-            PromptTemplateEscaper.escape(stack),
-            instructions);
-    return parser.parse(raw);
+        callAssistant(
+            COMMAND,
+            () ->
+                docGenerator.generate(
+                    PromptTemplateEscaper.fence(batch.text()),
+                    PromptTemplateEscaper.escape(
+                        PromptSections.prContext(
+                            planned.inputs().title(), planned.inputs().body())),
+                    PromptTemplateEscaper.escape(planned.stack()),
+                    planned.inputs().instructions()));
+    if (raw == null) {
+      return null;
+    }
+    try {
+      return parser.parse(raw);
+    } catch (RuntimeException e) {
+      Log.warnf(e, "Could not parse an /add-docs batch response — skipping that batch");
+      return null;
+    }
+  }
+
+  private static String orEmpty(String value) {
+    return value == null ? "" : value;
   }
 
   /** How many /add-docs comments landed, split into committable suggestions and plain notes. */
@@ -208,19 +340,23 @@ public class DocGenerationService {
 
   /**
    * Posts each postable suggestion that anchors cleanly to the diff; returns the per-kind counts.
+   *
+   * <p>The line map is built from the run's whole effective file list — every batch's files
+   * together, never one batch's — so a doc produced by any batch anchors to its correct absolute
+   * line. It is the same list the batches were planned over, so a file the repository asked the bot
+   * to ignore cannot be anchored onto either, even if the model names one.
    */
   DocPostOutcome postSuggestions(
       String auth,
       DocTask task,
       String commitSha,
       List<GitHubPullRequestClient.FileDiff> reviewable,
-      DocGenerationResponse response) {
-    var lineResolver = new DiffLineResolver(diffFormatter.patchesByReviewableFiles(reviewable));
-    int cap = config.review().maxReviewComments();
+      List<DocGenerationResponse.DocSuggestion> docs) {
+    var lineResolver = new DiffLineResolver(diffFormatter().patchesByReviewableFiles(reviewable));
+    int cap = config().review().maxReviewComments();
     int suggestions = 0;
     int notes = 0;
     int skippedByCap = 0;
-    var docs = response.docs();
     for (int i = 0; i < docs.size(); i++) {
       if (suggestions + notes >= cap) {
         skippedByCap =
@@ -341,16 +477,21 @@ public class DocGenerationService {
   }
 
   /**
-   * The summary comment for a completed {@code /add-docs} run, with a partial-coverage disclosure
-   * appended when the diff line budget dropped whole files — so docs derived from a truncated diff
-   * are never presented as if they covered the whole PR (reuses the review path's wording).
+   * The summary comment for a completed {@code /add-docs} run, with the batch-failure note and the
+   * partial-coverage disclosure appended when the token budget left whole files uncovered — so docs
+   * derived from part of the change set are never presented as if they covered the whole PR (reuses
+   * the review path's wording).
    */
   private String summaryMessage(
-      DocGenerationResponse response, DocPostOutcome outcome, int omittedFiles) {
-    return baseSummaryMessage(response, outcome) + ReviewResult.truncationDisclosure(omittedFiles);
+      Generated generated, DocPostOutcome outcome, DiffBudgetPlanner.BudgetPlan plan) {
+    return baseSummaryMessage(generated.docs(), outcome)
+        + batchFailureNote(
+            generated.failedBatches(), COMMAND, "the symbols in them are not documented here.")
+        + disclosure(plan);
   }
 
-  private String baseSummaryMessage(DocGenerationResponse response, DocPostOutcome outcome) {
+  private String baseSummaryMessage(
+      List<DocGenerationResponse.DocSuggestion> docs, DocPostOutcome outcome) {
     int suggestions = outcome.suggestions();
     int notes = outcome.notes();
     String capSuffix =
@@ -389,7 +530,7 @@ public class DocGenerationService {
           + outcome.skippedByCap()
           + "** changed symbol(s) were not documented. Raise the comment cap or re-run `/add-docs`.";
     }
-    return response.docs().isEmpty() ? NOTHING_TO_DOCUMENT : COULD_NOT_PLACE;
+    return docs.isEmpty() ? NOTHING_TO_DOCUMENT : COULD_NOT_PLACE;
   }
 
   // Command-specific guidance for the repository-instructions section.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGeneratorPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGeneratorPrompts.java
@@ -110,5 +110,28 @@ public final class DocGeneratorPrompts {
             {{/if}}
             """;
 
+  /**
+   * The system prompt as a runtime value, for callers that only need to <em>size</em> it — the
+   * batch planner's shared-overhead estimate. A reference to the {@code static final String}
+   * constant itself is inlined into the referencing class file at compile time, so a command that
+   * sized its own overhead would carry a second multi-kilobyte copy of the prompt (SpotBugs {@code
+   * HSC_HUGE_SHARED_STRING_CONSTANT}). The annotations still need the constant; nothing else does.
+   */
+  public static String systemPrompt() {
+    return SYSTEM;
+  }
+
+  /**
+   * The user-message template as a runtime value, for callers that only need to <em>size</em> it.
+   * See {@link #systemPrompt()} for why sizing callers avoid referencing the constant directly.
+   *
+   * <p>{@code /add-docs} has its own user template rather than sharing {@link
+   * PrSuggestionPrompts#USER} — it carries a project-stack section the others do not — so sizing
+   * one of its batches against the shared template would measure the wrong prompt.
+   */
+  public static String userPrompt() {
+    return USER;
+  }
+
   private DocGeneratorPrompts() {}
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
@@ -886,6 +886,71 @@ class DocGenerationServiceTest {
     assertTrue(postedSummary().contains("Partial pass"), postedSummary());
   }
 
+  /** The doc the model returns for {@code src/Foo.java}, anchored to its declaration line. */
+  private static final String DOC_FOR_FOO =
+      """
+      {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar(int)",
+      "suggestion_old":"public int bar(int x) {",
+      "suggestion_new":"/** Doubles x. */\\npublic int bar(int x) {"}]}
+      """;
+
+  @Test
+  void postsOneCommentWhenTwoBatchesBothDocumentTheSameDeclaration() {
+    // Batches hold disjoint files, but a model can still document a file it only saw named in
+    // another batch's context. Two comments on one declaration line would be noise on the PR, so
+    // the merge across batches is keyed on file:line.
+    budgetWithDiffRoom(40);
+    prWithFiles(fooWithPatch(), otherFile());
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(DOC_FOR_FOO);
+
+    service.handle(task());
+
+    assertEquals(2, diffsSentToGenerator().size(), "both batches must have been called");
+    verify(reviewClient, times(1))
+        .createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
+    var summary = postedSummary();
+    assertTrue(summary.contains("**1**"), summary);
+    assertFalse(summary.contains("**2**"), summary);
+  }
+
+  @Test
+  void skipsABatchWhoseResponseWillNotParseAndKeepsTheOthers() {
+    // A batch whose reply is not usable JSON is skipped like a failed call: the batches that did
+    // parse still cover most of the PR, and the loss is disclosed rather than failing the run.
+    budgetWithDiffRoom(40);
+    prWithFiles(fooWithPatch(), otherFile());
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenAnswer(
+            call ->
+                call.<String>getArgument(0).contains("src/Other.java")
+                    ? "Sure! Here are the docs I came up with."
+                    : DOC_FOR_FOO);
+
+    service.handle(task());
+
+    var inline = capturedInlineComment();
+    assertEquals("src/Foo.java", inline.path());
+    var summary = postedSummary();
+    assertTrue(summary.contains("**1**"), summary);
+    assertTrue(summary.contains("Partial pass"), summary);
+    assertTrue(summary.contains("1 batch(es) of this PR could not be analyzed"), summary);
+  }
+
+  @Test
+  void reportsFailureWhenNoBatchResponseWillParse() {
+    // Nothing was salvaged from any batch, so the run has no partial result to present — the
+    // maintainer gets the failure notice rather than a "nothing to document" verdict.
+    budgetWithDiffRoom(40);
+    prWithFiles(fooWithPatch(), otherFile());
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn("I could not do that.");
+
+    service.handle(task());
+
+    assertEquals(DocGenerationService.GENERATION_FAILED, postedSummary());
+    verify(reviewClient, never())
+        .createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
+  }
+
   @Test
   void reportsNoFilesWhenEveryChangedFileIsOutOfScopeForTheRepository() {
     when(repoSettingsResolver.resolve(any(), any(), any(), anyLong()))

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.thiagogonzaga.thrillhousebot.config.ActiveModelSettings;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
@@ -31,10 +32,13 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient.Ref;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.github.InstructionsResolver;
 import dev.thiagogonzaga.thrillhousebot.github.ProjectStackResolver;
+import dev.thiagogonzaga.thrillhousebot.github.RepoSettings;
+import dev.thiagogonzaga.thrillhousebot.github.RepoSettingsResolver;
 import dev.thiagogonzaga.thrillhousebot.review.ai.DocGenerationParser;
 import dev.thiagogonzaga.thrillhousebot.review.ai.DocGenerator;
+import dev.thiagogonzaga.thrillhousebot.review.ai.DocGeneratorPrompts;
+import dev.thiagogonzaga.thrillhousebot.review.ai.TokenCounter;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,6 +79,8 @@ class DocGenerationServiceTest {
   @Mock private GitHubCommentClient commentClient;
   @Mock private InstructionsResolver instructionsResolver;
   @Mock private ProjectStackResolver projectStackResolver;
+  @Mock private RepoSettingsResolver repoSettingsResolver;
+  @Mock private ActiveModelSettings activeModel;
   @Mock private DocGenerator docGenerator;
   @Mock private ThrillhouseConfig config;
   @Mock private ThrillhouseConfig.ReviewConfig reviewConfig;
@@ -91,22 +97,58 @@ class DocGenerationServiceTest {
     when(authClient.getAuthHeader(anyLong())).thenReturn(AUTH);
     when(config.review()).thenReturn(reviewConfig);
     when(reviewConfig.maxReviewComments()).thenReturn(50);
+    when(reviewConfig.maxAiCalls()).thenReturn(6);
+    // Budgeting on with ample room, so a normal PR is a single batch — the same shape the command
+    // had before it joined the batching seam.
+    when(activeModel.maxInputTokens()).thenReturn(1_000_000);
+    when(activeModel.tokenSafetyMargin()).thenReturn(1.0);
+    when(activeModel.outputBufferTokens()).thenReturn(0);
     when(instructionsResolver.resolve(any(), any(), any(), anyLong()))
         .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
     when(projectStackResolver.resolve(any(), any(), any(), anyLong())).thenReturn("");
-    service =
-        new DocGenerationService(
-            authClient,
-            prClient,
-            reviewClient,
-            commentClient,
-            diffFormatter,
-            suggestionFormatter,
-            instructionsResolver,
-            projectStackResolver,
-            docGenerator,
-            parser,
-            config);
+    when(repoSettingsResolver.resolve(any(), any(), any(), anyLong()))
+        .thenReturn(RepoSettings.EMPTY);
+    service = serviceWith(diffFormatter);
+  }
+
+  /** The service under test, wired around the given formatter. */
+  private DocGenerationService serviceWith(ReviewDiffFormatter formatter) {
+    return new DocGenerationService(
+        authClient,
+        prClient,
+        reviewClient,
+        commentClient,
+        formatter,
+        suggestionFormatter,
+        instructionsResolver,
+        projectStackResolver,
+        docGenerator,
+        parser,
+        repoSettingsResolver,
+        new DiffBudgetPlanner(formatter, new TokenCounter(), config, activeModel),
+        activeModel,
+        config);
+  }
+
+  /** A per-call budget with exactly {@code diffTokens} of room for diff text. */
+  private void budgetWithDiffRoom(int diffTokens) {
+    var overhead =
+        new TokenCounter()
+            .estimateTokens(
+                DocGeneratorPrompts.systemPrompt()
+                    + DocGeneratorPrompts.userPrompt()
+                    + PromptTemplateEscaper.fence(" ")
+                    + "Title"
+                    + "Body"
+                    + "");
+    when(activeModel.maxInputTokens()).thenReturn(overhead + diffTokens);
+  }
+
+  /** The diff text of every batch call the generator received, in order. */
+  private List<String> diffsSentToGenerator() {
+    var diff = ArgumentCaptor.forClass(String.class);
+    verify(docGenerator, atLeastOnce()).generate(diff.capture(), any(), any(), any());
+    return diff.getAllValues();
   }
 
   private DocGenerationService.DocTask task() {
@@ -122,6 +164,17 @@ class DocGenerationServiceTest {
 
   private static FileDiff fooWithPatch() {
     return new FileDiff("src/Foo.java", "modified", 6, 0, 6, PATCH);
+  }
+
+  /** A second changed file, so the planner has something to split into more than one batch. */
+  private static FileDiff otherFile() {
+    return new FileDiff(
+        "src/Other.java",
+        "modified",
+        3,
+        0,
+        3,
+        "@@ -0,0 +1,3 @@\n+public int hop(int n) {\n+  return n;\n+}");
   }
 
   private String postedSummary() {
@@ -165,28 +218,12 @@ class DocGenerationServiceTest {
   }
 
   @Test
-  void appendsPartialCoverageDisclosureToTheSummaryWhenFilesWereOmitted() {
-    var truncatingFormatter = mock(ReviewDiffFormatter.class);
-    var foo = fooWithPatch();
-    when(truncatingFormatter.reviewableFiles(anyList())).thenReturn(List.of(foo));
-    when(truncatingFormatter.buildDiffStringWithStats(anyList(), anyList()))
-        .thenReturn(new ReviewDiffFormatter.FormattedDiff("## Overview\n(truncated)", 48));
-    when(truncatingFormatter.patchesByReviewableFiles(anyList()))
-        .thenReturn(Map.of("src/Foo.java", PATCH));
-    var truncatingService =
-        new DocGenerationService(
-            authClient,
-            prClient,
-            reviewClient,
-            commentClient,
-            truncatingFormatter,
-            suggestionFormatter,
-            instructionsResolver,
-            projectStackResolver,
-            docGenerator,
-            parser,
-            config);
-    prWithFiles(foo);
+  void appendsPartialCoverageDisclosureNamingTheFilesNoBatchCouldCover() {
+    // One batch's worth of allowance and room for one file, so the second is left uncovered by the
+    // token budget — and named, rather than silently dropped at a line boundary.
+    when(reviewConfig.maxAiCalls()).thenReturn(1);
+    budgetWithDiffRoom(40);
+    prWithFiles(fooWithPatch(), otherFile());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
             """
@@ -195,13 +232,13 @@ class DocGenerationServiceTest {
             "suggestion_new":"/** Doubles x. */\\npublic int bar(int x) {"}]}
             """);
 
-    truncatingService.handle(task());
+    service.handle(task());
 
     verify(reviewClient).createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
     var summary = postedSummary();
     assertTrue(summary.contains("**1**"), summary);
-    assertTrue(summary.contains("48 file(s) were omitted"), summary);
     assertTrue(summary.contains("partial coverage"), summary);
+    assertTrue(summary.contains("src/Other.java"), summary);
     assertFalse(summary.contains("findings and verdict"), summary);
   }
 
@@ -457,25 +494,15 @@ class DocGenerationServiceTest {
   }
 
   @Test
-  void reportsFailureWhenDiffBuildThrows() {
+  void reportsFailureWhenBatchPlanningThrows() {
+    // Planning stays inside the command's own handler so a planner failure still surfaces the
+    // failure notice to the maintainer rather than only a log line.
     var throwingFormatter = mock(ReviewDiffFormatter.class);
     var foo = fooWithPatch();
     when(throwingFormatter.reviewableFiles(anyList())).thenReturn(List.of(foo));
-    when(throwingFormatter.buildDiffStringWithStats(anyList(), anyList()))
+    when(throwingFormatter.formatFileSection(any(), anySet()))
         .thenThrow(new RuntimeException("formatter boom"));
-    var throwingService =
-        new DocGenerationService(
-            authClient,
-            prClient,
-            reviewClient,
-            commentClient,
-            throwingFormatter,
-            suggestionFormatter,
-            instructionsResolver,
-            projectStackResolver,
-            docGenerator,
-            parser,
-            config);
+    var throwingService = serviceWith(throwingFormatter);
     prWithFiles(foo);
 
     throwingService.handle(task());
@@ -678,5 +705,221 @@ class DocGenerationServiceTest {
 
     verify(reviewClient).createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
     assertTrue(postedSummary().contains("**1**"));
+  }
+
+  /** The doc the model returns for {@code src/Other.java}, anchored to its declaration line. */
+  private static final String DOC_FOR_OTHER =
+      """
+      {"docs":[{"file":"src/Other.java","line":1,"symbol":"hop(int)",
+      "suggestion_old":"public int hop(int n) {",
+      "suggestion_new":"/** Hops. */\\npublic int hop(int n) {"}]}
+      """;
+
+  @Test
+  void postsNoSuggestionForAFileOnlyThePerRepoIgnorePatternExcludes() {
+    // src/Other.java is reviewable under the global ignore list (which is empty here) and is
+    // excluded only by the pattern the repository declared for itself. This command posts
+    // committable edits, so an ignored path must reach neither a batch nor the anchor resolver.
+    when(repoSettingsResolver.resolve(any(), any(), any(), anyLong()))
+        .thenReturn(
+            new RepoSettings(List.of("src/Other.java"), List.of(), ".github/thrillhousebot.yml"));
+    prWithFiles(fooWithPatch(), otherFile());
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(DOC_FOR_OTHER);
+
+    service.handle(task());
+
+    verify(reviewClient, never())
+        .createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
+    assertEquals(DocGenerationService.COULD_NOT_PLACE, postedSummary());
+    var sent = String.join("\n", diffsSentToGenerator());
+    assertFalse(sent.contains("src/Other.java"), "the ignored file must not reach a batch");
+    assertTrue(sent.contains("src/Foo.java"), "the in-scope file must still reach a batch");
+  }
+
+  @Test
+  void keepsTheGlobalIgnoreListWorkingForARepositoryWithNoOwnSettings() {
+    // No .github/thrillhousebot.yml: the effective ignore set must still be exactly the global
+    // list — the per-repo patterns are additive, never a replacement for it.
+    var globallyIgnoring = new ReviewDiffFormatter(List.of("**/*.md"), 5000);
+    var globalService = serviceWith(globallyIgnoring);
+    prWithFiles(fooWithPatch(), new FileDiff("docs/README.md", "modified", 1, 0, 1, "@@\n+hi"));
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenReturn(
+            """
+            {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
+            "suggestion_old":"public int bar(int x) {",
+            "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
+            """);
+
+    globalService.handle(task());
+
+    var sent = String.join("\n", diffsSentToGenerator());
+    assertFalse(sent.contains("docs/README.md"), sent);
+    assertTrue(sent.contains("src/Foo.java"), sent);
+    verify(reviewClient).createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
+    assertTrue(postedSummary().contains("**1**"), postedSummary());
+  }
+
+  @Test
+  void documentsFilesThatTheLineCapWouldHaveDroppedEntirely() {
+    // The point of the change: coverage is planned over the whole file list, so a file past the
+    // max-diff-lines boundary still reaches a model instead of falling off the end of a
+    // line-capped render with only a footnote to show for it.
+    var tinyLineCap = new ReviewDiffFormatter(List.of(), 8);
+    var cappedService = serviceWith(tinyLineCap);
+    prWithFiles(fooWithPatch(), otherFile());
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(DOC_FOR_OTHER);
+
+    cappedService.handle(task());
+
+    var sent = String.join("\n", diffsSentToGenerator());
+    assertTrue(sent.contains("public int hop(int n) {"), sent);
+    assertFalse(sent.contains("patch truncated"), sent);
+    var inline = capturedInlineComment();
+    assertEquals("src/Other.java", inline.path());
+    assertTrue(inline.body().contains("```suggestion"), inline.body());
+    assertFalse(postedSummary().contains("partial coverage"), postedSummary());
+  }
+
+  @Test
+  void plansOneBatchPerSliceOfTheChangeSetRatherThanOneCallOverTheWholeRender() {
+    budgetWithDiffRoom(40);
+    prWithFiles(fooWithPatch(), otherFile());
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn("{\"docs\":[]}");
+
+    service.handle(task());
+
+    var sent = diffsSentToGenerator();
+    assertEquals(2, sent.size(), sent.toString());
+    // Each batch carries its own slice: asserting only that the slices *contain* their file would
+    // also pass if every call were handed the whole-PR render, which is what this replaces.
+    assertTrue(sent.get(0).contains("src/Foo.java"), sent.get(0));
+    assertFalse(sent.get(0).contains("src/Other.java"), sent.get(0));
+    assertTrue(sent.get(1).contains("src/Other.java"), sent.get(1));
+    assertFalse(sent.get(1).contains("src/Foo.java"), sent.get(1));
+  }
+
+  @Test
+  void keepsTheGuardsAcrossBatchesSoOnlyTheAnchorableDocIsPosted() {
+    // The anchor and declaration-retention guards run over the merged docs of every batch, not one
+    // batch's: a second batch must not be able to slip past them.
+    budgetWithDiffRoom(40);
+    prWithFiles(fooWithPatch(), otherFile());
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenReturn(
+            """
+            {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
+            "suggestion_old":"public int bar(int x) {",
+            "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
+            """)
+        .thenReturn(
+            """
+            {"docs":[{"file":"src/Other.java","line":1,"symbol":"hop",
+            "suggestion_old":"public int hop(int n) {",
+            "suggestion_new":"/** just a docstring, no code */"}]}
+            """);
+
+    service.handle(task());
+
+    var inline = capturedInlineComment();
+    assertEquals("src/Foo.java", inline.path());
+    assertTrue(postedSummary().contains("**1**"), postedSummary());
+  }
+
+  @Test
+  void keepsTheCommentCapOverTheDocsMergedFromEveryBatch() {
+    when(reviewConfig.maxReviewComments()).thenReturn(1);
+    budgetWithDiffRoom(40);
+    prWithFiles(fooWithPatch(), otherFile());
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenReturn(
+            """
+            {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
+            "suggestion_old":"public int bar(int x) {",
+            "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
+            """)
+        .thenReturn(DOC_FOR_OTHER);
+
+    service.handle(task());
+
+    verify(reviewClient, times(1))
+        .createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
+    assertTrue(postedSummary().contains("1 more changed symbol"), postedSummary());
+  }
+
+  @Test
+  void reportsTheBudgetRatherThanAVerdictWhenNoFileFitsABatch() {
+    // Going quiet would hide a misconfigured budget, and NOTHING_TO_DOCUMENT here would be a
+    // verdict on code the model never read.
+    when(activeModel.maxInputTokens()).thenReturn(10);
+    prWithFiles(fooWithPatch(), otherFile());
+
+    service.handle(task());
+
+    verifyNoInteractions(docGenerator);
+    var summary = postedSummary();
+    assertTrue(summary.startsWith(DocGenerationService.NOT_COVERED), summary);
+    assertTrue(summary.contains("src/Foo.java"), summary);
+    assertTrue(summary.contains("src/Other.java"), summary);
+  }
+
+  @Test
+  void keepsTheDocsFromTheBatchesThatSucceededWhenOneBatchFails() {
+    budgetWithDiffRoom(40);
+    prWithFiles(fooWithPatch(), otherFile());
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenAnswer(
+            call -> {
+              if (call.<String>getArgument(0).contains("src/Other.java")) {
+                throw new RuntimeException("model down");
+              }
+              return """
+                  {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
+                  "suggestion_old":"public int bar(int x) {",
+                  "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
+                  """;
+            });
+
+    service.handle(task());
+
+    verify(reviewClient).createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
+    assertTrue(postedSummary().contains("Partial pass"), postedSummary());
+  }
+
+  @Test
+  void reportsNoFilesWhenEveryChangedFileIsOutOfScopeForTheRepository() {
+    when(repoSettingsResolver.resolve(any(), any(), any(), anyLong()))
+        .thenReturn(
+            new RepoSettings(
+                List.of("src/Foo.java", "src/Other.java"),
+                List.of(),
+                ".github/thrillhousebot.yml"));
+    prWithFiles(fooWithPatch(), otherFile());
+
+    service.handle(task());
+
+    assertEquals(DocGenerationService.NO_FILES, postedSummary());
+    verifyNoInteractions(docGenerator);
+  }
+
+  @Test
+  void continuesWithTheGlobalIgnoreListWhenRepositorySettingsCannotBeResolved() {
+    // The SoftLoaders contract: a failure in the new resolution path degrades to the previous
+    // behaviour rather than failing the command.
+    when(repoSettingsResolver.resolve(any(), any(), any(), anyLong()))
+        .thenThrow(new RuntimeException("repo config down"));
+    prWithFiles(fooWithPatch());
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenReturn(
+            """
+            {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
+            "suggestion_old":"public int bar(int x) {",
+            "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
+            """);
+
+    service.handle(task());
+
+    verify(reviewClient).createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
+    assertTrue(postedSummary().contains("**1**"), postedSummary());
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [x] 📝 Documentation
- [x] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`/add-docs` was the last on-request generator that had not moved onto the shared
`AbstractPrSuggestionGenerator` seam, and it had drifted behind the other four in two
user-visible ways.

**Per-repo ignore globs were not honoured — on the one command that writes.**
`DocGenerationService` filtered the changed files through the single-argument
`diffFormatter.reviewableFiles(files)`, which resolves to the deployment-wide ignore list
only. The globs a maintainer declares in `.github/thrillhousebot.yml` (#51) were never
asked for. Because this command posts committable ```` ```suggestion ```` blocks, a path a
repository had explicitly told the bot to leave alone could still come back as a one-click
commit button. The file list now goes through `respectPerRepoIgnores(...)`, and that one
list feeds both the batch plan and the `DiffLineResolver` line map, so an out-of-scope file
can reach neither a model call nor an anchor.

**Still line-capped instead of token-budgeted.** The prompt was built with
`buildDiffStringWithStats(...)`, which drops whole files at the `max-diff-lines` boundary
and appends a truncation footnote. Coverage is now planned as token-budgeted batches over
the whole change set through `planBatches(...)` (#457), matching how `UnitTestGenerator`
consumes a `BudgetPlan`: one call per batch, the per-batch docs merged locally (so no
reduce call is reserved and the whole `max-ai-calls` allowance buys batches), uncovered
files named through `disclosure(plan)` rather than counted, and failed batches disclosed
through `batchFailureNote(...)`. The line-cap truncation note is gone with the line cap.

The post-time guards are unchanged: the exact-line diff-anchor check, the "replacement must
retain the declaration line" guard, and the per-PR comment cap now simply run over the docs
merged from every batch. Repository-settings resolution goes through `SoftLoaders`, so a
failure there degrades to the previous (global-list) behaviour instead of failing the
command — the contract `/add-docs` already had.

Files touched:

- `review/DocGenerationService.java` — extends `AbstractPrSuggestionGenerator`; takes
  `RepoSettingsResolver`, `DiffBudgetPlanner` and `ActiveModelSettings`; filters through
  `respectPerRepoIgnores`; plans and generates per batch; merges and dedupes docs by
  `file:line`; drops the `omittedFiles` line-cap disclosure in favour of the plan's; adds a
  `NOT_COVERED` message so "nothing needs documentation" is never a verdict on code the
  model never read.
- `review/ai/DocGeneratorPrompts.java` — `systemPrompt()` / `userPrompt()` accessors so the
  batch planner can size the overhead without inlining a second copy of the prompt
  constants (SpotBugs `HSC_HUGE_SHARED_STRING_CONSTANT`), mirroring the other prompt classes.
- `review/DocGenerationServiceTest.java` — new coverage for the ignore filter, the batching,
  the guards across batches and the soft-fail path; the two tests that pinned the old
  line-cap render re-pointed at the plan.
- `README.md` — `/add-docs` moved from the `REVIEW_MAX_DIFF_LINES` list to the batched-command
  lists, and the "Known limitations" note that it was the one unbatched command removed.

`DocGenerationService` keeps its own PR/file loading rather than calling `loadInputs(...)`:
it distinguishes "the PR could not be loaded" from "the PR has nothing reviewable to
document" in what it posts back, and it needs the head SHA before doing any work at all.
That is documented on the class.

## Related Issues

Fixes #468

## How Has This Been Tested?

Unit tests, validated red/green. A blanket `git stash push -- src/main/java` does not
compile here — the constructor gains three parameters, so the test class would not build —
so each behaviour was neutralised surgically and the test re-run. Verbatim red-phase output:

**1. Per-repo ignore filter** — reverted `respectPerRepoIgnores(task.target(), COMMAND,
diffFormatter().reviewableFiles(files))` to the old `diffFormatter().reviewableFiles(files)`:

````
DocGenerationServiceTest.postsNoSuggestionForAFileOnlyThePerRepoIgnorePatternExcludes
org.mockito.exceptions.verification.NeverWantedButInvoked:

reviewClient.createPullRequestComment(
    <any>, <any>, <any>, <any>, <any integer>, <any>
);
Never wanted here:
-> at ...DocGenerationServiceTest.postsNoSuggestionForAFileOnlyThePerRepoIgnorePatternExcludes
But invoked here:
-> at ...DocGenerationService.postInline(DocGenerationService.java:452) with arguments:
   [token gh-abc, application/vnd.github+json, owner, repo, 7,
    CreatePullRequestCommentRequest[commitId=headsha1234567, body=**📝 Documentation for `hop(int)`**

```suggestion
/** Hops. */
public int hop(int n) {
```
, path=src/Other.java, line=1, side=RIGHT, startLine=null, startSide=null]]
````

```
DocGenerationServiceTest.reportsNoFilesWhenEveryChangedFileIsOutOfScopeForTheRepository
org.opentest4j.AssertionFailedError: expected: <📝 ThrillhouseBot found no reviewable changed
files to document in this PR.> but was: <📝 ThrillhouseBot could not generate documentation
for this PR. Please try `/add-docs` again.>
```

`src/Other.java` is reviewable under the global list (empty in that test) and excluded only
by the pattern the repository declared, so the failure is specifically about per-repo globs
— and it shows the exact harm: a committable suggestion handed out on an ignored path.

**2. Global ignore behaviour unchanged** — kept `respectPerRepoIgnores` but dropped the
global filter feeding it (`respectPerRepoIgnores(task.target(), COMMAND, files)`):

````
DocGenerationServiceTest.keepsTheGlobalIgnoreListWorkingForARepositoryWithNoOwnSettings
org.opentest4j.AssertionFailedError:
...
### docs/README.md (modified, +1 -0)
```diff
@@
+hi
```
... ==> expected: <false> but was: <true>
````

**3. Batching replaces the line cap** — restored the old whole-PR line-capped render as the
text sent to the model:

````
DocGenerationServiceTest.documentsFilesThatTheLineCapWouldHaveDroppedEntirely
org.opentest4j.AssertionFailedError:
## Overview: 2 files (+9 -0)

### src/Foo.java (modified, +6 -0)
```diff
@@ -0,0 +1,6 @@
(patch truncated — 6 lines omitted)
```

(diff truncated at 8 lines — 1 files omitted)
 ==> expected: <true> but was: <false>
````

```
DocGenerationServiceTest.plansOneBatchPerSliceOfTheChangeSetRatherThanOneCallOverTheWholeRender
org.opentest4j.AssertionFailedError: ... ==> expected: <false> but was: <true>
```

```
DocGenerationServiceTest.keepsTheDocsFromTheBatchesThatSucceededWhenOneBatchFails
Wanted but not invoked:
commentClient.createComment(...);
Actually, there were zero interactions with this mock.
```

The first is the acceptance criterion verbatim: under the line cap `src/Other.java` is
dropped entirely ("1 files omitted") and its declaration never reaches the model.

**4. Plan-sourced disclosure, budget message, planner failure** — dropped `disclosure(plan)`
from the summary, replaced `NOT_COVERED` with `NOTHING_TO_DOCUMENT`, and let a planner
failure fall through to the outer catch:

```
DocGenerationServiceTest.appendsPartialCoverageDisclosureNamingTheFilesNoBatchCouldCover
org.opentest4j.AssertionFailedError: 📝 ThrillhouseBot added **1** documentation
suggestion(s) for changed symbols. Review each one and commit the suggestions you want to
keep. ==> expected: <true> but was: <false>
```

```
DocGenerationServiceTest.reportsTheBudgetRatherThanAVerdictWhenNoFileFitsABatch
org.opentest4j.AssertionFailedError: 📝 ThrillhouseBot found no changed symbols that need
documentation in this PR. ==> expected: <true> but was: <false>
```

```
DocGenerationServiceTest.reportsFailureWhenBatchPlanningThrows
Wanted but not invoked:
commentClient.createComment(<any>, <any>, "owner", "repo", 7, <Capturing argument>);
Actually, there were zero interactions with this mock.
```

**5. Post-time guards** — the comment cap (`if (suggestions + notes >= cap)`) and the
declaration-retention guard (`if (!preservesExistingCode(doc))`) each stubbed out:

```
DocGenerationServiceTest.keepsTheCommentCapOverTheDocsMergedFromEveryBatch
org.mockito.exceptions.verification.TooManyActualInvocations:
reviewClient.createPullRequestComment(...);
Wanted 1 time: ... But was 2 times:
-> at ...DocGenerationService.postInline(DocGenerationService.java:453)
-> at ...DocGenerationService.postInline(DocGenerationService.java:453)
```

```
DocGenerationServiceTest.capsAtMaxReviewComments
org.mockito.exceptions.verification.TooManyActualInvocations: ... Wanted 1 time ... But was 2 times
```

````
DocGenerationServiceTest.disclosesCapDropEvenWhenNothingWasPosted
org.mockito.exceptions.verification.NeverWantedButInvoked: ... But invoked here:
-> at ...DocGenerationService.postInline(...) with arguments: [... body=**📝 Documentation for `bar`**

```suggestion
/** a */
public int bar(int x) {
```
, path=src/Foo.java, line=1, ...]]
````

```
DocGenerationServiceTest.keepsTheGuardsAcrossBatchesSoOnlyTheAnchorableDocIsPosted
org.mockito.exceptions.verification.TooManyActualInvocations
```

**6. Diff anchor guard** — stubbed out the exact-line anchor check:

````
DocGenerationServiceTest.doesNotPostSuggestionThatCannotAnchorCleanly(String, String)[1]
"declaration line is not in the diff"
org.mockito.exceptions.verification.NeverWantedButInvoked: ... But invoked here:
-> at ...DocGenerationService.postInline(...) with arguments: [... body=**📝 Documentation for `ghost`**

```suggestion
/** x */
whatever
```
...]]
````

**7. Soft-fail of the new resolution path** — replaced the `SoftLoaders.repoSettings(...)`
call in `AbstractPrSuggestionGenerator.respectPerRepoIgnores` with a direct
`repoSettingsResolver.resolve(...)`:

```
DocGenerationServiceTest.continuesWithTheGlobalIgnoreListWhenRepositorySettingsCannotBeResolved
Wanted but not invoked:
reviewClient.createPullRequestComment(<any>, <any>, <any>, <any>, <any integer>, <any>);
Actually, there were zero interactions with this mock.
```

**8. Cross-batch merge by `file:line`** — replaced the guarded merge in `generateEachBatch`
with an unconditional `seen.add(doc.file().strip() + ":" + doc.line()); merged.add(doc);`, so
a declaration two batches both documented is added twice:

```
DocGenerationServiceTest.postsOneCommentWhenTwoBatchesBothDocumentTheSameDeclaration
org.mockito.exceptions.verification.TooManyActualInvocations:

reviewClient.createPullRequestComment(
    <any>,
    <any>,
    <any>,
    <any>,
    <any integer>,
    <any>
);
Wanted 1 time:
-> at ...DocGenerationServiceTest.postsOneCommentWhenTwoBatchesBothDocumentTheSameDeclaration
But was 2 times:
-> at ...DocGenerationService.postInline(DocGenerationService.java:452)
-> at ...DocGenerationService.postInline(DocGenerationService.java:452)
```

Both batches return a doc for `src/Foo.java:1` — the collision the merge exists for, and the
harm it prevents: two inline comments on one declaration line.

**9. Per-batch parse guard, partial run** — deleted the `try`/`catch` around `parser.parse(raw)`
in `generateOne`, leaving a bare `return parser.parse(raw);`. One batch replies with prose, the
other with usable JSON; without the guard the `IllegalArgumentException` escapes to `handle`'s
outer catch and nothing at all is posted:

```
DocGenerationServiceTest.skipsABatchWhoseResponseWillNotParseAndKeepsTheOthers
Wanted but not invoked:
reviewClient.createPullRequestComment(
    <any>,
    <any>,
    "owner",
    "repo",
    7,
    <Capturing argument: CreatePullRequestCommentRequest>
);
-> at ...DocGenerationServiceTest.capturedInlineComment(DocGenerationServiceTest.java:190)
Actually, there were zero interactions with this mock.
```

**10. Per-batch parse guard, total failure** — same neutralisation, with no batch parsing at
all. The maintainer must still get the failure notice rather than silence:

```
DocGenerationServiceTest.reportsFailureWhenNoBatchResponseWillParse
Wanted but not invoked:
commentClient.createComment(
    <any>,
    <any>,
    "owner",
    "repo",
    7,
    <Capturing argument: CreateCommentRequest>
);
-> at ...DocGenerationServiceTest.postedSummary(DocGenerationServiceTest.java:183)
Actually, there were zero interactions with this mock.
```

Every production change was restored after each step and the class re-run green
(`DocGenerationServiceTest`: 45 tests, 0 failures).

Sections 8–10 were added after the first CI run: `codecov/patch` reported 95.06% on the patch,
and the two gaps were exactly the branches those tests now pin — the cross-batch dedupe branch
at `DocGenerationService.java:292` (the duplicate-drop side was never taken) and the per-batch
parse-failure catch at `DocGenerationService.java:322-324`. Patch coverage is now **100%
(81/81 lines, 0 missing, 0 partial)**, with no `codecov.yml` or threshold changes.

Build:

- `./mvnw -B spotless:apply` — clean
- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — **Tests run: 2327, Failures: 0, Errors: 0, Skipped: 0**

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

n/a

## Additional Notes

- `DocPostOutcome.skippedByCap` is **kept** — despite the shared name, it is the per-PR
  *comment* cap the acceptance criteria require, not the line cap. The line cap lived in
  `GeneratedDocs.omittedFiles` / `ReviewResult.truncationDisclosure(omittedFiles)`, and that
  is what was removed. `truncationDisclosure(int)` itself stays: `FollowUpDeltaSummary` and
  the review path still use it.
- Docs from two batches are deduplicated by `file:line`. Batches partition the file list so
  a collision is unusual, but a model can quote a file it saw named in another batch's
  context, and two inline comments on one declaration line would be noise.
- Non-postable docs are still merged rather than filtered during the reduce, so the summary
  keeps distinguishing "the model returned nothing" (`NOTHING_TO_DOCUMENT`) from "it returned
  something that could not be placed" (`COULD_NOT_PLACE`).
- `REVIEW_MAX_INPUT_TOKENS`'s README row still lists only review, `/improve`, `/describe` and
  `/changelog`; it already omitted `/generate-tests` before this PR, so correcting it is left
  as a separate docs fix rather than widened here.
