### PR TITLE
fix(review): keep real findings in the previous-findings context across a zero-finding round

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -130,8 +130,10 @@ public class FollowUpAnalyzer {
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       List<String> olderAiResponseJsons,
       BotIdentity botIdentity) {
+    var previous = parseResponse(previousAiResponseJson);
     return buildPreviousFindingsContext(
-        parsePreviousFindings(previousAiResponseJson),
+        previous.findings(),
+        isPersistedResponse(previous),
         priorReviews,
         inlineComments,
         parsePreviousResponses(olderAiResponseJsons),
@@ -141,20 +143,80 @@ public class FollowUpAnalyzer {
   /**
    * Same as the JSON overload, but consumes findings already deserialized for this review so the
    * prior-response JSON is not re-parsed.
+   *
+   * <p>{@code previousResponsePersisted} is what keeps the review-body fallback in its lane. The
+   * fallback exists for sessions that persisted no readable AI response at all; inferring that from
+   * an empty rendering instead also caught the ordinary case of a persisted round that legitimately
+   * found nothing, and fed the bot's own review prose back to the model under a header saying "the
+   * following issues were flagged in the previous review" (#455). The two cases are told apart by
+   * the caller, which knows which one it is in, not by the shape of the output.
    */
   public String buildPreviousFindingsContext(
       List<ReviewResponse.Finding> previousFindings,
+      boolean previousResponsePersisted,
       List<GitHubReviewClient.ReviewResponse> priorReviews,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       List<ReviewResponse> olderAiResponses,
       BotIdentity botIdentity) {
     var structured = formatStructuredFindings(previousFindings, inlineComments, botIdentity);
     var answered = formatAnsweredEarlier(olderAiResponses, inlineComments, botIdentity);
-    if (!structured.isEmpty()) {
+    if (!structured.isEmpty() || previousResponsePersisted) {
       return structured + answered;
     }
     var fallback = buildPreviousFindingsContext(priorReviews, botIdentity);
     return fallback + answered;
+  }
+
+  /**
+   * The prior round the current review reports on: the newest persisted round that actually raised
+   * findings, or an empty list when none did.
+   *
+   * <p>A round that legitimately found nothing has no findings of its own to be reported on, so
+   * treating it as "the previous round" evicted the still-open set entirely — the finding raised
+   * two rounds ago dropped out of the prompt, out of {@code previous_findings_status}, and out of
+   * every id-keyed consumer, and could never be marked resolved again (#455). Skipping such a round
+   * carries the open set forward.
+   *
+   * <p>The round's own list is returned <em>whole</em>, deliberately: every id stays exactly the
+   * 1-based position the finding had when it was posted, which is the index its inline comment's
+   * hidden marker carries and the id space {@code previous_findings_status} references. Filtering
+   * out findings a later round already closed would renumber the rest and break both.
+   *
+   * @param priorAiResponses every completed prior round's parsed response, newest first
+   */
+  public static List<ReviewResponse.Finding> effectivePreviousFindings(
+      List<ReviewResponse> priorAiResponses) {
+    var index = effectivePreviousRoundIndex(priorAiResponses);
+    return index < 0 ? List.of() : priorAiResponses.get(index).findings();
+  }
+
+  /**
+   * Position of {@link #effectivePreviousFindings}'s round in {@code priorAiResponses} (newest
+   * first), or {@code -1} when no prior round raised anything.
+   */
+  public static int effectivePreviousRoundIndex(List<ReviewResponse> priorAiResponses) {
+    if (priorAiResponses == null) {
+      return -1;
+    }
+    for (var i = 0; i < priorAiResponses.size(); i++) {
+      var response = priorAiResponses.get(i);
+      if (response != null && !response.findings().isEmpty()) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Whether a parsed round is a response the bot actually persisted, as opposed to the shared blank
+   * stand-in {@link #parseResponse} substitutes for a missing or unparseable one. Reference
+   * identity is the discriminator on purpose: a round that legitimately found nothing parses into
+   * its own instance — equal to the stand-in, but not the same object — and telling those two apart
+   * is exactly what keeps the review-body fallback out of a zero-finding round. It also lets
+   * callers reuse the single parse they already did rather than parsing the JSON a second time.
+   */
+  public static boolean isPersistedResponse(ReviewResponse response) {
+    return response != null && response != EMPTY_RESPONSE;
   }
 
   /**
@@ -934,19 +996,27 @@ public class FollowUpAnalyzer {
   /**
    * The still-open prior findings keyed by content (a finding carried across rounds is held at most
    * once; insertion order is preserved for stable, deterministic output). Each round closes what
-   * the next round's status addressed, and {@code currentStatuses} — which reports on the newest
-   * prior round — drops everything the current round accounted for.
+   * the next round's status addressed, and {@code currentStatuses} — which reports on the round
+   * {@link #effectivePreviousFindings} named — drops everything the current round accounted for.
+   *
+   * <p>The round a {@code previous_findings_status} block reports on is the newest <em>earlier</em>
+   * round that actually raised findings, not simply the round before it. A round that found nothing
+   * exposes no ids to reference, so the next round is shown — and reports on — the last round that
+   * did. Pairing a status block with an empty round instead left every id unmappable, so nothing
+   * ever closed and the held set drifted upward with each further round (#455).
    */
   private Map<String, OpenFinding> openFindingsAcrossRounds(
       List<ReviewResponse> chrono, List<ReviewResponse.PreviousFindingStatus> currentStatuses) {
     var open = new LinkedHashMap<String, OpenFinding>();
-    for (var i = 0; i < chrono.size(); i++) {
-      if (i > 0) {
-        closeAddressed(open, chrono.get(i - 1).findings(), chrono.get(i).previousFindingsStatus());
+    var reportedRound = List.<ReviewResponse.Finding>of();
+    for (var round : chrono) {
+      closeAddressed(open, reportedRound, round.previousFindingsStatus());
+      addOpenFindings(open, round.findings());
+      if (!round.findings().isEmpty()) {
+        reportedRound = round.findings();
       }
-      addOpenFindings(open, chrono.get(i).findings());
     }
-    closeReported(open, chrono.get(chrono.size() - 1).findings(), currentStatuses);
+    closeReported(open, reportedRound, currentStatuses);
     return open;
   }
 
@@ -1186,7 +1256,9 @@ public class FollowUpAnalyzer {
 
   /**
    * Fallback context built from the last bot review body, for sessions without a persisted AI
-   * response. The body carries no structured findings, so this is best-effort only.
+   * response. The body carries no structured findings, so this is best-effort only — and a body the
+   * bot generated about its own verdict carries nothing at all, so it is dropped rather than
+   * offered to the model as a prior finding ({@link #isSelfAuthoredStatusBody}).
    */
   public String buildPreviousFindingsContext(
       List<GitHubReviewClient.ReviewResponse> priorReviews, BotIdentity botIdentity) {
@@ -1201,8 +1273,42 @@ public class FollowUpAnalyzer {
 
     // The prompt template provides the lead-in sentence; emit only the review body
     var body = lastBotReview.get().body();
-    return body != null ? body : "";
+    if (body == null || isSelfAuthoredStatusBody(body)) {
+      return "";
+    }
+    return body;
   }
+
+  /**
+   * Whether a bot review body is the bot's own verdict prose rather than review content. The prompt
+   * frames whatever this fallback returns as "the following issues were flagged in the previous
+   * review … determine if each is resolved, unresolved, or justified", so a sentence the bot wrote
+   * about its own verdict would be handed back to it as an issue to account for, and re-counted
+   * every round (#455). The bot must never treat its own output as its input.
+   *
+   * <p>Recognition is by the body's first non-blank line against the producers' own constants — the
+   * unresolved-previous status sentence, the clean-review message, the two CI-hold notices, and the
+   * partial-review banner — so the check cannot drift from the text it recognizes. A body a human
+   * (or an older, findings-carrying review) wrote starts with none of them and is preserved.
+   */
+  static boolean isSelfAuthoredStatusBody(String body) {
+    var first = body.lines().map(String::strip).filter(line -> !line.isEmpty()).findFirst();
+    if (first.isEmpty()) {
+      return true;
+    }
+    var line = first.get();
+    return ReviewResult.isUnresolvedPreviousMessage(line)
+        || line.startsWith(ReviewResult.NO_ISSUES_CI_PENDING_LEAD_IN)
+        || line.startsWith(ReviewResult.NO_ISSUES_CI_UNREADABLE_LEAD_IN)
+        || line.startsWith(ReviewResult.TRUNCATION_NOTICE_LEAD_IN)
+        || line.startsWith(ZERO_ISSUES_FIRST_LINE);
+  }
+
+  /**
+   * First line of {@link PrSummaryGenerator#ZERO_ISSUES_MESSAGE} — the clean-review celebration.
+   */
+  private static final String ZERO_ISSUES_FIRST_LINE =
+      PrSummaryGenerator.ZERO_ISSUES_MESSAGE.lines().findFirst().orElse("");
 
   /**
    * Converts AI response's previous_findings_status into ReviewResult statuses, keeping only the

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -192,7 +192,10 @@ public class FollowUpAnalyzer {
 
   /**
    * Position of {@link #effectivePreviousFindings}'s round in {@code priorAiResponses} (newest
-   * first), or {@code -1} when no prior round raised anything.
+   * first), or {@code -1} when no prior round raised anything. An absent list, and an absent slot
+   * within one, count as rounds that raised nothing: this is the id space every downstream consumer
+   * keys off, so it degrades to "no previous round" rather than failing the review — the same way
+   * {@link #parsePreviousResponses} and {@link #toStatuses} treat absent input.
    */
   public static int effectivePreviousRoundIndex(List<ReviewResponse> priorAiResponses) {
     if (priorAiResponses == null) {
@@ -214,6 +217,9 @@ public class FollowUpAnalyzer {
    * its own instance — equal to the stand-in, but not the same object — and telling those two apart
    * is exactly what keeps the review-body fallback out of a zero-finding round. It also lets
    * callers reuse the single parse they already did rather than parsing the JSON a second time.
+   *
+   * <p>An absent response is the same absence a missing or unparseable one is, and so is not
+   * persisted either.
    */
   public static boolean isPersistedResponse(ReviewResponse response) {
     return response != null && response != EMPTY_RESPONSE;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
@@ -153,11 +153,14 @@ public class ReviewContextLoader {
     }
 
     /**
-     * Findings from the newest prior AI response (empty when this is a first review or the prior
-     * JSON was missing/unparseable). Parsed once in {@link #load}.
+     * The prior findings this round reports on — the newest prior AI response that actually raised
+     * findings, so a round that legitimately found nothing does not evict the still-open set or its
+     * ids ({@link FollowUpAnalyzer#effectivePreviousFindings}). Empty on a first review, when every
+     * prior JSON was missing/unparseable, or when no prior round found anything. Parsed once in
+     * {@link #load}.
      */
     public List<ReviewResponse.Finding> previousFindingsList() {
-      return priorAiResponses.isEmpty() ? List.of() : priorAiResponses.get(0).findings();
+      return FollowUpAnalyzer.effectivePreviousFindings(priorAiResponses);
     }
   }
 
@@ -221,22 +224,40 @@ public class ReviewContextLoader {
     // gate, approve backstop, and later thread matching all reuse these objects.
     List<ReviewResponse> priorAiResponses =
         followUpAnalyzer.parsePreviousResponses(priorAiResponseJsons);
+    // The round this review reports on is the newest prior round that actually raised findings: a
+    // round that legitimately found nothing exposes no ids, and treating it as "the previous round"
+    // dropped the still-open finding out of the prompt and out of every id-keyed consumer (#455).
+    // Everything derived from it — the rendered context, the id space, the raw JSON the supersede
+    // pass re-reads — is taken from that one round, so the three cannot drift apart. When no round
+    // raised anything there is nothing to skip past, and the newest round keeps both roles exactly
+    // as before.
+    var previousRoundIndex =
+        Math.max(FollowUpAnalyzer.effectivePreviousRoundIndex(priorAiResponses), 0);
     String previousAiResponseJson =
-        priorAiResponseJsons.isEmpty() ? null : priorAiResponseJsons.get(0);
+        priorAiResponseJsons.isEmpty() ? null : priorAiResponseJsons.get(previousRoundIndex);
     List<ReviewResponse> olderAiResponses =
-        priorAiResponses.size() > 1
-            ? priorAiResponses.subList(1, priorAiResponses.size())
+        previousRoundIndex + 1 < priorAiResponses.size()
+            ? priorAiResponses.subList(previousRoundIndex + 1, priorAiResponses.size())
             : List.of();
     List<GitHubReviewClient.PullRequestComment> inlineComments =
         hasContext
             ? fetchPullRequestComments(auth, req.owner(), req.repo(), req.prNumber())
             : List.of();
-    List<ReviewResponse.Finding> latestFindings =
-        priorAiResponses.isEmpty() ? List.of() : priorAiResponses.get(0).findings();
+    List<ReviewResponse.Finding> previousFindingsSource =
+        FollowUpAnalyzer.effectivePreviousFindings(priorAiResponses);
+    // The review-body fallback is for sessions carrying no readable AI response at all. Once any
+    // prior round parsed, the bot's own review prose must never stand in for structured findings.
+    boolean previousResponsePersisted =
+        priorAiResponses.stream().anyMatch(FollowUpAnalyzer::isPersistedResponse);
     String previousFindings =
         hasContext
             ? followUpAnalyzer.buildPreviousFindingsContext(
-                latestFindings, priorReviews, inlineComments, olderAiResponses, botIdentity)
+                previousFindingsSource,
+                previousResponsePersisted,
+                priorReviews,
+                inlineComments,
+                olderAiResponses,
+                botIdentity)
             : "";
 
     var instructions =

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -475,9 +475,7 @@ public class ReviewPublisher {
     var sb = new StringBuilder();
     boolean ciHeld = false;
     if (!result.offendingCiChecks().isEmpty()) {
-      sb.append(
-          "ThrillhouseBot found no issues in this PR, but some checks are still pending or"
-              + " failed:\n");
+      sb.append(ReviewResult.NO_ISSUES_CI_PENDING_LEAD_IN).append("\n");
       for (var check : result.offendingCiChecks()) {
         String status = check.isFailing() ? "failed" : CI_PENDING;
         sb.append("- Check **").append(check.name()).append("** is ").append(status).append("\n");
@@ -485,9 +483,7 @@ public class ReviewPublisher {
       ciHeld = true;
     }
     if (result.ciUnreadable()) {
-      sb.append(
-          "ThrillhouseBot found no issues in this PR, but the CI status could not be read, so"
-              + " approval is held until it can be confirmed.\n");
+      sb.append(ReviewResult.NO_ISSUES_CI_UNREADABLE_LEAD_IN).append("\n");
       ciHeld = true;
     }
     if (unresolved > 0) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -207,12 +207,44 @@ public record ReviewResult(
   // A backstop-held finding may have no inline thread (its line was outside the diff when raised),
   // hence the "where one exists" qualifier.
   public static String unresolvedPreviousMessage(long unresolved) {
-    return String.format(
-        "No new issues in this revision, but %d previous finding(s) remain unresolved — "
-            + "fix them, or reply on their review thread (where one exists) with why they are"
-            + " deferred.",
-        unresolved);
+    return UNRESOLVED_PREVIOUS_PREFIX + unresolved + UNRESOLVED_PREVIOUS_SUFFIX;
   }
+
+  private static final String UNRESOLVED_PREVIOUS_PREFIX = "No new issues in this revision, but ";
+
+  private static final String UNRESOLVED_PREVIOUS_SUFFIX =
+      " previous finding(s) remain unresolved — fix them, or reply on their review thread (where"
+          + " one exists) with why they are deferred.";
+
+  /**
+   * Whether {@code text} is {@link #unresolvedPreviousMessage(long)} for some count — the bot's own
+   * sentence about previous findings, which carries no finding of its own. Recognizing it is what
+   * lets the previous-findings context reject a review body the bot wrote itself instead of
+   * offering it to the model as an issue "flagged in the previous review" (#455).
+   */
+  public static boolean isUnresolvedPreviousMessage(String text) {
+    if (text == null) {
+      return false;
+    }
+    var stripped = text.strip();
+    return stripped.startsWith(UNRESOLVED_PREVIOUS_PREFIX)
+        && stripped.endsWith(UNRESOLVED_PREVIOUS_SUFFIX);
+  }
+
+  /**
+   * Lead-in of the no-new-findings review body posted when CI checks hold approval back. Shared
+   * with {@link ReviewPublisher} so the recognizer above cannot drift from the producer.
+   */
+  static final String NO_ISSUES_CI_PENDING_LEAD_IN =
+      "ThrillhouseBot found no issues in this PR, but some checks are still pending or failed:";
+
+  /** Lead-in of the no-new-findings review body posted when the CI status could not be read. */
+  static final String NO_ISSUES_CI_UNREADABLE_LEAD_IN =
+      "ThrillhouseBot found no issues in this PR, but the CI status could not be read, so approval"
+          + " is held until it can be confirmed.";
+
+  /** Lead-in of {@link #truncationNotice(int, TruncationDetail)}'s partial-review banner. */
+  static final String TRUNCATION_NOTICE_LEAD_IN = "> ⚠️ **Large PR — partial review.**";
 
   /**
    * The shared "N file(s) were omitted …" clause, so the review banner and the on-demand-command
@@ -239,8 +271,8 @@ public record ReviewResult(
    */
   public static String truncationNotice(int omittedFiles, TruncationDetail detail) {
     return String.format(
-        "> ⚠️ **Large PR — partial review.** %s; the findings and verdict below cover only the"
-            + " reviewed portion.%n%n",
+        TRUNCATION_NOTICE_LEAD_IN
+            + " %s; the findings and verdict below cover only the reviewed portion.%n%n",
         coverageGapClause(omittedFiles, detail));
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -221,6 +221,9 @@ public record ReviewResult(
    * sentence about previous findings, which carries no finding of its own. Recognizing it is what
    * lets the previous-findings context reject a review body the bot wrote itself instead of
    * offering it to the model as an issue "flagged in the previous review" (#455).
+   *
+   * <p>Both ends are required, because everything this accepts is discarded: a body that only opens
+   * with the same words is a human review carrying a real finding. Absent text matches nothing.
    */
   public static boolean isUnresolvedPreviousMessage(String text) {
     if (text == null) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -758,7 +758,8 @@ class FollowUpAnalyzerTest {
     assertTrue(analyzer.matchFindingThreads(List.of(), List.of(), BOT_ID).isEmpty());
 
     var ctx =
-        analyzer.buildPreviousFindingsContext(previous, List.of(), List.of(), List.of(), BOT_ID);
+        analyzer.buildPreviousFindingsContext(
+            previous, true, List.of(), List.of(), List.of(), BOT_ID);
     assertTrue(ctx.contains("src/A.java"));
     assertTrue(ctx.contains("src/B.java"));
 
@@ -766,7 +767,7 @@ class FollowUpAnalyzerTest {
     assertEquals(
         "",
         analyzer.buildPreviousFindingsContext(
-            (List<ReviewResponse.Finding>) null, List.of(), List.of(), List.of(), BOT_ID));
+            (List<ReviewResponse.Finding>) null, false, List.of(), List.of(), List.of(), BOT_ID));
 
     // Older rounds with no maintainer reply contribute nothing to the answered-earlier section.
     var older =
@@ -776,12 +777,12 @@ class FollowUpAnalyzerTest {
                     + "\"title\":\"Old\",\"description\":\"d\",\"suggestion_old\":\"o\","
                     + "\"suggestion_new\":\"n\"}],\"previous_findings_status\":[],\"summary\":null}"));
     var withOlder =
-        analyzer.buildPreviousFindingsContext(previous, List.of(), List.of(), older, BOT_ID);
+        analyzer.buildPreviousFindingsContext(previous, true, List.of(), List.of(), older, BOT_ID);
     assertTrue(withOlder.contains("src/A.java"));
     assertFalse(withOlder.contains("Answered in earlier rounds"));
     assertTrue(
         analyzer
-            .buildPreviousFindingsContext(previous, List.of(), List.of(), null, BOT_ID)
+            .buildPreviousFindingsContext(previous, true, List.of(), List.of(), null, BOT_ID)
             .contains("src/A.java"));
 
     assertTrue(
@@ -1809,6 +1810,69 @@ class FollowUpAnalyzerTest {
         """;
 
     assertEquals("", analyzer.buildPreviousFindingsContext(json, List.of(), BOT_ID));
+  }
+
+  private static List<GitHubReviewClient.ReviewResponse> botReviews(String body) {
+    return List.of(
+        new GitHubReviewClient.ReviewResponse(
+            1L, body, "COMMENTED", "abc", new GitHubReviewClient.ReviewResponse.User(BOT)));
+  }
+
+  /**
+   * #455 — on PR #449 round 2 found nothing and posted the bot's own "N previous finding(s) remain
+   * unresolved …" sentence as its review body; round 3's previous-findings section was that
+   * sentence verbatim, under a header telling the model those were issues flagged in the previous
+   * review. Neither path may hand the bot's own prose back to it: not the zero-finding round (which
+   * has a persisted response and must therefore render nothing), and not the legitimate
+   * no-persisted-response fallback (which must discard a body the bot generated itself).
+   */
+  @Test
+  void previousFindingsContextShouldNeverCarryTheBotsOwnStatusBody() {
+    var reviews = botReviews(ReviewResult.unresolvedPreviousMessage(1));
+    var zeroFindingRound =
+        """
+        {"findings": [], "previous_findings_status": [], "summary": null}
+        """;
+
+    assertEquals(
+        "",
+        analyzer.buildPreviousFindingsContext(zeroFindingRound, reviews, BOT_ID),
+        "a persisted round that legitimately found nothing must render no previous findings");
+    assertEquals(
+        "",
+        analyzer.buildPreviousFindingsContext(null, reviews, BOT_ID),
+        "the review-body fallback must discard a body the bot wrote about its own verdict");
+  }
+
+  /**
+   * Every review body the bot generates for a no-new-findings round is its own output, so none of
+   * them may be offered as a prior finding. A body it did not generate still is.
+   */
+  @Test
+  void reviewBodyFallbackShouldDropEveryBotGeneratedBodyAndKeepTheRest() {
+    assertEquals(
+        "",
+        analyzer.buildPreviousFindingsContext(
+            botReviews(PrSummaryGenerator.ZERO_ISSUES_MESSAGE), BOT_ID));
+    assertEquals(
+        "",
+        analyzer.buildPreviousFindingsContext(
+            botReviews(ReviewResult.NO_ISSUES_CI_PENDING_LEAD_IN + "\n- Check **build** is failed"),
+            BOT_ID));
+    assertEquals(
+        "",
+        analyzer.buildPreviousFindingsContext(
+            botReviews(ReviewResult.NO_ISSUES_CI_UNREADABLE_LEAD_IN), BOT_ID));
+    assertEquals(
+        "",
+        analyzer.buildPreviousFindingsContext(
+            botReviews(ReviewResult.truncationNotice(3)), BOT_ID));
+    assertEquals("", analyzer.buildPreviousFindingsContext(botReviews("   \n\n"), BOT_ID));
+    assertEquals(
+        "1. [HIGH] src/A.java:10 — Unsafe regex",
+        analyzer.buildPreviousFindingsContext(
+            botReviews("1. [HIGH] src/A.java:10 — Unsafe regex"), BOT_ID),
+        "a legacy body carrying real findings is still the only context such a session has");
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -25,6 +25,7 @@ import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -1873,6 +1874,54 @@ class FollowUpAnalyzerTest {
         analyzer.buildPreviousFindingsContext(
             botReviews("1. [HIGH] src/A.java:10 — Unsafe regex"), BOT_ID),
         "a legacy body carrying real findings is still the only context such a session has");
+
+    var humanEcho = "No new issues in this revision, but the null check on line 12 is still wrong.";
+    assertEquals(
+        humanEcho,
+        analyzer.buildPreviousFindingsContext(botReviews(humanEcho), BOT_ID),
+        "a body that only opens like the generated sentence carries a real finding and is kept");
+  }
+
+  /**
+   * The round-selection helpers are the id space every downstream consumer keys off, so an absent
+   * or unreadable round must degrade to "no previous round" rather than throw mid-review. Matches
+   * how the rest of this class treats absent input ({@code parsePreviousResponses(null)}, {@code
+   * toStatuses(null)}).
+   */
+  @Test
+  void effectivePreviousRoundHelpersShouldTreatAbsentRoundsAsNoPreviousRound() {
+    assertEquals(-1, FollowUpAnalyzer.effectivePreviousRoundIndex(null));
+    assertTrue(FollowUpAnalyzer.effectivePreviousFindings(null).isEmpty());
+
+    var rounds = new ArrayList<ReviewResponse>();
+    rounds.add(null);
+    rounds.add(analyzer.parseResponse(PREVIOUS_JSON));
+    assertEquals(
+        1,
+        FollowUpAnalyzer.effectivePreviousRoundIndex(rounds),
+        "an unreadable slot is skipped, not mistaken for the round that raised findings");
+    assertEquals("src/A.java", FollowUpAnalyzer.effectivePreviousFindings(rounds).get(0).file());
+  }
+
+  /**
+   * #455 — the review-body fallback is gated on whether the bot persisted a response at all, and
+   * {@link FollowUpAnalyzer#isPersistedResponse} is the discriminator. A missing or unparseable
+   * response is not persisted; a round that legitimately found nothing is, even though the two
+   * carry identical (empty) findings.
+   */
+  @Test
+  void isPersistedResponseShouldSeparateAStoredRoundFromAMissingOne() {
+    assertFalse(FollowUpAnalyzer.isPersistedResponse(null));
+    assertFalse(FollowUpAnalyzer.isPersistedResponse(analyzer.parseResponse(null)));
+    assertFalse(FollowUpAnalyzer.isPersistedResponse(analyzer.parseResponse("   ")));
+    assertFalse(
+        FollowUpAnalyzer.isPersistedResponse(analyzer.parseResponse("{not json")),
+        "an unparseable response is the same absence as a missing one");
+    assertTrue(
+        FollowUpAnalyzer.isPersistedResponse(
+            analyzer.parseResponse(
+                "{\"findings\":[],\"previous_findings_status\":[],\"summary\":null}")),
+        "a round that legitimately found nothing did persist a response");
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.config.ActiveModelSettings;
 import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
@@ -27,6 +28,7 @@ import dev.thiagogonzaga.thrillhousebot.github.*;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -1151,7 +1153,7 @@ class ReviewContextLoaderTest {
       when(followUpAnalyzer.parsePreviousResponses(List.of(priorJson, olderJson)))
           .thenReturn(parsed);
       when(followUpAnalyzer.buildPreviousFindingsContext(
-              anyList(), any(), any(), any(), any(BotIdentity.class)))
+              anyList(), anyBoolean(), any(), any(), any(), any(BotIdentity.class)))
           .thenReturn("ctx");
       stubLoad(
           List.of(
@@ -1170,10 +1172,196 @@ class ReviewContextLoaderTest {
       verify(followUpAnalyzer)
           .buildPreviousFindingsContext(
               eq(parsed.get(0).findings()),
+              eq(true),
               any(),
               any(),
               eq(parsed.subList(1, parsed.size())),
               any(BotIdentity.class));
+    }
+  }
+
+  /**
+   * #455 — a follow-up round that finds nothing must not evict the finding raised before it. These
+   * drive {@link ReviewContextLoader#load} with the real {@link FollowUpAnalyzer}, so the section
+   * asserted on is the one the model is actually handed.
+   */
+  @Nested
+  class PreviousFindingsAcrossAZeroFindingRound {
+
+    private static final String CARRIED_FILE =
+        "src/main/java/dev/thiagogonzaga/thrillhousebot/github/RepoSettingsResolver.java";
+    private static final String OTHER_FILE =
+        "src/main/java/dev/thiagogonzaga/thrillhousebot/github/RepoSettingsParser.java";
+    private static final String CARRIED_TITLE =
+        "Undecodable content causes fallback to alternate config name";
+    private static final String OTHER_TITLE = "Unbounded YAML document size";
+    private static final String CARRIED_ANCHOR = "var name = decode(content);";
+
+    private static String findingJson(String file, int line, String title) {
+      return "{\"risk\":\"medium\",\"file\":\""
+          + file
+          + "\",\"line\":"
+          + line
+          + ",\"title\":\""
+          + title
+          + "\",\"description\":\"The first existing config file must be selected.\","
+          + "\"suggestion_old\":\""
+          + CARRIED_ANCHOR
+          + "\"}";
+    }
+
+    /** Round 1 of the PR #449 sequence: one MEDIUM finding, summary-only (no inline thread). */
+    private static final String ROUND_ONE_JSON =
+        "{\"findings\":["
+            + findingJson(CARRIED_FILE, 166, CARRIED_TITLE)
+            + "],\"previous_findings_status\":[],\"summary\":null}";
+
+    private static final String ROUND_ONE_TWO_FINDINGS_JSON =
+        "{\"findings\":["
+            + findingJson(CARRIED_FILE, 166, CARRIED_TITLE)
+            + ","
+            + findingJson(OTHER_FILE, 42, OTHER_TITLE)
+            + "],\"previous_findings_status\":[],\"summary\":null}";
+
+    /** Round 2: no new issues, reporting round 1's finding still unresolved. */
+    private static final String ROUND_TWO_JSON =
+        "{\"findings\":[],\"previous_findings_status\":"
+            + "[{\"id\":1,\"status\":\"unresolved\",\"note\":\"still there\"}],\"summary\":null}";
+
+    private static ReviewOrchestrator.ReviewRequest request() {
+      return new ReviewOrchestrator.ReviewRequest(
+          "owner",
+          "repo",
+          1,
+          "headsha1",
+          "Title",
+          "body",
+          "basesha1",
+          "main",
+          99L,
+          true,
+          "main",
+          false);
+    }
+
+    private ReviewContextLoader realAnalyzerLoader() {
+      return new ReviewContextLoader(
+          prClient,
+          reviewClient,
+          commentClient,
+          instructionsResolver,
+          repoSettingsResolver,
+          projectStackResolver,
+          diffFormatter,
+          labeler,
+          new FollowUpAnalyzer(new ObjectMapper()),
+          new BugFixContextResolver(commentClient),
+          configKeyContextResolver,
+          patchCoverageResolver,
+          sessionPersistence,
+          BotIdentity.from(List.of(BOT_LOGIN)),
+          activeModel);
+    }
+
+    /** Round 2 posted the bot's own "1 previous finding(s) remain unresolved" body, as on #449. */
+    private void stubRoundThree(List<String> priorJsons) {
+      when(prClient.getPullRequestFiles(any(), any(), eq("owner"), eq("repo"), eq(1)))
+          .thenReturn(
+              List.of(
+                  new GitHubPullRequestClient.FileDiff(
+                      CARRIED_FILE, "modified", 1, 0, 1, "@@ -166 +166 @@\n+" + CARRIED_ANCHOR)));
+      when(prClient.getPullRequest(any(), any(), eq("owner"), eq("repo"), eq(1)))
+          .thenReturn(
+              new GitHubPullRequestClient.PullRequestDetails(
+                  "Title",
+                  "body",
+                  new GitHubPullRequestClient.Ref("headsha1"),
+                  new GitHubPullRequestClient.Ref("basesha1"),
+                  1,
+                  1,
+                  0));
+      when(reviewClient.listReviews(any(), any(), eq("owner"), eq("repo"), eq(1)))
+          .thenReturn(
+              List.of(
+                  new GitHubReviewClient.ReviewResponse(
+                      1L,
+                      ReviewResult.unresolvedPreviousMessage(1),
+                      "COMMENTED",
+                      "abc",
+                      new GitHubReviewClient.ReviewResponse.User(BOT_LOGIN))));
+      when(commentClient.listComments(any(), any(), eq("owner"), eq("repo"), eq(1)))
+          .thenReturn(List.of());
+      when(reviewClient.listPullRequestComments(any(), any(), eq("owner"), eq("repo"), eq(1)))
+          .thenReturn(List.of());
+      when(sessionPersistence.findAllPriorAiResponseJsons(any(), eq(1), anyLong()))
+          .thenReturn(priorJsons);
+      when(instructionsResolver.resolve(any(), any(), any(), anyLong()))
+          .thenReturn(new InstructionsResolver.ResolvedInstructions("", ""));
+      when(labeler.fetchExistingLabels(any(), any(), any())).thenReturn(List.of());
+      when(projectStackResolver.resolve(any(), any(), any(), anyLong())).thenReturn("");
+    }
+
+    private ReviewContextLoader.ReviewContext loadRoundThree(List<String> priorJsons) {
+      stubRoundThree(priorJsons);
+      var session = ReviewSession.create("owner/repo", 1, "Title", "headsha1");
+      session.id = 1L;
+      return realAnalyzerLoader().load("auth", request(), session, "owner/repo");
+    }
+
+    @Test
+    void findingFromRoundOneSurvivesAZeroFindingRoundNumberedAndInTheIdSpace() {
+      var ctx = loadRoundThree(List.of(ROUND_TWO_JSON, ROUND_ONE_JSON));
+
+      assertEquals(
+          1,
+          ctx.previousFindingsList().size(),
+          "the zero-finding round evicted the still-open finding from the id space");
+      assertEquals(CARRIED_TITLE, ctx.previousFindingsList().get(0).title());
+      assertTrue(
+          ctx.previousFindings()
+              .contains("1. [MEDIUM] " + CARRIED_FILE + ":166 — " + CARRIED_TITLE),
+          "previous-findings section was: " + ctx.previousFindings());
+      assertFalse(
+          ctx.previousFindings().contains("remain unresolved"),
+          "the bot's own review body was handed back to it as a previous finding");
+    }
+
+    /**
+     * The #169 id-space pin: with nothing to carry, a zero-finding round leaves {@code previous}
+     * empty — {@link VerdictBuilder} passes it to {@code recheckDeclines} as the id space, and a
+     * pseudo-finding fabricated from a review body must never enter it.
+     */
+    @Test
+    void zeroFindingRoundWithNothingToCarryLeavesTheIdSpaceEmptyAndTheSectionAbsent() {
+      var ctx = loadRoundThree(List.of(ROUND_TWO_JSON));
+
+      assertTrue(
+          ctx.previousFindingsList().isEmpty(),
+          "a review body must never be turned into a previous finding");
+      assertEquals(
+          "",
+          ctx.previousFindings(),
+          "an absent previous-findings section is what suppresses the prompt block entirely");
+    }
+
+    /**
+     * The carry-forward pin: a real prior finding keeps the id its own round gave it — the id its
+     * inline comment's marker carries and the one {@code previous_findings_status} references.
+     */
+    @Test
+    void carriedFindingsKeepTheIdsTheirOwnRoundGaveThem() {
+      var analyzer = new FollowUpAnalyzer(new ObjectMapper());
+
+      var ctx = loadRoundThree(List.of(ROUND_TWO_JSON, ROUND_ONE_TWO_FINDINGS_JSON));
+      var previous = ctx.previousFindingsList();
+
+      assertEquals(
+          Map.of(1, CARRIED_FILE, 2, OTHER_FILE), analyzer.previousFindingFilesById(previous));
+      var unresolved =
+          analyzer.unresolvedFindings(
+              previous, List.of(new ReviewResponse.PreviousFindingStatus(2, "unresolved", "n")));
+      assertEquals(1, unresolved.size());
+      assertEquals(OTHER_FILE, unresolved.get(0).file(), "id 2 no longer names the same finding");
     }
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2157,7 +2157,7 @@ class ReviewOrchestratorTest {
         when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
             .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
         when(followUpAnalyzer.buildPreviousFindingsContext(
-                anyList(), any(), any(), any(), eq(BOT_ID)))
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn("Previous finding context");
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of("{\"round\":2}", "{\"round\":1}"));
@@ -2194,7 +2194,7 @@ class ReviewOrchestratorTest {
         verify(followUpAnalyzer).parsePreviousResponses(List.of("{\"round\":2}", "{\"round\":1}"));
         verify(followUpAnalyzer)
             .buildPreviousFindingsContext(
-                eq(List.of()), any(), any(), eq(List.of(round1)), eq(BOT_ID));
+                eq(List.of()), eq(true), any(), any(), eq(List.of(round1)), eq(BOT_ID));
         verify(followUpAnalyzer)
             .dropRepliedDuplicates(
                 any(), eq(List.of("{\"round\":2}", "{\"round\":1}")), any(), eq(BOT_ID));
@@ -4760,7 +4760,7 @@ class ReviewOrchestratorTest {
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
         when(followUpAnalyzer.buildPreviousFindingsContext(
-                anyList(), any(), any(), any(), eq(BOT_ID)))
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn("1. [MEDIUM] src/Main.java:10 — Dropped finding");
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -4790,7 +4790,7 @@ class ReviewOrchestratorTest {
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
         when(followUpAnalyzer.buildPreviousFindingsContext(
-                anyList(), any(), any(), any(), eq(BOT_ID)))
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn("previous context");
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -4798,7 +4798,7 @@ class ReviewOrchestratorTest {
         orchestrator.review(followUpRequest());
 
         verify(followUpAnalyzer)
-            .buildPreviousFindingsContext(anyList(), any(), any(), any(), eq(BOT_ID));
+            .buildPreviousFindingsContext(anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID));
       }
     }
 
@@ -4812,7 +4812,7 @@ class ReviewOrchestratorTest {
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
         when(followUpAnalyzer.buildPreviousFindingsContext(
-                anyList(), any(), any(), any(), eq(BOT_ID)))
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn("previous context");
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -4830,7 +4830,7 @@ class ReviewOrchestratorTest {
                 anyInt(),
                 argThat(req -> req.body().contains("ThrillhouseBot PR Summary")));
         verify(followUpAnalyzer)
-            .buildPreviousFindingsContext(anyList(), any(), any(), any(), eq(BOT_ID));
+            .buildPreviousFindingsContext(anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID));
       }
     }
 
@@ -4869,7 +4869,7 @@ class ReviewOrchestratorTest {
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
         when(followUpAnalyzer.buildPreviousFindingsContext(
-                anyList(), any(), any(), any(), eq(BOT_ID)))
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID)))
             .thenReturn("1. [MEDIUM] src/Main.java:10 — Dropped finding");
         // The silent drop: this round reports neither the finding nor a status for it.
         when(aiReviewService.review(any(ReviewSession.class), any()))

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -185,4 +185,42 @@ class ReviewResultTest {
     assertFalse(disclosure.contains("findings and verdict"), disclosure);
     assertFalse(disclosure.contains("partial review"), disclosure);
   }
+
+  /**
+   * #455 — the recognizer decides whether a prior review body is the bot's own verdict prose (and
+   * so must never be fed back to the model as a "previous finding") or someone else's text, which
+   * must be kept. It has to match every count the generator can emit, in the shape a stored review
+   * body arrives in.
+   */
+  @Test
+  void isUnresolvedPreviousMessageShouldMatchTheGeneratedSentenceForAnyCount() {
+    for (var count : List.of(1L, 2L, 47L)) {
+      assertTrue(
+          ReviewResult.isUnresolvedPreviousMessage(ReviewResult.unresolvedPreviousMessage(count)),
+          "count " + count);
+    }
+    assertTrue(
+        ReviewResult.isUnresolvedPreviousMessage(
+            "  " + ReviewResult.unresolvedPreviousMessage(3) + "  "),
+        "a stored review body keeps its surrounding whitespace");
+  }
+
+  /**
+   * #455 — everything the recognizer accepts is dropped from the previous-findings context, so a
+   * near miss costs a maintainer their review body. A human sentence that merely opens with the
+   * same words, or that reproduces only the generated ending, is not the bot's own prose.
+   */
+  @Test
+  void isUnresolvedPreviousMessageShouldRejectTextThatOnlyResemblesIt() {
+    assertFalse(ReviewResult.isUnresolvedPreviousMessage(null));
+    assertFalse(
+        ReviewResult.isUnresolvedPreviousMessage(
+            "No new issues in this revision, but the null check on line 12 is still wrong."),
+        "a human review opening with the same words carries a real finding and must be kept");
+    assertFalse(
+        ReviewResult.isUnresolvedPreviousMessage(
+            "Please fix them, or reply on their review thread (where one exists) with why they are"
+                + " deferred."),
+        "the generated ending without the generated opening is not the sentence");
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -843,4 +843,113 @@ class VerdictBuilderTest {
 
     assertEquals(ReviewState.COMMENT, result.reviewState());
   }
+
+  // ---- #455: a zero-finding round must neither evict, double-count, nor phantom-hold ----
+
+  private static final String CARRIED_FILE = "src/Carried.java";
+  private static final String CARRIED_ANCHOR = "var name = decode(content);";
+
+  private static final String CARRIED_ROUND_JSON =
+      "{\"findings\":[{\"risk\":\"medium\",\"file\":\""
+          + CARRIED_FILE
+          + "\",\"line\":166,\"title\":\"Undecodable content\",\"description\":\"d\","
+          + "\"suggestion_old\":\""
+          + CARRIED_ANCHOR
+          + "\"}],\"previous_findings_status\":[],\"summary\":null}";
+
+  /** Round 1: the one MEDIUM finding this PR ever raised. */
+  private static final ReviewResponse CARRIED_ROUND =
+      new ReviewResponse(
+          List.of(
+              new ReviewResponse.Finding(
+                  "medium", CARRIED_FILE, 166, "Undecodable content", "d", CARRIED_ANCHOR, null)),
+          List.of(),
+          null);
+
+  /**
+   * Round 3 of the PR #449 sequence, with round 2 having found nothing and reported round 1's
+   * finding {@code carriedStatus}. The anchor is still in the diff, so nothing is superseded and
+   * only the status bookkeeping decides the verdict.
+   */
+  private static ReviewContextLoader.ReviewContext afterZeroFindingRound(String carriedStatus) {
+    var zeroFindingRound =
+        new ReviewResponse(
+            List.of(),
+            List.of(new ReviewResponse.PreviousFindingStatus(1, carriedStatus, "n")),
+            null);
+    return new ReviewContextLoader.ReviewContext(
+        List.of(),
+        "diff",
+        "",
+        0,
+        List.of(),
+        List.of("{\"findings\":[]}", CARRIED_ROUND_JSON),
+        List.of(zeroFindingRound, CARRIED_ROUND),
+        false,
+        true,
+        CARRIED_ROUND_JSON,
+        List.of(),
+        "",
+        new InstructionsResolver.ResolvedInstructions("", ""),
+        PathScopedInstructions.NONE,
+        List.of(),
+        "",
+        "",
+        "",
+        "",
+        List.of(new FileDiff(CARRIED_FILE, "modified", 1, 0, 1, "")),
+        () ->
+            new DiffLineResolver(
+                Map.of(CARRIED_FILE, "@@ -166,1 +166,1 @@\n-old\n+" + CARRIED_ANCHOR)),
+        null);
+  }
+
+  /**
+   * #455 — one finding was ever raised on the PR, so exactly one may be reported unresolved. The
+   * model's own status and the deterministic backstop each held it once, because the backstop
+   * mapped the current round's ids over the zero-finding round instead of the round they name.
+   */
+  @Test
+  void unresolvedCountAcrossAZeroFindingRoundStaysAtTheOneRealFinding() {
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var stillUnresolved =
+        new ReviewResponse(
+            List.of(),
+            List.of(new ReviewResponse.PreviousFindingStatus(1, "unresolved", "still there")),
+            null);
+
+    var result =
+        builderWithRealAnalyzer(summaryGenerator)
+            .build(afterZeroFindingRound("unresolved"), stillUnresolved, CI_CLEAR, plan);
+
+    assertEquals(
+        1,
+        result.unresolvedPreviousCount(),
+        "the unresolved count must equal the number of distinct real findings still open");
+  }
+
+  /**
+   * #455 — the PR's only prior finding is reported resolved this round, so nothing genuine is
+   * outstanding and approval must return. Before the fix the backstop could not see that report
+   * (its ids did not map through the zero-finding round) and a phantom held APPROVE open forever.
+   */
+  @Test
+  void resolvedPriorFindingNoLongerPhantomHoldsApproveAfterAZeroFindingRound() {
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var resolvedNow =
+        new ReviewResponse(
+            List.of(),
+            List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed")),
+            null);
+
+    var result =
+        builderWithRealAnalyzer(summaryGenerator)
+            .build(afterZeroFindingRound("unresolved"), resolvedNow, CI_CLEAR, plan);
+
+    assertEquals(0, result.unresolvedPreviousCount());
+    assertEquals(
+        ReviewState.APPROVE,
+        result.reviewState(),
+        "a PR with no genuine outstanding findings must be approvable again");
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

When a follow-up review round produced **zero** findings, the next round's `## Previous Review Findings` section was filled with the previous bot review's **body text verbatim** — including the bot's own `"No new issues in this revision, but N previous finding(s) remain unresolved …"` boilerplate — while the real prior finding vanished from tracking. The unresolved count then drifted upward every round and `VerdictBuilder` demoted APPROVE → COMMENT indefinitely.

Three defects, all in the context-construction path:

1. **The review-body fallback fired on the wrong condition.** `FollowUpAnalyzer.buildPreviousFindingsContext(...)` selected it whenever the structured rendering came out empty, which is true both when there is genuinely no persisted AI response (its documented purpose) *and* when a persisted round legitimately found nothing. The caller now passes that fact explicitly (`previousResponsePersisted`) instead of it being inferred from the shape of the output.

2. **The fallback offered the bot's own prose as findings.** Even in the legitimate no-persisted-response case, a review body the bot generated about its own verdict carries no finding, so presenting it under *"the following issues were flagged … determine if it is resolved, unresolved, or justified"* is a category error. The fallback now discards a body it recognizes as self-authored, matched against the producers' own constants (the unresolved-previous sentence, the clean-review message, the two CI-hold notices, the partial-review banner) so the recognizer cannot drift from the text it recognizes. A body it did not generate is still passed through.

3. **The open set was re-derived from the latest round rather than carried.** A zero-finding round exposes no ids, so treating it as "the previous round" evicted the still-open finding from the prompt, from `previous_findings_status`, and from every id-keyed consumer. The prior round a review reports on is now the newest persisted round that actually *raised* findings, and the deterministic backstop pairs each round's `previous_findings_status` with that same round instead of blindly with the round before it — which is why the count could never come back down (the ids never mapped, so nothing ever closed).

**Depth chosen.** The issue's suggested fix (3) — carry-forward — is implemented in the form that does not destabilise the id space the #169 decline re-check depends on: the effective previous round's list is carried **whole**, so every id stays exactly the 1-based position the finding had when it was posted, which is the index its inline comment's hidden `thrillhousebot:finding=N` marker carries. Filtering closed findings out of the carried list (the other reading of "carry forward") would renumber the survivors and silently break marker-based thread matching, so it is deliberately not done. Accumulating findings across rounds that *each* raised some remains the backstop's job, unchanged.

### Files

- `FollowUpAnalyzer.java` — explicit `previousResponsePersisted` flag on the context builder; `effectivePreviousFindings` / `effectivePreviousRoundIndex` (skip zero-finding rounds); `isPersistedResponse` (tells a parsed empty round from the blank stand-in without a second parse); `isSelfAuthoredStatusBody` guard on the review-body fallback; backstop replay now pairs a status block with the newest earlier round that raised findings.
- `ReviewContextLoader.java` — resolves that round once, and derives the rendered context, the id space (`previousFindingsList()`), the raw JSON the supersede pass re-reads, and the older-rounds slice from it, so the three cannot drift apart.
- `ReviewResult.java` — `isUnresolvedPreviousMessage(...)` plus shared lead-in constants for the CI-hold and partial-review bodies, so the guard above matches text the producers own.
- `ReviewPublisher.java` — `noIssuesBody` now builds from those shared constants (text unchanged, byte for byte).

## Related Issues

Fixes #455

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Eleven new tests, each validated red → green. Because the tests reference the new API, plain `git stash push -- src/main/java` yields a compile failure rather than an assertion; the production change was therefore neutralized *behaviourally* instead — the four changed decisions reverted to their old form with the new signatures kept — so every test fails on its assertion. Verbatim red-phase output (`?` is the console rendering the em dash / emoji):

```
FollowUpAnalyzerTest.previousFindingsContextShouldNeverCarryTheBotsOwnStatusBody:1837 a persisted round that legitimately found nothing must render no previous findings ==> expected: <> but was: <No new issues in this revision, but 1 previous finding(s) remain unresolved ? fix them, or reply on their review thread (where one exists) with why they are deferred.>
FollowUpAnalyzerTest.reviewBodyFallbackShouldDropEveryBotGeneratedBodyAndKeepTheRest:1853 expected: <> but was: <Everything's coming up Thrillhouse! ?

No issues found in this PR.>
ReviewContextLoaderTest.findingFromRoundOneSurvivesAZeroFindingRoundNumberedAndInTheIdSpace the zero-finding round evicted the still-open finding from the id space ==> expected: <1> but was: <0>
ReviewContextLoaderTest.zeroFindingRoundWithNothingToCarryLeavesTheIdSpaceEmptyAndTheSectionAbsent an absent previous-findings section is what suppresses the prompt block entirely ==> expected: <> but was: <No new issues in this revision, but 1 previous finding(s) remain unresolved ? fix them, or reply on their review thread (where one exists) with why they are deferred.>
ReviewContextLoaderTest.carriedFindingsKeepTheIdsTheirOwnRoundGaveThem expected: <{2=.../RepoSettingsParser.java, 1=.../RepoSettingsResolver.java}> but was: <{}>
VerdictBuilderTest.unresolvedCountAcrossAZeroFindingRoundStaysAtTheOneRealFinding:925 the unresolved count must equal the number of distinct real findings still open ==> expected: <1> but was: <2>
VerdictBuilderTest.resolvedPriorFindingNoLongerPhantomHoldsApproveAfterAZeroFindingRound:949 expected: <0> but was: <1>
```

Restoring the production change turns all seven green.

Four further tests landed in `a763f28` to close the `codecov/patch` gap, covering the absent-input branches of the new helpers (plus one added assertion on the existing `reviewBodyFallback…` test). Seven mutations in total, each neutralizing one guard or conjunct in the production method and nothing else:

```
dropped `if (priorAiResponses == null) return -1;`
FollowUpAnalyzerTest.effectivePreviousRoundHelpersShouldTreatAbsentRoundsAsNoPreviousRound:1893 ? NullPointer Cannot invoke "java.util.List.size()" because "priorAiResponses" is null

dropped `response != null &&` from the round-selection loop
FollowUpAnalyzerTest.effectivePreviousRoundHelpersShouldTreatAbsentRoundsAsNoPreviousRound:1901 ? NullPointer Cannot invoke "dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse.findings()" because "response" is null

dropped `response != null &&` from isPersistedResponse
FollowUpAnalyzerTest.isPersistedResponseShouldSeparateAStoredRoundFromAMissingOne:1914 expected: <false> but was: <true>

isPersistedResponse: reference identity `response != EMPTY_RESPONSE` weakened to `!response.equals(EMPTY_RESPONSE)`
FollowUpAnalyzerTest.isPersistedResponseShouldSeparateAStoredRoundFromAMissingOne:1920 a round that legitimately found nothing did persist a response ==> expected: <true> but was: <false>

dropped `if (text == null) return false;` from isUnresolvedPreviousMessage
ReviewResultTest.isUnresolvedPreviousMessageShouldRejectTextThatOnlyResemblesIt:215 ? NullPointer Cannot invoke "String.strip()" because "text" is null

dropped `&& stripped.endsWith(UNRESOLVED_PREVIOUS_SUFFIX)`
ReviewResultTest.isUnresolvedPreviousMessageShouldRejectTextThatOnlyResemblesIt:216 a human review opening with the same words carries a real finding and must be kept ==> expected: <false> but was: <true>
FollowUpAnalyzerTest.reviewBodyFallbackShouldDropEveryBotGeneratedBodyAndKeepTheRest:1879 a body that only opens like the generated sentence carries a real finding and is kept ==> expected: <No new issues in this revision, but the null check on line 12 is still wrong.> but was: <>

dropped `.strip()` from isUnresolvedPreviousMessage
ReviewResultTest.isUnresolvedPreviousMessageShouldMatchTheGeneratedSentenceForAnyCount:202 a stored review body keeps its surrounding whitespace ==> expected: <true> but was: <false>
```

The `equals()` mutation is the one worth keeping pinned: it is the obvious-looking simplification, and it silently puts the review-body fallback back into the exact path this PR removes it from, because a round that legitimately found nothing is *equal* to the blank stand-in without being the same object.

The three regression tests the issue names:

- **Round N raises a finding, round N+1 raises none → round N+2 still carries it, numbered, count stays at 1** — `ReviewContextLoaderTest.findingFromRoundOneSurvivesAZeroFindingRoundNumberedAndInTheIdSpace` (drives the real `load(...)` with the real `FollowUpAnalyzer`, asserting the section actually handed to the model) plus `VerdictBuilderTest.unresolvedCountAcrossAZeroFindingRoundStaysAtTheOneRealFinding`.
- **A body matching the `unresolvedPreviousMessage` shape never appears in `{{previousFindings}}`** — `FollowUpAnalyzerTest.previousFindingsContextShouldNeverCarryTheBotsOwnStatusBody`, covering both the zero-finding path and the legitimate fallback path; `reviewBodyFallbackShouldDropEveryBotGeneratedBodyAndKeepTheRest` extends it to every body the bot generates and pins that a body it did not generate is preserved.
- **A PR whose only prior finding was resolved returns to APPROVE** — `VerdictBuilderTest.resolvedPriorFindingNoLongerPhantomHoldsApproveAfterAZeroFindingRound`.

The two #169 pins:

- `ReviewContextLoaderTest.zeroFindingRoundWithNothingToCarryLeavesTheIdSpaceEmptyAndTheSectionAbsent` — with nothing to carry, `previous` stays empty and no pseudo-finding fabricated from a review body ever enters the id space `recheckDeclines` uses.
- `ReviewContextLoaderTest.carriedFindingsKeepTheIdsTheirOwnRoundGaveThem` — a real prior finding keeps the id its own round gave it across a zero-finding round, so `previous_findings_status` id 2 still names the same finding it always did.

Build:

- `./mvnw -B spotless:apply` — clean
- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — 2325 tests, 0 failures, 0 errors

Coverage: `codecov/patch` went 91.49% → 100% (47/47 lines, 0 misses, 0 partials). What was uncovered was the absent-input handling on the three new helpers — the `null` list and `null` slot guards in `effectivePreviousRoundIndex`, the `null` guard in `isPersistedResponse`, and the `null` guard plus the `endsWith` half of `isUnresolvedPreviousMessage`. All are now covered by the four tests above. No `codecov.yml`, `pom.xml`, or workflow file was changed.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Round 3 of PR #449, before this change (verbatim from the deployed app log):

```
## Previous Review Findings
The following issues were flagged in the previous review.
For each, determine if it is resolved, unresolved, or justified.
No new issues in this revision, but 1 previous finding(s) remain unresolved — fix them, or reply on their review thread (where one exists) with why they are deferred.
```

After this change the same round renders round 1's real finding, numbered `1.`, with its original id.

## Additional Notes

- No new configuration keys, so nothing to document in `README.md`.
- The user-facing review text is unchanged: the CI-hold and partial-review sentences moved into shared constants byte for byte, and existing assertions on them still pass.
- Deliberately out of scope, as the issue directs: the latent `Set.copyOf(plan.omittedFiles()).contains(file.filename())` NPE at `FindingPipeline.java:563`. It is untouched and still open.
- Also deliberately not attempted: accumulating open findings across rounds that each raised findings. That case is already covered by the deterministic backstop, and widening the numbered prompt list to span rounds would renumber findings away from their inline-comment markers.
- **A judgement call worth disagreeing with, if you do.** The absent-input guards the four coverage tests pin are structurally unreachable through the production path as it stands: `parsePreviousResponses` ends in `List.copyOf`, and `ReviewContext`'s compact constructor does too, so neither a `null` list nor a `null` element can actually reach `effectivePreviousRoundIndex` or `isPersistedResponse` today. I kept them and tested them rather than deleting them, on two grounds: they are `public static` methods rather than private helpers, and null-tolerance is the established convention of this class — `parsePreviousResponses(null)`, `toStatuses(null)` and `formatAnsweredEarlier(null)` all behave the same way and are already tested. Each guard now carries a javadoc sentence stating the contract, so the tests pin documented behaviour rather than an accident. The alternative — deleting the guards and letting the callers' `List.copyOf` be the only defence — is a defensible reading, and it is a small change in each of the three spots if preferred.