### PR TITLE
fix(github): cap outgoing comment bodies at GitHub's 65,536-character limit

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/CommentBodyLimit.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/CommentBodyLimit.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+/**
+ * Bounds an outgoing comment body to GitHub's hard {@value #MAX_LENGTH}-character limit. GitHub
+ * rejects a longer issue-comment, review, inline-comment, or reply body with a 422; that rejection
+ * is swallowed by the fail-soft posting wrapper, so an over-long comment posts <em>nothing</em> —
+ * no comment, no error. Capping at the client boundary turns that silent total failure into a
+ * posted-but-truncated comment carrying an honest {@link #TRUNCATION_NOTICE}.
+ *
+ * <p>Applied uniformly in the compact constructor of every body-bearing request record in {@link
+ * GitHubCommentClient} and {@link GitHubReviewClient}, so every poster is protected the same way
+ * and a future post path inherits the guard for free.
+ */
+final class CommentBodyLimit {
+
+  /**
+   * GitHub's hard maximum comment-body length, in characters. A longer body is rejected with 422.
+   */
+  static final int MAX_LENGTH = 65_536;
+
+  /**
+   * Appended when a body is truncated. Self-explanatory so the maintainer learns the output was cut
+   * rather than seeing a body that just stops. Its own length is reserved when truncating, so the
+   * final string — notice included — never exceeds {@link #MAX_LENGTH}.
+   */
+  static final String TRUNCATION_NOTICE = "\n\n… (truncated at GitHub's 65,536-character limit)";
+
+  private CommentBodyLimit() {}
+
+  /**
+   * Returns {@code body} unchanged when it is {@code null} or already within {@link #MAX_LENGTH}
+   * characters (byte-identical pass-through, including a body sitting exactly on the boundary);
+   * otherwise truncates it so the result — with {@link #TRUNCATION_NOTICE} appended — is at most
+   * {@link #MAX_LENGTH} characters. The cut never splits a UTF-16 surrogate pair.
+   */
+  static String cap(String body) {
+    if (body == null || body.length() <= MAX_LENGTH) {
+      return body;
+    }
+    int keep = MAX_LENGTH - TRUNCATION_NOTICE.length();
+    // Never leave a dangling high surrogate at the cut point — that would corrupt a code point.
+    if (keep > 0 && Character.isHighSurrogate(body.charAt(keep - 1))) {
+      keep--;
+    }
+    return body.substring(0, keep) + TRUNCATION_NOTICE;
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/CommentBodyLimit.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/CommentBodyLimit.java
@@ -52,9 +52,12 @@ final class CommentBodyLimit {
     if (body == null || body.length() <= MAX_LENGTH) {
       return body;
     }
+    // Both operands are compile-time constants and the notice is orders of magnitude shorter than
+    // the limit, so keep is always well above zero; and body is longer than MAX_LENGTH to reach
+    // here, so charAt(keep - 1) is always in range. No bounds guard is needed.
     int keep = MAX_LENGTH - TRUNCATION_NOTICE.length();
     // Never leave a dangling high surrogate at the cut point — that would corrupt a code point.
-    if (keep > 0 && Character.isHighSurrogate(body.charAt(keep - 1))) {
+    if (Character.isHighSurrogate(body.charAt(keep - 1))) {
       keep--;
     }
     return body.substring(0, keep) + TRUNCATION_NOTICE;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
@@ -97,7 +97,11 @@ public interface GitHubCommentClient {
       @PathParam("commentId") long commentId,
       CreateCommentRequest request);
 
-  record CreateCommentRequest(String body) {}
+  record CreateCommentRequest(String body) {
+    public CreateCommentRequest {
+      body = CommentBodyLimit.cap(body);
+    }
+  }
 
   /** Title and body of a linked issue, fetched to ground the bug-fix efficacy check. */
   record IssueDetails(int number, String title, String body) {}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -166,6 +166,7 @@ public interface GitHubReviewClient {
       String event, // APPROVE, REQUEST_CHANGES, COMMENT
       List<ReviewComment> comments) {
     public CreateReviewRequest {
+      body = CommentBodyLimit.cap(body);
       comments = comments == null ? List.of() : List.copyOf(comments);
     }
   }
@@ -191,10 +192,18 @@ public interface GitHubReviewClient {
       int line,
       String side,
       @JsonProperty("start_line") Integer startLine,
-      @JsonProperty("start_side") String startSide) {}
+      @JsonProperty("start_side") String startSide) {
+    public CreatePullRequestCommentRequest {
+      body = CommentBodyLimit.cap(body);
+    }
+  }
 
   /** Reply posted into an existing review thread, keyed by the thread's root comment id in path. */
-  record ReplyToReviewCommentRequest(String body) {}
+  record ReplyToReviewCommentRequest(String body) {
+    public ReplyToReviewCommentRequest {
+      body = CommentBodyLimit.cap(body);
+    }
+  }
 
   record PullRequestCommentResponse(long id, String body, String path, Integer line) {}
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/CommentBodyLimitTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/CommentBodyLimitTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct tests for the body cap. The client tests cover it through each request record; these pin
+ * the helper's own contract — in particular the surrogate-safe cut, which no realistic body built
+ * from ASCII filler would ever exercise.
+ */
+class CommentBodyLimitTest {
+
+  @Test
+  void returnsNullUnchanged() {
+    assertNull(CommentBodyLimit.cap(null));
+  }
+
+  @Test
+  void returnsAShortBodyByIdentity() {
+    var body = "a short comment";
+
+    assertSame(body, CommentBodyLimit.cap(body), "an in-limit body must pass through untouched");
+  }
+
+  @Test
+  void returnsABodyExactlyOnTheLimitByIdentity() {
+    var body = "x".repeat(CommentBodyLimit.MAX_LENGTH);
+
+    assertSame(
+        body,
+        CommentBodyLimit.cap(body),
+        "a body sitting exactly on the limit is valid and must not be truncated");
+  }
+
+  @Test
+  void truncatesOneCharacterOverTheLimit() {
+    var capped = CommentBodyLimit.cap("x".repeat(CommentBodyLimit.MAX_LENGTH + 1));
+
+    assertEquals(CommentBodyLimit.MAX_LENGTH, capped.length());
+    assertTrue(capped.endsWith(CommentBodyLimit.TRUNCATION_NOTICE), "the notice must be appended");
+  }
+
+  @Test
+  void doesNotSplitASurrogatePairAtTheCutPoint() {
+    // Place an astral code point (U+1F600, a high/low surrogate pair) so its HIGH surrogate lands
+    // exactly on the last kept character. Cutting there would emit a lone high surrogate and
+    // corrupt the code point, so the cut must step back one char.
+    var keep = CommentBodyLimit.MAX_LENGTH - CommentBodyLimit.TRUNCATION_NOTICE.length();
+    var body = "x".repeat(keep - 1) + "😀" + "y".repeat(CommentBodyLimit.MAX_LENGTH);
+
+    var capped = CommentBodyLimit.cap(body);
+    var kept = capped.substring(0, capped.length() - CommentBodyLimit.TRUNCATION_NOTICE.length());
+
+    assertFalse(
+        Character.isHighSurrogate(kept.charAt(kept.length() - 1)),
+        "the kept text must not end in a dangling high surrogate");
+    assertEquals(
+        keep - 1, kept.length(), "the cut steps back one character to keep the pair intact");
+    assertTrue(capped.endsWith(CommentBodyLimit.TRUNCATION_NOTICE));
+  }
+
+  @Test
+  void keepsAWholeSurrogatePairWhenItEndsBeforeTheCut() {
+    // The pair sits fully inside the kept region, so no step-back is needed — the false side of
+    // the surrogate check.
+    var keep = CommentBodyLimit.MAX_LENGTH - CommentBodyLimit.TRUNCATION_NOTICE.length();
+    var body = "x".repeat(keep - 2) + "😀" + "y".repeat(CommentBodyLimit.MAX_LENGTH);
+
+    var capped = CommentBodyLimit.cap(body);
+
+    assertEquals(CommentBodyLimit.MAX_LENGTH, capped.length());
+    assertTrue(
+        Character.isLowSurrogate(capped.charAt(keep - 1)),
+        "the pair ends on the last kept character, so nothing is trimmed");
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClientTest.java
@@ -16,6 +16,8 @@
 package dev.thiagogonzaga.thrillhousebot.github;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -24,6 +26,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient.CreateCommentRequest;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient.IssueComment;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -99,5 +102,57 @@ class GitHubCommentClientTest {
     when(client.listCommentsPage("auth", "json", "o", "r", 7, 100, 1)).thenReturn(null);
 
     assertEquals(0, client.listComments("auth", "json", "o", "r", 7).size());
+  }
+
+  // GitHub's hard comment-body limit and the notice the client appends when it truncates. Kept as
+  // literals here (not a reference to the production constants) so these tests pin the boundary and
+  // wording independently of the code under test.
+  private static final int MAX = 65_536;
+  private static final String NOTICE = "\n\n… (truncated at GitHub's 65,536-character limit)";
+
+  private static String repeat(char c, int n) {
+    return String.valueOf(c).repeat(n);
+  }
+
+  @Test
+  void createCommentBodyOverTheLimitIsTruncatedWithAnHonestNotice() {
+    var body = repeat('a', MAX + 5_000);
+
+    var capped = new CreateCommentRequest(body).body();
+
+    // The request must never carry more than GitHub's limit — otherwise the POST 422s and the
+    // fail-soft wrapper posts nothing.
+    assertEquals(MAX, capped.length(), "over-long body must be capped to exactly the limit");
+    assertTrue(capped.endsWith(NOTICE), "a truncated body must end with the truncation notice");
+    assertTrue(capped.startsWith("aaaa"), "the surviving prefix is the original content");
+  }
+
+  @Test
+  void createCommentBodyAtTheLimitIsNotTruncated() {
+    var body = repeat('a', MAX);
+
+    var capped = new CreateCommentRequest(body).body();
+
+    assertEquals(MAX, capped.length());
+    assertEquals(body, capped, "a body exactly at the limit passes through byte-identical");
+  }
+
+  @Test
+  void createCommentBodyOneOverTheLimitIsTruncated() {
+    var body = repeat('a', MAX + 1);
+
+    var capped = new CreateCommentRequest(body).body();
+
+    assertEquals(MAX, capped.length());
+    assertTrue(capped.endsWith(NOTICE));
+  }
+
+  @Test
+  void createCommentBodyUnderTheLimitPassesThroughUnchanged() {
+    var body = "a normal comment body";
+
+    var capped = new CreateCommentRequest(body).body();
+
+    assertSame(body, capped, "a body within the limit is returned untouched");
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClientTest.java
@@ -16,6 +16,8 @@
 package dev.thiagogonzaga.thrillhousebot.github;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -24,7 +26,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.CreatePullRequestCommentRequest;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.CreateReviewRequest;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.PullRequestComment;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.ReplyToReviewCommentRequest;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.ReviewResponse;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -171,5 +176,80 @@ class GitHubReviewClientTest {
     when(client.listReviewsPage("auth", "json", "o", "r", 7, 100, 1)).thenReturn(null);
 
     assertEquals(0, client.listReviews("auth", "json", "o", "r", 7).size());
+  }
+
+  // GitHub's hard body limit and the notice appended on truncation, as literals (see the comment
+  // client test) so the boundary and wording are pinned independently of the production constants.
+  private static final int MAX = 65_536;
+  private static final String NOTICE = "\n\n… (truncated at GitHub's 65,536-character limit)";
+
+  private static String repeat(char c, int n) {
+    return String.valueOf(c).repeat(n);
+  }
+
+  @Test
+  void reviewBodyOverTheLimitIsTruncatedWithAnHonestNotice() {
+    var body = repeat('a', MAX + 5_000);
+
+    var capped = new CreateReviewRequest("sha", body, "COMMENT", List.of()).body();
+
+    assertEquals(MAX, capped.length(), "over-long review body must be capped to exactly the limit");
+    assertTrue(capped.endsWith(NOTICE));
+  }
+
+  @Test
+  void reviewBodyAtTheLimitIsNotTruncated() {
+    var body = repeat('a', MAX);
+
+    var capped = new CreateReviewRequest("sha", body, "COMMENT", List.of()).body();
+
+    assertEquals(MAX, capped.length());
+    assertEquals(body, capped, "a review body exactly at the limit passes through byte-identical");
+  }
+
+  @Test
+  void reviewBodyOneOverTheLimitIsTruncated() {
+    var capped = new CreateReviewRequest("sha", repeat('a', MAX + 1), "COMMENT", List.of()).body();
+
+    assertEquals(MAX, capped.length());
+    assertTrue(capped.endsWith(NOTICE));
+  }
+
+  @Test
+  void inlineCommentBodyOverTheLimitIsTruncatedWithAnHonestNotice() {
+    var body = repeat('a', MAX + 5_000);
+
+    var capped =
+        new CreatePullRequestCommentRequest("sha", body, "src/Foo.java", 1, "RIGHT", null, null)
+            .body();
+
+    assertEquals(MAX, capped.length());
+    assertTrue(capped.endsWith(NOTICE));
+  }
+
+  @Test
+  void inlineCommentBodyUnderTheLimitPassesThroughUnchanged() {
+    var body = "a normal inline comment";
+
+    var capped =
+        new CreatePullRequestCommentRequest("sha", body, "src/Foo.java", 1, "RIGHT", null, null)
+            .body();
+
+    assertSame(body, capped);
+  }
+
+  @Test
+  void replyBodyOverTheLimitIsTruncatedWithAnHonestNotice() {
+    var capped = new ReplyToReviewCommentRequest(repeat('a', MAX + 5_000)).body();
+
+    assertEquals(MAX, capped.length());
+    assertTrue(capped.endsWith(NOTICE));
+  }
+
+  @Test
+  void replyBodyUnderTheLimitPassesThroughUnchanged() {
+    var body = "a normal reply";
+
+    assertSame(body, new ReplyToReviewCommentRequest(body).body());
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

GitHub rejects an issue-comment, review, inline-comment, or reply body longer than **65,536 characters** with a 422. Nothing guarded against that: the fail-soft posting wrapper swallows the rejection, so an over-long comment posts **nothing** — no comment, no error, no sign the command ran. The more useful the output (e.g. `/generate-tests` proposing several whole test files, or the PR summary comment), the more likely it silently vanished.

This caps the body at the **client boundary**, before the request leaves the layer, in the compact constructor of every body-bearing request record:

- `GitHubCommentClient.CreateCommentRequest` — covers `createComment` (POST) and `updateComment` (PATCH edit-in-place).
- `GitHubReviewClient.CreateReviewRequest` — the review body of `createReview`.
- `GitHubReviewClient.CreatePullRequestCommentRequest` — the inline body of `createPullRequestComment`.
- `GitHubReviewClient.ReplyToReviewCommentRequest` — the body of `replyToReviewComment`.

All four delegate to a new shared `CommentBodyLimit.cap(String)` helper. Behavior:

- A body within the limit (including one sitting **exactly** on 65,536) passes through **byte-identical** (same reference).
- An over-long body is truncated so the result — with the notice appended — is at most 65,536 characters. The notice's own length is reserved when truncating, and the cut never splits a UTF-16 surrogate pair. The appended marker is: `… (truncated at GitHub's 65,536-character limit)`.

Capping at the request-record boundary — rather than per command — protects **every** poster uniformly, and a future post path inherits the guard for free. This converts today's silent total failure into a posted-but-truncated comment with an honest marker.

**Follow-up (not in scope, not touched):** `GitHubCheckRunClient.UpdateCheckRunRequest.Output` (`title`/`summary`/`text`) is a separate check-run surface with its own GitHub size limits; it is not a comment body and is owned elsewhere. Worth a bounded guard of its own in a later change.

## Related Issues

Fixes #462

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Red/green, per the load-bearing-test-first rule. The production fix was stashed to confirm each new test **fails on the current (unfixed) code** — the request carries the full over-long body — then passes after the fix. Boundary pair covered: 65,536 is not truncated, 65,537 is. Full suite: **2405 tests, 0 failures**; `spotbugs:check` 0 bugs; `spotless:check` clean.

**Verbatim red-phase failures (fix reverted):**

```
GitHubCommentClientTest.createCommentBodyOverTheLimitIsTruncatedWithAnHonestNotice:125 over-long body must be capped to exactly the limit ==> expected: <65536> but was: <70536>
GitHubCommentClientTest.createCommentBodyOneOverTheLimitIsTruncated:146 expected: <65536> but was: <65537>
GitHubReviewClientTest.reviewBodyOverTheLimitIsTruncatedWithAnHonestNotice:196 over-long review body must be capped to exactly the limit ==> expected: <65536> but was: <70536>
GitHubReviewClientTest.reviewBodyOneOverTheLimitIsTruncated:214 expected: <65536> but was: <65537>
GitHubReviewClientTest.inlineCommentBodyOverTheLimitIsTruncatedWithAnHonestNotice:226 expected: <65536> but was: <70536>
GitHubReviewClientTest.replyBodyOverTheLimitIsTruncatedWithAnHonestNotice:245 expected: <65536> but was: <70536>
```

The "at limit" (65,536 → byte-identical) and "under limit → unchanged reference" tests pass both before and after — they pin the no-truncation guarantee, not the defect.

**After the fix:** all of the above pass; the over-long body is capped to exactly 65,536 and ends with the notice.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Scope was held to the two `github`-layer client files, their tests, and the new `CommentBodyLimit` helper. No `review/` package file was touched — capping at the client boundary is deliberately the design so every generator (summary, `/generate-tests`, `/improve`, `/describe`, `/changelog`) is protected without per-command changes.
