### PR TITLE
fix(ai): stop retrying a response truncated at the length cap

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -21,6 +21,7 @@ import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
+import dev.thiagogonzaga.thrillhousebot.review.ai.AiResponseTruncatedException;
 import dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewService;
 import dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService;
 import dev.thiagogonzaga.thrillhousebot.review.ai.PrReviewPrompts;
@@ -195,12 +196,24 @@ public class FindingPipeline {
         try {
           outcomesByIndex[i] = futures.get(i).join();
         } catch (CompletionException e) {
-          failedIndices.add(i);
-          Log.warnf(
-              e,
-              "Batch %d/%d failed in the parallel pass; will retry after the other batches finish",
-              i + 1,
-              batches.size());
+          if (isResponseTruncated(e)) {
+            // The batch's own retry below would re-send the identical prompt against the identical
+            // cap. Disclose the gap now rather than paying for a second guaranteed truncation.
+            Log.warnf(
+                e,
+                "Batch %d/%d hit the model's response-length cap; not retrying and disclosing its"
+                    + " files as not reviewed",
+                i + 1,
+                batches.size());
+            plan.recordUncoveredFiles(filenamesOf(batches.get(i).files()));
+          } else {
+            failedIndices.add(i);
+            Log.warnf(
+                e,
+                "Batch %d/%d failed in the parallel pass; will retry after the other batches finish",
+                i + 1,
+                batches.size());
+          }
         }
       }
     }
