### PR TITLE
feat(ai): xhigh/max reasoning tiers and deepseek-v4-flash defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,10 +144,11 @@ AI_TIMEOUT=300s
 
 # Reasoning control for reasoning-capable models (o-series/gpt-5.x, Gemini 2.5, qwen3, ...).
 # Disabled by default: no reasoning parameter is sent and the provider default applies. When
-# enabled, the effort (none/low/medium/high) is sent as the OpenAI-compatible reasoning_effort
-# on every AI call; providers map it to their thinking budgets, and 'none' explicitly asks the
-# model not to reason. Reasoning tokens are billed as output tokens, so higher effort means
-# higher cost and latency.
+# enabled, the effort (none/low/medium/high/xhigh/max) is sent as the OpenAI-compatible
+# reasoning_effort on every AI call; providers map it to their thinking budgets, 'none' explicitly
+# asks the model not to reason, and xhigh/max are the extended tiers newer reasoning models expose
+# above high — a provider that does not recognize a tier rejects the call rather than downgrading
+# it. Reasoning tokens are billed as output tokens, so higher effort means higher cost and latency.
 #AI_REASONING_ENABLED=true
 #AI_REASONING_EFFORT=low
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ will change per provider:
 | `AI_PROVIDER` | Provider label for telemetry (`gen_ai.provider.name`); derived from `AI_BASE_URL` when unset | _(derived)_ |
 | `AI_TIMEOUT` | Per-request timeout | `300s` |
 | `AI_REASONING_ENABLED` | Send a reasoning hint to reasoning-capable models; when `false` no reasoning parameter is sent and the provider default applies | `false` |
