### PR TITLE
fix(review): hold approval for patch-less and failed-batch coverage gaps

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -27,7 +27,9 @@ import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Splits a PR's reviewable files into token-budgeted batches so every file is covered by some model
@@ -75,21 +77,88 @@ public class DiffBudgetPlanner {
    * summary must not present them as fully reviewed. {@code budgeted} is false only for an explicit
    * {@code max-input-tokens=0} (legacy single uncapped batch) — consumers use it to pick between
    * the plan's omissions and the legacy line-cap count.
+   *
+   * <p>{@code runtimeUncoveredFiles} is a live, mutable accumulator, distinct from the planned
+   * omissions: the plan is built before the review runs, and the same instance flows to both the
+   * review pass and the verdict, so a batch that fails all its retries records its files here
+   * rather than aborting the whole review — the verdict still holds APPROVE and discloses the gap,
+   * but every batch that succeeded keeps its findings. Written only through {@link
+   * #recordUncoveredFiles(List)}; its accessor returns a defensive copy so the mutable backing
+   * never escapes. The {@code effective*} accessors fold it into the planned omissions.
    */
   public record BudgetPlan(
       List<DiffBatch> batches,
       List<String> omittedFiles,
       List<String> clippedFiles,
-      boolean budgeted) {
+      boolean budgeted,
+      List<String> runtimeUncoveredFiles) {
     public BudgetPlan {
       batches = List.copyOf(batches);
       omittedFiles = List.copyOf(omittedFiles);
       clippedFiles = List.copyOf(clippedFiles);
+      // Kept mutable on purpose (not List.copyOf): the review pass records runtime batch failures
+      // onto this shared instance after the plan is built.
+      runtimeUncoveredFiles =
+          runtimeUncoveredFiles == null ? new CopyOnWriteArrayList<>() : runtimeUncoveredFiles;
+    }
+
+    /**
+     * A fresh plan with no runtime coverage gaps yet; failures are recorded on it as they occur.
+     */
+    public BudgetPlan(
+        List<DiffBatch> batches,
+        List<String> omittedFiles,
+        List<String> clippedFiles,
+        boolean budgeted) {
+      this(batches, omittedFiles, clippedFiles, budgeted, new CopyOnWriteArrayList<>());
+    }
+
+    /** Defensive copy: the mutable runtime-gap backing must never escape the plan. */
+    @Override
+    public List<String> runtimeUncoveredFiles() {
+      return List.copyOf(runtimeUncoveredFiles);
+    }
+
+    /** Records files a batch left unreviewed at runtime, ignoring nulls and duplicates. */
+    void recordUncoveredFiles(List<String> filenames) {
+      for (var name : filenames) {
+        if (name != null && !runtimeUncoveredFiles.contains(name)) {
+          runtimeUncoveredFiles.add(name);
+        }
+      }
     }
 
     public boolean truncated() {
-      // Clipped unseen hunks withhold coverage like omitted files — both hold APPROVE.
-      return !omittedFiles.isEmpty() || !clippedFiles.isEmpty();
+      // Clipped unseen hunks and files a failed batch never covered withhold coverage like omitted
+      // files — all three hold APPROVE.
+      return !omittedFiles.isEmpty() || !clippedFiles.isEmpty() || !runtimeUncoveredFiles.isEmpty();
+    }
+
+    /**
+     * Files with no usable coverage: the planned omissions plus any file a failed batch left
+     * unreviewed at runtime, each listed once. Consumers gating and disclosing coverage use this,
+     * not {@link #omittedFiles()}, so a runtime batch failure is accounted for like an omission.
+     */
+    public List<String> effectiveOmittedFiles() {
+      if (runtimeUncoveredFiles.isEmpty()) {
+        return omittedFiles;
+      }
+      var merged = new LinkedHashSet<>(omittedFiles);
+      merged.addAll(runtimeUncoveredFiles);
+      return List.copyOf(merged);
+    }
+
+    /**
+     * Clipped (partially analyzed) files minus any a failed batch left wholly uncovered — those are
+     * reported as omitted, not merely clipped, so a runtime failure never has a file counted twice
+     * nor its coverage overstated.
+     */
+    public List<String> effectiveClippedFiles() {
+      if (runtimeUncoveredFiles.isEmpty()) {
+        return clippedFiles;
+      }
+      var gapSet = new HashSet<>(runtimeUncoveredFiles);
+      return clippedFiles.stream().filter(n -> !gapSet.contains(n)).toList();
     }
 
     public boolean multiCall() {
@@ -236,6 +305,15 @@ public class DiffBudgetPlanner {
       String section,
       int diffBudgetTokens,
       Rendered rendered) {
+    if (isPatchlessWithChanges(file)) {
+      // GitHub returns a null/blank patch for binary files and for text diffs too large to
+      // display, while still reporting real additions/deletions. Its rendered section is a bare
+      // header with no ```diff``` body — there is nothing for the model to read — so packing it
+      // would count the file as fully reviewed and let an unbacked "resolved" claim through.
+      // Omit it by name like an unclippable file: never packed, holds APPROVE, disclosed.
+      rendered.unclippable().add(file.filename());
+      return;
+    }
     var tokens = tokenCounter.estimateTokens(section);
     if (tokens > diffBudgetTokens) {
       var clipped = clipToBudget(section, diffBudgetTokens);
@@ -248,6 +326,16 @@ public class DiffBudgetPlanner {
       tokens = tokenCounter.estimateTokens(clipped);
     }
     rendered.sized().add(new Sized(file, section, tokens));
+  }
+
+  /**
+   * A reviewable file GitHub reported with real additions/deletions but no patch text (binary, or a
+   * text diff too large to display). It survives {@link ReviewDiffFormatter#isPureRename} (which
+   * needs a zero change count) yet has no diff to review, so it must be omitted, not packed.
+   */
+  private static boolean isPatchlessWithChanges(GitHubPullRequestClient.FileDiff file) {
+    var patch = file.patch();
+    return (patch == null || patch.isBlank()) && file.additions() + file.deletions() > 0;
   }
 
   private static DiffBatch toBatch(List<Sized> sized) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -157,12 +158,14 @@ public class FindingPipeline {
    * batch's own in-budget text (the combined diff would exceed the very budget the batches exist to
    * respect), union the results through the finishing chain, then a single summary call rolls them
    * up into the PR-level summary. A batch that fails after {@link AiReviewService}'s internal
-   * retries is retried once more synchronously after the parallel pass — other batches keep their
-   * results instead of being discarded. Previous-findings statuses are aggregated from the batch
-   * calls — they saw the diff; the code-blind summary call must not decide what was resolved. The
-   * passed {@code promptInputs} is reused as the shared-context template — only the diff slot
-   * changes per batch, and the base comparison is dropped (it is a near-duplicate of the diff that
-   * would otherwise be re-sent in every call).
+   * retries is retried once more synchronously after the parallel pass; if it still fails it is
+   * soft-failed — its files are recorded as uncovered on the shared plan (so the verdict holds
+   * APPROVE and the summary discloses the gap) and every batch that succeeded keeps its findings,
+   * rather than the whole review being discarded. Previous-findings statuses are aggregated from
+   * the batch calls — they saw the diff; the code-blind summary call must not decide what was
+   * resolved. The passed {@code promptInputs} is reused as the shared-context template — only the
+   * diff slot changes per batch, and the base comparison is dropped (it is a near-duplicate of the
+   * diff that would otherwise be re-sent in every call).
    */
   private ReviewResponse runMultiCall(
       ReviewSession session,
@@ -208,13 +211,25 @@ public class FindingPipeline {
             processBatch(index, batches, session, promptInputs, plan, previousFilesById);
         Log.infof("Batch %d/%d succeeded on retry", index + 1, batches.size());
       } catch (RuntimeException e) {
-        throw new IllegalStateException("Parallel batch review failed", e);
+        // Soft-fail like the on-request generators (DocGenerationService / PrImprovementService):
+        // one batch that never succeeds must not discard the batches that did. Keep their
+        // findings, record this batch's files as uncovered on the shared plan so the verdict holds
+        // APPROVE and the summary discloses the gap, and let the review proceed (outcome stays
+        // null and is skipped below).
+        Log.warnf(
+            e,
+            "Batch %d/%d failed after its retry; keeping the successful batches and disclosing its"
+                + " files as not reviewed rather than failing the whole review",
+            index + 1,
+            batches.size());
+        plan.recordUncoveredFiles(filenamesOf(batches.get(index).files()));
       }
     }
 
     var outcomes =
         IntStream.range(0, batches.size())
             .mapToObj(i -> outcomesByIndex[i])
+            .filter(Objects::nonNull)
             .sorted(Comparator.comparingInt(BatchOutcome::index))
             .toList();
 
@@ -274,6 +289,10 @@ public class FindingPipeline {
         verified.findings(),
         scopeStatusesToBatch(
             batchResponse.previousFindingsStatus(), batch, plan, previousFilesById));
+  }
+
+  private static List<String> filenamesOf(List<GitHubPullRequestClient.FileDiff> files) {
+    return files.stream().map(GitHubPullRequestClient.FileDiff::filename).toList();
   }
 
   /**
@@ -558,9 +577,13 @@ public class FindingPipeline {
     // Scope totals next, ahead of the per-file rows, for the same reason: clamping drops the tail.
     sb.append(changeScopeSummary(ctx));
     var omitted = Set.copyOf(plan.omittedFiles());
-    var clipped = Set.copyOf(plan.clippedFiles());
+    var uncovered = Set.copyOf(plan.runtimeUncoveredFiles());
+    // effectiveClippedFiles drops any clipped file a failed batch left wholly uncovered, so it is
+    // disclosed once, as uncovered, not also marked "partially analyzed".
+    var clipped = Set.copyOf(plan.effectiveClippedFiles());
     for (var file : ctx.reviewableFiles()) {
-      if (ReviewDiffFormatter.namesContain(omitted, file.filename())) {
+      if (ReviewDiffFormatter.namesContain(omitted, file.filename())
+          || ReviewDiffFormatter.namesContain(uncovered, file.filename())) {
         continue;
       }
       sb.append(file.filename())
@@ -578,6 +601,11 @@ public class FindingPipeline {
     }
     for (var name : plan.omittedFiles()) {
       sb.append(name).append(" (omitted — exceeded the review call budget; not analyzed)\n");
+    }
+    for (var name : plan.runtimeUncoveredFiles()) {
+      sb.append(name)
+          .append(
+              " (not reviewed — the review call for it did not complete; treated as uncovered)\n");
     }
     return sb.toString();
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -115,14 +115,16 @@ public class VerdictBuilder {
       ReviewResponse aiResponse,
       CiStatusEvaluator.CiEvaluation ciEvaluation,
       DiffBudgetPlanner.BudgetPlan plan) {
-    // Budgeted: plan omitted + clipped files; legacy: line-cap count — never sum both.
+    // Budgeted: plan omitted + clipped files, with any file a failed batch left uncovered folded
+    // into the omitted set (effective*); legacy: line-cap count — never sum both.
     var truncation =
         plan.budgeted()
-            ? new ReviewResult.TruncationDetail(plan.omittedFiles(), plan.clippedFiles())
+            ? new ReviewResult.TruncationDetail(
+                plan.effectiveOmittedFiles(), plan.effectiveClippedFiles())
             : ReviewResult.TruncationDetail.EMPTY;
     var omitted =
         plan.budgeted()
-            ? plan.omittedFiles().size() + plan.clippedFiles().size()
+            ? plan.effectiveOmittedFiles().size() + plan.effectiveClippedFiles().size()
             : ctx.omittedFiles();
     // GitHub PR-level totals when available; ignore-glob drops can undercount diff-derived stats.
     // Pure renames are excluded from reviewableFiles for AI budget (#386) but still belong in the

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -313,6 +313,46 @@ class DiffBudgetPlannerTest {
   }
 
   @Test
+  void aPlanBuiltWithANullRuntimeGapListStillAcceptsGaps() {
+    // The canonical constructor normalizes a null accumulator rather than storing it: a null here
+    // would NPE the moment a failed batch recorded a gap, on the async review thread, taking the
+    // whole review down with it.
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true, null);
+
+    assertTrue(plan.runtimeUncoveredFiles().isEmpty(), "a null accumulator normalizes to empty");
+
+    plan.recordUncoveredFiles(List.of("src/Failed.java"));
+
+    assertEquals(List.of("src/Failed.java"), plan.runtimeUncoveredFiles());
+  }
+
+  @Test
+  void clippedFilesAreReportedUnchangedWhenNoBatchFailed() {
+    // No runtime gap: the clipped list passes through, so a partially analyzed file keeps its
+    // "clipped" meaning rather than being reported as wholly uncovered.
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of("src/Clipped.java"), true);
+
+    assertEquals(List.of("src/Clipped.java"), plan.effectiveClippedFiles());
+  }
+
+  @Test
+  void aClippedFileAFailedBatchLeftUncoveredIsReportedOmittedNotClipped() {
+    // A file that was clipped AND then lost to a failed batch must not be counted twice: it drops
+    // out of the clipped list and is reported as omitted, so coverage is never overstated.
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of("src/Clipped.java", "src/Other.java"), true);
+
+    plan.recordUncoveredFiles(List.of("src/Clipped.java"));
+
+    assertEquals(List.of("src/Other.java"), plan.effectiveClippedFiles());
+    assertTrue(
+        plan.effectiveOmittedFiles().contains("src/Clipped.java"),
+        "the lost file is accounted for as omitted instead");
+  }
+
+  @Test
   void perCallInputBudgetIsUnboundedWhenBudgetingIsDisabled() {
     when(reviewConfig.maxInputTokens()).thenReturn(0);
     assertEquals(Integer.MAX_VALUE, planner.perCallInputBudget());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -28,6 +28,7 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient.FileDiff;
 import dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewService;
 import dev.thiagogonzaga.thrillhousebot.review.ai.TokenCounter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -273,6 +274,42 @@ class DiffBudgetPlannerTest {
     assertEquals(List.of("src/Blob.bin"), plan.omittedFiles());
     assertEquals(List.of("src/App.java"), coveredFilenames(plan));
     assertTrue(plan.truncated());
+  }
+
+  @Test
+  void aPatchlessFileWithNoChangesIsNotTreatedAsACoverageGap() {
+    // A pure rename carries no patch AND no additions/deletions. It has nothing to review, but it
+    // is also nothing the review failed to cover — omitting it would hold APPROVE over a file that
+    // never needed reviewing. Only a patch-less file with real changes is a gap.
+    var pureRename = new FileDiff("src/Renamed.java", "renamed", 0, 0, 0, null);
+    var plan = planner.plan(List.of(pureRename), 100_000, 3);
+
+    assertTrue(
+        plan.omittedFiles().isEmpty(), "a zero-change patch-less file is not a coverage gap");
+    assertFalse(plan.truncated(), "a pure rename must not hold APPROVE");
+  }
+
+  @Test
+  void recordingTheSameUncoveredFileTwiceKeepsOneEntry() {
+    // A batch can be recorded more than once (a retry path, or two batches sharing a file), and the
+    // coverage gap must not be double-counted in the disclosure or the omitted total.
+    var plan = planner.plan(List.of(file("src/App.java", 5, patch(5))), 100_000, 3);
+
+    plan.recordUncoveredFiles(List.of("src/Failed.java"));
+    plan.recordUncoveredFiles(List.of("src/Failed.java"));
+
+    assertEquals(List.of("src/Failed.java"), plan.runtimeUncoveredFiles());
+  }
+
+  @Test
+  void recordingANullFilenameIsIgnored() {
+    // A FileDiff can carry a null filename; recording it must not put a null into the gap list,
+    // where it would reach the disclosure text and the null-hostile immutable copies downstream.
+    var plan = planner.plan(List.of(file("src/App.java", 5, patch(5))), 100_000, 3);
+
+    plan.recordUncoveredFiles(Arrays.asList("src/Failed.java", null));
+
+    assertEquals(List.of("src/Failed.java"), plan.runtimeUncoveredFiles());
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -247,6 +247,35 @@ class DiffBudgetPlannerTest {
   }
 
   @Test
+  void aPatchlessChangedFileIsOmittedByNameNotSilentlyReviewed() {
+    // GitHub returns patch == null for binary files and for text diffs too large to display, while
+    // still reporting real additions/deletions. Such a file survives isPureRename (non-zero change
+    // count) and renders as a bare header with no ```diff``` body — there is nothing to review — so
+    // the planner must omit it by name, never pack it as if it were fully reviewed.
+    var patchless = new FileDiff("src/Huge.java", "modified", 4000, 10, 4010, null);
+    var plan = planner.plan(List.of(patchless), 100_000, 3);
+
+    assertEquals(List.of("src/Huge.java"), plan.omittedFiles());
+    assertTrue(
+        plan.truncated(), "an omitted patch-less file makes the review partial (holds APPROVE)");
+    assertTrue(
+        coveredFilenames(plan).isEmpty(), "a patch-less file must never be packed into a batch");
+  }
+
+  @Test
+  void aBlankPatchChangedFileIsOmittedWhileRealDiffsAreStillPacked() {
+    // The patch-less omission does not swallow files that do carry a diff: only the empty one is
+    // dropped, the real one is packed and covered.
+    var blank = new FileDiff("src/Blob.bin", "modified", 900, 0, 900, "   ");
+    var real = file("src/App.java", 5, patch(5));
+    var plan = planner.plan(List.of(blank, real), 100_000, 3);
+
+    assertEquals(List.of("src/Blob.bin"), plan.omittedFiles());
+    assertEquals(List.of("src/App.java"), coveredFilenames(plan));
+    assertTrue(plan.truncated());
+  }
+
+  @Test
   void perCallInputBudgetIsUnboundedWhenBudgetingIsDisabled() {
     when(reviewConfig.maxInputTokens()).thenReturn(0);
     assertEquals(Integer.MAX_VALUE, planner.perCallInputBudget());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -18,7 +18,6 @@ package dev.thiagogonzaga.thrillhousebot.review;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -198,7 +197,11 @@ class FindingPipelineTest {
   }
 
   @Test
-  void multiCallPropagatesBatchFailureAsIllegalStateException() {
+  void multiCallSoftFailsAPersistentlyFailingBatchAndKeepsTheSuccessfulOnes() {
+    // Lead#3: a batch that fails all its retries must not discard the batches that succeeded. The
+    // review keeps their findings, records the failed batch's files as uncovered (so the verdict
+    // holds APPROVE and the summary discloses the gap), and still produces a summary — instead of
+    // throwing IllegalStateException and reporting the whole review as failed.
     var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
     var ctx = reviewContext();
     var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
@@ -206,18 +209,28 @@ class FindingPipelineTest {
     when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt())).thenThrow(failure);
     when(aiReviewService.reviewBatch(eq(session), any(), eq(2), anyInt()))
         .thenReturn(new ReviewResponse(List.of(finding("b.java", "B")), List.of(), null));
+    var summary = new ReviewResponse.Summary(1, 0, 0, 1, 0, "ok", "does things", List.of());
+    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
+    when(aiReviewService.summarize(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), summary));
 
     var plan = multiBatchPlan();
-    var resolver = new DiffLineResolver(Map.of());
-    var thrown =
-        assertThrows(
-            IllegalStateException.class,
-            () -> pipeline.run(session, template, ctx, plan, resolver));
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
 
-    assertEquals("Parallel batch review failed", thrown.getMessage());
-    assertSame(failure, thrown.getCause());
+    // Batch 1 is tried in the parallel pass and retried once; both fail, then it is soft-failed.
     verify(aiReviewService, times(2)).reviewBatch(eq(session), any(), eq(1), anyInt());
-    verify(aiReviewService, never()).summarize(any(), any());
+    verify(aiReviewService).summarize(eq(session), any());
+    assertEquals(1, result.findings().size());
+    assertEquals("B", result.findings().get(0).title());
+    assertSame(summary, result.summary());
+
+    // The failed batch's file is recorded as an uncovered coverage gap on the shared plan, so the
+    // verdict (which reads the same instance) holds APPROVE and discloses it.
+    assertEquals(List.of("a.java"), plan.runtimeUncoveredFiles());
+    assertTrue(plan.truncated());
+    var changedFiles = captor.getValue().changedFiles();
+    assertTrue(changedFiles.contains("a.java (not reviewed"), changedFiles);
+    assertTrue(changedFiles.contains("b.java (modified"), changedFiles);
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -155,6 +155,41 @@ class VerdictBuilderTest {
   }
 
   @Test
+  void aFailedBatchsRuntimeUncoveredFilesHoldApprovalAndAreDisclosedAsOmitted() {
+    // Lead#3: a batch that failed all its retries records its files on the shared plan. The verdict
+    // reads that same instance and must fold them into the omitted set — holding APPROVE and naming
+    // them — exactly like a planned omission, so a partial review never claims full coverage.
+    var ctx = contextWithLineCapOmissions(0);
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    plan.recordUncoveredFiles(List.of("failed.java"));
+
+    var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    assertEquals(1, result.omittedFiles());
+    assertTrue(result.truncated());
+    assertEquals(ReviewState.COMMENT, result.reviewState());
+    assertTrue(
+        result.summaryMarkdown().contains("omitted entirely (failed.java)"),
+        result.summaryMarkdown());
+  }
+
+  @Test
+  void aRuntimeUncoveredFileThatWasAlsoClippedIsCountedOnceAsOmitted() {
+    // No double-count: a clipped file whose batch then failed is reported as omitted, not also as
+    // partially analyzed.
+    var ctx = contextWithLineCapOmissions(0);
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of("f.java"), true);
+    plan.recordUncoveredFiles(List.of("f.java"));
+
+    var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    assertEquals(1, result.omittedFiles());
+    assertTrue(
+        result.summaryMarkdown().contains("omitted entirely (f.java)"), result.summaryMarkdown());
+    assertFalse(result.summaryMarkdown().contains("partially analyzed"), result.summaryMarkdown());
+  }
+
+  @Test
   void clippedOnlyReviewIsDisclosedAsPartialAndHoldsApproval() {
     var ctx = contextWithLineCapOmissions(0);
     var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of("huge.java"), true);


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Two coverage-bookkeeping defects let a review claim coverage it did not actually have. Both feed `BudgetPlan.truncated()` and the APPROVE hold, so they are fixed together on one surface.

**P2 — a patch-less changed file was silently counted as fully reviewed.** GitHub returns `patch == null` for binary files and for text diffs too large to display, while still reporting non-zero `additions`/`deletions`. Such a file survived `reviewableFiles` (`isPureRename` needs a zero change count) and was packed into a batch as a bare `### … (modified, +N -M)` header with no ```` ```diff ```` body — so APPROVE was not held, a model "resolved" claim for it was trusted, and the overview showed it as a normal reviewed file. `DiffBudgetPlanner` now detects a reviewable file whose `patch()` is null/blank while it has real changes and routes it to `omittedFiles` instead of packing it. It then flows correctly: `omittedFiles` non-empty ⇒ `truncated()` true ⇒ APPROVE held; excluded from `batch.files()` ⇒ no "resolved" claim trusted; listed under omitted in the overview.

**Lead#3 — a persistent single-batch failure discarded every successful batch.** In `FindingPipeline.runMultiCall`, a batch that failed its synchronous retry did `throw new IllegalStateException("Parallel batch review failed", e)`, which bubbled to `ReviewOrchestrator.handleReviewFailure` and reported the *whole* review as failed — throwing away every already-succeeded batch's findings. It now soft-fails like the on-request generators (`DocGenerationService.generateEachBatch`, `PrImprovementService`): the failed batch's files are recorded as uncovered on the shared `BudgetPlan`, the successful batches keep their findings, and the summary discloses the shortfall.

To carry the runtime failure from the review pass to the verdict (the orchestrator builds one `BudgetPlan` and passes the same instance to both `run()` and `VerdictBuilder.build()`), `BudgetPlan` gained a live `runtimeUncoveredFiles` accumulator, written only through the package-private `recordUncoveredFiles(...)`, with its record accessor overridden to return a defensive copy (no mutable backing escapes — SpotBugs-clean). New `effectiveOmittedFiles()`/`effectiveClippedFiles()` fold it into the planned omissions, and a clipped file whose batch then failed is reported once as omitted (never also as "partially analyzed"), so the two findings never double-count.

## Related Issues

Refs audit a3-P2, a3-Lead#3. N/A (no tracked issue numbers).

## How Has This Been Tested?

- [x] Unit tests

Red/green per finding (verbatim red-phase failures captured against the unfixed code):

**P2** — new `DiffBudgetPlannerTest.aPatchlessChangedFileIsOmittedByNameNotSilentlyReviewed` (and `aBlankPatchChangedFileIsOmittedWhileRealDiffsAreStillPacked`). A `FileDiff("src/Huge.java","modified",4000,10,4010,null)` must land in `plan.omittedFiles()`, make `truncated()` true, and never appear in a batch's `files()`. Red (fix reverted):

```
[ERROR] DiffBudgetPlannerTest.aPatchlessChangedFileIsOmittedByNameNotSilentlyReviewed:258 expected: <[src/Huge.java]> but was: <[]>
[ERROR] DiffBudgetPlannerTest.aBlankPatchChangedFileIsOmittedWhileRealDiffsAreStillPacked:273 expected: <[src/Blob.bin]> but was: <[]>
```

The patch-less file was silently packed (`omittedFiles` empty). Green after the fix.

**Lead#3** — new `FindingPipelineTest.multiCallSoftFailsAPersistentlyFailingBatchAndKeepsTheSuccessfulOnes` drives `runMultiCall` with batch 1 stubbed to fail all retries; it asserts batch 2's findings survive, a summary is produced, and `a.java` is disclosed as uncovered. Red (soft-fail reverted to the old throw):

```
[ERROR] FindingPipelineTest.multiCallSoftFailsAPersistentlyFailingBatchAndKeepsTheSuccessfulOnes -- Time elapsed: 6.817 s <<< ERROR!
java.lang.IllegalStateException: Parallel batch review failed
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.runMultiCall(FindingPipeline.java:212)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.run(FindingPipeline.java:114)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.multiCallSoftFailsAPersistentlyFailingBatchAndKeepsTheSuccessfulOnes(FindingPipelineTest.java:218)
Caused by: dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewException: batch blew up
```

The whole review threw and lost the successful batch. Green after the fix.

**APPROVE-hold chain (verdict level)** — new `VerdictBuilderTest.aFailedBatchsRuntimeUncoveredFilesHoldApprovalAndAreDisclosedAsOmitted` proves a plan carrying a runtime-uncovered file downgrades APPROVE → COMMENT and names the file ("omitted entirely (failed.java)"); `aRuntimeUncoveredFileThatWasAlsoClippedIsCountedOnceAsOmitted` proves no double-count.

**Pinned-defect test replaced:** the old `multiCallPropagatesBatchFailureAsIllegalStateException` asserted the exact behavior being fixed (whole review throws on a persistent batch failure). It was rewritten to assert the corrected soft-fail behavior.

Gates (JDK 25): `spotless:apply` clean; `clean compile spotbugs:check spotless:check` → SpotBugs "No errors/warnings found", BUILD SUCCESS; full suite `./mvnw -B test` → **2398 tests, 0 failures, 0 errors, 0 skipped**.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (no user-facing config/message defaults changed)
- [x] My changes generate no new warnings or errors

## Additional Notes

- Files touched are limited to the assigned set: `DiffBudgetPlanner`, `FindingPipeline`, `VerdictBuilder`, and their tests. `ReviewDiffFormatter` needed no patch-null render change. `ReviewOrchestrator` was not modified — the runtime coverage gap reaches the verdict through the shared `BudgetPlan` instance.
- Minor known cosmetic gap (not fixed here, would touch the non-owned `ReviewResult`): the verdict's coarse coverage banner phrases every omission as "exceeded the review budget", which reads slightly off for a failed-batch file. The detailed summary overview (owned) discloses those accurately ("not reviewed — the review call for it did not complete; treated as uncovered").
