### PR TITLE
fix(review): stop null-hostile immutable collections from failing a review

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -560,7 +560,7 @@ public class FindingPipeline {
     var omitted = Set.copyOf(plan.omittedFiles());
     var clipped = Set.copyOf(plan.clippedFiles());
     for (var file : ctx.reviewableFiles()) {
-      if (omitted.contains(file.filename())) {
+      if (ReviewDiffFormatter.namesContain(omitted, file.filename())) {
         continue;
       }
       sb.append(file.filename())
@@ -571,7 +571,7 @@ public class FindingPipeline {
           .append(" -")
           .append(file.deletions())
           .append(
-              clipped.contains(file.filename())
+              ReviewDiffFormatter.namesContain(clipped, file.filename())
                   ? " — partially analyzed: clipped to fit the review call budget"
                   : "")
           .append(")\n");
@@ -661,11 +661,13 @@ public class FindingPipeline {
 
   /**
    * The file's parent directory, or a stable label for a path carrying no directory component —
-   * which also covers a blank one. A null path is not guarded here: the per-file loop above already
-   * dereferences the same name against an immutable set, so it could never reach this point.
+   * which also covers a blank one, and a null one. The directory breakdown runs ahead of the
+   * per-file rows, so this is the first place an unnamed file is dereferenced; a file with no path
+   * carries no directory component either, so it lands in the same bucket rather than failing the
+   * review.
    */
   private static String directoryOf(String path) {
-    var slash = path.lastIndexOf('/');
+    var slash = path == null ? -1 : path.lastIndexOf('/');
     return slash <= 0 ? "(repository root)" : path.substring(0, slash);
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -1245,15 +1245,22 @@ public class FollowUpAnalyzer {
 
   /**
    * Full persisted previous response, with empty (never null) findings and statuses on a missing or
-   * unparseable input — the backstop replay needs both lists, and the compact constructor of {@link
-   * ReviewResponse} guarantees non-null copies.
+   * unusable input — the backstop replay needs both lists, and the compact constructor of {@link
+   * ReviewResponse} guarantees non-null copies. Never returns null: a stored body that is the JSON
+   * literal {@code null} is syntactically valid, so Jackson returns Java null without throwing, and
+   * callers copy the result into immutable collections that reject null elements.
    */
   ReviewResponse parseResponse(String aiResponseJson) {
     if (aiResponseJson == null || aiResponseJson.isBlank()) {
       return EMPTY_RESPONSE;
     }
     try {
-      return mapper.readValue(aiResponseJson, ReviewResponse.class);
+      var parsed = mapper.readValue(aiResponseJson, ReviewResponse.class);
+      if (parsed == null) {
+        Log.warn("Previous AI response deserialized to null, falling back to review body context");
+        return EMPTY_RESPONSE;
+      }
+      return parsed;
     } catch (JsonProcessingException e) {
       Log.warn("Could not parse previous AI response, falling back to review body context", e);
       return EMPTY_RESPONSE;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
@@ -163,6 +163,18 @@ public class ReviewDiffFormatter {
     return globalGlobs.matches(filename);
   }
 
+  /**
+   * Whether a set of file names holds this file's name, tolerating a null name the way {@link
+   * IgnoreGlobs#matches(String)} does — {@code filename()} on a Jackson-deserialized {@link
+   * GitHubPullRequestClient.FileDiff} is not validated at construction (its {@code patch} and
+   * {@code previousFilename} siblings are legitimately null), and the name sets these lookups run
+   * against are immutable, whose {@code contains(null)} throws instead of returning false. A file
+   * with no name is simply not in the set.
+   */
+  static boolean namesContain(Set<String> names, String filename) {
+    return filename != null && names.contains(filename);
+  }
+
   /** Matches `**`-prefixed patterns against the file name and every sub-path of the file. */
   private static boolean matchesSuffix(PathMatcher suffix, Path path) {
     if (suffix == null) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -134,7 +134,9 @@ public class VerdictBuilder {
     var omittedNames = Set.copyOf(truncation.omittedFileNames());
     var changedFiles =
         toChangedFiles(
-            overviewFiles.stream().filter(f -> !omittedNames.contains(f.filename())).toList());
+            overviewFiles.stream()
+                .filter(f -> !ReviewDiffFormatter.namesContain(omittedNames, f.filename()))
+                .toList());
     // A model-reported "unresolved" whose targeted code left the diff (force-push) becomes
     // "superseded" before the gates run, so a vanished finding never holds APPROVE (#336).
     // Skip the DiffLineResolver when there are no statuses — first reviews and empty-status

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -652,6 +652,43 @@ class FindingPipelineTest {
     assertFalse(changedFiles.contains("b.java (modified, +2 -0 — partially"), changedFiles);
   }
 
+  /**
+   * #471 — {@code FileDiff.filename()} is not validated at construction, and the omitted/clipped
+   * lookups run against immutable sets whose {@code contains(null)} throws instead of answering
+   * false. An unnamed file must be treated as neither omitted nor clipped, matching the null guard
+   * the ignore globs already carry, rather than failing the whole review off the ack thread.
+   */
+  @Test
+  void anUnnamedReviewableFileIsNeitherOmittedNorClippedInTheSummaryOverview() {
+    var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
+    var ctx =
+        reviewContext(
+            List.of(),
+            List.of(
+                new FileDiff(null, "modified", 7, 0, 7, ""),
+                new FileDiff("a.java", "modified", 3, 0, 3, "")),
+            null);
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(batch("a.java"), batch("b.java")), List.of("z.java"), List.of("a.java"), true);
+    when(budgetPlanner.perCallInputBudget()).thenReturn(1_000_000);
+    when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
+    when(aiReviewService.summarize(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    var changedFiles = captor.getValue().changedFiles();
+    assertTrue(
+        changedFiles.contains("(modified, +7 -0)\n"),
+        "the unnamed file is kept as an ordinary row: not skipped as omitted, not marked clipped");
+    assertTrue(changedFiles.contains("a.java (modified, +3 -0 — partially analyzed"), changedFiles);
+    assertTrue(changedFiles.contains("z.java (omitted"), changedFiles);
+  }
+
   @Test
   void summaryFindingsJsonIsClampedToThePerCallBudget() throws Exception {
     var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -745,6 +745,30 @@ class FollowUpAnalyzerTest {
     assertEquals(2, parsed.get(0).findings().size());
   }
 
+  /**
+   * #471 — a persisted body that is the JSON literal {@code null} is syntactically valid, so
+   * Jackson returns Java null without throwing and the response never reached the parse-failure
+   * fallback. The null element then went straight into {@code List.copyOf}, which rejects it,
+   * failing every later review of that PR on the async thread. Unusable prior state must degrade to
+   * the empty response so the review proceeds.
+   */
+  @Test
+  void persistedResponseOfTheJsonLiteralNullDegradesToTheEmptyResponse() {
+    var parsed = analyzer.parsePreviousResponses(List.of("null", PREVIOUS_JSON));
+
+    assertEquals(2, parsed.size());
+    assertNotNull(parsed.get(0), "a literal-null body must not leave a null in the parsed list");
+    assertTrue(parsed.get(0).findings().isEmpty());
+    assertTrue(parsed.get(0).previousFindingsStatus().isEmpty());
+    assertFalse(
+        FollowUpAnalyzer.isPersistedResponse(parsed.get(0)),
+        "a literal-null body is the same absence as an unparseable one");
+    assertEquals(2, parsed.get(1).findings().size(), "the readable rounds still parse");
+    assertTrue(
+        analyzer.previousFindingFilesById("null").isEmpty(),
+        "the by-id lookup reads the same response and must not dereference null");
+  }
+
   @Test
   void preParsedApisReuseFindingsWithoutReReadingJson() {
     var previous = analyzer.parsePreviousResponses(List.of(PREVIOUS_JSON)).get(0).findings();

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
@@ -25,6 +25,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -744,6 +745,23 @@ class ReviewDiffFormatterTest {
 
       assertFalse(formatter.isIgnored(null));
       assertFalse(formatter.isIgnored("  "));
+    }
+
+    /**
+     * #471 — the name-set lookups the review path runs against {@code Set.copyOf(...)} must
+     * tolerate a null filename the same way the ignore globs above do. An immutable set throws on
+     * {@code contains(null)} rather than answering false, which failed whole reviews off the ack
+     * thread.
+     */
+    @Test
+    void shouldTreatANullFilenameAsAbsentFromAnImmutableNameSet() {
+      var names = Set.copyOf(List.of("src/Main.java"));
+
+      assertFalse(
+          ReviewDiffFormatter.namesContain(names, null),
+          "an unnamed file is simply not in the set");
+      assertTrue(ReviewDiffFormatter.namesContain(names, "src/Main.java"));
+      assertFalse(ReviewDiffFormatter.namesContain(names, "src/Other.java"));
     }
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -93,6 +93,13 @@ class VerdictBuilderTest {
 
   /** A context whose legacy diff render dropped {@code lineCapOmitted} files. */
   private static ReviewContextLoader.ReviewContext contextWithLineCapOmissions(int lineCapOmitted) {
+    return contextWithLineCapOmissions(
+        lineCapOmitted, List.of(new FileDiff("a.java", "modified", 1, 0, 1, "")));
+  }
+
+  /** Same context with a caller-supplied reviewable-file list. */
+  private static ReviewContextLoader.ReviewContext contextWithLineCapOmissions(
+      int lineCapOmitted, List<FileDiff> reviewableFiles) {
     return new ReviewContextLoader.ReviewContext(
         List.of(),
         "diff",
@@ -113,7 +120,7 @@ class VerdictBuilderTest {
         "",
         "",
         "",
-        List.of(new FileDiff("a.java", "modified", 1, 0, 1, "")),
+        reviewableFiles,
         () -> new DiffLineResolver(Map.of()),
         null);
   }
@@ -188,6 +195,33 @@ class VerdictBuilderTest {
     verify(summaryGenerator)
         .generate(anyInt(), anyInt(), anyInt(), rowsCaptor.capture(), any(), any());
     assertTrue(rowsCaptor.getValue().isEmpty(), rowsCaptor.getValue().toString());
+  }
+
+  /**
+   * #471 — the walkthrough filter is the third site that asks an immutable name set whether it
+   * holds a {@code FileDiff.filename()} that Jackson never validated. {@code contains(null)} throws
+   * there instead of answering false, so one unnamed file would fail the whole verdict on the async
+   * review thread. An unnamed file is simply not in the omitted set and keeps its row.
+   */
+  @Test
+  void anUnnamedFileIsNotTreatedAsOmittedFromTheWalkthroughRows() {
+    var ctx =
+        contextWithLineCapOmissions(
+            0,
+            List.of(
+                new FileDiff(null, "modified", 1, 0, 1, ""),
+                new FileDiff("a.java", "modified", 1, 0, 1, "")));
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of("a.java"), List.of(), true);
+    var rowsCaptor = ArgumentCaptor.forClass(List.class);
+
+    builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    verify(summaryGenerator)
+        .generate(anyInt(), anyInt(), anyInt(), rowsCaptor.capture(), any(), any());
+    assertEquals(
+        List.of(new PrSummaryGenerator.ChangedFile(null, "modified")),
+        rowsCaptor.getValue(),
+        "only the named omitted file is dropped; the unnamed one keeps its row");
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Two spots in the review path fed a possibly-`null` value into an immutable collection that rejects `null`. Both run **after the 200 ack**, on the async review thread, so the failure was not a bad review — it was *no* review, with nothing surfaced on the PR explaining why.

**1. A persisted response body of the JSON literal `null`.** `FollowUpAnalyzer.parseResponse` guarded the Java null and the blank string and caught `JsonProcessingException`, but `"null"` is syntactically valid JSON: Jackson returns Java `null` and throws nothing, so the parse-failure fallback was never reached. The caller put that null straight into `List.copyOf`, which rejects null elements — a stored session row containing those four characters failed every subsequent review of that PR, permanently, until the row was edited. It now degrades to `EMPTY_RESPONSE`, which is exactly what the `catch` directly above it already promised for unreadable prior state.

**2. `Set.copyOf(...).contains(<possibly-null filename>)`.** `GitHubPullRequestClient.FileDiff` is a Jackson-deserialized record with no compact constructor validating `filename`, and it deliberately tolerates nulls in its siblings (`patch` is null for binary files, `previousFilename` for non-renames). Meanwhile `ReviewDiffFormatter.IgnoreGlobs.matches` opens with an explicit `filename == null` guard. The two disagreed about whether a null filename was possible, and that disagreement was the actual defect.

This takes the side the codebase already established — **a null filename is tolerated and means "not matched"** — rather than adding validation to `FileDiff`. Validating at construction is the other reading, but it converts a silent null into a hard failure at parse time for *every* file the API returns, which is a much wider behavior change than the defect calls for. The contract now lives in one place, `ReviewDiffFormatter.namesContain`, next to the glob matcher that already stated it.

Three call sites move onto it:

| Site | Lookup |
| --- | --- |
| `FindingPipeline.changedFilesOverview` | `omitted.contains(...)` — reported in the issue |
| `FindingPipeline.changedFilesOverview` | `clipped.contains(...)` — reported in the issue |
| `VerdictBuilder.build` | `Set.copyOf(truncation.omittedFileNames()).contains(...)` — **a third instance, not in the issue**, in the same review path and equally null-hostile |

Two things worth flagging that the issue does not mention:

- **`plan.omittedFiles()` / `plan.clippedFiles()` cannot themselves contain null.** `DiffBudgetPlanner.BudgetPlan`'s compact constructor already runs `List.copyOf` on both, so `Set.copyOf(...)` in `FindingPipeline` can only ever fail on the `contains(null)` argument, never on the collection's contents. No extra guard is needed there.
- **`directoryOf` needed the same guard.** The directory breakdown that builds the scope header runs *ahead* of the per-file rows, so it dereferenced the unnamed file first and the `contains` guard alone would have been unreachable. Its comment claimed "a null path is not guarded here: the per-file loop above already dereferences the same name against an immutable set" — that had the ordering backwards. A file with no path carries no directory component either, so it lands in the existing `(repository root)` bucket.

## Related Issues

Fixes #471

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Four tests, each validated red/green by neutralizing **only** the production behavior it covers (surgically, one at a time — a blanket revert would have produced compile errors, which prove nothing) and confirming the failure, then restoring and confirming green.

**1. `FollowUpAnalyzerTest.persistedResponseOfTheJsonLiteralNullDegradesToTheEmptyResponse`**

Mutation: `parseResponse` returns `mapper.readValue(...)` directly again, without the null check.

```
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:220)
	at java.base/java.util.ImmutableCollections$List12.<init>(ImmutableCollections.java:590)
	at java.base/java.util.List.of(List.java:1168)
	at java.base/java.util.ImmutableCollections.listCopy(ImmutableCollections.java:191)
	at java.base/java.util.List.copyOf(List.java:1191)
	at dev.thiagogonzaga.thrillhousebot.review.FollowUpAnalyzer.parsePreviousResponses(FollowUpAnalyzer.java:1243)
	at dev.thiagogonzaga.thrillhousebot.review.FollowUpAnalyzerTest.persistedResponseOfTheJsonLiteralNullDegradesToTheEmptyResponse(FollowUpAnalyzerTest.java:757)
```

That is the exact `List.copyOf` line named in the issue. The test also pins `previousFindingFilesById("null")`, which reads the same response and would otherwise dereference the null.

**2. `ReviewDiffFormatterTest.GlobMatching.shouldTreatANullFilenameAsAbsentFromAnImmutableNameSet`**

Mutation: `namesContain` drops its `filename != null &&` and delegates straight to `names.contains(filename)`.

```
java.lang.NullPointerException: Cannot invoke "Object.equals(Object)" because "o" is null
	at java.base/java.util.ImmutableCollections$Set12.contains(ImmutableCollections.java:1036)
	at dev.thiagogonzaga.thrillhousebot.review.ReviewDiffFormatter.namesContain(ReviewDiffFormatter.java:175)
	at dev.thiagogonzaga.thrillhousebot.review.ReviewDiffFormatterTest$GlobMatching.shouldTreatANullFilenameAsAbsentFromAnImmutableNameSet(ReviewDiffFormatterTest.java:761)
```

Covers all three arms: null, present, and absent-but-named.

**3. `FindingPipelineTest.anUnnamedReviewableFileIsNeitherOmittedNorClippedInTheSummaryOverview`**

Same mutation as (2), driven through the real multi-call pipeline:

```
java.lang.NullPointerException: Cannot invoke "Object.equals(Object)" because "o" is null
	at java.base/java.util.ImmutableCollections$Set12.contains(ImmutableCollections.java:1036)
	at dev.thiagogonzaga.thrillhousebot.review.ReviewDiffFormatter.namesContain(ReviewDiffFormatter.java:175)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.changedFilesOverview(FindingPipeline.java:563)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.runMultiCall(FindingPipeline.java:235)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.run(FindingPipeline.java:113)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.anUnnamedReviewableFileIsNeitherOmittedNorClippedInTheSummaryOverview(FindingPipelineTest.java:682)
```

The same test also pins the `directoryOf` guard. Mutation: restore `path.lastIndexOf('/')` without the null check.

```
java.lang.NullPointerException: Cannot invoke "String.lastIndexOf(int)" because "path" is null
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.directoryOf(FindingPipeline.java:670)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.appendDirectoryBreakdown(FindingPipeline.java:636)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.changeScopeSummary(FindingPipeline.java:621)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.changedFilesOverview(FindingPipeline.java:559)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.runMultiCall(FindingPipeline.java:235)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.run(FindingPipeline.java:113)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.anUnnamedReviewableFileIsNeitherOmittedNorClippedInTheSummaryOverview(FindingPipelineTest.java:682)
```

Those two stack traces are the concrete evidence for the ordering claim above: the breakdown is reached first.

**4. `VerdictBuilderTest.anUnnamedFileIsNotTreatedAsOmittedFromTheWalkthroughRows`** — the third instance.

Same mutation as (2):

```
java.lang.NullPointerException: Cannot invoke "Object.equals(Object)" because "o" is null
	at java.base/java.util.ImmutableCollections$Set12.contains(ImmutableCollections.java:1036)
	at dev.thiagogonzaga.thrillhousebot.review.ReviewDiffFormatter.namesContain(ReviewDiffFormatter.java:175)
	at dev.thiagogonzaga.thrillhousebot.review.VerdictBuilder.lambda$build$0(VerdictBuilder.java:138)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:196)
```

It asserts the named omitted file is dropped from the walkthrough rows while the unnamed one keeps its row — the null case and the ordinary case in the same assertion.

Build gates:

```
./mvnw -B spotless:apply                                   # clean
./mvnw -B clean compile spotbugs:check spotless:check      # BugInstance size is 0, BUILD SUCCESS
./mvnw -B clean test                                       # Tests run: 2342, Failures: 0, Errors: 0, Skipped: 0
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A — see the red-phase stack traces above.

## Additional Notes

No config keys, no schema changes, no user-visible behavior change on today's inputs: GitHub always sends a filename, and no production session row holds a literal `null`. Every path this touches is the one that previously threw.

**Left for a follow-up rather than folded in.** `DiffBudgetPlanner` has two more sites that a null filename would still break, both *upstream* of the code changed here, and both needing a semantic decision this defect does not license:

- `renderAndSize` sorts with `.thenComparing(FileDiff::filename)`, which throws once two files tie on `additions + deletions`. Deciding where an unnamed file sorts is a design call, not a null guard.
- `omitted.add(s.file().filename())` feeds `BudgetPlan`'s `List.copyOf`, which rejects the null. Filtering it out would silently shrink `omittedFiles().size()` — the count that holds APPROVE in `VerdictBuilder` — so an unreviewed file could stop withholding approval. That trade needs its own issue.

Neither blocks this fix: a review can reach the sites changed here without passing through either (the sort does no comparisons on a single-file batch, and a file that fits its budget is never added to `omitted`). Happy to file them if you'd like.