-| `AI_REASONING_EFFORT` | Effort sent while enabled: `none`/`low`/`medium`/`high` (`none` explicitly asks the model not to reason); reasoning tokens are billed as output tokens | `low` |
+| `AI_REASONING_EFFORT` | Effort sent while enabled: `none`/`low`/`medium`/`high`/`xhigh`/`max` (`none` explicitly asks the model not to reason; `xhigh`/`max` are the extended tiers newer reasoning models expose above `high`); reasoning tokens are billed as output tokens | `low` |
 | `GITHUB_APP_ID` | GitHub App ID | _(required)_ |
 | `GITHUB_PRIVATE_KEY` | GitHub App private key (PEM) | _(required)_ |
 | `GITHUB_WEBHOOK_SECRET` | Webhook HMAC secret | _(required)_ |

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -537,7 +537,7 @@ public interface ThrillhouseConfig {
      */
     interface ReasoningConfig {
       /** Effort values accepted by {@link #effort()}, in ascending cost/quality order. */
-      List<String> ALLOWED_EFFORTS = List.of("none", "low", "medium", "high");
+      List<String> ALLOWED_EFFORTS = List.of("none", "low", "medium", "high", "xhigh", "max");
 
       /** Master switch — no reasoning parameter is sent unless this is {@code true}. */
       @WithDefault("false")
@@ -545,8 +545,11 @@ public interface ThrillhouseConfig {
 
       /**
        * Effort sent while {@link #enabled()}: one of {@code none}, {@code low}, {@code medium},
-       * {@code high} (case-insensitive). {@code none} explicitly asks the model not to reason —
-       * useful to pin down a reasoning-capable model that reasons by default. Validated at boot by
+       * {@code high}, {@code xhigh}, {@code max} (case-insensitive). {@code none} explicitly asks
+       * the model not to reason — useful to pin down a reasoning-capable model that reasons by
+       * default; {@code xhigh} and {@code max} are the extended tiers newer reasoning models expose
+       * above {@code high}. The value rides the wire verbatim, so a provider that does not
+       * recognize a tier rejects the call rather than silently downgrading it. Validated at boot by
        * {@link StartupConfigValidator}.
        */
       @WithDefault("low")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -83,6 +83,11 @@ thrillhousebot.ai.reasoning.effort=${AI_REASONING_EFFORT:low}
 #thrillhousebot.ai.models.deepseek-chat.frequency-penalty=0.1
 #thrillhousebot.ai.models.deepseek-chat.presence-penalty=0.1
 #thrillhousebot.ai.models.deepseek-chat.seed=42
+#
+# deepseek-v4-flash is the exception below: it ships its real caps rather than an empty stub, so a
+# deployment gets the model's own 1M context window instead of the 128000 fallback. Its
+# max-output-tokens rides the wire as max_tokens on every call — lower it (or clear it) if the
+# effective input budget plus the output cap would overshoot the context window.
 thrillhousebot.ai.models."gpt-5.5".max-input-tokens=
 thrillhousebot.ai.models."gpt-5.5-pro".max-input-tokens=
 thrillhousebot.ai.models."gpt-5.4".max-input-tokens=
@@ -90,7 +95,8 @@ thrillhousebot.ai.models."gpt-5.4-mini".max-input-tokens=
 thrillhousebot.ai.models."gpt-5.4-nano".max-input-tokens=
 thrillhousebot.ai.models.gpt-4o.max-input-tokens=
 thrillhousebot.ai.models.gpt-4o-mini.max-input-tokens=
-thrillhousebot.ai.models.deepseek-v4-flash.max-input-tokens=
+thrillhousebot.ai.models.deepseek-v4-flash.max-input-tokens=1000000
+thrillhousebot.ai.models.deepseek-v4-flash.max-output-tokens=384000
 thrillhousebot.ai.models.deepseek-v4-pro.max-input-tokens=
 thrillhousebot.ai.models.deepseek-chat.max-input-tokens=
 thrillhousebot.ai.models.deepseek-reasoner.max-input-tokens=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -53,9 +53,11 @@ thrillhousebot.ai.base-url=${quarkus.langchain4j.openai.base-url}
 thrillhousebot.ai.provider-name=${AI_PROVIDER:}
 # Reasoning-effort control for reasoning-capable models. Disabled by default: no reasoning
 # parameter is sent and the provider default applies. When enabled, the effort (none/low/medium/
-# high) is sent as the OpenAI-compatible reasoning_effort on every chat call — providers map it to
-# their thinking budgets; 'none' explicitly asks the model not to reason. Reasoning tokens are
-# billed as output tokens, so enabling this raises cost and latency.
+# high/xhigh/max) is sent as the OpenAI-compatible reasoning_effort on every chat call — providers
+# map it to their thinking budgets; 'none' explicitly asks the model not to reason, and xhigh/max
+# are the extended tiers newer reasoning models expose above high (a provider that does not know a
+# tier rejects the call rather than downgrading it). Reasoning tokens are billed as output tokens,
+# so enabling this raises cost and latency.
 thrillhousebot.ai.reasoning.enabled=${AI_REASONING_ENABLED:false}
 thrillhousebot.ai.reasoning.effort=${AI_REASONING_EFFORT:low}
 # Per-model AI settings keyed by the model name (the AI_MODEL value), mirroring the pricing map's

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/AiPricingConfigTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/AiPricingConfigTest.java
@@ -71,4 +71,24 @@ class AiPricingConfigTest {
     assertEquals(0.00014, pricing.inputPer1k(), 1e-9);
     assertEquals(0.00028, pricing.outputPer1k(), 1e-9);
   }
+
+  @Test
+  void shouldPriceDeepSeekV4FlashAtItsPublishedRate() {
+    // $0.14 per 1M input / $0.28 per 1M output, expressed per 1K. Pinned because a wrong factor of
+    // ten here is invisible — every session still gets a cost, just the wrong one.
+    var pricing = config.ai().pricing().get("deepseek-v4-flash");
+    assertNotNull(pricing, "deepseek-v4-flash pricing must resolve");
+    assertEquals(0.00014, pricing.inputPer1k(), 1e-9);
+    assertEquals(0.00028, pricing.outputPer1k(), 1e-9);
+  }
+
+  @Test
+  void shouldShipDeepSeekV4FlashContextAndOutputCaps() {
+    // Unlike the other entries in the models map, deepseek-v4-flash ships real values rather than
+    // an empty binding stub, so the caps are a shipped default a deployment inherits silently.
+    var settings = config.ai().models().get("deepseek-v4-flash");
+    assertNotNull(settings, "deepseek-v4-flash model settings must resolve");
+    assertEquals(1_000_000, settings.maxInputTokens().orElseThrow());
+    assertEquals(384_000, settings.maxOutputTokens().orElseThrow());
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -512,9 +512,10 @@ class StartupConfigValidatorTest {
 
   @Test
   void failsFastWhenReasoningEffortIsInvalid() {
-    var ex = assertFailsValidation(new ConfigBuilder().reasoningEffort("max").build());
+    var ex = assertFailsValidation(new ConfigBuilder().reasoningEffort("maximum").build());
     assertTrue(
-        ex.getMessage().contains("AI_REASONING_EFFORT must be one of none, low, medium, high"),
+        ex.getMessage()
+            .contains("AI_REASONING_EFFORT must be one of none, low, medium, high, xhigh, max"),
         ex.getMessage());
   }
 
@@ -561,7 +562,7 @@ class StartupConfigValidatorTest {
 
   @Test
   void acceptsEveryReasoningEffortCaseInsensitivelyWithWhitespace() {
-    for (var effort : new String[] {"none", "LOW", " Medium ", "high"}) {
+    for (var effort : new String[] {"none", "LOW", " Medium ", "high", "XHigh", " max "}) {
       new ConfigBuilder().reasoningEnabled(true).reasoningEffort(effort).build().validate();
     }
   }


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature
- [x] 📝 Documentation

## Description

Two independent AI-configuration changes, one commit each.

### 1. `xhigh` and `max` reasoning-effort tiers

`AI_REASONING_EFFORT` was validated against a closed allow-list that stopped at `high`. Newer reasoning models expose two tiers above it, so an operator asking for either got a hard **startup failure** on a value the provider would have accepted — the boot validator, not the provider, was the thing rejecting it.

`ReasoningConfig.ALLOWED_EFFORTS` now reads `none, low, medium, high, xhigh, max`, still in ascending cost/quality order. Nothing else in the path changes: the effort already rides the OpenAI-compatible wire verbatim via `ChatModelCustomizers.reasoningEffort(...)`, so a provider that does not recognize a tier rejects the call rather than silently downgrading it — the same contract `high` has always had. Validation stays active while reasoning is disabled, so a typo is still caught at boot.

### 2. Real caps for `deepseek-v4-flash`

`deepseek-v4-flash` carried only an **empty binding stub** in the models map. An empty stub exists to make the env var bindable, not to supply a value, so a deployment naming that model fell through to `ModelSettings.DEFAULT_MAX_INPUT_TOKENS` — 128 000 tokens, an eighth of the model's real window. Every review was budgeted far below what the model could take, silently.

It now ships real values:

```properties
thrillhousebot.ai.models.deepseek-v4-flash.max-input-tokens=1000000
thrillhousebot.ai.models.deepseek-v4-flash.max-output-tokens=384000
```

Both remain overridable per deployment through the usual `THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_FLASH_*` env vars — the entry simply stops being a stub and starts being a default. It is the only non-empty entry in that block, so a comment says why.

**One thing a reviewer should weigh.** `max-output-tokens` is not budgeting metadata: `ChatModelCustomizers` maps it to `builder.maxTokens(...)`, so `max_tokens=384000` now goes out on **every** chat call for this model. Providers that validate `input + max_tokens` against the context window will reject a call where the two overshoot — an operator running `REVIEW_MAX_INPUT_TOKENS` near the 1 M window has to keep the sum inside it. The properties comment says so at the point of change. The token budgeter is unaffected; it reserves output space through `review.output-buffer-tokens`, which is a separate knob.

The shipped pricing for the model — `0.00014` / `0.00028` per 1K, i.e. **$0.14 / $0.28 per 1M** — was already correct and is unchanged here; it was simply untested, so it is now pinned (see below).

Docs for the reasoning tiers updated in `README.md`, `.env.example`, and the `application.properties` comment. The website configuration page includes the README section, so it picks the change up with no separate edit; the versioned `website/src/content/docs/0.4.0/` snapshot and the historical `CHANGELOG` entry are deliberately left alone — they describe what shipped then.

## Related Issues

N/A — both are operator-reported gaps found while configuring a reasoning model.

## How Has This Been Tested?

- [x] Unit tests

### Reasoning tiers — red/green on `StartupConfigValidatorTest`

**Red**, with `acceptsEveryReasoningEffortCaseInsensitivelyWithWhitespace` extended by `"XHigh"` and `" max "` (mixed case + whitespace, to pin normalization on the new tiers too):

```
[ERROR] StartupConfigValidatorTest.acceptsEveryReasoningEffortCaseInsensitivelyWithWhitespace:566 ? ConfigValidation ThrillhouseBot cannot start ? required configuration is missing or invalid:
  - AI_REASONING_EFFORT must be one of none, low, medium, high (thrillhousebot.ai.reasoning.effort): XHigh
```

**Green** after the one-line `ALLOWED_EFFORTS` change.

One existing test had to change, and it is worth attention: `failsFastWhenReasoningEffortIsInvalid` used **`max`** as its invalid sample, which is now a valid tier. It uses `maximum` instead — still not a tier — so the test keeps proving the same thing (an unrecognized value fails fast) rather than being weakened; its message assertion tracks the widened list. Its red phase:

```
[ERROR] StartupConfigValidatorTest.failsFastWhenReasoningEffortIsInvalid:516 ...
  - AI_REASONING_EFFORT must be one of none, low, medium, high (thrillhousebot.ai.reasoning.effort): maximum
  ==> expected: <true> but was: <false>
```

`rejectsInvalidReasoningEffortEvenWhileReasoningIsDisabled` (`hgih`) was already unaffected and still passes.

### Model caps — red/green on `AiPricingConfigTest`

That test is a `@QuarkusTest` reading the real `application.properties`, so it asserts against what actually ships. `shouldShipDeepSeekV4FlashContextAndOutputCaps` run with the properties change stashed away:

```
[ERROR] AiPricingConfigTest.shouldShipDeepSeekV4FlashContextAndOutputCaps:91 ? NoSuchElement No value present
```

— the empty stub resolving to an absent `Optional`, which is precisely the bug. Green with the change applied.

To be straight about it: the companion `shouldPriceDeepSeekV4FlashAtItsPublishedRate` is a **characterization test, not a red/green one**. The rates were already correct in `application.properties`; that test passes before and after and exists to stop a future edit from moving them undetected.

### Gates, on the final tree

- `./mvnw -B spotless:apply` / `spotless:check` — clean
- `./mvnw -B clean compile spotbugs:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — **Tests run: 2426, Failures: 0, Errors: 0, Skipped: 0**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The reasoning change is purely widening — every previously valid value stays valid and the default (`low`) is unchanged, so no deployment is affected unless it opts into a new tier. Whether a given endpoint honours `xhigh`/`max` is the provider's business; the bot passes the value through and surfaces the provider's own error if it does not.

The model-caps change **is** a behavior change for anyone already running `deepseek-v4-flash`: their effective input budget rises from the 128 000 fallback to `min(REVIEW_MAX_INPUT_TOKENS, 1000000)`, and calls start carrying an explicit `max_tokens`. That is the intended correction, but it is not a no-op, and it is the reason the `max_tokens` caveat above is worth reading before deploying.