### PR TITLE
fix(ai): stop shipping a response cap for deepseek-v4-flash

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -84,10 +84,14 @@ thrillhousebot.ai.reasoning.effort=${AI_REASONING_EFFORT:low}
 #thrillhousebot.ai.models.deepseek-chat.presence-penalty=0.1
 #thrillhousebot.ai.models.deepseek-chat.seed=42
 #
-# deepseek-v4-flash is the exception below: it ships its real caps rather than an empty stub, so a
-# deployment gets the model's own 1M context window instead of the 128000 fallback. Its
-# max-output-tokens rides the wire as max_tokens on every call — lower it (or clear it) if the
-# effective input budget plus the output cap would overshoot the context window.
+# deepseek-v4-flash is the exception below: it ships a real max-input-tokens rather than an empty
+# stub, so a deployment gets the model's own 1M context window instead of the 128000 fallback.
+#
+# It deliberately ships NO max-output-tokens. That key is not a capability note — it rides the wire
+# as max_tokens on every call, and StartupConfigValidator requires output-buffer-tokens >= it for
+# the active model, so shipping the model's 384000-token ceiling would refuse to boot every
+# deployment on the default 8192 buffer. A deployment that wants an explicit response cap sets it
+# per-model and raises the buffer to match.
 thrillhousebot.ai.models."gpt-5.5".max-input-tokens=
 thrillhousebot.ai.models."gpt-5.5-pro".max-input-tokens=
 thrillhousebot.ai.models."gpt-5.4".max-input-tokens=
@@ -96,7 +100,7 @@ thrillhousebot.ai.models."gpt-5.4-nano".max-input-tokens=
 thrillhousebot.ai.models.gpt-4o.max-input-tokens=
 thrillhousebot.ai.models.gpt-4o-mini.max-input-tokens=
 thrillhousebot.ai.models.deepseek-v4-flash.max-input-tokens=1000000
-thrillhousebot.ai.models.deepseek-v4-flash.max-output-tokens=384000
+thrillhousebot.ai.models.deepseek-v4-flash.max-output-tokens=
 thrillhousebot.ai.models.deepseek-v4-pro.max-input-tokens=
 thrillhousebot.ai.models.deepseek-chat.max-input-tokens=
 thrillhousebot.ai.models.deepseek-reasoner.max-input-tokens=

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/AiPricingConfigTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/AiPricingConfigTest.java
@@ -17,6 +17,7 @@ package dev.thiagogonzaga.thrillhousebot.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -83,12 +84,49 @@ class AiPricingConfigTest {
   }
 
   @Test
