### PR TITLE
feat(ai): let a model declare an output budget separate from its input window

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,6 +128,14 @@ AI_TIMEOUT=300s
 # presence-penalty, and seed are sent on every chat call when set (no top_k on the
 # OpenAI-compatible wire). A low temperature (e.g. 0.2) makes reviews more deterministic.
 #
+# separate-output-budget (default false) says whether the model's response allowance is its own or
+# a slice of the input window. Left false, prompt and completion share one window: the budgeter
+# reserves output-buffer-tokens out of the input budget and max-output-tokens may not exceed that
+# reservation (boot fails if it does). Set it true for a model that publishes its output allowance
+# on top of the input window — e.g. deepseek-v4-flash at 1M in and 384000 out, which ships that way
+# by default. Marking such a model shared silently costs ~40% of every call's diff budget:
+#THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_FLASH_SEPARATE_OUTPUT_BUDGET=true
+#
 # Env form: the underscores depend on whether the key needs quoting in application.properties.
 # A hyphen-only key (deepseek-v4-pro) is unquoted there and takes SINGLE underscores; a key with a
 # dot (gpt-5.5) is quoted and takes DOUBLE underscores either side. The wrong form resolves to

--- a/README.md
+++ b/README.md
@@ -435,6 +435,9 @@ thrillhousebot.ai.models.deepseek-chat.max-output-tokens=8192
 thrillhousebot.ai.models.deepseek-chat.frequency-penalty=0.1
 thrillhousebot.ai.models.deepseek-chat.presence-penalty=0.1
 thrillhousebot.ai.models.deepseek-chat.seed=42
