### PR TITLE
fix(review): guard /add-docs cross-batch merge with isPostable

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
@@ -288,8 +288,12 @@ public class DocGenerationService extends AbstractPrSuggestionGenerator {
       }
       for (var doc : response.docs()) {
         // Batches hold disjoint files, but a model can still quote a file it saw named in another
-        // batch's context — two comments on one declaration line would be noise on the PR.
-        if (seen.add(doc.file().strip() + ":" + doc.line())) {
+        // batch's context — two comments on one declaration line would be noise on the PR. The
+        // postability check gates the dedupe key: file is nullable, so keying on doc.file().strip()
+        // first would throw on a malformed entry (losing every valid entry in the same reply), and
+        // a non-postable entry consuming file:line would both block a later batch's valid
+        // suggestion for that declaration and leave a malformed reply reported as COULD_NOT_PLACE.
+        if (doc.isPostable() && seen.add(doc.file().strip() + ":" + doc.line())) {
           merged.add(doc);
         }
       }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
@@ -398,7 +398,8 @@ class DocGenerationServiceTest {
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("unpostableSuggestions")
-  void doesNotPostSuggestionThatCannotAnchorCleanly(String reason, String docsJson) {
+  void doesNotPostSuggestionThatCannotAnchorCleanly(
+      String reason, String docsJson, String expectedSummary) {
     prWithFiles(fooWithPatch());
     when(docGenerator.generate(any(), any(), any(), any())).thenReturn(docsJson);
 
@@ -406,43 +407,52 @@ class DocGenerationServiceTest {
 
     verify(reviewClient, never())
         .createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
-    assertEquals(DocGenerationService.COULD_NOT_PLACE, postedSummary());
+    assertEquals(expectedSummary, postedSummary());
   }
 
   static Stream<Arguments> unpostableSuggestions() {
+    // A postable doc the anchor resolver cannot place yields COULD_NOT_PLACE — real documentation
+    // was generated but did not map onto the diff. A non-postable (malformed) entry never reaches
+    // the merged list at all, so the run is empty of usable docs and reports NOTHING_TO_DOCUMENT
+    // rather than the force-push wording, which would misdescribe a simply malformed reply.
     return Stream.of(
         arguments(
             "declaration line is not in the diff",
             """
             {"docs":[{"file":"src/Foo.java","line":99,"symbol":"ghost",
             "suggestion_old":"whatever","suggestion_new":"/** x */\\nwhatever"}]}
-            """),
+            """,
+            DocGenerationService.COULD_NOT_PLACE),
         arguments(
             "replacement would drop the existing declaration line",
             """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {",
             "suggestion_new":"/** just a docstring, no code */"}]}
-            """),
+            """,
+            DocGenerationService.COULD_NOT_PLACE),
         arguments(
             "suggestion_new is blank (not postable)",
             """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {","suggestion_new":""}]}
-            """),
+            """,
+            DocGenerationService.NOTHING_TO_DOCUMENT),
         arguments(
             "suggestion_old is omitted (no anchor to verify against)",
             """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"","suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
-            """),
+            """,
+            DocGenerationService.NOTHING_TO_DOCUMENT),
         arguments(
             "file is not part of the diff",
             """
             {"docs":[{"file":"src/Other.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {",
             "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
-            """));
+            """,
+            DocGenerationService.COULD_NOT_PLACE));
   }
 
   @Test
@@ -965,6 +975,60 @@ class DocGenerationServiceTest {
 
     assertEquals(DocGenerationService.NO_FILES, postedSummary());
     verifyNoInteractions(docGenerator);
+  }
+
+  @Test
+  void postsTheValidDocWhenAnEarlierEntryInTheSameBatchOmitsItsFile() {
+    // A reply that omits "file" on one entry leaves that field null; the cross-batch merge must
+    // consult isPostable() before keying on file:line, or the .strip() throws an NPE that the outer
+    // catch swallows with only a log line — losing every valid entry in the same reply and posting
+    // no comment at all. The malformed entry is dropped; the valid one is still posted.
+    prWithFiles(fooWithPatch());
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenReturn(
+            """
+            {"docs":[
+              {"line":1,"symbol":"bar",
+               "suggestion_old":"public int bar(int x) {",
+               "suggestion_new":"/** a */\\npublic int bar(int x) {"},
+              {"file":"src/Foo.java","line":4,"symbol":"baz",
+               "suggestion_old":"public int baz(int y) {",
+               "suggestion_new":"/** b */\\npublic int baz(int y) {"}]}
+            """);
+
+    service.handle(task());
+
+    var inline = capturedInlineComment();
+    assertEquals("src/Foo.java", inline.path());
+    assertEquals(4, inline.line());
+    assertTrue(inline.body().contains("```suggestion"), inline.body());
+    assertTrue(postedSummary().contains("**1**"), postedSummary());
+  }
+
+  @Test
+  void aNonPostableEntryDoesNotConsumeTheDedupeKeyForALaterBatchsValidOne() {
+    // A non-postable doc for a declaration line must not reach the dedupe set: if it did, it would
+    // consume file:line and block a later batch's postable suggestion for the same declaration, and
+    // it would itself land in the merged list, making the summary report COULD_NOT_PLACE for a
+    // reply that was simply malformed. isPostable() gates the key, so the valid one still posts.
+    budgetWithDiffRoom(40);
+    prWithFiles(fooWithPatch(), otherFile());
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenReturn(
+            """
+            {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
+            "suggestion_old":"public int bar(int x) {","suggestion_new":""}]}
+            """)
+        .thenReturn(DOC_FOR_FOO);
+
+    service.handle(task());
+
+    var inline = capturedInlineComment();
+    assertEquals("src/Foo.java", inline.path());
+    assertEquals(1, inline.line());
+    var summary = postedSummary();
+    assertTrue(summary.contains("**1**"), summary);
+    assertNotEquals(DocGenerationService.COULD_NOT_PLACE, summary);
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

The cross-batch merge loop in `DocGenerationService.generateEachBatch` built its dedupe key as `doc.file().strip() + ":" + doc.line()` **before** any postability check. `DocGenerationResponse.DocSuggestion.file` is nullable — `isPostable()` exists precisely because `file`, `line`, `suggestion_old` and `suggestion_new` may be null/absent. A model reply that omits `"file"` on one entry therefore threw `NullPointerException` at the `.strip()`.

That call site is in `handle()`, **outside** `planOrReportFailure`'s try, so the throw landed in `handle()`'s outer `catch (RuntimeException)` which only logs. The maintainer who ran `/add-docs` got **no comment at all** (not even `GENERATION_FAILED`), and every valid entry in the same reply was silently lost. The sibling `/improve` guards the identical line with `improvement.isPostable() && seen.add(dedupeKey(improvement))`; `/add-docs` lost that guard when it was migrated onto the shared generator seam in #469.

The fix mirrors `PrImprovementService` — gate the dedupe key with `doc.isPostable()`:

```java
if (doc.isPostable() && seen.add(doc.file().strip() + ":" + doc.line())) {
  merged.add(doc);
}
```

This fixes three defects at once:
1. **The NPE** — a doc entry with null `file` no longer throws.
2. **Dedupe-key consumption** — a non-postable entry no longer consumes `file:line`, so it can no longer block a later batch's valid suggestion for the same declaration line.
3. **Misleading summary** — non-postable entries no longer reach `merged`, so the summary no longer reports `COULD_NOT_PLACE` ("This usually happens after a force-push") for a reply that was simply malformed; it correctly reports `NOTHING_TO_DOCUMENT`.

Change is confined to `DocGenerationService.java` and its test.

## Related Issues

Refs audit a3-P1 (validated HIGH regression introduced by #469). N/A for a tracked issue number.

## How Has This Been Tested?

Red/green, per finding, on the current base before and after the one-line fix.

### Test 1 — `postsTheValidDocWhenAnEarlierEntryInTheSameBatchOmitsItsFile`

A batch reply with two doc entries: the first omits `"file"` (parsed as null), the second is valid. Asserts the valid suggestion is still posted and a real comment is produced.

**Red (before fix)** — the NPE is thrown in the merge loop and swallowed by `handle()`'s outer catch, so nothing is posted. Captured verbatim from the run:

```
WARN  [...DocGenerationService] Failed to handle /add-docs on owner/repo #7: java.lang.NullPointerException: Cannot invoke "String.strip()" because the return value of "dev.thiagogonzaga.thrillhousebot.review.ai.DocGenerationResponse$DocSuggestion.file()" is null
```

and the test then fails on the missing post:

```
Wanted but not invoked:
reviewClient.createPullRequestComment(...);
Actually, there were zero interactions with this mock.
```

**Green (after fix)** — the null-`file` entry is dropped, the valid one is posted (`/add-docs posted 1 suggestion(s) and 0 note(s)`). Passes.

### Test 2 — `aNonPostableEntryDoesNotConsumeTheDedupeKeyForALaterBatchsValidOne`

Batch 1 returns a non-postable doc for `src/Foo.java:1` (blank `suggestion_new`); batch 2 returns a postable doc for the same `src/Foo.java:1`. Asserts the postable one is still posted and the summary is not `COULD_NOT_PLACE`.

**Red (before fix)** — the non-postable entry consumed the `file:line` key and suppressed the later valid suggestion; nothing was posted:

```
Wanted but not invoked:
reviewClient.createPullRequestComment(...);
Actually, there were zero interactions with this mock.
```

**Green (after fix)** — `isPostable()` gates the key, the non-postable entry is skipped, the valid suggestion posts. Passes.

### Existing test that pinned the defect

Two cases of the parameterized `doesNotPostSuggestionThatCannotAnchorCleanly` (`suggestion_new is blank`, `suggestion_old is omitted`) previously asserted `COULD_NOT_PLACE` — the exact misleading verdict this fix removes. They now assert `NOTHING_TO_DOCUMENT`, the correct verdict for a reply carrying no usable documentation. The postable-but-unanchorable cases still assert `COULD_NOT_PLACE`.

### Gates

- `./mvnw -B spotless:apply` — BUILD SUCCESS
- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — **Tests run: 2344, Failures: 0, Errors: 0, Skipped: 0**, BUILD SUCCESS

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Scope is limited to the `/add-docs` generator and its test; no unrelated files were touched or reformatted. One existing test was changed (not disabled) to assert the corrected summary verdict — explained above.