### PR TITLE
fix(review): honor per-repo ignore globs and disclose truncation in maintainer replies

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
@@ -19,6 +19,7 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
+import dev.thiagogonzaga.thrillhousebot.github.RepoSettingsResolver;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReplyAssistant;
 import dev.thiagogonzaga.thrillhousebot.webhook.ManualReviewAuthorizer;
 import dev.thiagogonzaga.thrillhousebot.webhook.TriggerDetector;
@@ -52,6 +53,7 @@ public class MaintainerReplyService {
   private final GitHubPullRequestClient prClient;
   private final ReviewDiffFormatter diffFormatter;
   private final ReplyAssistant replyAssistant;
+  private final RepoSettingsResolver repoSettingsResolver;
 
   @Inject
   public MaintainerReplyService(
@@ -62,7 +64,8 @@ public class MaintainerReplyService {
       @RestClient GitHubCommentClient commentClient,
       @RestClient GitHubPullRequestClient prClient,
       ReviewDiffFormatter diffFormatter,
-      ReplyAssistant replyAssistant) {
+      ReplyAssistant replyAssistant,
+      RepoSettingsResolver repoSettingsResolver) {
     this.authClient = authClient;
     this.authorizer = authorizer;
     this.triggerDetector = triggerDetector;
@@ -71,6 +74,7 @@ public class MaintainerReplyService {
     this.prClient = prClient;
     this.diffFormatter = diffFormatter;
     this.replyAssistant = replyAssistant;
+    this.repoSettingsResolver = repoSettingsResolver;
   }
 
   /**
@@ -185,23 +189,26 @@ public class MaintainerReplyService {
   }
 
   private void handleMention(String auth, ReplyTask task) {
+    var diff = fetchDiff(auth, task);
     String reply =
         generateReply(
             task.question(),
             PromptSections.prContext(task.prTitle(), task.prDescription()),
             "",
-            fetchDiff(auth, task),
+            diff.text(),
             "");
     if (reply == null) {
       return;
     }
+    // Append the partial-coverage disclosure (empty unless the diff was line-capped), so a large-PR
+    // answer is never presented as derived from the whole change — matching every other surface.
     commentClient.createComment(
         auth,
         ACCEPT,
         task.owner(),
         task.repo(),
         task.prNumber(),
-        new GitHubCommentClient.CreateCommentRequest(reply));
+        new GitHubCommentClient.CreateCommentRequest(reply + diff.disclosure()));
     Log.infof(
         "Posted conversational reply to mention on %s/%s #%d",
         task.owner(), task.repo(), task.prNumber());
@@ -268,14 +275,43 @@ public class MaintainerReplyService {
     return sb.toString();
   }
 
-  private String fetchDiff(String auth, ReplyTask task) {
+  /**
+   * The rendered PR diff handed to the reply model, plus any partial-coverage disclosure to append
+   * to the posted answer ({@code ""} when nothing was omitted).
+   */
+  private record MentionDiff(String text, String disclosure) {
+    static final MentionDiff EMPTY = new MentionDiff("", "");
+  }
+
+  private MentionDiff fetchDiff(String auth, ReplyTask task) {
     try {
       var files =
           prClient.getPullRequestFiles(auth, ACCEPT, task.owner(), task.repo(), task.prNumber());
-      return diffFormatter.buildDiffString(files);
+      // Honor the repository's own ignore globs (#51) — the same trust boundary the review path and
+      // every on-request command respect (#468/#469). A path a maintainer excluded in
+      // .github/thrillhousebot.yml must not reach the model on a bot-mention reply. Resolved from
+      // the base repo's default branch (no ref pinned), so a fork PR cannot inject its own ignore
+      // list; fails soft to the global list, so a config load failure degrades rather than drops
+      // the reply.
+      var repoSettings =
+          SoftLoaders.repoSettings(
+              repoSettingsResolver,
+              task.owner(),
+              task.repo(),
+              null,
+              task.installationId(),
+              "mention reply");
+      var globs = diffFormatter.ignoreGlobs(repoSettings.ignoredFiles());
+      var reviewable = diffFormatter.reviewableFiles(files, globs);
+      // buildDiffStringWithStats keeps the omitted-file count the stats-free overload discarded, so
+      // a line-capped diff can be disclosed instead of silently answered from a partial view.
+      var formatted = diffFormatter.buildDiffStringWithStats(files, reviewable);
+      String disclosure =
+          formatted.truncated() ? ReviewResult.truncationDisclosure(formatted.omittedFiles()) : "";
+      return new MentionDiff(formatted.text(), disclosure);
     } catch (RuntimeException e) {
       Log.warn("Failed to fetch PR diff for mention reply, continuing without it", e);
-      return "";
+      return MentionDiff.EMPTY;
     }
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
@@ -23,6 +23,8 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
+import dev.thiagogonzaga.thrillhousebot.github.RepoSettings;
+import dev.thiagogonzaga.thrillhousebot.github.RepoSettingsResolver;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReplyAssistant;
 import dev.thiagogonzaga.thrillhousebot.webhook.ManualReviewAuthorizer;
 import dev.thiagogonzaga.thrillhousebot.webhook.TriggerDetector;
@@ -45,6 +47,7 @@ class MaintainerReplyServiceTest {
   @Mock private GitHubPullRequestClient prClient;
   @Mock private ReviewDiffFormatter diffFormatter;
   @Mock private ReplyAssistant replyAssistant;
+  @Mock private RepoSettingsResolver repoSettingsResolver;
 
   // A real TriggerDetector — its bot-login check is the actual logic we want exercised.
   private final TriggerDetector triggerDetector = new TriggerDetector();
@@ -54,17 +57,33 @@ class MaintainerReplyServiceTest {
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
-    service =
-        new MaintainerReplyService(
-            authClient,
-            authorizer,
-            triggerDetector,
-            reviewClient,
-            commentClient,
-            prClient,
-            diffFormatter,
-            replyAssistant);
+    service = serviceWith(diffFormatter);
     when(authClient.getAuthHeader(anyLong())).thenReturn(AUTH);
+  }
+
+  /**
+   * Builds a service with the given diff formatter. The default suite uses the {@code @Mock} one
+   * for interaction assertions; the per-repo-ignore and disclosure tests pass a <em>real</em>
+   * {@link ReviewDiffFormatter} so the actual filtering and line-cap logic is exercised, not merely
+   * a stubbed call.
+   */
+  private MaintainerReplyService serviceWith(ReviewDiffFormatter formatter) {
+    return new MaintainerReplyService(
+        authClient,
+        authorizer,
+        triggerDetector,
+        reviewClient,
+        commentClient,
+        prClient,
+        formatter,
+        replyAssistant,
+        repoSettingsResolver);
+  }
+
+  private static GitHubPullRequestClient.FileDiff fileDiff(
+      String filename, String patch, int additions) {
+    return new GitHubPullRequestClient.FileDiff(
+        filename, "modified", additions, 0, additions, patch);
   }
 
   private static GitHubReviewClient.PullRequestComment comment(
@@ -217,7 +236,9 @@ class MaintainerReplyServiceTest {
     authorize();
     when(prClient.getPullRequestFiles(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of());
-    when(diffFormatter.buildDiffString(any())).thenReturn("diff --git a/Foo b/Foo");
+    when(diffFormatter.reviewableFiles(any(), any())).thenReturn(List.of());
+    when(diffFormatter.buildDiffStringWithStats(any(), any()))
+        .thenReturn(new ReviewDiffFormatter.FormattedDiff("diff --git a/Foo b/Foo", 0));
     when(replyAssistant.reply(any(), any(), any(), any(), any()))
         .thenReturn("It is safe because...");
 
@@ -338,7 +359,8 @@ class MaintainerReplyServiceTest {
     verify(commentClient)
         .createComment(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), body.capture());
     assertEquals("Answer.", body.getValue().body());
-    verify(diffFormatter, never()).buildDiffString(any()); // never reached — fetch threw first
+    verify(diffFormatter, never())
+        .buildDiffStringWithStats(any(), any()); // never reached — fetch threw first
   }
 
   @Test
@@ -361,7 +383,9 @@ class MaintainerReplyServiceTest {
     authorize();
     when(prClient.getPullRequestFiles(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of());
-    when(diffFormatter.buildDiffString(any())).thenReturn("diff");
+    when(diffFormatter.reviewableFiles(any(), any())).thenReturn(List.of());
+    when(diffFormatter.buildDiffStringWithStats(any(), any()))
+        .thenReturn(new ReviewDiffFormatter.FormattedDiff("diff", 0));
     when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("");
 
     service.handle(mentionTask());
@@ -472,7 +496,9 @@ class MaintainerReplyServiceTest {
     authorize();
     when(prClient.getPullRequestFiles(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of());
-    when(diffFormatter.buildDiffString(any())).thenReturn("d");
+    when(diffFormatter.reviewableFiles(any(), any())).thenReturn(List.of());
+    when(diffFormatter.buildDiffStringWithStats(any(), any()))
+        .thenReturn(new ReviewDiffFormatter.FormattedDiff("d", 0));
     when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("ok");
     // Whitespace-only (non-null) title and description exercise the !isBlank() branch.
     var task =
@@ -496,5 +522,83 @@ class MaintainerReplyServiceTest {
 
     verify(commentClient)
         .createComment(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), any());
+  }
+
+  // A file reviewable under the (empty) global list but excluded only by a per-repo pattern: its
+  // patch must not reach the model. Uses a real formatter so the actual glob filtering is
+  // exercised.
+  @Test
+  void mentionExcludesFileMatchedOnlyByPerRepoIgnorePattern() {
+    authorize();
+    // Empty global ignore list: secret.txt is reviewable globally, excluded only per-repo.
+    var realService = serviceWith(new ReviewDiffFormatter(List.of(), 5000));
+    when(prClient.getPullRequestFiles(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+        .thenReturn(
+            List.of(
+                fileDiff("src/Foo.java", "@@ -1 +1 @@\n-old\n+VISIBLE_CHANGE", 1),
+                fileDiff("vendor/secret.txt", "@@ -0,0 +1 @@\n+TOPSECRET_VENDORED_KEY", 1)));
+    when(repoSettingsResolver.resolve(eq("owner"), eq("repo"), any(), anyLong()))
+        .thenReturn(new RepoSettings(List.of("vendor/**"), List.of(), "src"));
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("Answer.");
+
+    realService.handle(mentionTask());
+
+    var codeContext = ArgumentCaptor.forClass(String.class);
+    verify(replyAssistant).reply(any(), any(), any(), codeContext.capture(), any());
+    assertTrue(
+        codeContext.getValue().contains("VISIBLE_CHANGE"), "reviewable file's patch is sent");
+    assertFalse(
+        codeContext.getValue().contains("TOPSECRET_VENDORED_KEY"),
+        "per-repo-ignored file's patch must not reach the model");
+  }
+
+  // A repository that declares no config resolves to the global list only — behaves exactly as
+  // before, so a globally-reviewable file's patch is still sent.
+  @Test
+  void mentionWithNoRepoConfigSendsGloballyReviewableFile() {
+    authorize();
+    var realService = serviceWith(new ReviewDiffFormatter(List.of(), 5000));
+    when(prClient.getPullRequestFiles(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+        .thenReturn(
+            List.of(fileDiff("vendor/secret.txt", "@@ -0,0 +1 @@\n+TOPSECRET_VENDORED_KEY", 1)));
+    // No repo config: resolver returns EMPTY (the default mock returns null → SoftLoaders → EMPTY).
+    when(repoSettingsResolver.resolve(eq("owner"), eq("repo"), any(), anyLong()))
+        .thenReturn(RepoSettings.EMPTY);
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("Answer.");
+
+    realService.handle(mentionTask());
+
+    var codeContext = ArgumentCaptor.forClass(String.class);
+    verify(replyAssistant).reply(any(), any(), any(), codeContext.capture(), any());
+    assertTrue(
+        codeContext.getValue().contains("TOPSECRET_VENDORED_KEY"),
+        "with no per-repo ignore, a globally-reviewable file is still sent (behaves as before)");
+  }
+
+  // A diff over max-diff-lines must produce a reply that discloses the omission — the surface could
+  // not say so before. Real formatter with a tiny line cap forces truncation.
+  @Test
+  void mentionDisclosesTruncationOnLargePr() {
+    authorize();
+    // A 3-line cap against two multi-line files forces at least one omitted file.
+    var realService = serviceWith(new ReviewDiffFormatter(List.of(), 3));
+    when(prClient.getPullRequestFiles(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+        .thenReturn(
+            List.of(
+                fileDiff("src/A.java", "@@ -1 +1 @@\n-a\n+aa\n+aaa\n+aaaa", 3),
+                fileDiff("src/B.java", "@@ -1 +1 @@\n-b\n+bb\n+bbb\n+bbbb", 3),
+                fileDiff("src/C.java", "@@ -1 +1 @@\n-c\n+cc\n+ccc\n+cccc", 3)));
+    when(repoSettingsResolver.resolve(eq("owner"), eq("repo"), any(), anyLong()))
+        .thenReturn(RepoSettings.EMPTY);
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("Answer.");
+
+    realService.handle(mentionTask());
+
+    var body = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+    verify(commentClient)
+        .createComment(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), body.capture());
+    assertTrue(
+        body.getValue().body().contains("partial coverage"),
+        "a truncated diff must disclose the omission in the posted reply");
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [x] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`MaintainerReplyService.fetchDiff(...)` was the last diff-loading path never wired into the v0.6.0 work. It had two independent defects, both fixed here (only `review/MaintainerReplyService.java` and its test are touched):

**1. Per-repo ignore globs were not applied (trust boundary).** `buildDiffString(files)` resolves to the single-argument `reviewableFiles(files)` — the global ignore list only. A path a repository excluded in `.github/thrillhousebot.yml` (#51) was still sent to the model on every bot-mention reply. Same defect class as #468 (`/add-docs`). `fetchDiff` now resolves the repo's `RepoSettings` via `SoftLoaders.repoSettings(...)` (fail-soft), computes the effective ignore set with `ReviewDiffFormatter.ignoreGlobs(perRepoPatterns)` (global ∪ per-repo), and filters with the two-arg `reviewableFiles(files, globs)`. Config is read from the base repo's default branch (no ref pinned, so GitHub serves the base repo's default branch) — a fork PR cannot inject its own ignore list. `RepoSettingsResolver` is injected into the constructor.

**2. Line-capped with no disclosure.** `buildDiffString` is the stats-free overload — it truncates at `max-diff-lines` and discards `omittedFiles()`, so a large-PR reply silently answered from a partial diff. `fetchDiff` now uses `buildDiffStringWithStats(...)` and, when the render was truncated, appends `ReviewResult.truncationDisclosure(...)` to the posted reply — the same wording the other surfaces use.

A repository with no config resolves to the global list, so behavior is unchanged there.

## Related Issues

Fixes #476

## How Has This Been Tested?

Full gates on `release/v0.6.0` base, `JAVA_HOME=java-25`:

- `./mvnw -B spotless:apply` — clean
- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, spotless clean
- `./mvnw -B clean test` — **Tests run: 2397, Failures: 0, Errors: 0, Skipped: 0**

Three load-bearing tests were written first and confirmed red on the unfixed code, then green after the fix. Verbatim red-phase failures (run against the pre-fix `fetchDiff`):

**Finding 1 — per-repo ignore globs.** A file matched only by a per-repo pattern (`vendor/**`), reviewable under the empty global list, must not have its patch reach the model:

```
MaintainerReplyServiceTest.mentionExcludesFileMatchedOnlyByPerRepoIgnorePattern:550
per-repo-ignored file's patch must not reach the model ==> expected: <false> but was: <true>
```

Uses a real `ReviewDiffFormatter` so the actual glob filtering is exercised. Green after the fix (the `vendor/secret.txt` patch is excluded; the reviewable file's patch is still sent).

**Finding 2 — truncation disclosure.** A diff over `max-diff-lines` must produce a reply that discloses the omission:

```
MaintainerReplyServiceTest.mentionDisclosesTruncationOnLargePr:600
a truncated diff must disclose the omission in the posted reply ==> expected: <true> but was: <false>
```

Real formatter with a 3-line cap forces truncation; before the fix the posted reply carried no disclosure. Green after: the reply body contains the "partial coverage" disclosure.

**No-config regression guard.** `mentionWithNoRepoConfigSendsGloballyReviewableFile` — a repository with no `.github/thrillhousebot.yml` resolves to the global list, so a globally-reviewable file is still sent. Passes both before and after the fix (by design, this is a guard that behavior is unchanged there).

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Scope was limited to `MaintainerReplyService` and its test. Because the mention `ReplyTask` does not carry a default branch and is constructed in `WebhookController` (owned by adjacent code), the per-repo config is resolved with no explicit ref — GitHub's contents API then serves the base repo's default branch, which is the same ref the review path targets and keeps a fork PR from supplying its own ignore list.