-  void shouldShipDeepSeekV4FlashContextAndOutputCaps() {
-    // Unlike the other entries in the models map, deepseek-v4-flash ships real values rather than
-    // an empty binding stub, so the caps are a shipped default a deployment inherits silently.
+  void shouldShipDeepSeekV4FlashContextWindowWithoutAResponseCap() {
+    // Unlike the other entries in the models map, deepseek-v4-flash ships a real input cap rather
+    // than an empty binding stub, so it is a default a deployment inherits silently. It ships no
+    // max-output-tokens on purpose — see noShippedModelCapCanRefuseToBoot.
     var settings = config.ai().models().get("deepseek-v4-flash");
     assertNotNull(settings, "deepseek-v4-flash model settings must resolve");
     assertEquals(1_000_000, settings.maxInputTokens().orElseThrow());
-    assertEquals(384_000, settings.maxOutputTokens().orElseThrow());
+    assertTrue(
+        settings.maxOutputTokens().isEmpty(),
+        "shipping a response cap here refuses to boot on the default output buffer");
+  }
+
+  @Test
+  void noShippedModelCapCanRefuseToBoot() {
+    // StartupConfigValidator rejects a configuration whose max-output-tokens exceeds the effective
+    // output buffer, so a shipped max-output-tokens above the default buffer takes down every
+    // deployment naming that model — with a startup failure, not a degraded review.
+    //
+    // That rule only fires for the ACTIVE model, which is why no ordinary test sees it: the suite
+    // activates one model and the shipped table names eighteen. Walk the table directly instead.
+    var reviewBuffer = config.review().outputBufferTokens();
+
+    config
+        .ai()
+        .models()
+        .forEach(
+            (model, settings) ->
+                settings
+                    .maxOutputTokens()
+                    .ifPresent(
+                        cap -> {
+                          // A model may raise its own buffer alongside the cap; that is consistent
+                          // and boots. Only the pair as it actually resolves matters.
+                          int buffer = settings.outputBufferTokens().orElse(reviewBuffer);
+                          assertTrue(
+                              cap <= buffer,
+                              "shipped max-output-tokens "
+                                  + cap
+                                  + " for '"
+                                  + model
+                                  + "' exceeds its effective output buffer "
+                                  + buffer
+                                  + " — every deployment naming this model would fail to start");
+                        }));
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Fixes a startup regression I introduced in #490.

That PR shipped `thrillhousebot.ai.models.deepseek-v4-flash.max-output-tokens=384000` as a default. `StartupConfigValidator.validateEffectiveBudget` requires `output-buffer-tokens >= max-output-tokens` for the active model, and the shipped default buffer is `8192`. So **every deployment naming this model refused to boot** — a hard startup failure, not a degraded review:

```
ThrillhouseBot cannot start — required configuration is missing or invalid:
  - the effective output buffer (16384) must be >= max-output-tokens (384000) for model
    'deepseek-v4-flash' so the token budget reserves the configured response cap
```

(Reported from a production deployment on a 16384 buffer.)

**Kept:** `max-input-tokens=1000000`. That is the part that was genuinely wrong before #490 — the model carried only an empty binding stub, so it fell through to `ModelSettings.DEFAULT_MAX_INPUT_TOKENS` (128 000) and every review was budgeted at an eighth of the real window.

**Reverted:** the output cap, back to an empty stub. 384 000 is the model's *ceiling*, not a sensible per-call request. Beyond the boot failure it has two other costs: it rides the wire as `max_tokens` on every call, and it reserves 384 K of the token budget away from the diff. A deployment that genuinely wants an explicit cap sets it per-model and raises the buffer to match — which is now spelled out in the properties comment.

## Related Issues

Regression from #490. No issue filed — caught in production within the hour.

## How Has This Been Tested?

- [x] Unit tests

The interesting question is why the 2426-test suite went green on a change that cannot boot. `validateEffectiveBudget` reads `activeModel`, so the rule only fires for the **one** model `AI_MODEL` selects; the shipped table names eighteen. Nothing in the suite activates `deepseek-v4-flash`, so nothing evaluated the pair.

So the new guard does not test the validator — it walks the shipped table directly and asserts no entry ships a `max-output-tokens` above its own effective buffer (per-model override, else `review.output-buffer-tokens`). That holds for any future entry, not just this one.

**Red** — `noShippedModelCapCanRefuseToBoot`, run against the properties as #490 shipped them:

```
org.opentest4j.AssertionFailedError: shipped max-output-tokens 384000 for 'deepseek-v4-flash'
exceeds its effective output buffer 8192 — every deployment naming this model would fail to start
==> expected: <true> but was: <false>
```

That is the production failure reproduced as a test, from the shipped config rather than a mock.

`shouldShipDeepSeekV4FlashContextWindowWithoutAResponseCap` fails alongside it (it replaces #490's `shouldShipDeepSeekV4FlashContextAndOutputCaps`, which asserted the value that broke boot).

**Green** after dropping the cap: `Tests run: 8` in that class.

Gates on the final tree:

- `./mvnw -B spotless:apply` / `spotless:check` — clean
- `./mvnw -B clean compile spotbugs:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — **Tests run: 2427, Failures: 0, Errors: 0, Skipped: 0**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

**Operators already on `deepseek-v4-flash` and stuck at boot** can unblock without waiting for this to merge, by capping to their existing buffer:

```bash
THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_FLASH_MAX_OUTPUT_TOKENS=16384
```

Raising `REVIEW_OUTPUT_BUFFER_TOKENS` to 384000 also boots, but it carves 384 K out of the input budget — the override above is the better move. After this merges, neither is needed.

The `max_tokens`-versus-context-window concern I raised on #490 is now moot for the shipped default: with no `max-output-tokens`, no `max_tokens` goes out and the provider default applies. It returns only for a deployment that sets the cap deliberately.