### PR TITLE
fix(github): cap check-run output fields at their own GitHub limits

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/CommentBodyLimit.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/CommentBodyLimit.java
@@ -15,16 +15,20 @@
  */
 package dev.thiagogonzaga.thrillhousebot.github;
 
+import java.util.Locale;
+
 /**
- * Bounds an outgoing comment body to GitHub's hard {@value #MAX_LENGTH}-character limit. GitHub
- * rejects a longer issue-comment, review, inline-comment, or reply body with a 422; that rejection
- * is swallowed by the fail-soft posting wrapper, so an over-long comment posts <em>nothing</em> —
- * no comment, no error. Capping at the client boundary turns that silent total failure into a
- * posted-but-truncated comment carrying an honest {@link #TRUNCATION_NOTICE}.
+ * Bounds an outgoing text field to the hard character limit GitHub enforces for it — {@value
+ * #MAX_LENGTH} for a comment body, and its own per-field limit for anything else. GitHub rejects an
+ * over-long issue-comment, review, inline-comment, reply body, or check-run output field with a
+ * 422; that rejection is swallowed by the fail-soft posting wrapper, so an over-long comment posts
+ * <em>nothing</em> and an over-long check-run output updates nothing — no output, no error. Capping
+ * at the client boundary turns that silent total failure into a posted-but-truncated value carrying
+ * an honest truncation notice.
  *
- * <p>Applied uniformly in the compact constructor of every body-bearing request record in {@link
- * GitHubCommentClient} and {@link GitHubReviewClient}, so every poster is protected the same way
- * and a future post path inherits the guard for free.
+ * <p>Applied uniformly in the compact constructor of every text-bearing request record in {@link
+ * GitHubCommentClient}, {@link GitHubReviewClient} and {@link GitHubCheckRunClient}, so every
+ * poster is protected the same way and a future post path inherits the guard for free.
  */
 final class CommentBodyLimit {
 
@@ -34,11 +38,11 @@ final class CommentBodyLimit {
   static final int MAX_LENGTH = 65_536;
 
   /**
-   * Appended when a body is truncated. Self-explanatory so the maintainer learns the output was cut
-   * rather than seeing a body that just stops. Its own length is reserved when truncating, so the
-   * final string — notice included — never exceeds {@link #MAX_LENGTH}.
+   * Appended when a comment body is truncated. Self-explanatory so the maintainer learns the output
+   * was cut rather than seeing a body that just stops. Its own length is reserved when truncating,
+   * so the final string — notice included — never exceeds {@link #MAX_LENGTH}.
    */
-  static final String TRUNCATION_NOTICE = "\n\n… (truncated at GitHub's 65,536-character limit)";
+  static final String TRUNCATION_NOTICE = truncationNotice(MAX_LENGTH);
 
   private CommentBodyLimit() {}
 
@@ -49,17 +53,42 @@ final class CommentBodyLimit {
    * {@link #MAX_LENGTH} characters. The cut never splits a UTF-16 surrogate pair.
    */
   static String cap(String body) {
-    if (body == null || body.length() <= MAX_LENGTH) {
-      return body;
+    return cap(body, MAX_LENGTH);
+  }
+
+  /**
+   * The same guard against an arbitrary {@code limit}, for fields GitHub bounds differently from a
+   * comment body. Returns {@code value} unchanged when it is {@code null} or already within {@code
+   * limit} characters; otherwise truncates it so the result — with a notice naming that limit
+   * appended — is at most {@code limit} characters, again never splitting a surrogate pair.
+   *
+   * <p>{@code limit} is expected to be comfortably larger than the notice it produces (every call
+   * site passes a GitHub limit of at least a few hundred characters); a limit shorter than its own
+   * notice is a programming error, not a runtime condition to defend against.
+   */
+  static String cap(String value, int limit) {
+    if (value == null || value.length() <= limit) {
+      return value;
     }
-    // Both operands are compile-time constants and the notice is orders of magnitude shorter than
-    // the limit, so keep is always well above zero; and body is longer than MAX_LENGTH to reach
-    // here, so charAt(keep - 1) is always in range. No bounds guard is needed.
-    int keep = MAX_LENGTH - TRUNCATION_NOTICE.length();
+    var notice = truncationNotice(limit);
+    // The notice is far shorter than any limit passed here, so keep is well above zero; and value
+    // is longer than limit to reach here, so charAt(keep - 1) is always in range.
+    int keep = limit - notice.length();
     // Never leave a dangling high surrogate at the cut point — that would corrupt a code point.
-    if (Character.isHighSurrogate(body.charAt(keep - 1))) {
+    if (Character.isHighSurrogate(value.charAt(keep - 1))) {
       keep--;
     }
-    return body.substring(0, keep) + TRUNCATION_NOTICE;
+    return value.substring(0, keep) + notice;
+  }
+
+  /**
+   * The notice for a given limit, naming the limit so a reader of the truncated value can tell
+   * which GitHub boundary cut it. {@link Locale#ROOT} keeps the grouping separator a comma whatever
+   * the host locale is, so the wording is stable.
+   */
+  private static String truncationNotice(int limit) {
+    return "\n\n… (truncated at GitHub's "
+        + String.format(Locale.ROOT, "%,d", limit)
+        + "-character limit)";
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
@@ -230,8 +230,35 @@ public interface GitHubCheckRunClient {
       @JsonProperty("completed_at") String completedAt,
       @JsonProperty("details_url") String detailsUrl,
       Output output) {
+    /**
+     * The check-run output panel. Each field is bounded at its own GitHub limit in the compact
+     * constructor — they are not the same number — because GitHub rejects an over-long output with
+     * a 422 and the fail-soft update wrapper swallows it, leaving the check run silently stale
+     * exactly when the review is largest and the check matters most.
+     */
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public record Output(String title, String summary, String text) {}
+    public record Output(String title, String summary, String text) {
+
+      /**
+       * Maximum title length. GitHub's REST reference states no length for {@code output.title}
+       * itself; 255 is the limit documented for the sibling {@code output.annotations[].title} and
+       * the value the API enforces in practice. A check-run title is a one-line verdict, so a cap
+       * here only ever bites on a pathological title.
+       */
+      static final int MAX_TITLE_LENGTH = 255;
+
+      /** Maximum summary length, per GitHub's documented {@code maxLength} for the field. */
+      static final int MAX_SUMMARY_LENGTH = 65_535;
+
+      /** Maximum details-text length, per GitHub's documented {@code maxLength} for the field. */
+      static final int MAX_TEXT_LENGTH = 65_535;
+
+      public Output {
+        title = CommentBodyLimit.cap(title, MAX_TITLE_LENGTH);
+        summary = CommentBodyLimit.cap(summary, MAX_SUMMARY_LENGTH);
+        text = CommentBodyLimit.cap(text, MAX_TEXT_LENGTH);
+      }
+    }
   }
 
   record CheckRunResponse(long id, @JsonProperty("html_url") String htmlUrl) {}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/CommentBodyLimitTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/CommentBodyLimitTest.java
@@ -93,4 +93,30 @@ class CommentBodyLimitTest {
         Character.isLowSurrogate(capped.charAt(keep - 1)),
         "the pair ends on the last kept character, so nothing is trimmed");
   }
+
+  @Test
+  void keepsTheCommentNoticeWordingItHasAlwaysHad() {
+    // The notice is now derived from the limit rather than written out; pin the exact wording so
+    // the comment path stays byte-identical (a locale-sensitive grouping separator would break it).
+    assertEquals(
+        "\n\n… (truncated at GitHub's 65,536-character limit)", CommentBodyLimit.TRUNCATION_NOTICE);
+  }
+
+  @Test
+  void capsAtAnExplicitLimitAndNamesItInTheNotice() {
+    var capped = CommentBodyLimit.cap("x".repeat(300), 255);
+
+    assertEquals(255, capped.length());
+    assertTrue(
+        capped.endsWith("\n\n… (truncated at GitHub's 255-character limit)"),
+        "the notice must name the limit that actually cut the value");
+  }
+
+  @Test
+  void returnsAValueExactlyOnAnExplicitLimitByIdentity() {
+    var value = "x".repeat(255);
+
+    assertSame(value, CommentBodyLimit.cap(value, 255));
+    assertNull(CommentBodyLimit.cap(null, 255));
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClientTest.java
@@ -85,4 +85,97 @@ class GitHubCheckRunClientTest {
             .contains("\"details_url\":\"https://bot.example/session/7\""));
     assertFalse(mapper.writeValueAsString(withoutUrl).contains("\"details_url\""));
   }
+
+  // GitHub's own limits for the check-run output fields, plus the notice the client appends when
+  // it truncates. Kept as literals here (not references to the production constants) so these
+  // tests pin the boundaries and wording independently of the code under test.
+  private static final int MAX_TITLE = 255;
+  private static final int MAX_SUMMARY = 65_535;
+  private static final int MAX_TEXT = 65_535;
+  private static final String TITLE_NOTICE = "\n\n… (truncated at GitHub's 255-character limit)";
+  private static final String BODY_NOTICE = "\n\n… (truncated at GitHub's 65,535-character limit)";
+
+  private static GitHubCheckRunClient.UpdateCheckRunRequest.Output output(
+      String title, String summary, String text) {
+    return new GitHubCheckRunClient.UpdateCheckRunRequest.Output(title, summary, text);
+  }
+
+  @Test
+  void outputFieldsExactlyOnTheirLimitsPassThroughUnchanged() {
+    var title = "t".repeat(MAX_TITLE);
+    var summary = "s".repeat(MAX_SUMMARY);
+    var text = "x".repeat(MAX_TEXT);
+
+    var out = output(title, summary, text);
+
+    assertEquals(title, out.title(), "a title exactly on the limit is valid and must not be cut");
+    assertEquals(summary, out.summary(), "a summary exactly on the limit must not be cut");
+    assertEquals(text, out.text(), "a text exactly on the limit must not be cut");
+  }
+
+  @Test
+  void outputTitleOneOverItsLimitIsTruncatedWithAnHonestNotice() {
+    var out = output("t".repeat(MAX_TITLE + 1), null, null);
+
+    // Over the limit GitHub 422s the PATCH, and the fail-soft wrapper swallows it — the check run
+    // would silently never update. Capping keeps the update going out.
+    assertEquals(MAX_TITLE, out.title().length());
+    assertTrue(out.title().endsWith(TITLE_NOTICE), "the notice must name the title limit");
+    assertTrue(out.title().startsWith("tttt"), "the surviving prefix is the original content");
+  }
+
+  @Test
+  void outputSummaryOneOverItsLimitIsTruncatedWithAnHonestNotice() {
+    var out = output("ok", "s".repeat(MAX_SUMMARY + 1), null);
+
+    assertEquals(MAX_SUMMARY, out.summary().length());
+    assertTrue(out.summary().endsWith(BODY_NOTICE), "the notice must name the summary limit");
+    assertTrue(out.summary().startsWith("ssss"));
+  }
+
+  @Test
+  void outputTextOneOverItsLimitIsTruncatedWithAnHonestNotice() {
+    var out = output("ok", "fine", "x".repeat(MAX_TEXT + 1));
+
+    assertEquals(MAX_TEXT, out.text().length());
+    assertTrue(out.text().endsWith(BODY_NOTICE), "the notice must name the text limit");
+    assertTrue(out.text().startsWith("xxxx"));
+  }
+
+  @Test
+  void outputFieldsAreCappedAtTheirOwnLimitNotASharedOne() {
+    var out = output("t".repeat(MAX_TITLE + 1), "s".repeat(MAX_TITLE + 1), null);
+
+    assertEquals(MAX_TITLE, out.title().length(), "the title is bounded at 255");
+    assertEquals(
+        MAX_TITLE + 1,
+        out.summary().length(),
+        "a summary far under its own 65,535 limit must not be cut to the title's limit");
+  }
+
+  @Test
+  void outputTitleTruncationDoesNotSplitASurrogatePair() {
+    // Place an astral code point (U+1F600, a high/low surrogate pair) so its HIGH surrogate lands
+    // exactly on the last kept character; cutting there would emit a lone high surrogate.
+    var keep = MAX_TITLE - TITLE_NOTICE.length();
+    var title = "t".repeat(keep - 1) + "😀" + "y".repeat(MAX_TITLE);
+
+    var capped = output(title, null, null).title();
+    var kept = capped.substring(0, capped.length() - TITLE_NOTICE.length());
+
+    assertFalse(
+        Character.isHighSurrogate(kept.charAt(kept.length() - 1)),
+        "the kept text must not end in a dangling high surrogate");
+    assertEquals(keep - 1, kept.length(), "the cut steps back one character to keep the pair");
+    assertTrue(capped.endsWith(TITLE_NOTICE));
+  }
+
+  @Test
+  void nullOutputFieldsStayNull() {
+    var out = output(null, null, null);
+
+    assertNull(out.title());
+    assertNull(out.summary());
+    assertNull(out.text());
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`GitHubCheckRunClient.UpdateCheckRunRequest.Output` carried `title`, `summary` and `text` straight to the API with no length guard. GitHub rejects an over-long output with a 422, and the fail-soft update wrapper swallows that rejection — so the check run silently never updates. It fails exactly when the review is large enough for the check to matter to the merge decision, which is the same silent-total-failure shape #462 fixed for comment bodies.

The fix follows that pattern: cap at the client boundary, in the record's compact constructor, so every current and future caller inherits the guard without remembering to.

**The three limits are not one number:**

| Field | Limit | Source |
| --- | --- | --- |
| `output.summary` | 65,535 | `maxLength: 65535` on the field in GitHub's official OpenAPI description (`github/rest-api-description`, `descriptions/api.github.com/api.github.com.json`, `PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}`), which is what generates the REST reference |
| `output.text` | 65,535 | same — `maxLength: 65535` on the field in the same schema |
| `output.title` | 255 | GitHub's REST reference states **no** length for `output.title` itself. 255 is the length documented for the sibling `output.annotations[].title` ("The maximum size is 255 characters") and the value the API is widely reported to enforce on the output title. A check-run title is a one-line verdict, so this cap only ever bites on a pathological title; it is deliberately conservative rather than invented upward. Flagged here so a reviewer can weigh it. |

Note these differ from the comment-body limit (65,536), so the truncation notice text differs per field and names the limit that actually cut the value.

The surrogate-safe truncation is **reused, not reimplemented**: `CommentBodyLimit.cap` gains a package-private overload taking the limit and derives the notice from it (`Locale.ROOT` so the grouping separator stays a comma on any host locale); `cap(String)` now delegates at the comment-body limit, so the comment path is byte-identical — the existing tests pinning it, including both sides of the surrogate check, pass unchanged.

Out of scope, reported not fixed: the check-run **annotations** path. This client does not model or send `output.annotations` at all, so there is nothing unguarded today. If annotations are added later they carry their own documented limits (max 50 per request; `message` and `raw_details` 64 KB each; `title` 255) and would need the same treatment — a separate issue.

## Related Issues

Fixes #501

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Red first: the new tests were run against the unfixed `Output` record and fail, showing each field going out unbounded — over-long values pass through at their original length and the surrogate-safe cut never happens.

```
[ERROR] Tests run: 11, Failures: 5, Errors: 0, Skipped: 0, Time elapsed: 0.942 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.github.GitHubCheckRunClientTest
[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubCheckRunClientTest.outputTextOneOverItsLimitIsTruncatedWithAnHonestNotice -- Time elapsed: 0.016 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <65535> but was: <65536>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:569)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubCheckRunClientTest.outputTextOneOverItsLimitIsTruncatedWithAnHonestNotice(GitHubCheckRunClientTest.java:140)

[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubCheckRunClientTest.outputTitleTruncationDoesNotSplitASurrogatePair -- Time elapsed: 0.003 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the cut steps back one character to keep the pair ==> expected: <207> but was: <417>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:601)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubCheckRunClientTest.outputTitleTruncationDoesNotSplitASurrogatePair(GitHubCheckRunClientTest.java:169)

[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubCheckRunClientTest.outputFieldsAreCappedAtTheirOwnLimitNotASharedOne -- Time elapsed: 0.002 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the title is bounded at 255 ==> expected: <255> but was: <256>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:601)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubCheckRunClientTest.outputFieldsAreCappedAtTheirOwnLimitNotASharedOne(GitHubCheckRunClientTest.java:149)

[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubCheckRunClientTest.outputSummaryOneOverItsLimitIsTruncatedWithAnHonestNotice -- Time elapsed: 0.002 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <65535> but was: <65536>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:569)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubCheckRunClientTest.outputSummaryOneOverItsLimitIsTruncatedWithAnHonestNotice(GitHubCheckRunClientTest.java:131)

[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubCheckRunClientTest.outputTitleOneOverItsLimitIsTruncatedWithAnHonestNotice -- Time elapsed: 0.002 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <255> but was: <256>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:569)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubCheckRunClientTest.outputTitleOneOverItsLimitIsTruncatedWithAnHonestNotice(GitHubCheckRunClientTest.java:122)

[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   GitHubCheckRunClientTest.outputFieldsAreCappedAtTheirOwnLimitNotASharedOne:149 the title is bounded at 255 ==> expected: <255> but was: <256>
[ERROR]   GitHubCheckRunClientTest.outputSummaryOneOverItsLimitIsTruncatedWithAnHonestNotice:131 expected: <65535> but was: <65536>
[ERROR]   GitHubCheckRunClientTest.outputTextOneOverItsLimitIsTruncatedWithAnHonestNotice:140 expected: <65535> but was: <65536>
[ERROR]   GitHubCheckRunClientTest.outputTitleOneOverItsLimitIsTruncatedWithAnHonestNotice:122 expected: <255> but was: <256>
[ERROR]   GitHubCheckRunClientTest.outputTitleTruncationDoesNotSplitASurrogatePair:169 the cut steps back one character to keep the pair ==> expected: <207> but was: <417>
[INFO] 
[ERROR] Tests run: 11, Failures: 5, Errors: 0, Skipped: 0
[INFO] BUILD FAILURE
```

Green after applying the compact-constructor cap — same tests, no assertion changed:

```
[INFO] Results:
[INFO] 
[INFO] Tests run: 2436, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

Gates, all clean:

- `./mvnw -B spotless:apply` + `spotless:check` — BUILD SUCCESS, no reformat needed
- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`
- `./mvnw -B clean test` — 2436 tests, 0 failures, 0 errors, 0 skipped

Coverage: every executable line added to `src/main/java` is covered with no partial branches — intersecting `target/site/jacoco/jacoco.xml` with `git diff -U0` on the added lines gives 10/10 covered in `CommentBodyLimit.java` and 5/5 in `GitHubCheckRunClient.java`.

New/updated tests:

- `GitHubCheckRunClientTest` — each field exactly on its limit passes through unchanged; one character over is truncated to exactly the limit with a notice naming *that* limit; the title cap does not shrink an in-limit summary (the limits really are separate); a surrogate pair at the cut point is not split; null fields stay null.
- `CommentBodyLimitTest` — the existing comment-body tests are untouched and still pass; added a pin on the exact historic notice wording (the notice is now derived from the limit, so this guards against a locale-sensitive grouping separator changing it) plus direct cover for the explicit-limit overload.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No existing test was changed or disabled. The only behavioural change to the comment path is that `TRUNCATION_NOTICE` is now computed instead of written as a literal — the resulting string is identical and is asserted as such.

The `output.title` limit is the one number not stated outright in GitHub's REST reference; if a maintainer knows the enforced value to be higher, it is a one-constant change in `Output`.