+# Set true only when the model's response allowance is separate from its input
+# window (1M in with 384K out on top, rather than 384K carved out of the 1M)
+thrillhousebot.ai.models.deepseek-v4-flash.separate-output-budget=true
 ```
 
 Notes:
@@ -456,9 +459,20 @@ Notes:
   relevant only with native provider integrations.
 - **`max-output-tokens` vs `output-buffer-tokens`**: `max-output-tokens` is the
   hard response-length cap sent to the provider; `output-buffer-tokens` only
-  reserves input-budget headroom for the map-reduce budgeter. Keep the buffer
-  at least as large as the output cap so a response the model is allowed to
-  produce always has reserved room — set both when capping output.
+  reserves input-budget headroom for the map-reduce budgeter. On a shared-window
+  model, keep the buffer at least as large as the output cap so a response the
+  model is allowed to produce always has reserved room — set both when capping
+  output. Boot fails if you don't.
+- **`separate-output-budget`** (default `false`) says which contract the model is
+  on. Left off, prompt and completion share one window: the budgeter reserves
+  `output-buffer-tokens` out of the input budget, and the buffer must cover
+  `max-output-tokens`. Set it `true` for a model that publishes a response
+  allowance *on top of* its input window rather than inside it — then the
+  budgeter stops reserving (the response never draws on the diff budget) and the
+  buffer no longer has to cover the cap. Getting it wrong is expensive in one
+  direction and unbootable in the other, so it is explicit rather than inferred:
+  a 384000-token cap on a 1M window silently costs ~40% of every call's diff
+  budget if the model is wrongly marked shared.
 - **`seed`** is a best-effort determinism hint (same seed + same parameters aims
   for the same sampling) on providers that support it; unsupported providers
   ignore it. For deterministic reviews, prefer a low `temperature` first.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ActiveModelSettings.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ActiveModelSettings.java
@@ -86,6 +86,25 @@ public class ActiveModelSettings {
         .orElseGet(() -> config.review().outputBufferTokens());
   }
 
+  /**
+   * Whether the active model's response allowance is independent of its input window. Defaults to
+   * {@code false} — the shared-window contract every model assumed before this existed — so an
+   * unconfigured model keeps exactly today's budgeting.
+   */
+  public boolean separateOutputBudget() {
+    return settings().flatMap(ModelSettings::separateOutputBudget).orElse(false);
+  }
+
+  /**
+   * Tokens the budgeter must hold back from the input budget for the response: {@link
+   * #outputBufferTokens()} on a shared window, and zero when the response draws from a budget of
+   * its own. Single source of truth for that decision so the planner and the startup validator
+   * cannot disagree about it.
+   */
+  public int reservedOutputTokens() {
+    return separateOutputBudget() ? 0 : outputBufferTokens();
+  }
+
   /** Token safety margin: the model's override, else the global review value. */
   public double tokenSafetyMargin() {
     return settings()

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -222,7 +222,9 @@ public class StartupConfigValidator {
   private void validateEffectiveBudget(List<String> problems) {
     var maxInputTokens = activeModel.maxInputTokens();
     var margin = activeModel.tokenSafetyMargin();
-    var outputBuffer = activeModel.outputBufferTokens();
+    // What the budgeter will actually hold back — zero when the response has a budget of its own.
+    // Reading the same value the planner reads keeps the two from disagreeing about the arithmetic.
+    var outputBuffer = activeModel.reservedOutputTokens();
     if (maxInputTokens > 0
         && Double.isFinite(margin)
         && margin > 0
@@ -238,7 +240,11 @@ public class StartupConfigValidator {
               + "' so there is budget left for the diff (thrillhousebot.review.* with"
               + " thrillhousebot.ai.models overrides)");
     }
-    if (maxInputTokens > 0) {
+    // Only meaningful on a shared window, where output tokens are spent out of the same pool the
+    // budgeter packed the prompt into: licensing more output than was reserved overruns it. When
+    // the response has a budget of its own there is nothing to reserve, and enforcing the ceiling
+    // would make the model's real output allowance unconfigurable — so the rule does not apply.
+    if (maxInputTokens > 0 && !activeModel.separateOutputBudget()) {
       activeModel
           .maxOutputTokens()
           .filter(maxOutput -> maxOutput > outputBuffer)
@@ -251,7 +257,11 @@ public class StartupConfigValidator {
                           + maxOutput
                           + ") for model '"
                           + activeModel.modelName()
-                          + "' so the token budget reserves the configured response cap"));
+                          + "' so the token budget reserves the configured response cap. Set"
+                          + " thrillhousebot.ai.models.\""
+                          + activeModel.modelName()
+                          + "\".separate-output-budget=true if this model's response allowance is"
+                          + " independent of its input window."));
     }
   }
 
@@ -394,6 +404,7 @@ public class StartupConfigValidator {
           "OUTPUT_BUFFER_TOKENS",
           "TOKEN_SAFETY_MARGIN",
           "MAX_OUTPUT_TOKENS",
+          "SEPARATE_OUTPUT_BUDGET",
           "FREQUENCY_PENALTY",
           "PRESENCE_PENALTY",
           "TEMPERATURE",

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -172,7 +172,12 @@ public interface ThrillhouseConfig {
     @WithName("max-input-tokens")
     int maxInputTokens();
 
-    /** Tokens reserved out of the context window for the model's response (findings JSON). */
+    /**
+     * Tokens held back from the input budget for the model's response (findings JSON), because on a
+     * shared window the response is spent from the same pool the prompt was packed into. Ignored
+     * for a model marked {@link AiPricingConfig.ModelSettings#separateOutputBudget()}, whose
+     * response draws on an allowance of its own and so takes nothing from the diff.
+     */
     @WithDefault("8192")
     @WithName("output-buffer-tokens")
     int outputBufferTokens();
@@ -586,8 +591,9 @@ public interface ThrillhouseConfig {
       Optional<Integer> maxInputTokens();
 
       /**
-       * Per-model override of {@code thrillhousebot.review.output-buffer-tokens} — tokens reserved
-       * out of the context window for the model's response.
+       * Per-model override of {@code thrillhousebot.review.output-buffer-tokens} — tokens held back
+       * from the input budget for the model's response. Only meaningful on a shared window: with
+       * {@link #separateOutputBudget()} set, nothing is held back regardless of this value.
        */
       @WithName("output-buffer-tokens")
       Optional<Integer> outputBufferTokens();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -616,11 +616,35 @@ public interface ThrillhouseConfig {
       /**
        * OpenAI-compatible {@code max_tokens} sent on every chat call, bounding the response length
        * (and spend). Absent leaves the provider default. Independent of {@link
-       * #outputBufferTokens()}, which only reserves input-budget headroom — set both when capping
-       * output.
+       * #outputBufferTokens()}, which only reserves input-budget headroom — on a shared-window
+       * model, set both when capping output.
        */
       @WithName("max-output-tokens")
       Optional<Integer> maxOutputTokens();
+
+      /**
+       * Whether this model's response allowance is a budget of its own rather than a slice of the
+       * window {@link #maxInputTokens()} describes.
+       *
+       * <p>The default ({@code false}) is the classic OpenAI-style contract: prompt and completion
+       * share one window, so tokens spent on the response are tokens unavailable to the diff. The
+       * budgeter reserves {@link #outputBufferTokens()} out of the input budget accordingly, and
+       * {@code max-output-tokens} may not exceed that reservation — licensing more output than was
+       * reserved is how a call overruns the window.
+       *
+       * <p>Set {@code true} for a model that publishes an input window and a response allowance
+       * that do not compete (e.g. 1M in with 384K out <em>on top</em>). Both of those rules are
+       * then wrong rather than merely conservative: the reservation would take budget from the diff
+       * to protect a pool the response never draws from, and the ceiling would make the model's
+       * real output allowance unconfigurable. So the budgeter stops subtracting and {@link
+       * StartupConfigValidator} stops requiring the buffer to cover the cap.
+       *
+       * <p>Deliberately explicit rather than inferred from a model declaring both caps: getting
+       * this wrong silently picks the wrong arithmetic, and an operator should be able to read
+       * which contract a model is on straight from its config.
+       */
+      @WithName("separate-output-budget")
+      Optional<Boolean> separateOutputBudget();
 
       /**
        * OpenAI-compatible {@code frequency_penalty} in {@code [-2, 2]} sent on every chat call —

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -213,7 +213,7 @@ public class DiffBudgetPlanner {
       return Integer.MAX_VALUE;
     }
     return (int) (maxInputTokens * activeModel.tokenSafetyMargin())
-        - activeModel.outputBufferTokens();
+        - activeModel.reservedOutputTokens();
   }
 
   /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -84,10 +84,16 @@ thrillhousebot.ai.reasoning.effort=${AI_REASONING_EFFORT:low}
 #thrillhousebot.ai.models.deepseek-chat.presence-penalty=0.1
 #thrillhousebot.ai.models.deepseek-chat.seed=42
 #
-# deepseek-v4-flash is the exception below: it ships its real caps rather than an empty stub, so a
-# deployment gets the model's own 1M context window instead of the 128000 fallback. Its
-# max-output-tokens rides the wire as max_tokens on every call — lower it (or clear it) if the
-# effective input budget plus the output cap would overshoot the context window.
+# deepseek-v4-flash is the exception below: it ships its real caps rather than empty stubs, so a
+# deployment gets the model's own 1M input window instead of the 128000 fallback, and its full
+# 384000-token response allowance instead of the provider default.
+#
+# separate-output-budget=true is what makes that pair correct. Those two numbers do not compete:
+# the 384000 output is on top of the 1M input, not carved out of it. Without the flag the budgeter
+# would reserve 384000 out of the input budget for a response that never draws on it (costing ~40%
+# of the per-call diff), and the startup validator would refuse to boot unless output-buffer-tokens
+# were raised to match. Leave the flag off for a shared-window model (OpenAI-style, where prompt +
+# completion share one context) — there the reservation and the ceiling are both correct.
 thrillhousebot.ai.models."gpt-5.5".max-input-tokens=
 thrillhousebot.ai.models."gpt-5.5-pro".max-input-tokens=
 thrillhousebot.ai.models."gpt-5.4".max-input-tokens=
@@ -97,6 +103,7 @@ thrillhousebot.ai.models.gpt-4o.max-input-tokens=
 thrillhousebot.ai.models.gpt-4o-mini.max-input-tokens=
 thrillhousebot.ai.models.deepseek-v4-flash.max-input-tokens=1000000
 thrillhousebot.ai.models.deepseek-v4-flash.max-output-tokens=384000
+thrillhousebot.ai.models.deepseek-v4-flash.separate-output-budget=true
 thrillhousebot.ai.models.deepseek-v4-pro.max-input-tokens=
 thrillhousebot.ai.models.deepseek-chat.max-input-tokens=
 thrillhousebot.ai.models.deepseek-reasoner.max-input-tokens=

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/ActiveModelSettingsTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/ActiveModelSettingsTest.java
@@ -59,6 +59,7 @@ class ActiveModelSettingsTest {
     lenient().when(settings.frequencyPenalty()).thenReturn(Optional.empty());
     lenient().when(settings.presencePenalty()).thenReturn(Optional.empty());
     lenient().when(settings.seed()).thenReturn(Optional.empty());
+    lenient().when(settings.separateOutputBudget()).thenReturn(Optional.empty());
     return settings;
   }
 
@@ -75,6 +76,26 @@ class ActiveModelSettingsTest {
     assertTrue(active.presencePenalty().isEmpty());
     assertTrue(active.seed().isEmpty());
     assertFalse(active.budgetClampedByModelCap());
+    assertFalse(
+        active.separateOutputBudget(), "an unconfigured model keeps the shared-window contract");
+    assertEquals(
+        8_192, active.reservedOutputTokens(), "a shared window still reserves the output buffer");
+  }
+
+  @Test
+  void reservesNothingWhenTheModelsOutputBudgetIsSeparate() {
+    // #493: the reservation exists because output tokens are spent out of the input window. When
+    // the response has an allowance of its own it takes nothing from the diff, so holding budget
+    // back for it is pure loss — here 384000 of a 1M window, ~40% of the per-call diff budget.
+    var settings = entry();
+    lenient().when(settings.separateOutputBudget()).thenReturn(Optional.of(true));
+    lenient().when(settings.outputBufferTokens()).thenReturn(Optional.of(384_000));
+    models.put(MODEL, settings);
+
+    assertTrue(active.separateOutputBudget());
+    assertEquals(384_000, active.outputBufferTokens(), "the configured buffer itself is unchanged");
+    assertEquals(
+        0, active.reservedOutputTokens(), "but nothing is held back from the input budget");
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/AiPricingConfigTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/AiPricingConfigTest.java
@@ -17,9 +17,11 @@ package dev.thiagogonzaga.thrillhousebot.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -90,5 +92,44 @@ class AiPricingConfigTest {
     assertNotNull(settings, "deepseek-v4-flash model settings must resolve");
     assertEquals(1_000_000, settings.maxInputTokens().orElseThrow());
     assertEquals(384_000, settings.maxOutputTokens().orElseThrow());
+    assertEquals(
+        Optional.of(true),
+        settings.separateOutputBudget(),
+        "the 384000 output is on top of the 1M input, not carved out of it — without this flag the"
+            + " shipped pair cannot boot and would cost ~40% of the diff budget if it could");
+  }
+
+  @Test
+  void noShippedModelCapExceedsItsBufferOnASharedWindow() {
+    // A shipped max-output-tokens above the effective buffer refuses to boot every deployment
+    // naming that model. The validator rule only fires for the ACTIVE model — one of eighteen in
+    // the table — so no ordinary test sees it. Walk the table directly instead.
+    var reviewBuffer = config.review().outputBufferTokens();
+
+    config
+        .ai()
+        .models()
+        .forEach(
+            (model, settings) -> {
+              if (settings.separateOutputBudget().orElse(false)) {
+                return; // its response draws on a budget of its own; nothing to reserve
+              }
+              settings
+                  .maxOutputTokens()
+                  .ifPresent(
+                      cap -> {
+                        int buffer = settings.outputBufferTokens().orElse(reviewBuffer);
+                        assertTrue(
+                            cap <= buffer,
+                            "shipped max-output-tokens "
+                                + cap
+                                + " for '"
+                                + model
+                                + "' exceeds its effective output buffer "
+                                + buffer
+                                + " — every deployment naming this model would fail to start."
+                                + " Either lower the cap or mark it separate-output-budget");
+                      });
+            });
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -199,6 +199,7 @@ class StartupConfigValidatorTest {
     lenient().when(settings.frequencyPenalty()).thenReturn(Optional.empty());
     lenient().when(settings.presencePenalty()).thenReturn(Optional.empty());
     lenient().when(settings.seed()).thenReturn(Optional.empty());
+    lenient().when(settings.separateOutputBudget()).thenReturn(Optional.empty());
     return settings;
   }
 
@@ -335,6 +336,46 @@ class StartupConfigValidatorTest {
         ex.getMessage()
             .contains("effective output buffer (8192) must be >= max-output-tokens (8193)"),
         ex.getMessage());
+  }
+
+  @Test
+  void pointsAtSeparateOutputBudgetWhenTheResponseCapExceedsTheBuffer() {
+    // The message has to name the way out, or an operator on a separate-budget model reads it as
+    // "raise the buffer" and pays 384000 tokens of diff budget to satisfy a rule that should not
+    // have applied to them.
+    var settings = emptyModelSettings();
+    lenient().when(settings.maxOutputTokens()).thenReturn(Optional.of(8_193));
+
+    var ex = assertFailsValidation(new ConfigBuilder().model("deepseek-chat", settings).build());
+    assertTrue(
+        ex.getMessage().contains("separate-output-budget=true"),
+        "the failure must point at the escape hatch: " + ex.getMessage());
+  }
+
+  @Test
+  void allowsAResponseCapAboveTheBufferWhenTheOutputBudgetIsSeparate() {
+    // #494: on a model whose response allowance is independent of its input window, requiring the
+    // buffer to cover the cap makes the model's real output allowance unconfigurable. 384000 out
+    // against an 8192 buffer is exactly the deepseek-v4-flash shape, and it must boot.
+    var settings = emptyModelSettings();
+    lenient().when(settings.maxInputTokens()).thenReturn(Optional.of(1_000_000));
+    lenient().when(settings.maxOutputTokens()).thenReturn(Optional.of(384_000));
+    lenient().when(settings.separateOutputBudget()).thenReturn(Optional.of(true));
+
+    new ConfigBuilder().model("deepseek-chat", settings).build().validate();
+  }
+
+  @Test
+  void stillRejectsAResponseCapAboveTheBufferOnASharedWindow() {
+    // The narrowing must not become a deletion: without the flag the rule stands, because there
+    // the output really is spent out of the window the prompt was packed into.
+    var settings = emptyModelSettings();
+    lenient().when(settings.maxInputTokens()).thenReturn(Optional.of(1_000_000));
+    lenient().when(settings.maxOutputTokens()).thenReturn(Optional.of(384_000));
+    lenient().when(settings.separateOutputBudget()).thenReturn(Optional.of(false));
+
+    var ex = assertFailsValidation(new ConfigBuilder().model("deepseek-chat", settings).build());
+    assertTrue(ex.getMessage().contains("must be >= max-output-tokens (384000)"), ex.getMessage());
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -70,6 +70,7 @@ class DiffBudgetPlannerTest {
     lenient().when(settings.maxInputTokens()).thenReturn(maxInputTokens);
     lenient().when(settings.outputBufferTokens()).thenReturn(outputBufferTokens);
     lenient().when(settings.tokenSafetyMargin()).thenReturn(tokenSafetyMargin);
+    lenient().when(settings.separateOutputBudget()).thenReturn(Optional.empty());
     return settings;
   }
 
@@ -364,6 +365,33 @@ class DiffBudgetPlannerTest {
     when(reviewConfig.tokenSafetyMargin()).thenReturn(0.9);
     when(reviewConfig.outputBufferTokens()).thenReturn(8192);
     assertEquals(43200 - 8192, planner.perCallInputBudget());
+  }
+
+  @Test
+  void perCallInputBudgetKeepsTheWholeWindowWhenTheOutputBudgetIsSeparate() {
+    // #493: the output buffer is subtracted because a shared window spends output tokens out of
+    // the input pool. When the model's response allowance is its own, that subtraction hands the
+    // diff budget away for nothing — here it would cost 384000 of a 900000-token budget.
+    var settings = modelSettings(Optional.of(1_000_000), Optional.of(384_000), Optional.empty());
+    lenient().when(settings.separateOutputBudget()).thenReturn(Optional.of(true));
+    models.put(MODEL, settings);
+    when(reviewConfig.maxInputTokens()).thenReturn(1_000_000);
+    when(reviewConfig.tokenSafetyMargin()).thenReturn(0.9);
+
+    assertEquals(900_000, planner.perCallInputBudget());
+  }
+
+  @Test
+  void perCallInputBudgetStillSubtractsTheBufferOnASharedWindow() {
+    // The counterpart: without the flag the subtraction stands, so this change cannot quietly
+    // widen the budget for every existing deployment.
+    var settings = modelSettings(Optional.of(1_000_000), Optional.of(384_000), Optional.empty());
+    lenient().when(settings.separateOutputBudget()).thenReturn(Optional.of(false));
+    models.put(MODEL, settings);
+    when(reviewConfig.maxInputTokens()).thenReturn(1_000_000);
+    when(reviewConfig.tokenSafetyMargin()).thenReturn(0.9);
+
+    assertEquals(900_000 - 384_000, planner.perCallInputBudget());
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature
- [x] 🐛 Bug fix
- [x] 📝 Documentation

## Description

Fixes #493 and #494, and **supersedes #491** — which took the wrong branch of the fork. #491 removed `max-output-tokens=384000` to stop the boot failure, but the point of setting it is to *use* the model's 384 K response allowance. Deleting the value makes the bot boot by giving up the capability. This keeps the value and fixes the thing that made it unbootable.

### The shared assumption

Two places encode the same premise — that prompt and completion are spent from one window:

```java
// DiffBudgetPlanner.perCallInputBudget()
return (int) (maxInputTokens * activeModel.tokenSafetyMargin())
    - activeModel.outputBufferTokens();