@@ -293,6 +306,23 @@ public class FindingPipeline {
 
   private static List<String> filenamesOf(List<GitHubPullRequestClient.FileDiff> files) {
     return files.stream().map(GitHubPullRequestClient.FileDiff::filename).toList();
+  }
+
+  /**
+   * Whether a batch failure was the model hitting its response-length cap. Walks the cause chain
+   * because the failure arrives wrapped — {@link CompletionException} over the {@link
+   * dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewException} the service threw.
+   */
+  private static boolean isResponseTruncated(Throwable failure) {
+    for (var cause = failure; cause != null; cause = cause.getCause()) {
+      if (cause instanceof AiResponseTruncatedException) {
+        return true;
+      }
+      if (cause.getCause() == cause) {
+        break;
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -56,6 +56,9 @@ public class FindingPipeline {
   /** Directory rows listed in the scope header before the remainder is rolled up by count. */
   private static final int MAX_SCOPE_DIRECTORIES = 10;
 
+  /** Cause-chain links inspected before giving up, so a cyclic chain cannot spin. */
+  private static final int MAX_CAUSE_DEPTH = 16;
+
   private record BatchOutcome(
       int index,
       List<ReviewResponse.Finding> findings,
@@ -311,15 +314,21 @@ public class FindingPipeline {
   /**
    * Whether a batch failure was the model hitting its response-length cap. Walks the cause chain
    * because the failure arrives wrapped — {@link CompletionException} over the {@link
-   * dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewException} the service threw.
+   * dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewException} the service threw, so depth 2 in
+   * practice.
+   *
+   * <p>Bounded rather than walked to {@code null}: a cause chain can cycle — a {@link Throwable}
+   * overriding {@code getCause()}, or plain {@code A caused-by B caused-by A} — and an unbounded
+   * walk would spin forever on the review thread. The bound is far above any real chain, so a
+   * truncation is never missed for depth.
    */
   private static boolean isResponseTruncated(Throwable failure) {
-    for (var cause = failure; cause != null; cause = cause.getCause()) {
+    var cause = failure;
+    for (var depth = 0;
+        cause != null && depth < MAX_CAUSE_DEPTH;
+        depth++, cause = cause.getCause()) {
       if (cause instanceof AiResponseTruncatedException) {
         return true;
-      }
-      if (cause.getCause() == cause) {
-        break;
       }
     }
     return false;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponseTruncatedException.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponseTruncatedException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+/**
+ * Raised when the model stopped because it hit its response-length cap ({@code finish_reason:
+ * length}) rather than because it finished answering. The body is cut mid-structure, so it would
+ * fail to parse — but as a <em>deterministic</em> failure, not a transient one.
+ *
+ * <p>That distinction is the whole point of the type. Without it a truncation is just an
+ * unparseable body, which lands in the transient-failure retry path and re-runs the identical call:
+ * same prompt, same cap, same cut, {@code max-ai-retries} times over, and then again for the batch
+ * retry above it. Every one of those calls is knowably futile and every one is billed. Carrying the
+ * cause in the type lets each retry layer decline to repeat a call that cannot succeed.
+ *
+ * <p>Extends {@link AiReviewException} so it survives {@link
+ * AiReviewService#asAiReviewException(java.util.concurrent.ExecutionException)} with its identity
+ * intact — that unwrapper returns an {@code AiReviewException} cause as-is.
+ */
+public class AiResponseTruncatedException extends AiReviewException {
+
+  public AiResponseTruncatedException(String message) {
+    super(message, 1, null);
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewService.java
@@ -17,6 +17,7 @@ package dev.thiagogonzaga.thrillhousebot.review.ai;
 
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingHandle;
+import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.service.TokenStream;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
@@ -127,6 +128,14 @@ public class AiReviewService {
 
       try {
         return streamOnce(session, streamFactory, attempt, broadcastTokens);
+      } catch (AiResponseTruncatedException e) {
+        // Deterministic: the next attempt sends the identical prompt against the identical cap and
+        // is cut at the identical point. Retrying only bills the same failure again.
+        Log.warnf(
+            "AI review attempt %d/%d for session %d hit the response-length cap; not retrying"
+                + " (identical call would truncate identically)",
+            attempt, maxAttempts, session.id);
+        throw e;
       } catch (RuntimeException e) {
         lastFailure = e;
         Log.warnf(
@@ -252,6 +261,18 @@ public class AiReviewService {
       flushStream.run();
       // ChatResponse guarantees a non-null aiMessage; its text may still be null.
       var text = buffer.textOrFallback(response.aiMessage().text());
+      // A length stop means the body is cut mid-structure. Naming it here is what keeps it out of
+      // the transient-retry path below — parsing it first would surface only "not valid review
+      // JSON", which is indistinguishable from a malformed response and gets retried.
+      if (response.finishReason() == FinishReason.LENGTH) {
+        result.completeExceptionally(
+            new AiResponseTruncatedException(
+                "Model stopped at its response-length cap (finish_reason=length) after "
+                    + text.length()
+                    + " characters, so the response is incomplete. Raise the active model's"
+                    + " max-output-tokens, or leave it unset to use the provider default."));
+        return;
+      }
       result.complete(parser.parse(text));
     } catch (RuntimeException e) {
       result.completeExceptionally(e);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -35,6 +35,7 @@ import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient.FileDiff;
 import dev.thiagogonzaga.thrillhousebot.github.InstructionsResolver;
+import dev.thiagogonzaga.thrillhousebot.review.ai.AiResponseTruncatedException;
 import dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewException;
 import dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewService;
 import dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService;
@@ -194,6 +195,39 @@ class FindingPipelineTest {
     assertEquals(2, result.findings().size());
     assertSame(summary, result.summary());
     assertEquals(List.of(batchTwoStatus), result.previousFindingsStatus());
+  }
+
+  @Test
+  void multiCallDoesNotRetryABatchTruncatedAtTheModelsLengthCap() {
+    // #492: a length stop is deterministic — re-sending the identical prompt against the identical
+    // cap is cut at the identical point. The generic soft-fail path retries once before giving up,
+    // which for a truncation is a second guaranteed-futile billed call. It must go straight to the
+    // disclosure instead, exactly once.
+    var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt()))
+        .thenThrow(new AiResponseTruncatedException("finish_reason=length"));
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(2), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("b.java", "B")), List.of(), null));
+    var summary = new ReviewResponse.Summary(1, 0, 0, 1, 0, "ok", "does things", List.of());
+    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
+    when(aiReviewService.summarize(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), summary));
+
+    var plan = multiBatchPlan();
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    verify(aiReviewService, times(1))
+        .reviewBatch(eq(session), any(), eq(1), anyInt()); // no second, futile call
+
+    // The rest of the soft-fail contract is unchanged: the successful batch keeps its findings and
+    // the truncated batch's files are disclosed rather than silently dropped.
+    assertEquals(1, result.findings().size());
+    assertEquals("B", result.findings().get(0).title());
+    assertEquals(List.of("a.java"), plan.runtimeUncoveredFiles());
+    assertTrue(plan.truncated());
+    assertTrue(captor.getValue().changedFiles().contains("a.java (not reviewed"));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -18,6 +18,7 @@ package dev.thiagogonzaga.thrillhousebot.review;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -228,6 +229,52 @@ class FindingPipelineTest {
     assertEquals(List.of("a.java"), plan.runtimeUncoveredFiles());
     assertTrue(plan.truncated());
     assertTrue(captor.getValue().changedFiles().contains("a.java (not reviewed"));
+  }
+
+  @Test
+  void multiCallSurvivesACyclicCauseChainOnAFailedBatch() {
+    // The truncation check walks the cause chain, and a cycle (here A caused-by B caused-by A)
+    // would spin forever on the review thread if the walk were unbounded. The batch must instead
+    // fall through to the ordinary soft-fail path — retried once, then disclosed.
+    var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    var cyclic = cyclicFailure();
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt())).thenThrow(cyclic);
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(2), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("b.java", "B")), List.of(), null));
+    var summary = new ReviewResponse.Summary(1, 0, 0, 1, 0, "ok", "does things", List.of());
+    when(aiReviewService.summarize(eq(session), any()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), summary));
+
+    var plan = multiBatchPlan();
+    var result =
+        assertTimeoutPreemptively(
+            java.time.Duration.ofSeconds(10),
+            () -> pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of())));
+
+    // Not a truncation, so the generic path applies: tried once, retried once, then disclosed.
+    verify(aiReviewService, times(2)).reviewBatch(eq(session), any(), eq(1), anyInt());
+    assertEquals(1, result.findings().size());
+    assertEquals(List.of("a.java"), plan.runtimeUncoveredFiles());
+  }
+
+  /** A RuntimeException whose cause chain loops back on itself after one hop. */
+  private static RuntimeException cyclicFailure() {
+    var head = new RuntimeException("head");
+    var tail =
+        new RuntimeException("tail") {
+          @Override
+          public synchronized Throwable getCause() {
+            return head;
+          }
+        };
+    return new RuntimeException("outer", tail) {
+      @Override
+      public synchronized Throwable getCause() {
+        return tail;
+      }
+    };
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -259,22 +259,32 @@ class FindingPipelineTest {
     assertEquals(List.of("a.java"), plan.runtimeUncoveredFiles());
   }
 
-  /** A RuntimeException whose cause chain loops back on itself after one hop. */
+  /**
+   * A cause chain that genuinely loops: {@code a -> b -> a -> b -> ...}, never reaching {@code
+   * null}. Built through a holder because the two exceptions have to reference each other.
+   *
+   * <p>An earlier version of this helper ended in a plain exception, so the walk terminated on
+   * {@code cause != null} and the depth bound was never exercised — the test passed without testing
+   * anything. Coverage caught it.
+   */
   private static RuntimeException cyclicFailure() {
-    var head = new RuntimeException("head");
-    var tail =
-        new RuntimeException("tail") {
+    var forward = new java.util.concurrent.atomic.AtomicReference<Throwable>();
+    var a =
+        new RuntimeException("a") {
           @Override
           public synchronized Throwable getCause() {
-            return head;
+            return forward.get();
           }
         };
-    return new RuntimeException("outer", tail) {
-      @Override
-      public synchronized Throwable getCause() {
-        return tail;
-      }
-    };
+    var b =
+        new RuntimeException("b") {
+          @Override
+          public synchronized Throwable getCause() {
+            return a;
+          }
+        };
+    forward.set(b);
+    return a;
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewServiceTest.java
@@ -929,6 +929,59 @@ class AiReviewServiceTest {
     assertNull(service.streamingHandleOf(new FakeTokenStream("{\"findings\":[]}")));
   }
 
+  @Test
+  void shouldNotRetryAResponseTruncatedAtTheLengthCap() {
+    // A length stop is deterministic: the same prompt against the same cap is cut at the same
+    // point. Retrying it bills maxAiRetries identical failures, so exactly one call must be made.
+    var starts = new java.util.concurrent.atomic.AtomicInteger();
+    ReviewSession session = reviewSession();
+    when(prReviewer.reviewStream(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString()))
+        .thenAnswer(invocation -> new TruncatedTokenStream("{\"findings\":[{\"file\":\"A", starts));
+
+    var thrown =
+        assertThrows(
+            AiResponseTruncatedException.class, () -> service.review(session, PROMPT_INPUTS));
+
+    assertEquals(1, starts.get(), "a deterministic truncation must be attempted exactly once");
+    assertTrue(
+        thrown.getMessage().contains("max-output-tokens"),
+        "the message must name the knob an operator has to change: " + thrown.getMessage());
+    verify(parser, never()).parse(anyString());
+  }
+
+  @Test
+  void shouldNotBroadcastRetryEventsForATruncatedResponse() {
+    // The dashboard must not show a retry that never happens.
+    var starts = new java.util.concurrent.atomic.AtomicInteger();
+    ReviewSession session = reviewSession();
+    when(prReviewer.reviewStream(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString()))
+        .thenAnswer(invocation -> new TruncatedTokenStream("{\"findings\":[", starts));
+
+    assertThrows(AiResponseTruncatedException.class, () -> service.review(session, PROMPT_INPUTS));
+
+    verify(broadcaster, never())
+        .broadcast(
+            argThat(
+                event ->
+                    SessionEventBroadcaster.SessionEvent.TYPE_RETRY.equals(event.type())
+                        || SessionEventBroadcaster.SessionEvent.TYPE_STREAM_FAILED.equals(
+                            event.type())));
+  }
+
   private static ReviewSession reviewSession() {
     var session = new ReviewSession();
     session.id = 42L;

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedTokenStream.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedTokenStream.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.tool.ToolExecution;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+/**
+ * Emits a body cut mid-JSON with {@code finish_reason: length} — what a provider actually returns
+ * when the response hits {@code max_tokens}. Counts its own starts so a test can assert how many
+ * calls a truncation cost.
+ */
+final class TruncatedTokenStream implements TokenStream {
+
+  private final String partialText;
+  private final AtomicInteger starts;
+  private Consumer<ChatResponse> completeHandler;
+
+  TruncatedTokenStream(String partialText, AtomicInteger starts) {
+    this.partialText = partialText;
+    this.starts = starts;
+  }
+
+  @Override
+  public TokenStream onPartialResponse(Consumer<String> handler) {
+    return this;
+  }
+
+  @Override
+  public TokenStream onRetrieved(Consumer<List<Content>> handler) {
+    return this;
+  }
+
+  @Override
+  public TokenStream onToolExecuted(Consumer<ToolExecution> handler) {
+    return this;
+  }
+
+  @Override
+  public TokenStream onCompleteResponse(Consumer<ChatResponse> handler) {
+    this.completeHandler = handler;
+    return this;
+  }
+
+  @Override
+  public TokenStream onError(Consumer<Throwable> handler) {
+    return this;
+  }
+
+  @Override
+  public TokenStream ignoreErrors() {
+    return this;
+  }
+
+  @Override
+  public void start() {
+    starts.incrementAndGet();
+    if (completeHandler != null) {
+      completeHandler.accept(
+          ChatResponse.builder()
+              .aiMessage(AiMessage.from(partialText))
+              .finishReason(FinishReason.LENGTH)
+              .build());
+    }
+  }
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Fixes #492.

A model that stops on `finish_reason: length` returns a body cut mid-JSON. Nothing read the finish reason, so a truncation surfaced only as `"Model response is not valid review JSON"` — indistinguishable from a genuinely malformed response, and therefore routed into the **transient**-failure retry path.

It is not transient. The same prompt against the same cap is cut at the same point every time. So:

- `AiReviewService.runWithRetries` retried it `max-ai-retries` times (default **5**) with exponential backoff
- `FindingPipeline` then treated the exhausted-retries failure as a batch failure and re-ran `processBatch`, entering that loop again

One over-cap batch therefore cost roughly **ten full-price input calls**, every one knowably futile, before the batch was dropped and its files disclosed as unreviewed. The only knob that bounds output spend multiplied it instead — and none of those retries counted against `REVIEW_MAX_AI_CALLS`, which caps only *planned* calls.

### The change

Read `finishReason` off the `ChatResponse` and raise a distinct `AiResponseTruncatedException`. Both retry layers now decline it:

- the service rethrows immediately, without retrying and without broadcasting a retry event to the dashboard (a retry that never happens should not appear in the live feed)
- the pipeline goes straight to the existing disclosure path rather than paying for a second guaranteed truncation

The soft-fail contract is otherwise untouched: successful batches keep their findings, the truncated batch's files are still recorded as uncovered so the verdict holds and the summary discloses the gap.

Two details worth noting for review:

- `AiResponseTruncatedException extends AiReviewException` deliberately. `asAiReviewException` returns an `AiReviewException` cause as-is, so the subclass survives the `CompletableFuture` unwrapping with its identity intact. Extending `RuntimeException` instead would have been silently re-wrapped and the guard would never fire.
- `isResponseTruncated` walks the cause chain (the failure arrives as `CompletionException` over the service's exception) with a self-reference guard so a malformed chain cannot loop.

The message names `max-output-tokens` explicitly, so an operator reading the log can see which knob caused it and that leaving it unset falls back to the provider default.

## Related Issues

Fixes #492

Companions, not included here: #493 (`output-buffer-tokens` subtracted from input on separate-budget models) and #494 (the startup rule built on the same shared-window assumption). This one is independent of both — it bites on any model, shared-window or not, for anyone who sets `max-output-tokens` at all.

## How Has This Been Tested?

- [x] Unit tests

New fake `TruncatedTokenStream` emits a body cut mid-JSON with `FinishReason.LENGTH` — what a provider actually returns — and counts its own `start()` calls so a test can assert what a truncation *cost*.

**Service layer**, `AiReviewServiceTest`. Red phase with only the no-retry guard reverted (detection left in place), so the failure isolates the guard:

```
[ERROR] AiReviewServiceTest.shouldNotRetryAResponseTruncatedAtTheLengthCap:949 Unexpected exception type thrown,
expected: <...AiResponseTruncatedException> but was: <...AiReviewException>
[ERROR] AiReviewServiceTest.shouldNotBroadcastRetryEventsForATruncatedResponse:974 Unexpected exception type thrown,
expected: <...AiResponseTruncatedException> but was: <...AiReviewException>
```

That generic `AiReviewException` is the defect visible in one line: the truncation was retried to exhaustion and reported as "AI review failed after N attempts". Green with the guard restored. The first test asserts `starts.get() == 1` — exactly one call — and that the parser is never reached.

**Batch layer**, `FindingPipelineTest.multiCallDoesNotRetryABatchTruncatedAtTheModelsLengthCap`. Red with the branch disabled:

```
org.mockito.exceptions.verification.TooManyActualInvocations:
aiReviewService.reviewBatch(
    ReviewSession<null>,
    <any>,
    1,
    <any integer>
);
```

The second, futile call caught directly. The test also pins the parts that must *not* change — the successful batch keeps its finding, `plan.runtimeUncoveredFiles()` still lists the truncated batch's file, and the summary still says `a.java (not reviewed`.

Gates on the final tree:

- `./mvnw -B spotless:apply` / `spotless:check` — clean
- `./mvnw -B clean compile spotbugs:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — **Tests run: 2429, Failures: 0, Errors: 0, Skipped: 0**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

**Scope, stated plainly.** This makes a truncation cheap and legible instead of expensive and mute. It does **not** yet recover the findings — a truncated batch is still disclosed as unreviewed rather than re-run split smaller or salvaged for whatever parsed. That is a deliberate follow-up: batches are planned up front by `DiffBudgetPlanner` with token accounting, so re-splitting one mid-flight duplicates that logic and deserves its own change. The cost amplification was the urgent half and it is self-contained.

No behaviour changes for any deployment that does not set `max-output-tokens`, since no `max_tokens` is sent and no length stop can occur.