### PR TITLE
fix(review): harden follow-up trust and verdict accounting (audit a2)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -198,13 +198,32 @@ public interface GitHubReviewClient {
 
   record PullRequestCommentResponse(long id, String body, String path, Integer line) {}
 
-  /** An inline review comment; replies carry the root comment's id in {@code inReplyToId}. */
+  /**
+   * An inline review comment; replies carry the root comment's id in {@code inReplyToId}.
+   *
+   * <p>{@code authorAssociation} is GitHub's per-comment statement of the author's relationship to
+   * the repository ({@code OWNER}/{@code MEMBER}/{@code COLLABORATOR}/{@code CONTRIBUTOR}/{@code
+   * NONE}/…). The follow-up analyzer uses it to tell a write-capable maintainer's reply — which may
+   * clear an approve hold or overrule a finding — from a fork-PR author's, which may not.
+   */
   record PullRequestComment(
       long id,
       @JsonProperty("in_reply_to_id") Long inReplyToId,
       String path,
       String body,
-      ReviewResponse.User user) {}
+      ReviewResponse.User user,
+      @JsonProperty("author_association") String authorAssociation) {
+
+    /**
+     * Back-compat convenience for callers/tests that carry no author association. Defaults it to
+     * {@code null}, which the analyzer treats as not write-capable — the safe direction, since a
+     * comment with an unknown association must not clear a hold or overrule a finding.
+     */
+    public PullRequestComment(
+        long id, Long inReplyToId, String path, String body, ReviewResponse.User user) {
+      this(id, inReplyToId, path, body, user, null);
+    }
+  }
 
   record ReviewResponse(
       long id,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -1277,8 +1277,14 @@ public class FollowUpAnalyzer {
    * file to its rename target as {@link #hasVanished} does. A content-identical pure rename (blank
    * target) leaves the anchor resolvable at neither path but the finding unchanged, so it counts as
    * present — the same way {@link #addUnreportedVanished} keeps it {@code unresolved}.
+   *
+   * <p>The {@code file() == null} guard is defensive: {@link #holdableTarget} only passes cluster
+   * members, and {@link #addOpenFindings} admits a finding to a cluster only when {@link
+   * #findingKey} is non-null — which it never is for a null-file finding — so no production caller
+   * can reach it with a null file. Package-private (not {@code private}) so that contract can be
+   * pinned directly by a unit test rather than left as an unreachable branch.
    */
-  private static boolean isStillPresent(
+  static boolean isStillPresent(
       ReviewResponse.Finding finding,
       DiffLineResolver lineResolver,
       Map<String, String> renameTargets) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -1020,7 +1020,8 @@ public class FollowUpAnalyzer {
 
   /**
    * Same as the JSON overload, using prior responses already deserialized for this review so each
-   * persisted round is not re-parsed.
+   * persisted round is not re-parsed. Rename-blind overload; the verdict path uses the {@code
+   * renameTargets} variant below.
    */
   public List<ReviewResult.PreviousFindingStatus> unreportedUnresolvedStatusesFromParsed(
       List<ReviewResponse> priorAiResponses,
@@ -1028,13 +1029,32 @@ public class FollowUpAnalyzer {
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       DiffLineResolver lineResolver,
       BotIdentity botIdentity) {
+    return unreportedUnresolvedStatusesFromParsed(
+        priorAiResponses, currentStatuses, inlineComments, lineResolver, botIdentity, Map.of());
+  }
+
+  /**
+   * Rename-aware variant used by the review verdict path. A still-present finding whose file was
+   * renamed-and-edited lives at {@code renameTargets.get(finding.file())} in the current diff, not
+   * at its pre-rename path; {@link #supersedeVanished}/{@link #addUnreportedVanished} already map
+   * through {@code renameTargets}, so the backstop's presence check must too — otherwise a finding
+   * moved by a rename escapes both gates and sails past APPROVE (F5 — the sibling defect of F2,
+   * where one of two paths got the guard and the twin did not).
+   */
+  public List<ReviewResult.PreviousFindingStatus> unreportedUnresolvedStatusesFromParsed(
+      List<ReviewResponse> priorAiResponses,
+      List<ReviewResponse.PreviousFindingStatus> currentStatuses,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      DiffLineResolver lineResolver,
+      BotIdentity botIdentity,
+      Map<String, String> renameTargets) {
     if (priorAiResponses == null || priorAiResponses.isEmpty() || lineResolver == null) {
       return List.of();
     }
     var chrono = toChronological(priorAiResponses);
     var open = openFindingsAcrossRounds(chrono, currentStatuses);
     var clusters = clusterByIdentity(open);
-    return heldFromClusters(clusters, inlineComments, lineResolver, botIdentity);
+    return heldFromClusters(clusters, inlineComments, lineResolver, botIdentity, renameTargets);
   }
 
   /**
@@ -1103,10 +1123,12 @@ public class FollowUpAnalyzer {
       List<List<OpenFinding>> clusters,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       DiffLineResolver lineResolver,
-      BotIdentity botIdentity) {
+      BotIdentity botIdentity,
+      Map<String, String> renameTargets) {
     var held = new ArrayList<ReviewResult.PreviousFindingStatus>();
     for (var cluster : clusters) {
-      OpenFinding target = holdableTarget(cluster, inlineComments, lineResolver, botIdentity);
+      OpenFinding target =
+          holdableTarget(cluster, inlineComments, lineResolver, botIdentity, renameTargets);
       if (target != null) {
         held.add(
             new ReviewResult.PreviousFindingStatus(
@@ -1124,18 +1146,22 @@ public class FollowUpAnalyzer {
    * OpenFinding#id()}) plus the finding's own content rather than by title, so a null-title
    * finding's thread is still seen and a thread-less finding cannot bind to a different finding
    * that reused the same marker index in another round.
+   *
+   * <p>Presence is resolved through {@code renameTargets} the same way {@link #hasVanished} does:
+   * the finding's flagged code lives at its rename target, not its pre-rename path, when the file
+   * was renamed-and-edited (F5).
    */
   private OpenFinding holdableTarget(
       List<OpenFinding> cluster,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       DiffLineResolver lineResolver,
-      BotIdentity botIdentity) {
+      BotIdentity botIdentity,
+      Map<String, String> renameTargets) {
     OpenFinding target = null;
     boolean anyReplied = false;
     for (var member : cluster) {
       var finding = member.finding();
-      if (target == null
-          && lineResolver.isFindingPresent(finding.file(), finding.suggestionOld())) {
+      if (target == null && isStillPresent(finding, lineResolver, renameTargets)) {
         target = member;
       }
       if (answeredRootComment(finding, member.id(), inlineComments, botIdentity) != null) {
@@ -1143,6 +1169,26 @@ public class FollowUpAnalyzer {
       }
     }
     return anyReplied ? null : target;
+  }
+
+  /**
+   * Whether a finding's flagged code is still in the current diff, resolving a renamed-and-edited
+   * file to its rename target as {@link #hasVanished} does. A content-identical pure rename (blank
+   * target) leaves the anchor resolvable at neither path but the finding unchanged, so it counts as
+   * present — the same way {@link #addUnreportedVanished} keeps it {@code unresolved}.
+   */
+  private static boolean isStillPresent(
+      ReviewResponse.Finding finding,
+      DiffLineResolver lineResolver,
+      Map<String, String> renameTargets) {
+    if (finding.file() == null) {
+      return false;
+    }
+    var currentPath = renameTargets.getOrDefault(finding.file(), finding.file());
+    if (currentPath.isBlank()) {
+      return true;
+    }
+    return lineResolver.isFindingPresent(currentPath, finding.suggestionOld());
   }
 
   /** A still-open prior finding and the 1-based id it carried within the round that raised it. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -602,6 +602,20 @@ public class FollowUpAnalyzer {
         >= FindingDeduplicator.CONTENT_OVERLAP_THRESHOLD;
   }
 
+  /**
+   * A maintainer reply that may clear an approve hold, drop a re-raised finding, or overrule a
+   * decline — a non-bot reply whose author holds (or may hold) write access to the repository.
+   *
+   * <p>A reply's {@code author_association} is GitHub's per-comment statement of the author's
+   * relationship to the repo; only {@code OWNER}/{@code MEMBER}/{@code COLLABORATOR} can carry
+   * write access, so a fork-PR author's reply ({@code CONTRIBUTOR}/{@code NONE}/…) is not a
+   * maintainer decision and must not clear the backstop, delete a finding, or drive an override —
+   * it renders as context in the prompt only. This mirrors the cheap association prefilter {@code
+   * ManualReviewAuthorizer}/{@code FindingFeedbackCaptureService} apply before any write. The
+   * authoritative collaborator-permission call those services follow up with is not repeated here:
+   * these predicates run deep in the verdict path with no installation token in hand, and deferring
+   * a bot hold to an invited collaborator who engaged on the thread is the safe direction.
+   */
   private static boolean hasHumanReply(
       Long rootId,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
@@ -611,7 +625,21 @@ public class FollowUpAnalyzer {
             c ->
                 rootId.equals(c.inReplyToId())
                     && c.user() != null
-                    && !botIdentity.matches(c.user().login()));
+                    && !botIdentity.matches(c.user().login())
+                    && mayHoldWriteAccess(c.authorAssociation()));
+  }
+
+  /**
+   * GitHub {@code author_association} values a write-access holder can present. Any other value
+   * provably lacks write access — association precedence guarantees a collaborator/member is never
+   * reported as one of those — so a reply carrying it is not a maintainer decision.
+   */
+  private static final Set<String> WRITE_CAPABLE_ASSOCIATIONS =
+      Set.of("OWNER", "MEMBER", "COLLABORATOR");
+
+  private static boolean mayHoldWriteAccess(String authorAssociation) {
+    return authorAssociation != null
+        && WRITE_CAPABLE_ASSOCIATIONS.contains(authorAssociation.strip().toUpperCase(Locale.ROOT));
   }
 
   /** Maps each previous finding's prompt id to its bot root comment, for thread resolution. */
@@ -889,7 +917,11 @@ public class FollowUpAnalyzer {
     return RebuttalContradiction.find(finding, humanReplies.get(0), reviewedCode).orElse(null);
   }
 
-  /** Bodies of the maintainer replies on a thread, oldest first; bot replies are not rebuttals. */
+  /**
+   * Bodies of the maintainer replies on a thread, oldest first; bot replies are not rebuttals, and
+   * neither is a reply from an author without write access ({@link #mayHoldWriteAccess}) — a
+   * fork-PR author cannot supply the rebuttal the decline re-check reads.
+   */
   private static List<String> humanReplies(
       Long rootId,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
@@ -897,6 +929,7 @@ public class FollowUpAnalyzer {
     return inlineComments.stream()
         .filter(c -> rootId.equals(c.inReplyToId()))
         .filter(c -> c.user() != null && !botIdentity.matches(c.user().login()))
+        .filter(c -> mayHoldWriteAccess(c.authorAssociation()))
         .map(GitHubReviewClient.PullRequestComment::body)
         .filter(body -> body != null && !body.isBlank())
         .toList();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -344,18 +344,36 @@ public class FollowUpAnalyzer {
   }
 
   /**
-   * The bot's root inline comment for a finding. Preferred match: the hidden finding marker the bot
-   * embeds in every comment, which is unambiguous even when findings share a title. Fallback for
-   * comments posted before the marker existed: same file and the title in the body.
+   * The bot's root inline comment for a finding, for prompt context ({@link #appendThreadReplies}),
+   * thread resolution ({@link #matchFindingThreads}), and the decline re-check ({@link
+   * #declineContradiction}). Marker indices are per-round 1-based positions, so index {@code N}
+   * recurs every round; the same three-step content match {@link
+   * #answeredRootComment(ReviewResponse.Finding, int, List, BotIdentity)} uses for the
+   * safety-critical clearing decision applies here so a summary-only finding (no inline thread of
+   * its own that round, because {@link Finding#postsInline} routed it to the summary) does not bind
+   * to an <em>earlier, unrelated</em> round's same-index thread (F2 — the sibling defect of F5):
+   *
+   * <ol>
+   *   <li>the finding's own {@code finding=N} thread ({@code requireOwnContent}: its title, or its
+   *       description when it has no title, in the comment) — the unambiguous match;
+   *   <li>otherwise, when a {@code finding=N} comment <em>does</em> exist on the file it belongs to
+   *       a different finding (the index recurs across rounds), so nothing binds rather than
+   *       binding to it;
+   *   <li>only when no {@code finding=N} comment exists on the file at all does the title scan run,
+   *       for genuinely pre-marker comments.
+   * </ol>
    */
   private static Long rootCommentId(
       ReviewResponse.Finding finding,
       int findingId,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       BotIdentity botIdentity) {
-    Long markerRoot = markerRootComment(finding, findingId, false, inlineComments, botIdentity);
-    if (markerRoot != null) {
-      return markerRoot;
+    Long own = markerRootComment(finding, findingId, true, inlineComments, botIdentity);
+    if (own != null) {
+      return own;
+    }
+    if (markerRootComment(finding, findingId, false, inlineComments, botIdentity) != null) {
+      return null;
     }
     return rootCommentByTitle(finding, inlineComments, botIdentity);
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -158,7 +158,32 @@ public class FollowUpAnalyzer {
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       List<ReviewResponse> olderAiResponses,
       BotIdentity botIdentity) {
-    var structured = formatStructuredFindings(previousFindings, inlineComments, botIdentity);
+    return buildPreviousFindingsContext(
+        previousFindings,
+        previousResponsePersisted,
+        priorReviews,
+        inlineComments,
+        olderAiResponses,
+        botIdentity,
+        Set.of());
+  }
+
+  /**
+   * Variant that also skips prior findings a newer round already closed ({@code settledIds}, {@link
+   * #settledPreviousIds}) so the model is not re-shown a finding that has been settled and asked to
+   * re-account for it (#470). The settled entries keep their id slots — only their content is
+   * omitted — so the surviving ids do not shift.
+   */
+  public String buildPreviousFindingsContext(
+      List<ReviewResponse.Finding> previousFindings,
+      boolean previousResponsePersisted,
+      List<GitHubReviewClient.ReviewResponse> priorReviews,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      List<ReviewResponse> olderAiResponses,
+      BotIdentity botIdentity,
+      Set<Integer> settledIds) {
+    var structured =
+        formatStructuredFindings(previousFindings, inlineComments, botIdentity, settledIds);
     var answered = formatAnsweredEarlier(olderAiResponses, inlineComments, botIdentity);
     if (!structured.isEmpty() || previousResponsePersisted) {
       return structured + answered;
@@ -208,6 +233,42 @@ public class FollowUpAnalyzer {
       }
     }
     return -1;
+  }
+
+  /**
+   * Ids (1-based positions in the effective previous round) that a <em>newer</em> round already
+   * closed with a resolved/justified verdict, and that therefore must be treated as settled: not
+   * re-listed to the model as still open, and never re-emitted as {@code superseded} when their
+   * code later leaves the diff.
+   *
+   * <p>The effective previous round is the newest round that raised findings, so every round newer
+   * than it raised nothing and reports on it (ids reference that round). {@link
+   * #effectivePreviousFindings} returns that round's list <em>whole</em> — ids stay stable — so a
+   * later round's close is invisible to the id-keyed supersede/context passes; without this set
+   * {@link #addUnreportedVanished} re-supersedes a finding a newer round already resolved, which
+   * pins {@code hasSupersededPrevious} on and re-posts the summary every push while suppressing the
+   * follow-up delta (#470). This is the same {@code closeAddressed} replay the backstop does.
+   *
+   * @param priorAiResponses every completed prior round's parsed response, newest first
+   */
+  public static Set<Integer> settledPreviousIds(List<ReviewResponse> priorAiResponses) {
+    var index = effectivePreviousRoundIndex(priorAiResponses);
+    if (index <= 0) {
+      return Set.of();
+    }
+    var settled = new HashSet<Integer>();
+    for (var i = 0; i < index; i++) {
+      var round = priorAiResponses.get(i);
+      if (round == null) {
+        continue;
+      }
+      for (var status : round.previousFindingsStatus()) {
+        if (isAddressedVerdict(status.status())) {
+          settled.add(status.id());
+        }
+      }
+    }
+    return settled;
   }
 
   /**
@@ -289,7 +350,8 @@ public class FollowUpAnalyzer {
   private String formatStructuredFindings(
       List<ReviewResponse.Finding> previous,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      BotIdentity botIdentity) {
+      BotIdentity botIdentity,
+      Set<Integer> settledIds) {
     if (previous == null || previous.isEmpty()) {
       return "";
     }
@@ -297,6 +359,12 @@ public class FollowUpAnalyzer {
     var sb = new StringBuilder();
     var id = 1;
     for (var finding : previous) {
+      // A finding a newer round already closed keeps its id slot (so the surviving ids do not
+      // shift) but is not re-shown as open for the model to re-account for (#470).
+      if (settledIds.contains(id)) {
+        id++;
+        continue;
+      }
       sb.append(id)
           .append(". [")
           .append(finding.risk() == null ? "UNKNOWN" : finding.risk().toUpperCase(Locale.ROOT))
@@ -747,6 +815,22 @@ public class FollowUpAnalyzer {
       List<ReviewResponse.PreviousFindingStatus> statuses,
       DiffLineResolver lineResolver,
       Map<String, String> renameTargets) {
+    return supersedeVanished(
+        previousAiResponseJson, statuses, lineResolver, renameTargets, Set.of());
+  }
+
+  /**
+   * Rename- and settle-aware variant: a finding a newer round already closed ({@code settledIds},
+   * {@link #settledPreviousIds}) is left untouched rather than rewritten to {@code superseded} when
+   * its code later leaves the diff — the close already accounted for it, and a phantom supersede
+   * would pin {@code hasSupersededPrevious} on and re-post the summary every push (#470).
+   */
+  public List<ReviewResponse.PreviousFindingStatus> supersedeVanished(
+      String previousAiResponseJson,
+      List<ReviewResponse.PreviousFindingStatus> statuses,
+      DiffLineResolver lineResolver,
+      Map<String, String> renameTargets,
+      Set<Integer> settledIds) {
     if (statuses == null || statuses.isEmpty() || lineResolver == null) {
       return statuses == null ? List.of() : statuses;
     }
@@ -756,7 +840,8 @@ public class FollowUpAnalyzer {
     }
     var rewritten = new ArrayList<ReviewResponse.PreviousFindingStatus>(statuses.size());
     for (var status : statuses) {
-      if (hasVanished(status, previous, lineResolver, renameTargets)) {
+      if (!settledIds.contains(status.id())
+          && hasVanished(status, previous, lineResolver, renameTargets)) {
         Log.infof(
             "Superseding unresolved previous finding #%d — its targeted code is no longer in the"
                 + " current diff",
@@ -782,6 +867,22 @@ public class FollowUpAnalyzer {
       List<ReviewResponse.PreviousFindingStatus> statuses,
       DiffLineResolver lineResolver,
       Map<String, String> renameTargets) {
+    return addUnreportedVanished(previous, statuses, lineResolver, renameTargets, Set.of());
+  }
+
+  /**
+   * Settle-aware variant: a prior finding a newer round already closed ({@code settledIds}, {@link
+   * #settledPreviousIds}) is not re-emitted here — neither superseded when its code left the diff
+   * nor held as unresolved — because the close already accounted for it. Re-superseding it pins
+   * {@code hasSupersededPrevious} on and re-posts the summary every push while suppressing the
+   * follow-up delta (#470). Its id slot is still skipped by position, so no id shifts.
+   */
+  public List<ReviewResponse.PreviousFindingStatus> addUnreportedVanished(
+      List<ReviewResponse.Finding> previous,
+      List<ReviewResponse.PreviousFindingStatus> statuses,
+      DiffLineResolver lineResolver,
+      Map<String, String> renameTargets,
+      Set<Integer> settledIds) {
     if (previous == null || previous.isEmpty() || lineResolver == null) {
       return statuses == null ? List.of() : statuses;
     }
@@ -793,7 +894,7 @@ public class FollowUpAnalyzer {
     for (int index = 0; index < previous.size(); index++) {
       var id = index + 1;
       var finding = previous.get(index);
-      if (reportedIds.contains(id) || finding.file() == null) {
+      if (reportedIds.contains(id) || settledIds.contains(id) || finding.file() == null) {
         continue;
       }
       var currentPath = renameTargets.getOrDefault(finding.file(), finding.file());

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummary.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummary.java
@@ -84,8 +84,10 @@ final class FollowUpDeltaSummary {
             + result.unresolvedPreviousCount()
             + "\n"
             // Same partial-coverage wording the on-demand commands use: these counts cover only the
-            // reviewed portion of a truncated diff, so the comment has to say so.
-            + ReviewResult.truncationDisclosure(result.omittedFiles());
+            // reviewed portion of a truncated diff, so the comment has to say so. Pass the
+            // truncation detail, not just the count — on the budgeted path the count folds in
+            // clipped files, which are partially analyzed, not omitted (F8).
+            + ReviewResult.truncationDisclosure(result.omittedFiles(), result.truncation());
     return Optional.of(body);
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -160,13 +160,48 @@ final class RebuttalContradiction {
     if (claim == null) {
       return Optional.empty();
     }
-    Matcher evidence = earliestMatch(CONCURRENT_DISPATCHES, reviewedCode);
+    // Match evidence only against right-side (added/context) code with line comments stripped: a
+    // dispatch the maintainer deleted this revision, or one that survives only in a comment, is not
+    // live code and must not reopen the finding by quoting a line the code no longer runs (F3).
+    var rightSide = rightSideCode(reviewedCode);
+    Matcher evidence = earliestMatch(CONCURRENT_DISPATCHES, rightSide);
     if (evidence == null) {
       return Optional.empty();
     }
     return Optional.of(
         new Contradiction(
-            sentenceAround(asserted, claim.start()), lineAround(reviewedCode, evidence.start())));
+            sentenceAround(asserted, claim.start()), lineAround(rightSide, evidence.start())));
+  }
+
+  /**
+   * The reviewed patch reduced to the code the revision actually runs: removed ({@code -}) lines
+   * are dropped and line comments are stripped, so a dispatch construct that was deleted or only
+   * mentioned in a comment cannot pose as live evidence. Added ({@code +}) and context lines are
+   * kept verbatim (including their leading marker, which {@link #clip} removes when quoting),
+   * across every file in the patch — cross-file evidence is intentional.
+   */
+  private static String rightSideCode(String reviewedCode) {
+    var kept = new ArrayList<String>();
+    for (var line : reviewedCode.split("\n", -1)) {
+      // A unified-diff removed line (and the "---" old-file header) starts with '-'.
+      if (line.startsWith("-")) {
+        continue;
+      }
+      kept.add(stripLineComment(line));
+    }
+    return String.join("\n", kept);
+  }
+
+  /**
+   * Drops a trailing {@code //} line comment, leaving any code before it intact. A {@code ://}
+   * sequence (a URL scheme) is not treated as a comment start.
+   */
+  private static String stripLineComment(String line) {
+    var idx = line.indexOf("//");
+    while (idx > 0 && line.charAt(idx - 1) == ':') {
+      idx = line.indexOf("//", idx + 2);
+    }
+    return idx < 0 ? line : line.substring(0, idx);
   }
 
   /**
@@ -186,12 +221,20 @@ final class RebuttalContradiction {
     return earliest;
   }
 
+  /**
+   * Lead-in of {@link Contradiction#note()}, shared with the review body surface ({@code
+   * ReviewPublisher.noIssuesBody}) so a reopened decline can be told apart from an ordinary
+   * unresolved note and rendered next to the "previous finding(s) remain unresolved" line (F6).
+   */
+  static final String NOTE_LEAD_IN = "Decline re-checked against the code and not accepted:";
+
   /** The quoted claim and the quoted code line that refutes it, both already trimmed for a note. */
   record Contradiction(String claim, String evidence) {
 
     /** One-line status note naming the contradiction, for {@code previous_findings_status}. */
     String note() {
-      return "Decline re-checked against the code and not accepted: the reply argues \""
+      return NOTE_LEAD_IN
+          + " the reply argues \""
           + claim
           + "\", but the reviewed code dispatches this path concurrently — \""
           + evidence

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
@@ -249,6 +249,9 @@ public class ReviewContextLoader {
     // prior round parsed, the bot's own review prose must never stand in for structured findings.
     boolean previousResponsePersisted =
         priorAiResponses.stream().anyMatch(FollowUpAnalyzer::isPersistedResponse);
+    // Findings a round newer than the effective previous round already closed are settled: not
+    // re-shown to the model as still open, and never re-superseded downstream (#470).
+    var settledPreviousIds = FollowUpAnalyzer.settledPreviousIds(priorAiResponses);
     String previousFindings =
         hasContext
             ? followUpAnalyzer.buildPreviousFindingsContext(
@@ -257,7 +260,8 @@ public class ReviewContextLoader {
                 priorReviews,
                 inlineComments,
                 olderAiResponses,
-                botIdentity)
+                botIdentity,
+                settledPreviousIds)
             : "";
 
     var instructions =

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -298,11 +298,7 @@ public class ReviewOrchestrator {
           "resolve addressed threads",
           () ->
               reviewPublisher.resolveAddressedThreads(
-                  auth,
-                  doneReq,
-                  previousFindings,
-                  inlineComments,
-                  aiResponse.previousFindingsStatus()));
+                  auth, doneReq, previousFindings, inlineComments, result.previousStatuses()));
       runPostResultStep(
           doneReq,
           "capture finding feedback",

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -489,6 +489,7 @@ public class ReviewPublisher {
     if (unresolved > 0) {
       sb.append(ciHeld ? "\nAdditionally, " : "")
           .append(ReviewResult.unresolvedPreviousMessage(unresolved));
+      appendReopenedDeclineNotes(sb, result);
     }
     if (result.truncated()) {
       if (!sb.isEmpty()) {
@@ -497,6 +498,24 @@ public class ReviewPublisher {
       sb.append(result.truncationNotice().strip());
     }
     return sb.toString();
+  }
+
+  /**
+   * Appends the explanatory note of each unresolved previous finding whose decline the re-check
+   * overturned ({@link RebuttalContradiction}) — the reply's premise, the contradicting line, and
+   * the "reply again to keep the decline" escape hatch. Without this the maintainer sees only the
+   * generic "N previous finding(s) remain unresolved" line and no reason their decline was not
+   * honored (F6). Only the reopened-decline note is surfaced; the backstop's generic carry-over
+   * note and the model's own unresolved notes stay out of the review body.
+   */
+  private static void appendReopenedDeclineNotes(StringBuilder sb, ReviewResult result) {
+    for (var status : result.previousStatuses()) {
+      if ("unresolved".equalsIgnoreCase(status.status())
+          && status.note() != null
+          && status.note().startsWith(RebuttalContradiction.NOTE_LEAD_IN)) {
+        sb.append("\n\n").append(status.note().strip());
+      }
+    }
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -719,13 +719,18 @@ public class ReviewPublisher {
    * Resolves the GitHub threads of previous findings the model judged resolved (fix landed) or
    * justified (a reply explains the deferral), so addressed feedback stops cluttering the PR.
    * Best-effort: the review outcome is already posted when this runs.
+   *
+   * <p>Takes the <em>effective</em> statuses the verdict computed ({@link
+   * ReviewResult#previousStatuses}), not the raw model statuses: a decline the re-check overturned
+   * is {@code unresolved} here, so its thread is correctly left open rather than resolved on a
+   * status the code already rejected (F7).
    */
   void resolveAddressedThreads(
       String auth,
       ReviewOrchestrator.ReviewRequest req,
       List<ReviewResponse.Finding> previousFindings,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
-      List<ReviewResponse.PreviousFindingStatus> statuses) {
+      List<ReviewResult.PreviousFindingStatus> statuses) {
     try {
       List<Integer> addressed =
           statuses.stream()
@@ -733,7 +738,7 @@ public class ReviewPublisher {
                   s ->
                       "resolved".equalsIgnoreCase(s.status())
                           || "justified".equalsIgnoreCase(s.status()))
-              .map(ReviewResponse.PreviousFindingStatus::id)
+              .map(ReviewResult.PreviousFindingStatus::id)
               .toList();
       if (addressed.isEmpty() || inlineComments.isEmpty()) {
         return;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -143,19 +143,24 @@ public class VerdictBuilder {
     // paths must not pay for a patch re-parse (#135).
     var rawStatuses = aiResponse.previousFindingsStatus();
     var currentRenameTargets = renameTargets(ctx.files());
+    // Ids a newer round already closed must not be re-superseded — that phantom supersede would
+    // pin hasSupersededPrevious on and re-post the summary every push (#470).
+    var settledIds = FollowUpAnalyzer.settledPreviousIds(ctx.priorAiResponses());
     var effectiveStatuses =
         followUpAnalyzer.supersedeVanished(
             ctx.previousAiResponseJson(),
             rawStatuses,
             rawStatuses.isEmpty() ? null : ctx.lineResolver(),
-            currentRenameTargets);
+            currentRenameTargets,
+            settledIds);
     if (ctx.hasContext()) {
       effectiveStatuses =
           followUpAnalyzer.addUnreportedVanished(
               ctx.previousFindingsList(),
               effectiveStatuses,
               ctx.lineResolver(),
-              currentRenameTargets);
+              currentRenameTargets,
+              settledIds);
     }
     // A maintainer's decline is a claim, not ground truth: a "justified" whose stated reason the
     // reviewed code plainly contradicts goes back to "unresolved" for one more round (#169).

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -180,7 +180,8 @@ public class VerdictBuilder {
                 effectiveStatuses,
                 ctx.inlineComments(),
                 ctx.lineResolver(),
-                botIdentity)
+                botIdentity,
+                currentRenameTargets)
             : List.<ReviewResult.PreviousFindingStatus>of();
     return buildResult(
         effectiveResponse,

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -28,6 +28,7 @@ import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -1017,6 +1018,82 @@ class FollowUpAnalyzerTest {
     assertEquals("superseded", statuses.get(2).status());
     assertEquals("unresolved", statuses.get(3).status());
     assertTrue(statuses.get(3).note().contains("renamed without content changes"));
+  }
+
+  @Test
+  void addUnreportedVanishedShouldNotResupersedeAFindingANewerRoundAlreadyClosed() {
+    // f2's code vanished, but a newer round already closed it (settled). Re-superseding it would
+    // pin hasSupersededPrevious on and re-post the summary every push while suppressing the delta
+    // (#470).
+    var previous =
+        List.of(
+            new ReviewResponse.Finding(
+                "medium", "src/A.java", 1, "Open", "d", "openAnchor()", null),
+            new ReviewResponse.Finding(
+                "medium", "src/B.java", 2, "Closed", "d", "goneAnchor()", null));
+    var resolver =
+        new DiffLineResolver(Map.of("src/A.java", "@@ -1,1 +1,1 @@\n-old\n+openAnchor()"));
+
+    // Without the settled set, f2 (id 2) is superseded — the phantom the fix removes.
+    var naive = analyzer.addUnreportedVanished(previous, List.of(), resolver, Map.of());
+    assertEquals(List.of(2), naive.stream().map(s -> s.id()).toList());
+    assertEquals("superseded", naive.get(0).status());
+
+    var settled =
+        analyzer.addUnreportedVanished(previous, List.of(), resolver, Map.of(), Set.of(2));
+    assertTrue(
+        settled.stream().noneMatch(s -> s.id() == 2),
+        "a finding a newer round already closed must not be re-superseded");
+  }
+
+  @Test
+  void settledPreviousIdsShouldCollectClosuresFromRoundsNewerThanTheEffectiveOne() {
+    // newest-first: two zero-finding rounds close #1 (resolved) and #2 (justified); the effective
+    // previous round raised #1..#3. #3 stays open.
+    var roundC =
+        new ReviewResponse(
+            List.of(),
+            List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed")),
+            null);
+    var roundB =
+        new ReviewResponse(
+            List.of(),
+            List.of(new ReviewResponse.PreviousFindingStatus(2, "justified", "declined")),
+            null);
+    var roundA =
+        new ReviewResponse(
+            List.of(
+                new ReviewResponse.Finding("medium", "high", "src/A.java", 1, "1", "d", null, null),
+                new ReviewResponse.Finding("medium", "high", "src/B.java", 2, "2", "d", null, null),
+                new ReviewResponse.Finding(
+                    "medium", "high", "src/C.java", 3, "3", "d", null, null)),
+            List.of(),
+            null);
+
+    assertEquals(
+        Set.of(1, 2), FollowUpAnalyzer.settledPreviousIds(List.of(roundC, roundB, roundA)));
+    assertEquals(Set.of(), FollowUpAnalyzer.settledPreviousIds(List.of(roundA)));
+  }
+
+  @Test
+  void contextShouldOmitSettledFindingsButKeepTheirIdSlots() {
+    // Finding #2 was closed by a newer round; it must not be re-shown to the model, but #1 and #3
+    // must keep their original id numbers (no renumber) (#470).
+    var previous =
+        List.of(
+            new ReviewResponse.Finding(
+                "critical", "high", "src/A.java", 10, "First", "d", null, null),
+            new ReviewResponse.Finding(
+                "medium", "high", "src/B.java", 5, "Second", "d", null, null),
+            new ReviewResponse.Finding("high", "high", "src/C.java", 7, "Third", "d", null, null));
+
+    var context =
+        analyzer.buildPreviousFindingsContext(
+            previous, true, List.of(), List.of(), List.of(), BOT_ID, Set.of(2));
+
+    assertTrue(context.contains("1. [CRITICAL] src/A.java:10 — First"), context);
+    assertFalse(context.contains("Second"), context);
+    assertTrue(context.contains("3. [HIGH] src/C.java:7 — Third"), context);
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -176,6 +176,45 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void matchFindingThreadsShouldNotBindSummaryOnlyFindingToAnEarlierRoundsSameIndexThread() {
+    // The effective previous round's finding #1 was summary-only (no inline thread of its own). An
+    // earlier round posted a DIFFERENT finding under the recurring finding=1 marker on the same
+    // file. Finding #1 must not bind to that unrelated same-index thread (F2).
+    var json =
+        """
+        {"findings": [
+          {"risk": "medium", "file": "src/B.java", "line": 5, "title": "Missing null check",
+           "description": "may NPE"}
+        ]}
+        """;
+    var comments =
+        List.of(
+            comment(
+                300L,
+                null,
+                "src/B.java",
+                "**HIGH — Unrelated earlier bug**\n<!-- thrillhousebot:finding=1 -->",
+                BOT));
+
+    var threads = analyzer.matchFindingThreads(json, comments, BOT_ID);
+
+    assertFalse(
+        threads.containsKey(1),
+        "a summary-only finding must not bind to a different finding's same-index thread");
+  }
+
+  @Test
+  void matchFindingThreadsShouldStillBindViaTitleWhenNoMarkerExistsOnTheFile() {
+    // No finding=N marker anywhere on the file: the pre-marker title fallback still binds (F2 must
+    // not regress the marker-free path).
+    var comments = List.of(comment(100L, null, "src/A.java", "**CRITICAL — SQL injection**", BOT));
+
+    var threads = analyzer.matchFindingThreads(PREVIOUS_JSON, comments, BOT_ID);
+
+    assertEquals(100L, threads.get(1));
+  }
+
+  @Test
   void dropRepliedDuplicatesShouldTolerateNullPriorList() {
     var comments = List.of(comment(100L, null, "src/B.java", "**MEDIUM — X**", BOT));
     var withFinding =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -1593,6 +1593,21 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void isStillPresentShouldReturnFalseForANullFileFinding() {
+    // Defensive-contract test: a null-file finding cannot reach isStillPresent in production —
+    // addOpenFindings admits a finding to a cluster only when findingKey is non-null, and
+    // findingKey
+    // returns null for a null file, so holdableTarget's cluster members always carry a file.
+    // Pinning
+    // the guard directly means a future refactor that drops it is caught.
+    var nullFile = new ReviewResponse.Finding("medium", null, 1, "No file", "d", "anchor()", null);
+
+    assertFalse(
+        FollowUpAnalyzer.isStillPresent(nullFile, new DiffLineResolver(Map.of()), Map.of()),
+        "a null-file finding cannot be placed in the diff, so it is never present");
+  }
+
+  @Test
   void unreportedUnresolvedShouldReturnEmptyForMissingInputs() {
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -55,8 +55,15 @@ class FollowUpAnalyzerTest {
 
   private static GitHubReviewClient.PullRequestComment comment(
       long id, Long inReplyTo, String path, String body, String author) {
+    // Default replies to a write-capable association so existing maintainer-reply fixtures still
+    // clear holds after the author-association gate (F1). Non-privileged replies use the overload.
+    return comment(id, inReplyTo, path, body, author, "MEMBER");
+  }
+
+  private static GitHubReviewClient.PullRequestComment comment(
+      long id, Long inReplyTo, String path, String body, String author, String association) {
     return new GitHubReviewClient.PullRequestComment(
-        id, inReplyTo, path, body, new GitHubReviewClient.ReviewResponse.User(author));
+        id, inReplyTo, path, body, new GitHubReviewClient.ReviewResponse.User(author), association);
   }
 
   @Test
@@ -444,6 +451,27 @@ class FollowUpAnalyzerTest {
         List.of(
             comment(100L, null, "src/B.java", "**MEDIUM — Missing null check**", BOT),
             comment(101L, 100L, "src/B.java", "bot self-reply", BOT));
+    var reRaised =
+        new ReviewResponse(
+            List.of(
+                new ReviewResponse.Finding(
+                    "medium", "high", "src/B.java", 5, "Missing null check", "d", null, null)),
+            List.of(),
+            null);
+
+    assertSame(
+        reRaised,
+        analyzer.dropRepliedDuplicates(reRaised, List.of(PREVIOUS_JSON), comments, BOT_ID));
+  }
+
+  @Test
+  void dropRepliedDuplicatesShouldKeepFindingRepliedToByANonWriteAuthor() {
+    // A fork-PR author (author_association CONTRIBUTOR) replies on the finding thread. Their reply
+    // is not a maintainer decision, so it must not delete the re-raised finding (F1).
+    var comments =
+        List.of(
+            comment(100L, null, "src/B.java", "**MEDIUM — Missing null check**", BOT),
+            comment(101L, 100L, "src/B.java", "Not a real bug.", "fork-author", "CONTRIBUTOR"));
     var reRaised =
         new ReviewResponse(
             List.of(
@@ -1111,6 +1139,23 @@ class FollowUpAnalyzerTest {
             List.of(PREVIOUS_JSON), List.of(), comments, resolver, BOT_ID);
 
     assertEquals(List.of(2), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldNotClearHoldForNonWriteReply() {
+    // A fork-PR author's reply (author_association NONE) must not clear the approve backstop, so
+    // both findings stay held (F1).
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+    var comments =
+        List.of(
+            comment(100L, null, "src/A.java", "**CRITICAL — SQL injection**", BOT),
+            comment(101L, 100L, "src/A.java", "looks fine to me", "fork-author", "NONE"));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(PREVIOUS_JSON), List.of(), comments, resolver, BOT_ID);
+
+    assertEquals(List.of(1, 2), heldIds(held));
   }
 
   @Test
@@ -2154,6 +2199,33 @@ class FollowUpAnalyzerTest {
     assertTrue(
         rechecked.get(0).note().contains("executor.execute(() -> execute(ctx));"),
         "the note must quote the contradicting line, was: " + rechecked.get(0).note());
+  }
+
+  @Test
+  void recheckShouldIgnoreARebuttalFromANonWriteAuthor() {
+    // The contradicting rebuttal text is supplied by a fork-PR author (author_association
+    // CONTRIBUTOR), not a maintainer. It must not drive the decline override — with no maintainer
+    // reply, the "exactly one reply" leg fails and the status is left untouched (F1).
+    var comments =
+        List.of(
+            comment(700L, null, PAUSE_FILE, "**MEDIUM — " + RACE_TITLE + "**", BOT),
+            comment(
+                701L,
+                700L,
+                PAUSE_FILE,
+                "Not changed — pause() is only ever called from the /pause command path, which runs"
+                    + " asynchronously on the review executor after the webhook has returned 200.",
+                "fork-author",
+                "CONTRIBUTOR"));
+
+    var rechecked =
+        analyzer.recheckDeclines(
+            RACE_PREVIOUS, justified(), comments, BOT_ID, () -> DISPATCHING_DIFF);
+
+    assertEquals(
+        "justified",
+        rechecked.get(0).status(),
+        "a rebuttal from an author without write access must not drive the override");
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -908,6 +908,23 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void supersedeVanishedShouldNotSupersedeASettledId() {
+    // Finding #2's code vanished, but a newer round already closed it (settled). It must not be
+    // rewritten to superseded, or hasSupersededPrevious would pin on and re-post the summary every
+    // push (#470).
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10)));
+    var statuses = List.of(new ReviewResponse.PreviousFindingStatus(2, "unresolved", "still"));
+
+    var rewritten =
+        analyzer.supersedeVanished(PREVIOUS_JSON, statuses, resolver, Map.of(), Set.of(2));
+
+    assertEquals(
+        "unresolved",
+        rewritten.get(0).status(),
+        "a settled id must not be re-superseded even when its code vanished");
+  }
+
+  @Test
   void supersedeVanishedShouldJudgePresenceByTheAnchorNotTheFile() {
     var anchoredJson =
         """
@@ -1073,6 +1090,14 @@ class FollowUpAnalyzerTest {
     assertEquals(
         Set.of(1, 2), FollowUpAnalyzer.settledPreviousIds(List.of(roundC, roundB, roundA)));
     assertEquals(Set.of(), FollowUpAnalyzer.settledPreviousIds(List.of(roundA)));
+
+    // A null newer round (missing/unparseable persisted response) is skipped, not dereferenced,
+    // while a non-null newer round beside it still contributes its closure.
+    var withNull = new ArrayList<ReviewResponse>();
+    withNull.add(null);
+    withNull.add(roundC);
+    withNull.add(roundA);
+    assertEquals(Set.of(1), FollowUpAnalyzer.settledPreviousIds(withNull));
   }
 
   @Test
@@ -1266,6 +1291,23 @@ class FollowUpAnalyzerTest {
         List.of(
             comment(100L, null, "src/A.java", "**CRITICAL — SQL injection**", BOT),
             comment(101L, 100L, "src/A.java", "looks fine to me", "fork-author", "NONE"));
+
+    var held =
+        analyzer.unreportedUnresolvedStatuses(
+            List.of(PREVIOUS_JSON), List.of(), comments, resolver, BOT_ID);
+
+    assertEquals(List.of(1, 2), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldTreatANullAssociationReplyAsNonWrite() {
+    // A reply whose author_association is absent (null) cannot be shown to hold write access, so it
+    // must not clear the hold — both findings stay held (F1).
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+    var comments =
+        List.of(
+            comment(100L, null, "src/A.java", "**CRITICAL — SQL injection**", BOT),
+            comment(101L, 100L, "src/A.java", "looks fine to me", "someone", null));
 
     var held =
         analyzer.unreportedUnresolvedStatuses(
@@ -1520,6 +1562,28 @@ class FollowUpAnalyzerTest {
     var resolver =
         new DiffLineResolver(Map.of("new/Moved.java", "@@ -5,1 +5,1 @@\n-old\n+movedFlagged()"));
     var renameTargets = Map.of("old/Moved.java", "new/Moved.java");
+
+    var held =
+        analyzer.unreportedUnresolvedStatusesFromParsed(
+            List.of(round), List.of(), List.of(), resolver, BOT_ID, renameTargets);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
+  void unreportedUnresolvedShouldHoldFindingUnderAContentIdenticalPureRename() {
+    // The finding's file was renamed without content changes (blank rename target), so its anchor
+    // resolves at neither path — but the finding is unchanged and must still be held (F5), matching
+    // addUnreportedVanished's pure-rename handling.
+    var round =
+        new ReviewResponse(
+            List.of(
+                new ReviewResponse.Finding(
+                    "medium", "old/Pure.java", 5, "Still open", "d", "unchanged()", null)),
+            List.of(),
+            null);
+    var resolver = new DiffLineResolver(Map.of());
+    var renameTargets = Map.of("old/Pure.java", "");
 
     var held =
         analyzer.unreportedUnresolvedStatusesFromParsed(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -1429,6 +1429,29 @@ class FollowUpAnalyzerTest {
   }
 
   @Test
+  void unreportedUnresolvedShouldHoldStillPresentFindingUnderARenamedAndEditedFile() {
+    // The finding's file was renamed-and-edited; its flagged code is still present at the rename
+    // target, not the pre-rename path. The backstop must resolve through renameTargets — as
+    // supersedeVanished/addUnreportedVanished already do — or the finding escapes the hold (F5).
+    var round =
+        new ReviewResponse(
+            List.of(
+                new ReviewResponse.Finding(
+                    "medium", "old/Moved.java", 5, "Still open", "d", "movedFlagged()", null)),
+            List.of(),
+            null);
+    var resolver =
+        new DiffLineResolver(Map.of("new/Moved.java", "@@ -5,1 +5,1 @@\n-old\n+movedFlagged()"));
+    var renameTargets = Map.of("old/Moved.java", "new/Moved.java");
+
+    var held =
+        analyzer.unreportedUnresolvedStatusesFromParsed(
+            List.of(round), List.of(), List.of(), resolver, BOT_ID, renameTargets);
+
+    assertEquals(List.of(1), heldIds(held));
+  }
+
+  @Test
   void unreportedUnresolvedShouldReturnEmptyForMissingInputs() {
     var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummaryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummaryTest.java
@@ -116,6 +116,37 @@ class FollowUpDeltaSummaryTest {
   }
 
   @Test
+  void budgetedReviewDescribesClippedFilesAsPartiallyAnalyzedNotOmitted() {
+    // On the budgeted path omittedFiles folds in clipped files. Passing only the count would
+    // describe a clipped (partially analyzed) file as omitted; the detail must distinguish them
+    // (F8).
+    var truncation =
+        new ReviewResult.TruncationDetail(List.of("omitted.java"), List.of("clipped.java"));
+    var result =
+        new ReviewResult(
+            List.of(finding("a.java")),
+            0,
+            0,
+            1,
+            0,
+            RiskLevel.MEDIUM,
+            ReviewState.COMMENT,
+            false,
+            "summary",
+            List.of(),
+            List.of(),
+            2,
+            false,
+            true,
+            truncation);
+
+    var body = FollowUpDeltaSummary.render(result).orElseThrow();
+
+    assertTrue(body.contains("only partially analyzed (clipped.java)"), body);
+    assertTrue(body.contains("omitted entirely (omitted.java)"), body);
+  }
+
+  @Test
   void untruncatedReviewCarriesNoDisclosure() {
     var body = FollowUpDeltaSummary.render(followUp(List.of(finding("a.java")), List.of(), 0));
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -353,6 +353,37 @@ class RebuttalContradictionTest {
   }
 
   @Test
+  void shouldNotTreatAUrlSchemeSlashesAsALineComment() {
+    // A "://" URL scheme must not be mistaken for a // line-comment start when stripping comments
+    // from right-side code, so a dispatch on a later line is still seen as live evidence (F3).
+    var codeWithUrl =
+        "diff --git a/Worker.java\n@@ -1,2 +1,3 @@\n"
+            + "+    var docs = \"http://example.com/submit\";\n"
+            + "+    executor.submit(() -> run(ctx));\n";
+
+    var contradiction = RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeWithUrl);
+
+    assertTrue(
+        contradiction.isPresent(),
+        "the URL's // is a scheme, not a comment, so the dispatch below it stays live evidence");
+    assertEquals("executor.submit(() -> run(ctx));", contradiction.get().evidence());
+  }
+
+  @Test
+  void shouldStripALeadingListDashFromTheQuotedClaim() {
+    // A maintainer's reply written as a markdown bullet ("- ...") is still their assertion; the
+    // leading "- " must be trimmed from the quoted claim.
+    var contradiction =
+        RebuttalContradiction.find(RACE_FINDING, "- It is single-threaded.", DISPATCHING_CODE);
+
+    assertTrue(contradiction.isPresent());
+    assertEquals(
+        "It is single-threaded.",
+        contradiction.get().claim(),
+        "the leading list dash must be stripped from the quote");
+  }
+
+  @Test
   void shouldQuoteAConcurrentDispatchThatSurvivesOnAContextLine() {
     // The dispatch is on an unchanged context line (space-prefixed): still live code, so it refutes
     // the decline and the marker is stripped from the quote.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -326,17 +326,43 @@ class RebuttalContradictionTest {
   }
 
   @Test
-  void shouldStripTheDiffMarkerFromAnEvidenceLineOnEitherSide() {
+  void shouldNotQuoteAConcurrentDispatchThatOnlyAppearsOnARemovedLine() {
+    // The maintainer deleted the dispatch in this revision, so the finding's premise is no longer
+    // refuted by live code. A removed (-) line must not be quoted as evidence, and clip() would
+    // otherwise strip the leading '-' and present the deleted line as if it still ran (F3).
     var removedDispatch =
         "diff --git a/Worker.java\n@@ -1,3 +1,2 @@\n-    pool.submit(task);\n+    run(task);\n";
 
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", removedDispatch).isEmpty(),
+        "a dispatch that survives only on a removed line is not live code and keeps the decline");
+  }
+
+  @Test
+  void shouldNotQuoteAConcurrentDispatchThatOnlyAppearsInALineComment() {
+    // The dispatch is mentioned only in a // comment on an added line — commented-out or
+    // explanatory text, not live code — so it must not refute the decline (F3).
+    var commentedDispatch =
+        "diff --git a/Worker.java\n@@ -1,2 +1,3 @@\n"
+            + "+    // executor.submit(() -> run(ctx)); removed, now synchronous\n"
+            + "+    run(ctx);\n";
+
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", commentedDispatch).isEmpty(),
+        "a dispatch mentioned only in a line comment is not live code and keeps the decline");
+  }
+
+  @Test
+  void shouldQuoteAConcurrentDispatchThatSurvivesOnAContextLine() {
+    // The dispatch is on an unchanged context line (space-prefixed): still live code, so it refutes
+    // the decline and the marker is stripped from the quote.
+    var contextDispatch =
+        "diff --git a/Worker.java\n@@ -1,3 +1,3 @@\n     pool.submit(task);\n+    log(task);\n";
+
     var contradiction =
-        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", removedDispatch);
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", contextDispatch);
 
     assertTrue(contradiction.isPresent());
-    assertEquals(
-        "pool.submit(task);",
-        contradiction.get().evidence(),
-        "a leading -/+ diff marker is noise in the quote");
+    assertEquals("pool.submit(task);", contradiction.get().evidence());
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
@@ -1153,7 +1153,7 @@ class ReviewContextLoaderTest {
       when(followUpAnalyzer.parsePreviousResponses(List.of(priorJson, olderJson)))
           .thenReturn(parsed);
       when(followUpAnalyzer.buildPreviousFindingsContext(
-              anyList(), anyBoolean(), any(), any(), any(), any(BotIdentity.class)))
+              anyList(), anyBoolean(), any(), any(), any(), any(BotIdentity.class), any()))
           .thenReturn("ctx");
       stubLoad(
           List.of(
@@ -1176,7 +1176,8 @@ class ReviewContextLoaderTest {
               any(),
               any(),
               eq(parsed.subList(1, parsed.size())),
-              any(BotIdentity.class));
+              any(BotIdentity.class),
+              any());
     }
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -202,7 +202,7 @@ class ReviewOrchestratorTest {
     lenient()
         .when(
             followUpAnalyzer.unreportedUnresolvedStatusesFromParsed(
-                any(), any(), any(), any(), any()))
+                any(), any(), any(), any(), any(), any()))
         .thenReturn(List.of());
     lenient()
         .when(
@@ -4803,7 +4803,7 @@ class ReviewOrchestratorTest {
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
         when(followUpAnalyzer.unreportedUnresolvedStatusesFromParsed(
-                any(), any(), any(), any(), eq(BOT_ID)))
+                any(), any(), any(), any(), eq(BOT_ID), any()))
             .thenReturn(
                 List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still present")));
 
@@ -4936,12 +4936,64 @@ class ReviewOrchestratorTest {
       }
     }
 
+    @Test
+    void shouldNotResolveThreadForADeclineTheRecheckOverturned() {
+      try (var mockedStatic = mockStatic(ReviewSession.class)) {
+        var session = followUpSession();
+        mockedStatic
+            .when(() -> ReviewSession.create(anyString(), anyInt(), anyString(), anyString()))
+            .thenReturn(session);
+        delegateStatusGate();
+        // The model justified finding #1, but the decline re-check overturned it to unresolved.
+        // Thread resolution must run on the verdict's effective statuses, not the raw model
+        // statuses, so the still-open thread is not resolved on a status the code rejected (F7).
+        when(followUpAnalyzer.supersedeVanished(any(), any(), any(), any()))
+            .thenAnswer(inv -> inv.getArgument(1));
+        when(followUpAnalyzer.addUnreportedVanished(any(), any(), any(), any()))
+            .thenAnswer(inv -> inv.getArgument(1));
+        when(followUpAnalyzer.recheckDeclines(any(), any(), any(), any(), any()))
+            .thenReturn(
+                List.of(new ReviewResponse.PreviousFindingStatus(1, "unresolved", "reopened")));
+        when(followUpAnalyzer.matchFindingThreads(
+                ArgumentMatchers.<List<ReviewResponse.Finding>>any(), any(), any()))
+            .thenReturn(Map.of(1, 100L));
+        when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
+            .thenReturn(List.of(PRIOR_FINDING_JSON));
+        when(followUpAnalyzer.buildPreviousFindingsContext(
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID)))
+            .thenReturn("previous context");
+        when(reviewClient.listPullRequestComments(
+                anyString(), anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(
+                List.of(
+                    new GitHubReviewClient.PullRequestComment(
+                        100L,
+                        null,
+                        "src/Main.java",
+                        "**MEDIUM — Dropped finding**\n" + SuggestionFormatter.findingMarker(1),
+                        new GitHubReviewClient.ReviewResponse.User("thrillhousebot[bot]"))));
+        when(reviewThreadService.threadsByRootComment(
+                anyString(), anyString(), anyString(), anyInt()))
+            .thenReturn(Map.of(100L, new ReviewThreadService.ThreadRef("T1", false)));
+        when(aiReviewService.review(any(ReviewSession.class), any()))
+            .thenReturn(
+                new ReviewResponse(
+                    List.of(),
+                    List.of(new ReviewResponse.PreviousFindingStatus(1, "justified", "declined")),
+                    null));
+
+        orchestrator.review(followUpRequest());
+
+        verify(reviewThreadService, never()).resolve(anyString(), anyString());
+      }
+    }
+
     /** Runs the real parse + backstop computation instead of a canned status list. */
     private void delegateBackstopComputation() {
       when(followUpAnalyzer.parsePreviousResponses(any()))
           .thenAnswer(invocation -> realAnalyzer.parsePreviousResponses(invocation.getArgument(0)));
       when(followUpAnalyzer.unreportedUnresolvedStatusesFromParsed(
-              any(), any(), any(), any(), eq(BOT_ID)))
+              any(), any(), any(), any(), eq(BOT_ID), any()))
           .thenAnswer(
               invocation ->
                   realAnalyzer.unreportedUnresolvedStatusesFromParsed(
@@ -4949,7 +5001,8 @@ class ReviewOrchestratorTest {
                       invocation.getArgument(1),
                       invocation.getArgument(2),
                       invocation.getArgument(3),
-                      invocation.getArgument(4)));
+                      invocation.getArgument(4),
+                      invocation.getArgument(5)));
     }
 
     private static final String PRIOR_FINDING_JSON =
@@ -5011,10 +5064,10 @@ class ReviewOrchestratorTest {
     void shouldResolveThreadsForResolvedAndJustifiedFindings() {
       var statuses =
           List.of(
-              new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed"),
-              new ReviewResponse.PreviousFindingStatus(2, "justified", "intentional"),
-              new ReviewResponse.PreviousFindingStatus(3, "unresolved", "still"),
-              new ReviewResponse.PreviousFindingStatus(4, "resolved", "fixed"));
+              new ReviewResult.PreviousFindingStatus(1, "resolved", "fixed"),
+              new ReviewResult.PreviousFindingStatus(2, "justified", "intentional"),
+              new ReviewResult.PreviousFindingStatus(3, "unresolved", "still"),
+              new ReviewResult.PreviousFindingStatus(4, "resolved", "fixed"));
       when(followUpAnalyzer.matchFindingThreads(
               ArgumentMatchers.<List<ReviewResponse.Finding>>any(), any(), any()))
           .thenReturn(Map.of(1, 100L, 2, 200L, 3, 300L, 4, 400L));
@@ -5039,7 +5092,7 @@ class ReviewOrchestratorTest {
 
     @Test
     void shouldSkipFindingsWithoutAMatchedThread() {
-      var statuses = List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed"));
+      var statuses = List.of(new ReviewResult.PreviousFindingStatus(1, "resolved", "fixed"));
       when(followUpAnalyzer.matchFindingThreads(
               ArgumentMatchers.<List<ReviewResponse.Finding>>any(), any(), any()))
           .thenReturn(Map.of());
@@ -5054,8 +5107,8 @@ class ReviewOrchestratorTest {
     @Test
     void shouldDoNothingWhenNoFindingWasAddressedOrNoComments() {
       var unresolvedOnly =
-          List.of(new ReviewResponse.PreviousFindingStatus(1, "unresolved", "still"));
-      var resolved = List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed"));
+          List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still"));
+      var resolved = List.of(new ReviewResult.PreviousFindingStatus(1, "resolved", "fixed"));
 
       reviewPublisher.resolveAddressedThreads(
           AUTH, request(), List.of(), List.of(rootComment()), unresolvedOnly);
@@ -5066,7 +5119,7 @@ class ReviewOrchestratorTest {
 
     @Test
     void shouldSwallowThreadResolutionFailures() {
-      var statuses = List.of(new ReviewResponse.PreviousFindingStatus(1, "resolved", "fixed"));
+      var statuses = List.of(new ReviewResult.PreviousFindingStatus(1, "resolved", "fixed"));
       when(followUpAnalyzer.matchFindingThreads(
               ArgumentMatchers.<List<ReviewResponse.Finding>>any(), any(), any()))
           .thenReturn(Map.of(1, 100L));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2195,7 +2195,7 @@ class ReviewOrchestratorTest {
         when(instructionsResolver.resolve(anyString(), anyString(), anyString(), anyLong()))
             .thenReturn(InstructionsResolver.ResolvedInstructions.EMPTY);
         when(followUpAnalyzer.buildPreviousFindingsContext(
-                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID)))
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID), any()))
             .thenReturn("Previous finding context");
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of("{\"round\":2}", "{\"round\":1}"));
@@ -2232,7 +2232,7 @@ class ReviewOrchestratorTest {
         verify(followUpAnalyzer).parsePreviousResponses(List.of("{\"round\":2}", "{\"round\":1}"));
         verify(followUpAnalyzer)
             .buildPreviousFindingsContext(
-                eq(List.of()), eq(true), any(), any(), eq(List.of(round1)), eq(BOT_ID));
+                eq(List.of()), eq(true), any(), any(), eq(List.of(round1)), eq(BOT_ID), any());
         verify(followUpAnalyzer)
             .dropRepliedDuplicates(
                 any(), eq(List.of("{\"round\":2}", "{\"round\":1}")), any(), eq(BOT_ID));
@@ -4798,7 +4798,7 @@ class ReviewOrchestratorTest {
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
         when(followUpAnalyzer.buildPreviousFindingsContext(
-                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID)))
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID), any()))
             .thenReturn("1. [MEDIUM] src/Main.java:10 — Dropped finding");
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -4828,7 +4828,7 @@ class ReviewOrchestratorTest {
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
         when(followUpAnalyzer.buildPreviousFindingsContext(
-                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID)))
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID), any()))
             .thenReturn("previous context");
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -4836,7 +4836,8 @@ class ReviewOrchestratorTest {
         orchestrator.review(followUpRequest());
 
         verify(followUpAnalyzer)
-            .buildPreviousFindingsContext(anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID));
+            .buildPreviousFindingsContext(
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID), any());
       }
     }
 
@@ -4850,7 +4851,7 @@ class ReviewOrchestratorTest {
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
         when(followUpAnalyzer.buildPreviousFindingsContext(
-                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID)))
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID), any()))
             .thenReturn("previous context");
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -4868,7 +4869,8 @@ class ReviewOrchestratorTest {
                 anyInt(),
                 argThat(req -> req.body().contains("ThrillhouseBot PR Summary")));
         verify(followUpAnalyzer)
-            .buildPreviousFindingsContext(anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID));
+            .buildPreviousFindingsContext(
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID), any());
       }
     }
 
@@ -4907,7 +4909,7 @@ class ReviewOrchestratorTest {
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
         when(followUpAnalyzer.buildPreviousFindingsContext(
-                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID)))
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID), any()))
             .thenReturn("1. [MEDIUM] src/Main.java:10 — Dropped finding");
         // The silent drop: this round reports neither the finding nor a status for it.
         when(aiReviewService.review(any(ReviewSession.class), any()))
@@ -4960,7 +4962,7 @@ class ReviewOrchestratorTest {
         when(sessionPersistence.findAllPriorAiResponseJsons("owner/repo", 42, 1L))
             .thenReturn(List.of(PRIOR_FINDING_JSON));
         when(followUpAnalyzer.buildPreviousFindingsContext(
-                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID)))
+                anyList(), anyBoolean(), any(), any(), any(), eq(BOT_ID), any()))
             .thenReturn("previous context");
         when(reviewClient.listPullRequestComments(
                 anyString(), anyString(), anyString(), anyString(), anyInt()))

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -407,6 +407,44 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void reopenedDeclineBodySurfacesTheContradictionNote() {
+      // A maintainer's decline the code contradicts is reopened as unresolved carrying the
+      // contradiction note. The review body must surface that note next to the unresolved line so
+      // the maintainer sees why their decline was not honored, and how to keep it (F6).
+      var note =
+          RebuttalContradiction.NOTE_LEAD_IN
+              + " the reply argues \"only ever called from the command path\", but the reviewed"
+              + " code dispatches this path concurrently — \"executor.execute(() -> execute(ctx));"
+              + "\". A single call site does not serialize work handed to an executor or a new"
+              + " thread, so the premise does not refute the finding. Reply again to keep the"
+              + " decline.";
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.COMMENT,
+              false,
+              "",
+              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", note)),
+              List.of(),
+              0);
+
+      reviewPublisher.postReview("auth", "owner", "repo", 5, "sha", result, resolverFor());
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      var body = captor.getValue().body();
+      assertTrue(body.contains("1 previous finding(s) remain unresolved"), body);
+      assertTrue(body.contains("Reply again to keep the decline."), body);
+      assertTrue(body.contains("executor.execute(() -> execute(ctx));"), body);
+    }
+
+    @Test
     void truncatedFirstReviewBodyNowDisclosesPartialReview() {
       var result =
           new ReviewResult(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -445,6 +445,39 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void unresolvedBodyOmitsNotesThatAreNotReopenedDeclines() {
+      // Only a reopened-decline note (RebuttalContradiction.NOTE_LEAD_IN) is surfaced. An
+      // unresolved
+      // status with a null note, and a non-unresolved status, must both be skipped — the body shows
+      // the generic unresolved line with no extra note (F6).
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.COMMENT,
+              false,
+              "",
+              List.of(
+                  new ReviewResult.PreviousFindingStatus(1, "unresolved", null),
+                  new ReviewResult.PreviousFindingStatus(2, "resolved", "fixed")),
+              List.of(),
+              0);
+
+      reviewPublisher.postReview("auth", "owner", "repo", 5, "sha", result, resolverFor());
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      var body = captor.getValue().body();
+      assertTrue(body.contains("1 previous finding(s) remain unresolved"), body);
+      assertFalse(body.contains(RebuttalContradiction.NOTE_LEAD_IN), body);
+    }
+
+    @Test
     void truncatedFirstReviewBodyNowDisclosesPartialReview() {
       var result =
           new ReviewResult(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -391,7 +391,8 @@ class VerdictBuilderTest {
                       + " runs asynchronously on the review executor after the webhook has"
                       + " returned 200.",
                   new dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.ReviewResponse
-                      .User("maintainer")));
+                      .User("maintainer"),
+                  "MEMBER"));
 
   private static final ReviewResponse DECLINED_PRIOR_RESPONSE =
       new ReviewResponse(


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [x] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Remediates the validated **follow-up / verdict** findings (audit group a2) in the follow-up review subsystem. Each finding is fixed in its own commit, test-first, against base `release/v0.6.0`.

- **F1 (HIGH)** — Any non-bot login was treated as a maintainer, so a fork-PR author could clear the APPROVE backstop, delete a re-raised finding, and supply the rebuttal the decline re-check reads. `PullRequestComment` now carries `author_association`, and `hasHumanReply`/`humanReplies` require a write-capable association (OWNER/MEMBER/COLLABORATOR) before a reply clears a hold, drops a duplicate, or drives an override. A non-privileged reply still renders as prompt context only.
- **F2 (HIGH)** — `finding=N` marker indices recur every round, so `rootCommentId` bound a summary-only finding to an earlier round's same-index thread (feeding the prompt, a GitHub thread-resolve write, and the decline re-check). It now applies the same three-step own-content match `answeredRootComment` uses.
- **F3 + F6 (MEDIUM-HIGH)** — The decline re-check matched concurrent-dispatch evidence over the whole patch, including removed (`-`) lines and comment text (and `clip` strips the marker), so a maintainer who deletes the dispatch could see the finding reopened quoting the deleted line. Evidence is now matched only against right-side (added/context) lines with line comments stripped; cross-file matching is preserved. The contradiction note that `recheckDeclines` writes is now surfaced in the no-issues review body next to the "previous finding(s) remain unresolved" line (F6).
- **F5 (MEDIUM)** — The approve backstop's `holdableTarget` checked the pre-rename `finding.file()` while `supersedeVanished`/`addUnreportedVanished` map through `renameTargets`, so a still-present finding under a renamed-and-edited file escaped the hold. `renameTargets` is now threaded into the backstop and presence resolved the way `hasVanished` does. (F2 and F5 are the same defect shape — a javadoc cross-reference was added in each.)
- **F7 (MEDIUM)** — The orchestrator passed the raw model statuses to `resolveAddressedThreads`, so a decline the re-check overturned still had its GitHub thread resolved. It now passes the verdict's effective statuses (`ReviewResult.previousStatuses`).
- **F4 (MEDIUM)** — `effectivePreviousFindings` returns the newest finding-raising round's list whole, including ids a later zero-finding round already resolved/justified; `addUnreportedVanished` then emitted a phantom `superseded`, pinning `hasSupersededPrevious` on (re-editing the summary every push) and suppressing the follow-up delta (#470). A settled-id set (rounds newer than the effective previous round) is now skipped by `supersedeVanished`/`addUnreportedVanished`/the prompt context, keeping id slots so nothing renumbers.
- **F8 (LOW)** — `FollowUpDeltaSummary` used the count-only `truncationDisclosure(int)`; on the budgeted path that count folds in clipped files, so they read as omitted. It now passes the truncation detail so clipped files read as "only partially analyzed".

## Related Issues

Audit group a2 (validated follow-up / verdict findings): F1, F2, F3, F4, F5, F6, F7, F8. Related to #470 (F4), #327 (F4 delta), #169 (decline re-check), #336/#455 (supersede/backstop context).

## How Has This Been Tested?

Each finding was reconstructed test-first: a test that fails on the unfixed code, then passes after the fix. Verbatim red-phase failures below. Full gates run before every commit: `spotless:apply`, `clean compile spotbugs:check spotless:check`, and `clean test` — the full suite is green (**2356 tests, 0 failures**).

**F1** — `FollowUpAnalyzerTest` (gate removed to reproduce):
```
dropRepliedDuplicatesShouldKeepFindingRepliedToByANonWriteAuthor
  expected: <ReviewResponse[findings=[Finding[...title=Missing null check...]], ...]>
   but was: <ReviewResponse[findings=[], ...]>
recheckShouldIgnoreARebuttalFromANonWriteAuthor
  a rebuttal from an author without write access must not drive the override ==> expected: <justified> but was: <unresolved>
unreportedUnresolvedShouldNotClearHoldForNonWriteReply
  expected: <[1, 2]> but was: <[2]>
```

**F2** — `FollowUpAnalyzerTest.matchFindingThreadsShouldNotBindSummaryOnlyFindingToAnEarlierRoundsSameIndexThread`:
```
a summary-only finding must not bind to a different finding's same-index thread ==> expected: <false> but was: <true>
```

**F3** — `RebuttalContradictionTest`:
```
shouldNotQuoteAConcurrentDispatchThatOnlyAppearsOnARemovedLine
  a dispatch that survives only on a removed line is not live code and keeps the decline ==> expected: <true> but was: <false>
shouldNotQuoteAConcurrentDispatchThatOnlyAppearsInALineComment
  a dispatch mentioned only in a line comment is not live code and keeps the decline ==> expected: <true> but was: <false>
```

**F6** — `ReviewOrchestratorTest.reopenedDeclineBodySurfacesTheContradictionNote` (asserts the body contains the note "Reply again to keep the decline." and the quoted line):
```
No new issues in this revision, but 1 previous finding(s) remain unresolved — fix them, or reply on their review thread (where one exists) with why they are deferred. ==> expected: <true> but was: <false>
```

**F5** — `FollowUpAnalyzerTest.unreportedUnresolvedShouldHoldStillPresentFindingUnderARenamedAndEditedFile`:
```
expected: <[1]> but was: <[]>
```

**F7** — `ReviewOrchestratorTest$ApproveBackstop.shouldNotResolveThreadForADeclineTheRecheckOverturned` (verify `reviewThreadService.resolve(...)` is never called; on the unfixed orchestrator it is):
```
Never wanted here:
reviewThreadService.resolve(...);
```

**F4** — `FollowUpAnalyzerTest`:
```
addUnreportedVanishedShouldNotResupersedeAFindingANewerRoundAlreadyClosed
  a finding a newer round already closed must not be re-superseded ==> expected: <true> but was: <false>
contextShouldOmitSettledFindingsButKeepTheirIdSlots
  expected: <false> but was: <true>
```

**F8** — `FollowUpDeltaSummaryTest.budgetedReviewDescribesClippedFilesAsPartiallyAnalyzedNotOmitted` (unfixed body: "2 file(s) were omitted"):
```
> ⚠️ **Large PR — partial coverage.** 2 file(s) were omitted because the diff exceeded the size budget, so this covers only part of the diff. ==> expected: <true> but was: <false>
```

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

One pre-existing test pinned the F3 defect — `RebuttalContradictionTest.shouldStripTheDiffMarkerFromAnEvidenceLineOnEitherSide` asserted a **removed** (`-`) dispatch line was quoted as evidence. It was rewritten to assert the corrected behavior (a removed-line dispatch keeps the decline), and a context-line evidence test was added to keep the marker-stripping coverage. No test was disabled or deleted.

Scope note on F1: the fix uses GitHub's per-comment `author_association` as the write-capability gate — the same cheap prefilter `ManualReviewAuthorizer`/`FindingFeedbackCaptureService` apply. The authoritative `collaboratorPermission` network call those services follow up with is deliberately not repeated here: these predicates run deep in the verdict path with no installation token in hand, and threading one through would cross into non-owned files (`FindingPipeline`). Deferring a bot hold to an invited collaborator who engaged on the thread is the safe direction; the fork-PR-author hole the finding describes is fully closed.