```

```java
// StartupConfigValidator.validateEffectiveBudget()
.filter(maxOutput -> maxOutput > outputBuffer)   // refuse to boot
```

That is the OpenAI-style contract, and it was right for every model in the table until now. It is wrong for a model publishing an input window and a response allowance that don't compete. `deepseek-v4-flash` is **1M in with 384000 out on top**, not 384000 carved out of the 1M.

On such a model the reservation takes budget from the diff to protect a pool the response never draws on, and the ceiling makes the real output allowance unconfigurable. There was no configuration expressing "1M in, 384K out, independent" — you could have the input budget or the output allowance, not both.

The config already contradicted itself about this: `max-input-tokens` is documented as *"the model's input hard cap"* while `output-buffer-tokens` is documented as coming *"out of the context window"*. Both can't be true.

### The change

A per-model `separate-output-budget` flag, **default `false`** — so every existing deployment keeps today's arithmetic byte for byte. When `true`, the budgeter stops subtracting and the validator stops requiring the buffer to cover the cap.

`ActiveModelSettings.reservedOutputTokens()` is the single source of truth for that decision, read by both the planner and the validator, so the two cannot drift into disagreeing about the arithmetic.

`deepseek-v4-flash` ships all three values together:

```properties
thrillhousebot.ai.models.deepseek-v4-flash.max-input-tokens=1000000
thrillhousebot.ai.models.deepseek-v4-flash.max-output-tokens=384000
thrillhousebot.ai.models.deepseek-v4-flash.separate-output-budget=true
```

Two deliberate choices worth review:

- **Explicit, not inferred.** Treating "declares both caps" as implying independence would silently pick the wrong arithmetic for a shared-window model that legitimately sets both. An operator should be able to read which contract a model is on straight from its config.
- **Narrowed, not deleted.** The validator rule still fires without the flag — it is a real protection there. A test pins that specifically, so this cannot decay into "the rule was removed".

The failure message now names the flag, so someone on a separate-budget model isn't misled into raising `output-buffer-tokens` to 384000 — which would satisfy a rule that shouldn't have applied to them, at the cost of ~40% of every call's diff budget.

`SEPARATE_OUTPUT_BUDGET` is registered in `MODEL_SETTING_SUFFIXES` so a mis-underscored env var gets the same startup warning as every other per-model key.

## Related Issues

Fixes #493
Fixes #494

Supersedes #491 — close it unmerged; its `application.properties` change conflicts with this and its approach was wrong. Its shipped-defaults guard is carried over here, extended to skip separate-budget models.

Independent of #495 (truncation detection, disjoint files).

## How Has This Been Tested?

- [x] Unit tests

Red/green on each half, plus a counterpart test for each so the narrowing can't become a deletion.

**Planner** — `DiffBudgetPlannerTest.perCallInputBudgetKeepsTheWholeWindowWhenTheOutputBudgetIsSeparate`, with the subtraction reverted:

```
expected: <900000> but was: <516000>
```

Exactly the 384 K handed away. Its counterpart `perCallInputBudgetStillSubtractsTheBufferOnASharedWindow` asserts `900000 - 384000` without the flag, so the change cannot quietly widen the budget for existing deployments.

**Validator** — `allowsAResponseCapAboveTheBufferWhenTheOutputBudgetIsSeparate`, with the guard reverted:

```
ThrillhouseBot cannot start — required configuration is missing or invalid:
  - the effective output buffer (0) must be >= max-output-tokens (384000) for model 'deepseek-chat'
```

The production failure, reproduced. Its counterpart `stillRejectsAResponseCapAboveTheBufferOnASharedWindow` keeps the rule honest without the flag, and `pointsAtSeparateOutputBudgetWhenTheResponseCapExceedsTheBuffer` pins that the message names the escape hatch.

**Shipped defaults** — `AiPricingConfigTest` (a `@QuarkusTest` reading the real `application.properties`) asserts the flash entry ships all three values, and `noShippedModelCapExceedsItsBufferOnASharedWindow` walks the whole table so no future entry can ship an unbootable pair. That guard exists because the validator rule only ever evaluates the **active** model — one of eighteen — which is how #490 shipped a config that couldn't boot past a 2426-test suite.

**One caught in the writing, worth flagging.** My first version of the validator tests registered settings under `"deepseek-v4-flash"` while the builder's active model defaults to `"deepseek-chat"`, so the entry was never read. The "allows" test passed — for the wrong reason, proving nothing. Both now use the active model's key, and the red phase above confirms they actually exercise the rule.

Gates on the final tree:

- `./mvnw -B spotless:apply` / `spotless:check` — clean
- `./mvnw -B clean compile spotbugs:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — **Tests run: 2433, Failures: 0, Errors: 0, Skipped: 0**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

**Deployment effect.** Anyone already on `deepseek-v4-flash` gets the full 1M input budget *and* the full 384 K response allowance, and can drop the `THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_FLASH_MAX_OUTPUT_TOKENS` workaround from their environment. No other model changes behaviour — the flag defaults to `false` everywhere else.

**Worth pairing with #495.** With the full 384 K allowance in play a length stop is unlikely, but #495 is what makes one cheap and legible if it happens rather than ~10 futile billed calls.