### PR TITLE
fix(ai): detect a length stop on the blocking command paths

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
@@ -15,11 +15,14 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import dev.langchain4j.service.Result;
 import dev.thiagogonzaga.thrillhousebot.config.ActiveModelSettings;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
 import dev.thiagogonzaga.thrillhousebot.github.InstructionsResolver;
 import dev.thiagogonzaga.thrillhousebot.github.RepoSettingsResolver;
+import dev.thiagogonzaga.thrillhousebot.review.ai.AiResponseTruncatedException;
+import dev.thiagogonzaga.thrillhousebot.review.ai.AiResponses;
 import io.quarkus.logging.Log;
 import java.util.List;
 import java.util.function.Supplier;
@@ -289,14 +292,20 @@ public abstract class AbstractPrSuggestionGenerator {
    * stripped. {@code command} labels the operation in logs (e.g. {@code "/describe"}). Subclasses
    * supply the actual call (and apply any command-specific post-filtering to the result).
    */
-  protected String callAssistant(String command, Supplier<String> assistantCall) {
+  protected String callAssistant(String command, Supplier<Result<String>> assistantCall) {
     try {
-      String suggestion = assistantCall.get();
+      String suggestion =
+          AiResponses.textOrThrowOnTruncation(assistantCall.get(), command + " assistant");
       if (suggestion == null || suggestion.isBlank()) {
         Log.debugf("%s assistant produced an empty suggestion — posting nothing", command);
         return null;
       }
       return suggestion.strip();
+    } catch (AiResponseTruncatedException e) {
+      // Distinct from the generic failure below on purpose: "call failed" sends an operator looking
+      // for a provider error, when the cause is a cap they set and can raise.
+      Log.warnf("%s — posting nothing. %s", command, e.getMessage());
+      return null;
     } catch (RuntimeException e) {
       Log.warnf(e, "%s assistant call failed — posting nothing", command);
       return null;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
@@ -20,6 +20,8 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.github.RepoSettingsResolver;
+import dev.thiagogonzaga.thrillhousebot.review.ai.AiResponseTruncatedException;
+import dev.thiagogonzaga.thrillhousebot.review.ai.AiResponses;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReplyAssistant;
 import dev.thiagogonzaga.thrillhousebot.webhook.ManualReviewAuthorizer;
 import dev.thiagogonzaga.thrillhousebot.webhook.TriggerDetector;
@@ -219,18 +221,25 @@ public class MaintainerReplyService {
       String question, String prContext, String finding, String codeContext, String thread) {
     try {
       String reply =
-          replyAssistant.reply(
-              PromptTemplateEscaper.escape(question),
-              PromptTemplateEscaper.escape(prContext),
-              PromptTemplateEscaper.escape(finding),
-              // codeContext is the diff/hunk under discussion: fence it byte-exact.
-              PromptTemplateEscaper.fence(codeContext),
-              PromptTemplateEscaper.escape(thread));
+          AiResponses.textOrThrowOnTruncation(
+              replyAssistant.reply(
+                  PromptTemplateEscaper.escape(question),
+                  PromptTemplateEscaper.escape(prContext),
+                  PromptTemplateEscaper.escape(finding),
+                  // codeContext is the diff/hunk under discussion: fence it byte-exact.
+                  PromptTemplateEscaper.fence(codeContext),
+                  PromptTemplateEscaper.escape(thread)),
+              "Maintainer reply");
       if (reply == null || reply.isBlank()) {
         Log.debug("Reply assistant produced an empty reply — posting nothing");
         return null;
       }
       return reply.strip();
+    } catch (AiResponseTruncatedException e) {
+      // Named separately from the generic failure: the cause is a cap the operator set, not a
+      // provider error, and the message says which knob to raise.
+      Log.warnf("Reply assistant — posting nothing. %s", e.getMessage());
+      return null;
     } catch (RuntimeException e) {
       Log.warn("Reply assistant call failed — posting nothing", e);
       return null;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponses.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponses.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.service.Result;
+
+/**
+ * Unwraps a blocking AI-service {@link Result}, turning a response the model cut short into a named
+ * failure instead of an unparseable body.
+ *
+ * <p>The streaming review path reads {@code finishReason} off its {@code ChatResponse} directly.
+ * The blocking assistants return their text through {@link Result}, which carries the same signal —
+ * so every command path can distinguish "the model ran out of room" from "the model emitted bad
+ * JSON" rather than reporting the second when the first happened. Without it an operator who capped
+ * {@code max-output-tokens} too low sees only a parse warning and has nothing pointing at the cap.
+ */
+public final class AiResponses {
+
+  private AiResponses() {}
+
+  /**
+   * Returns the response text, or throws {@link AiResponseTruncatedException} when the model
+   * stopped at its response-length cap. {@code what} names the call for the operator ("/improve",
+   * "Finding verification"), since the exception is what the caller logs.
+   *
+   * <p>A {@code null} result passes through as {@code null}: the callers already treat "no
+   * response" as a soft failure, and that is not the same condition as a truncation.
+   */
+  public static String textOrThrowOnTruncation(Result<String> result, String what) {
+    if (result == null) {
+      return null;
+    }
+    if (result.finishReason() == FinishReason.LENGTH) {
+      throw new AiResponseTruncatedException(
+          what
+              + " stopped at the model's response-length cap (finish_reason=length), so the"
+              + " response is incomplete. Raise the active model's max-output-tokens, or leave it"
+              + " unset to use the provider default.");
+    }
+    return result.content();
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChangelogAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChangelogAssistant.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
+import dev.langchain4j.service.Result;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
@@ -32,7 +33,7 @@ public interface ChangelogAssistant {
   // parameter's raw value and silently drops every other @V.
   @SystemMessage(ChangelogAssistantPrompts.SYSTEM)
   @UserMessage(PrSuggestionPrompts.USER)
-  String draft(
+  Result<String> draft(
       @V("diff") String diff,
       @V("prNumber") String prNumber,
       @V("currentTitle") String currentTitle,
@@ -46,7 +47,7 @@ public interface ChangelogAssistant {
    */
   @SystemMessage(ChangelogAssistantPrompts.MERGE_SYSTEM)
   @UserMessage(ChangelogAssistantPrompts.MERGE_USER)
-  String merge(
+  Result<String> merge(
       @V("candidates") String candidates,
       @V("prNumber") String prNumber,
       @V("currentTitle") String currentTitle,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGenerator.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
+import dev.langchain4j.service.Result;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
@@ -33,7 +34,7 @@ public interface DocGenerator {
   // parameter's raw value and silently drops every other @V.
   @SystemMessage(DocGeneratorPrompts.SYSTEM)
   @UserMessage(DocGeneratorPrompts.USER)
-  String generate(
+  Result<String> generate(
       @V("diff") String diff,
       @V("prContext") String prContext,
       @V("projectStack") String projectStack,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -72,14 +72,20 @@ public class FindingVerificationService {
     }
     try {
       var raw =
-          verifier.verify(
-              PromptTemplateEscaper.escape(renderCandidates(screened.findings())),
-              diff,
-              projectStack,
-              previousFindings == null ? "" : previousFindings);
+          AiResponses.textOrThrowOnTruncation(
+              verifier.verify(
+                  PromptTemplateEscaper.escape(renderCandidates(screened.findings())),
+                  diff,
+                  projectStack,
+                  previousFindings == null ? "" : previousFindings),
+              "Finding verification");
       var verdicts =
           mapper.readValue(ReviewResponseParser.extractJson(raw), VerificationResponse.class);
       return apply(screened, verdicts);
+    } catch (AiResponseTruncatedException e) {
+      // The verifier fails open by design; say why so a cap is not mistaken for a provider fault.
+      Log.warnf("Finding verification — keeping unverified findings. %s", e.getMessage());
+      return screened;
     } catch (IOException | RuntimeException e) {
       Log.warn("Finding verification failed — keeping unverified findings", e);
       return screened;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifier.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifier.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
+import dev.langchain4j.service.Result;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
@@ -33,7 +34,7 @@ public interface FindingVerifier {
   // parameter's raw value and silently drops every other @V.
   @SystemMessage(FindingVerifierPrompts.SYSTEM)
   @UserMessage(FindingVerifierPrompts.USER)
-  String verify(
+  Result<String> verify(
       @V("findings") String findings,
       @V("diff") String diff,
       @V("projectStack") String projectStack,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrDescribeAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrDescribeAssistant.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
+import dev.langchain4j.service.Result;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
@@ -31,7 +32,7 @@ public interface PrDescribeAssistant {
   // parameter's raw value and silently drops every other @V.
   @SystemMessage(PrDescribeAssistantPrompts.SYSTEM)
   @UserMessage(PrSuggestionPrompts.USER)
-  String describe(
+  Result<String> describe(
       @V("diff") String diff,
       @V("currentTitle") String currentTitle,
       @V("currentDescription") String currentDescription,
@@ -44,7 +45,7 @@ public interface PrDescribeAssistant {
    */
   @SystemMessage(PrDescribeAssistantPrompts.SYNTHESIS_SYSTEM)
   @UserMessage(PrDescribeAssistantPrompts.SYNTHESIS_USER)
-  String synthesize(
+  Result<String> synthesize(
       @V("partials") String partials,
       @V("currentTitle") String currentTitle,
       @V("currentDescription") String currentDescription,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrImproveAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrImproveAssistant.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
+import dev.langchain4j.service.Result;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
@@ -33,7 +34,7 @@ public interface PrImproveAssistant {
   // parameter's raw value and silently drops every other @V.
   @SystemMessage(PrImproveAssistantPrompts.SYSTEM)
   @UserMessage(PrSuggestionPrompts.USER)
-  String improve(
+  Result<String> improve(
       @V("diff") String diff,
       @V("currentTitle") String currentTitle,
       @V("currentDescription") String currentDescription,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReplyAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReplyAssistant.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
+import dev.langchain4j.service.Result;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
@@ -31,7 +32,7 @@ public interface ReplyAssistant {
   // parameter's raw value and silently drops every other @V.
   @SystemMessage(ReplyAssistantPrompts.SYSTEM)
   @UserMessage(ReplyAssistantPrompts.USER)
-  String reply(
+  Result<String> reply(
       @V("question") String question,
       @V("prContext") String prContext,
       @V("finding") String finding,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/UnitTestAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/UnitTestAssistant.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
+import dev.langchain4j.service.Result;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
@@ -33,7 +34,7 @@ public interface UnitTestAssistant {
   // parameter's raw value and silently drops every other @V.
   @SystemMessage(UnitTestAssistantPrompts.SYSTEM)
   @UserMessage(UnitTestAssistantPrompts.USER)
-  String generate(
+  Result<String> generate(
       @V("diff") String diff,
       @V("prContext") String prContext,
       @V("projectStack") String projectStack,

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGeneratorTest.java
@@ -15,6 +15,8 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiOk;
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiTruncated;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -126,7 +128,7 @@ class ChangelogEntryGeneratorTest {
   }
 
   private void draftReturns(String entry) {
-    when(changelogAssistant.draft(any(), any(), any(), any(), any())).thenReturn(entry);
+    when(changelogAssistant.draft(any(), any(), any(), any(), any())).thenReturn(aiOk(entry));
   }
 
   private String generate() {
@@ -249,6 +251,17 @@ class ChangelogEntryGeneratorTest {
   }
 
   @Test
+  void postsNothingWhenTheAssistantResponseIsCutShortAtTheLengthCap() {
+    // #497: a length stop used to reach the parser and be reported as malformed JSON. It is now a
+    // named failure, so the command declines to post rather than posting a half-built entry.
+    prWithFiles(foo());
+    when(changelogAssistant.draft(any(), any(), any(), any(), any()))
+        .thenReturn(aiTruncated("### Added\n- Streams are clo"));
+
+    assertNull(generate());
+  }
+
+  @Test
   void stillDraftsWhenPrDetailsFetchFails() {
     when(prClient.getPullRequestFiles(eq(AUTH), any(), eq("owner"), eq("repo"), eq(7)))
         .thenReturn(List.of(foo()));
@@ -359,11 +372,12 @@ class ChangelogEntryGeneratorTest {
     when(changelogAssistant.draft(any(), any(), any(), any(), any()))
         .thenAnswer(
             call ->
-                call.<String>getArgument(0).contains("src/Other.java")
-                    ? "### Added\n- Retries are bounded (#7)"
-                    : "### Added\n- Streams are closed (#7)");
+                aiOk(
+                    call.<String>getArgument(0).contains("src/Other.java")
+                        ? "### Added\n- Retries are bounded (#7)"
+                        : "### Added\n- Streams are closed (#7)"));
     when(changelogAssistant.merge(any(), any(), any(), any(), any()))
-        .thenReturn("### Added\n- **Reliability**: bounded retries and closed streams (#7)");
+        .thenReturn(aiOk("### Added\n- **Reliability**: bounded retries and closed streams (#7)"));
 
     String body = generate();
 
@@ -403,9 +417,10 @@ class ChangelogEntryGeneratorTest {
     when(changelogAssistant.draft(any(), any(), any(), any(), any()))
         .thenAnswer(
             call ->
-                call.<String>getArgument(0).contains("src/Other.java")
-                    ? "NONE"
-                    : "### Added\n- Streams are closed (#7)");
+                aiOk(
+                    call.<String>getArgument(0).contains("src/Other.java")
+                        ? "NONE"
+                        : "### Added\n- Streams are closed (#7)"));
 
     String body = generate();
 
@@ -431,7 +446,7 @@ class ChangelogEntryGeneratorTest {
     budgetWithDiffRoom(40);
     prWithFiles(foo(), otherFile());
     draftReturns("### Added\n- x (#7)");
-    when(changelogAssistant.merge(any(), any(), any(), any(), any())).thenReturn("**NONE**");
+    when(changelogAssistant.merge(any(), any(), any(), any(), any())).thenReturn(aiOk("**NONE**"));
 
     assertNull(generate());
   }
@@ -445,7 +460,7 @@ class ChangelogEntryGeneratorTest {
     prWithFiles(foo(), otherFile(), thirdFile());
     draftReturns("### Added\n- x (#7)");
     when(changelogAssistant.merge(any(), any(), any(), any(), any()))
-        .thenReturn("### Added\n- merged (#7)");
+        .thenReturn(aiOk("### Added\n- merged (#7)"));
 
     generate();
 
@@ -516,7 +531,7 @@ class ChangelogEntryGeneratorTest {
               if (call.<String>getArgument(0).contains("src/Other.java")) {
                 throw new RuntimeException("model down");
               }
-              return "### Added\n- Streams are closed (#7)";
+              return aiOk("### Added\n- Streams are closed (#7)");
             });
 
     String body = generate();

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiOk;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.*;
@@ -196,11 +197,12 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar(int)",
             "suggestion_old":"public int bar(int x) {",
             "suggestion_new":"/** Doubles x. */\\npublic int bar(int x) {"}]}
-            """);
+            """));
 
     service.handle(task());
 
@@ -226,11 +228,12 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch(), otherFile());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar(int)",
             "suggestion_old":"public int bar(int x) {",
             "suggestion_new":"/** Doubles x. */\\npublic int bar(int x) {"}]}
-            """);
+            """));
 
     service.handle(task());
 
@@ -247,11 +250,12 @@ class DocGenerationServiceTest {
     prWithFiles(new FileDiff("src/Wrap.java", "added", 5, 0, 5, WRAP_PATCH));
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Wrap.java","line":1,"symbol":"wrap",
             "suggestion_old":"public int wrap(\\n    int x,\\n    int y) {",
             "suggestion_new":"/** Adds x and y. */\\npublic int wrap(\\n    int x,\\n    int y) {"}]}
-            """);
+            """));
 
     service.handle(task());
 
@@ -266,11 +270,12 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {\\n  return x * 99;",
             "suggestion_new":"/** Doubles. */\\npublic int bar(int x) {\\n  return x * 99;"}]}
-            """);
+            """));
 
     service.handle(task());
 
@@ -297,11 +302,12 @@ class DocGenerationServiceTest {
     prWithFiles(new FileDiff("src/Wrap.java", "added", 3, 0, 3, patch));
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Wrap.java","line":10,"symbol":"wrap",
             "suggestion_old":"public int wrap(\\n    int x,\\n    int y) {",
             "suggestion_new":"/** Adds x and y. */\\npublic int wrap(\\n    int x,\\n    int y) {"}]}
-            """);
+            """));
 
     service.handle(task());
 
@@ -316,11 +322,12 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {\\n  return x * 99;",
             "suggestion_new":"/** d */\\npublic int bar(int x) {\\n  return x * 99;"}]}
-            """);
+            """));
     doThrow(new RuntimeException("422 Unprocessable Entity"))
         .when(reviewClient)
         .createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
@@ -335,7 +342,8 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[
               {"file":"src/Foo.java","line":1,"symbol":"bar",
                "suggestion_old":"public int bar(int x) {",
@@ -343,7 +351,7 @@ class DocGenerationServiceTest {
               {"file":"src/Foo.java","line":4,"symbol":"baz",
                "suggestion_old":"public int baz(int y) {\\n  return y + 99;",
                "suggestion_new":"/** b */\\npublic int baz(int y) {\\n  return y + 99;"}]}
-            """);
+            """));
 
     service.handle(task());
 
@@ -358,7 +366,8 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[
               {"file":"src/Foo.java","line":1,"symbol":"bar",
                "suggestion_old":"public int bar(int x) {",
@@ -366,7 +375,7 @@ class DocGenerationServiceTest {
               {"file":"src/Foo.java","line":4,"symbol":"baz",
                "suggestion_old":"public int baz(int y) {",
                "suggestion_new":"/** b */\\npublic int baz(int y) {"}]}
-            """);
+            """));
 
     service.handle(task());
 
@@ -382,11 +391,12 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
              "suggestion_old":"public int bar(int x) {",
              "suggestion_new":"/** a */\\npublic int bar(int x) {"}]}
-            """);
+            """));
 
     service.handle(task());
 
@@ -401,7 +411,7 @@ class DocGenerationServiceTest {
   void doesNotPostSuggestionThatCannotAnchorCleanly(
       String reason, String docsJson, String expectedSummary) {
     prWithFiles(fooWithPatch());
-    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(docsJson);
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(aiOk(docsJson));
 
     service.handle(task());
 
@@ -458,7 +468,7 @@ class DocGenerationServiceTest {
   @Test
   void reportsNothingToDocumentOnEmptyResult() {
     prWithFiles(fooWithPatch());
-    when(docGenerator.generate(any(), any(), any(), any())).thenReturn("{\"docs\":[]}");
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(aiOk("{\"docs\":[]}"));
 
     service.handle(task());
 
@@ -545,7 +555,7 @@ class DocGenerationServiceTest {
                 "Use British spelling.", ".github/thrillhousebot.md"));
     when(projectStackResolver.resolve(any(), any(), any(), anyLong()))
         .thenReturn("Maven artifacts: quarkus-core");
-    when(docGenerator.generate(any(), any(), any(), any())).thenReturn("{\"docs\":[]}");
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(aiOk("{\"docs\":[]}"));
 
     service.handle(task());
 
@@ -564,11 +574,12 @@ class DocGenerationServiceTest {
         .thenThrow(new RuntimeException("stack down"));
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {",
             "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
-            """);
+            """));
 
     service.handle(task());
 
@@ -581,7 +592,7 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch());
     when(instructionsResolver.resolve(any(), any(), any(), anyLong()))
         .thenThrow(new RuntimeException("instructions down"));
-    when(docGenerator.generate(any(), any(), any(), any())).thenReturn("{\"docs\":[]}");
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(aiOk("{\"docs\":[]}"));
 
     service.handle(task());
 
@@ -596,11 +607,12 @@ class DocGenerationServiceTest {
         .thenReturn(List.of(fooWithPatch()));
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {",
             "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
-            """);
+            """));
 
     service.handle(task());
 
@@ -660,11 +672,12 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {",
             "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
-            """);
+            """));
     when(reviewClient.createPullRequestComment(any(), any(), any(), any(), anyInt(), any()))
         .thenThrow(new RuntimeException("422 line outside diff"));
 
@@ -679,7 +692,7 @@ class DocGenerationServiceTest {
         .thenReturn(new PullRequestDetails("  ", "  ", new Ref(HEAD_SHA), new Ref("base")));
     when(prClient.getPullRequestFiles(any(), any(), eq("owner"), eq("repo"), eq(7)))
         .thenReturn(List.of(fooWithPatch()));
-    when(docGenerator.generate(any(), any(), any(), any())).thenReturn("{\"docs\":[]}");
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(aiOk("{\"docs\":[]}"));
 
     service.handle(task());
 
@@ -705,11 +718,12 @@ class DocGenerationServiceTest {
         new FileDiff("src/Empty.java", "modified", 0, 0, 0, "  "));
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {",
             "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
-            """);
+            """));
 
     service.handle(task());
 
@@ -734,7 +748,7 @@ class DocGenerationServiceTest {
         .thenReturn(
             new RepoSettings(List.of("src/Other.java"), List.of(), ".github/thrillhousebot.yml"));
     prWithFiles(fooWithPatch(), otherFile());
-    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(DOC_FOR_OTHER);
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(aiOk(DOC_FOR_OTHER));
 
     service.handle(task());
 
@@ -755,11 +769,12 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch(), new FileDiff("docs/README.md", "modified", 1, 0, 1, "@@\n+hi"));
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {",
             "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
-            """);
+            """));
 
     globalService.handle(task());
 
@@ -778,7 +793,7 @@ class DocGenerationServiceTest {
     var tinyLineCap = new ReviewDiffFormatter(List.of(), 8);
     var cappedService = serviceWith(tinyLineCap);
     prWithFiles(fooWithPatch(), otherFile());
-    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(DOC_FOR_OTHER);
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(aiOk(DOC_FOR_OTHER));
 
     cappedService.handle(task());
 
@@ -795,7 +810,7 @@ class DocGenerationServiceTest {
   void plansOneBatchPerSliceOfTheChangeSetRatherThanOneCallOverTheWholeRender() {
     budgetWithDiffRoom(40);
     prWithFiles(fooWithPatch(), otherFile());
-    when(docGenerator.generate(any(), any(), any(), any())).thenReturn("{\"docs\":[]}");
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(aiOk("{\"docs\":[]}"));
 
     service.handle(task());
 
@@ -817,17 +832,19 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch(), otherFile());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {",
             "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
-            """)
+            """))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Other.java","line":1,"symbol":"hop",
             "suggestion_old":"public int hop(int n) {",
             "suggestion_new":"/** just a docstring, no code */"}]}
-            """);
+            """));
 
     service.handle(task());
 
@@ -843,12 +860,13 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch(), otherFile());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {",
             "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
-            """)
-        .thenReturn(DOC_FOR_OTHER);
+            """))
+        .thenReturn(aiOk(DOC_FOR_OTHER));
 
     service.handle(task());
 
@@ -883,11 +901,12 @@ class DocGenerationServiceTest {
               if (call.<String>getArgument(0).contains("src/Other.java")) {
                 throw new RuntimeException("model down");
               }
-              return """
+              return aiOk(
+                  """
                   {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
                   "suggestion_old":"public int bar(int x) {",
                   "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
-                  """;
+                  """);
             });
 
     service.handle(task());
@@ -911,7 +930,7 @@ class DocGenerationServiceTest {
     // the merge across batches is keyed on file:line.
     budgetWithDiffRoom(40);
     prWithFiles(fooWithPatch(), otherFile());
-    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(DOC_FOR_FOO);
+    when(docGenerator.generate(any(), any(), any(), any())).thenReturn(aiOk(DOC_FOR_FOO));
 
     service.handle(task());
 
@@ -932,9 +951,10 @@ class DocGenerationServiceTest {
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenAnswer(
             call ->
-                call.<String>getArgument(0).contains("src/Other.java")
-                    ? "Sure! Here are the docs I came up with."
-                    : DOC_FOR_FOO);
+                aiOk(
+                    call.<String>getArgument(0).contains("src/Other.java")
+                        ? "Sure! Here are the docs I came up with."
+                        : DOC_FOR_FOO));
 
     service.handle(task());
 
@@ -952,7 +972,8 @@ class DocGenerationServiceTest {
     // maintainer gets the failure notice rather than a "nothing to document" verdict.
     budgetWithDiffRoom(40);
     prWithFiles(fooWithPatch(), otherFile());
-    when(docGenerator.generate(any(), any(), any(), any())).thenReturn("I could not do that.");
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenReturn(aiOk("I could not do that."));
 
     service.handle(task());
 
@@ -986,7 +1007,8 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[
               {"line":1,"symbol":"bar",
                "suggestion_old":"public int bar(int x) {",
@@ -994,7 +1016,7 @@ class DocGenerationServiceTest {
               {"file":"src/Foo.java","line":4,"symbol":"baz",
                "suggestion_old":"public int baz(int y) {",
                "suggestion_new":"/** b */\\npublic int baz(int y) {"}]}
-            """);
+            """));
 
     service.handle(task());
 
@@ -1015,11 +1037,12 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch(), otherFile());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {","suggestion_new":""}]}
-            """)
-        .thenReturn(DOC_FOR_FOO);
+            """))
+        .thenReturn(aiOk(DOC_FOR_FOO));
 
     service.handle(task());
 
@@ -1040,11 +1063,12 @@ class DocGenerationServiceTest {
     prWithFiles(fooWithPatch());
     when(docGenerator.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {",
             "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
-            """);
+            """));
 
     service.handle(task());
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
@@ -15,6 +15,8 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiOk;
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiTruncated;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -159,7 +161,7 @@ class MaintainerReplyServiceTest {
                 comment(500L, 99L, "maintainer", "are you sure?"),
                 comment(1000L, 99L, "octocat", "Why is this flagged?")));
     when(replyAssistant.reply(any(), any(), any(), any(), any()))
-        .thenReturn("Because foo can be null.");
+        .thenReturn(aiOk("Because foo can be null."));
 
     service.handle(reviewThreadTask(false));
 
@@ -218,7 +220,7 @@ class MaintainerReplyServiceTest {
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of(comment(99L, null, "someone", "what does the bot think?")));
     when(replyAssistant.reply(any(), any(), any(), any(), any()))
-        .thenReturn("My take: looks fine.");
+        .thenReturn(aiOk("My take: looks fine."));
 
     service.handle(reviewThreadTask(true));
 
@@ -240,7 +242,7 @@ class MaintainerReplyServiceTest {
     when(diffFormatter.buildDiffStringWithStats(any(), any()))
         .thenReturn(new ReviewDiffFormatter.FormattedDiff("diff --git a/Foo b/Foo", 0));
     when(replyAssistant.reply(any(), any(), any(), any(), any()))
-        .thenReturn("It is safe because...");
+        .thenReturn(aiOk("It is safe because..."));
 
     service.handle(mentionTask());
 
@@ -261,7 +263,7 @@ class MaintainerReplyServiceTest {
     when(reviewClient.listPullRequestComments(
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("   ");
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(aiOk("   "));
 
     service.handle(reviewThreadTask(false));
 
@@ -277,6 +279,23 @@ class MaintainerReplyServiceTest {
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
     when(replyAssistant.reply(any(), any(), any(), any(), any()))
         .thenThrow(new RuntimeException("model down"));
+
+    assertDoesNotThrow(() -> service.handle(reviewThreadTask(false)));
+
+    verify(reviewClient, never())
+        .replyToReviewComment(any(), any(), any(), any(), anyInt(), anyLong(), any());
+  }
+
+  @Test
+  void truncatedReplyIsSwallowedRatherThanPostedHalfWritten() {
+    // #497: same swallow as any other failure, but reached by a distinct path — the reply was cut
+    // at the model's cap, not rejected by the provider, and the log says so.
+    authorize();
+    when(reviewClient.listPullRequestComments(
+            eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+        .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
+    when(replyAssistant.reply(any(), any(), any(), any(), any()))
+        .thenReturn(aiTruncated("You are right that the retry loop"));
 
     assertDoesNotThrow(() -> service.handle(reviewThreadTask(false)));
 
@@ -318,7 +337,7 @@ class MaintainerReplyServiceTest {
     when(reviewClient.listPullRequestComments(
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenThrow(new RuntimeException("GitHub 503"));
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("Still here.");
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(aiOk("Still here."));
 
     service.handle(reviewThreadTask(true));
 
@@ -333,7 +352,7 @@ class MaintainerReplyServiceTest {
     authorize();
     when(prClient.getPullRequestFiles(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenThrow(new RuntimeException("files 500"));
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("Answer.");
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(aiOk("Answer."));
 
     // Null title and description exercise the blank-PR-context branches.
     var task =
@@ -369,7 +388,7 @@ class MaintainerReplyServiceTest {
     when(reviewClient.listPullRequestComments(
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("answer");
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(aiOk("answer"));
     doThrow(new RuntimeException("GitHub 422"))
         .when(reviewClient)
         .replyToReviewComment(any(), any(), any(), any(), anyInt(), anyLong(), any());
@@ -386,7 +405,7 @@ class MaintainerReplyServiceTest {
     when(diffFormatter.reviewableFiles(any(), any())).thenReturn(List.of());
     when(diffFormatter.buildDiffStringWithStats(any(), any()))
         .thenReturn(new ReviewDiffFormatter.FormattedDiff("diff", 0));
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("");
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(aiOk(""));
 
     service.handle(mentionTask());
 
@@ -399,7 +418,7 @@ class MaintainerReplyServiceTest {
     when(reviewClient.listPullRequestComments(
             eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
         .thenReturn(List.of(comment(99L, null, BOT, "**HIGH — bug**")));
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("ok");
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(aiOk("ok"));
     var task =
         new MaintainerReplyService.ReplyTask(
             "owner", "repo", 42, 12345L, "octocat", "OWNER", "why?", "t", "b", true, 99L, 1000L,
@@ -426,7 +445,7 @@ class MaintainerReplyServiceTest {
                 commentNoUser(500L, 99L, "anon reply"), // no user object → rendered as @unknown
                 comment(600L, 77L, "x", "different thread reply"), // belongs to another root (77)
                 comment(1000L, 99L, "octocat", "Why?"))); // the triggering comment
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("ok");
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(aiOk("ok"));
 
     service.handle(reviewThreadTask(false));
 
@@ -482,7 +501,7 @@ class MaintainerReplyServiceTest {
             List.of(
                 comment(500L, 88L, "x", "unrelated thread"),
                 comment(99L, null, BOT, "**finding**")));
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("ok");
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(aiOk("ok"));
 
     service.handle(reviewThreadTask(false));
 
@@ -499,7 +518,7 @@ class MaintainerReplyServiceTest {
     when(diffFormatter.reviewableFiles(any(), any())).thenReturn(List.of());
     when(diffFormatter.buildDiffStringWithStats(any(), any()))
         .thenReturn(new ReviewDiffFormatter.FormattedDiff("d", 0));
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("ok");
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(aiOk("ok"));
     // Whitespace-only (non-null) title and description exercise the !isBlank() branch.
     var task =
         new MaintainerReplyService.ReplyTask(
@@ -539,7 +558,7 @@ class MaintainerReplyServiceTest {
                 fileDiff("vendor/secret.txt", "@@ -0,0 +1 @@\n+TOPSECRET_VENDORED_KEY", 1)));
     when(repoSettingsResolver.resolve(eq("owner"), eq("repo"), any(), anyLong()))
         .thenReturn(new RepoSettings(List.of("vendor/**"), List.of(), "src"));
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("Answer.");
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(aiOk("Answer."));
 
     realService.handle(mentionTask());
 
@@ -564,7 +583,7 @@ class MaintainerReplyServiceTest {
     // No repo config: resolver returns EMPTY (the default mock returns null → SoftLoaders → EMPTY).
     when(repoSettingsResolver.resolve(eq("owner"), eq("repo"), any(), anyLong()))
         .thenReturn(RepoSettings.EMPTY);
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("Answer.");
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(aiOk("Answer."));
 
     realService.handle(mentionTask());
 
@@ -590,7 +609,7 @@ class MaintainerReplyServiceTest {
                 fileDiff("src/C.java", "@@ -1 +1 @@\n-c\n+cc\n+ccc\n+cccc", 3)));
     when(repoSettingsResolver.resolve(eq("owner"), eq("repo"), any(), anyLong()))
         .thenReturn(RepoSettings.EMPTY);
-    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn("Answer.");
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(aiOk("Answer."));
 
     realService.handle(mentionTask());
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrDescriptionGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrDescriptionGeneratorTest.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiOk;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -126,7 +127,7 @@ class PrDescriptionGeneratorTest {
   }
 
   private void describeReturns(String partial) {
-    when(describeAssistant.describe(any(), any(), any(), any())).thenReturn(partial);
+    when(describeAssistant.describe(any(), any(), any(), any())).thenReturn(aiOk(partial));
   }
 
   private String generate() {
@@ -332,11 +333,12 @@ class PrDescriptionGeneratorTest {
     when(describeAssistant.describe(any(), any(), any(), any()))
         .thenAnswer(
             call ->
-                call.<String>getArgument(0).contains("src/Other.java")
-                    ? "### Suggested title\n`retry work`"
-                    : "### Suggested title\n`stream work`");
+                aiOk(
+                    call.<String>getArgument(0).contains("src/Other.java")
+                        ? "### Suggested title\n`retry work`"
+                        : "### Suggested title\n`stream work`"));
     when(describeAssistant.synthesize(any(), any(), any(), any()))
-        .thenReturn("### Suggested title\n`feat: stream and retry`");
+        .thenReturn(aiOk("### Suggested title\n`feat: stream and retry`"));
 
     String body = generate();
 
@@ -374,7 +376,7 @@ class PrDescriptionGeneratorTest {
     budgetWithDiffRoom(40);
     prWithFiles(foo(), otherFile(), thirdFile());
     describeReturns("### Suggested title\n`x`");
-    when(describeAssistant.synthesize(any(), any(), any(), any())).thenReturn("### merged");
+    when(describeAssistant.synthesize(any(), any(), any(), any())).thenReturn(aiOk("### merged"));
 
     generate();
 
@@ -445,7 +447,7 @@ class PrDescriptionGeneratorTest {
               if (call.<String>getArgument(0).contains("src/Other.java")) {
                 throw new RuntimeException("model down");
               }
-              return "### Suggested title\n`stream work`";
+              return aiOk("### Suggested title\n`stream work`");
             });
 
     String body = generate();

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrImprovementServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrImprovementServiceTest.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiOk;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.*;
@@ -145,7 +146,7 @@ class PrImprovementServiceTest {
   }
 
   private void assistantReturns(String json) {
-    when(improveAssistant.improve(any(), any(), any(), any())).thenReturn(json);
+    when(improveAssistant.improve(any(), any(), any(), any())).thenReturn(aiOk(json));
   }
 
   private String postedSummary() {
@@ -781,12 +782,13 @@ class PrImprovementServiceTest {
     when(improveAssistant.improve(any(), any(), any(), any()))
         .thenThrow(new RuntimeException("provider 503"))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"improvements":[{"file":"src/Foo.java","line":1,"title":"Close the stream",
             "category":"error-handling","rationale":"Leaks a handle.",
             "suggestion_old":"var in = Files.newInputStream(path);",
             "suggestion_new":"try (var in = Files.newInputStream(path)) {"}]}
-            """);
+            """));
 
     service.handle(task(), AUTH);
 
@@ -866,9 +868,10 @@ class PrImprovementServiceTest {
     when(improveAssistant.improve(any(), any(), any(), any()))
         .thenAnswer(
             call ->
-                call.<String>getArgument(0).contains("src/Late.java")
-                    ? LATE_IMPROVEMENT
-                    : "{\"improvements\":[]}");
+                aiOk(
+                    call.<String>getArgument(0).contains("src/Late.java")
+                        ? LATE_IMPROVEMENT
+                        : "{\"improvements\":[]}"));
 
     service.handle(task(), AUTH);
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/UnitTestGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/UnitTestGeneratorTest.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiOk;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -160,7 +161,7 @@ class UnitTestGeneratorTest {
   void rendersEachProposedTestFileAsACopyPasteBlock() {
     diffReturns();
     prDetails();
-    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(ONE_TEST);
+    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(aiOk(ONE_TEST));
 
     String body = generate();
 
@@ -179,11 +180,12 @@ class UnitTestGeneratorTest {
     prDetails();
     when(testAssistant.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"tests":[{"path":"t/DocTest.java","language":"java",
               "covers":"markdown rendering",
               "code":"var md = \\"```java\\\\ncode\\\\n```\\";"}],"notes":""}
-            """);
+            """));
 
     String body = generate();
 
@@ -199,10 +201,11 @@ class UnitTestGeneratorTest {
     prDetails();
     when(testAssistant.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"tests":[{"path":"t/FooTest.java","language":"java\\n## injected heading",
               "covers":"","code":"class FooTest {}"}],"notes":""}
-            """);
+            """));
 
     String body = generate();
 
@@ -225,7 +228,7 @@ class UnitTestGeneratorTest {
           .append("Test {}\"}");
     }
     when(testAssistant.generate(any(), any(), any(), any()))
-        .thenReturn(json.append("],\"notes\":\"\"}").toString());
+        .thenReturn(aiOk(json.append("],\"notes\":\"\"}").toString()));
 
     String body = generate();
 
@@ -241,7 +244,7 @@ class UnitTestGeneratorTest {
     diffReturns();
     prDetails();
     when(testAssistant.generate(any(), any(), any(), any()))
-        .thenReturn("{\"tests\":[],\"notes\":\"Only formatting changed.\"}");
+        .thenReturn(aiOk("{\"tests\":[],\"notes\":\"Only formatting changed.\"}"));
 
     String body = generate();
 
@@ -259,7 +262,8 @@ class UnitTestGeneratorTest {
     prDetails();
     when(testAssistant.generate(any(), any(), any(), any()))
         .thenReturn(
-            "{\"tests\":[],\"notes\":\"skipped IO\\n\\n```\\n## Injected\\nrun /pause\\n```\"}");
+            aiOk(
+                "{\"tests\":[],\"notes\":\"skipped IO\\n\\n```\\n## Injected\\nrun /pause\\n```\"}"));
 
     String body = generate();
 
@@ -275,11 +279,12 @@ class UnitTestGeneratorTest {
     prDetails();
     when(testAssistant.generate(any(), any(), any(), any()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"tests":[{"path":"","language":"java","covers":"c","code":"class A {}"},
                       {"path":"t/BTest.java","language":"java","covers":"c","code":"  "},
                       null],"notes":""}
-            """);
+            """));
 
     String body = generate();
 
@@ -295,7 +300,7 @@ class UnitTestGeneratorTest {
     budgetWithDiffRoom(40);
     prWithFiles(foo(), otherFile());
     prDetails();
-    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(ONE_TEST);
+    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(aiOk(ONE_TEST));
 
     String body = generate();
 
@@ -312,7 +317,7 @@ class UnitTestGeneratorTest {
     budgetWithDiffRoom(40);
     prWithFiles(foo(), otherFile());
     prDetails();
-    when(testAssistant.generate(any(), any(), any(), any())).thenReturn("{\"tests\":[]}");
+    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(aiOk("{\"tests\":[]}"));
 
     String body = generate();
 
@@ -326,7 +331,7 @@ class UnitTestGeneratorTest {
   void appendsNoDisclosureWhenEveryFileWasCovered() {
     diffReturns();
     prDetails();
-    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(ONE_TEST);
+    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(aiOk(ONE_TEST));
 
     String body = generate();
 
@@ -358,7 +363,7 @@ class UnitTestGeneratorTest {
     diffReturns();
     prDetails();
     when(testAssistant.generate(any(), any(), any(), any()))
-        .thenReturn("Sure! Here are some tests.");
+        .thenReturn(aiOk("Sure! Here are some tests."));
 
     assertNull(generate());
   }
@@ -369,7 +374,7 @@ class UnitTestGeneratorTest {
     prDetails();
     when(projectStackResolver.resolve("owner", "repo", "main", 12345L))
         .thenReturn("pom.xml: junit");
-    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(ONE_TEST);
+    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(aiOk(ONE_TEST));
 
     generate();
 
@@ -390,7 +395,7 @@ class UnitTestGeneratorTest {
     prDetails();
     when(projectStackResolver.resolve(any(), any(), any(), anyLong()))
         .thenThrow(new RuntimeException("github down"));
-    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(ONE_TEST);
+    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(aiOk(ONE_TEST));
 
     assertNotNull(generate());
     var stack = ArgumentCaptor.forClass(String.class);
@@ -403,7 +408,7 @@ class UnitTestGeneratorTest {
     diffReturns();
     when(prClient.getPullRequest(eq(AUTH), any(), eq("owner"), eq("repo"), eq(7)))
         .thenThrow(new RuntimeException("404"));
-    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(ONE_TEST);
+    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(aiOk(ONE_TEST));
 
     assertNotNull(generate());
     var prContext = ArgumentCaptor.forClass(String.class);
@@ -426,7 +431,7 @@ class UnitTestGeneratorTest {
     budgetWithDiffRoom(40);
     prWithFiles(foo(), otherFile());
     prDetails();
-    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(ONE_TEST);
+    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(aiOk(ONE_TEST));
 
     generate();
 
@@ -449,12 +454,13 @@ class UnitTestGeneratorTest {
     prWithFiles(foo(), otherFile());
     prDetails();
     when(testAssistant.generate(any(), any(), any(), any()))
-        .thenReturn(ONE_TEST)
+        .thenReturn(aiOk(ONE_TEST))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"tests":[{"path":"t/OtherTest.java","language":"java","covers":"retry bound",
               "code":"class OtherTest {}"}],"notes":""}
-            """);
+            """));
 
     String body = generate();
 
@@ -471,7 +477,7 @@ class UnitTestGeneratorTest {
     budgetWithDiffRoom(40);
     prWithFiles(foo(), otherFile());
     prDetails();
-    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(ONE_TEST);
+    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(aiOk(ONE_TEST));
 
     String body = generate();
 
@@ -512,7 +518,7 @@ class UnitTestGeneratorTest {
             new RepoSettings(List.of("src/Other.java"), List.of(), ".github/thrillhousebot.yml"));
     prWithFiles(foo(), otherFile());
     prDetails();
-    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(ONE_TEST);
+    when(testAssistant.generate(any(), any(), any(), any())).thenReturn(aiOk(ONE_TEST));
 
     generate();
 
@@ -532,7 +538,7 @@ class UnitTestGeneratorTest {
               if (call.<String>getArgument(0).contains("src/Other.java")) {
                 throw new RuntimeException("model down");
               }
-              return ONE_TEST;
+              return aiOk(ONE_TEST);
             });
 
     String body = generate();

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponsesTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponsesTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiOk;
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiTruncated;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The single place every blocking command path decides whether a response was cut short. Its whole
+ * job is to make a length stop distinguishable from bad JSON, so that is what these pin.
+ */
+class AiResponsesTest {
+
+  @Test
+  void returnsTheTextOfACompletedResponse() {
+    assertEquals("{\"docs\":[]}", AiResponses.textOrThrowOnTruncation(aiOk("{\"docs\":[]}"), "X"));
+  }
+
+  @Test
+  void passesANullResultThrough() {
+    // "no response" is a different condition from "cut short" and the callers already handle it.
+    assertNull(AiResponses.textOrThrowOnTruncation(null, "X"));
+  }
+
+  @Test
+  void throwsOnALengthStopRatherThanReturningTheCutBody() {
+    // Returning the partial would send it to a JSON parser, which reports "not valid JSON" — the
+    // exact misdiagnosis this exists to prevent.
+    var thrown =
+        assertThrows(
+            AiResponseTruncatedException.class,
+            () ->
+                AiResponses.textOrThrowOnTruncation(aiTruncated("{\"docs\":[{\"file\":\"A"), "X"));
+
+    assertTrue(
+        thrown.getMessage().contains("max-output-tokens"),
+        "the message must name the knob an operator can change: " + thrown.getMessage());
+  }
+
+  @Test
+  void namesTheCallSoTheOperatorKnowsWhichCommandWasCutShort() {
+    var thrown =
+        assertThrows(
+            AiResponseTruncatedException.class,
+            () ->
+                AiResponses.textOrThrowOnTruncation(aiTruncated("partial"), "/improve assistant"));
+
+    assertTrue(thrown.getMessage().startsWith("/improve assistant"), thrown.getMessage());
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResults.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResults.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.service.Result;
+
+/**
+ * Builds the {@link Result} wrapper the blocking AI services now return, so a test stubs an
+ * assistant with the response text it cares about and nothing else.
+ *
+ * <p>{@link #aiOk(String)} carries {@link FinishReason#STOP} — a model that finished answering —
+ * which is what every pre-existing stub meant before the wrapper existed. {@link #aiTruncated} is
+ * its counterpart for the cut-short case.
+ */
+public final class AiResults {
+
+  private AiResults() {}
+
+  /** A complete response: the model stopped because it was done. */
+  public static Result<String> aiOk(String text) {
+    return Result.<String>builder().content(text).finishReason(FinishReason.STOP).build();
+  }
+
+  /** A response cut short at the model's response-length cap. */
+  public static Result<String> aiTruncated(String partialText) {
+    return Result.<String>builder().content(partialText).finishReason(FinishReason.LENGTH).build();
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -15,6 +15,8 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiOk;
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiTruncated;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -157,10 +159,11 @@ class FindingVerificationServiceTest {
     ReviewResponse original = response(finding("critical", "high", "Bug"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"verdicts": [{"id": 1, "verdict": "confirmed", "risk": "critical",
             "confidence": "high", "reason": "verified"}]}
-            """);
+            """));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -176,13 +179,14 @@ class FindingVerificationServiceTest {
             finding("critical", "high", "Real injection"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"verdicts": [
               {"id": 1, "verdict": "rejected", "reason": "framework idiom, suggestion is a no-op"},
               {"id": 2, "verdict": "confirmed", "risk": "low", "confidence": "high", "reason": "ok"},
               {"id": 3, "verdict": "confirmed", "risk": "critical", "confidence": "high", "reason": "ok"}
             ]}
-            """);
+            """));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -203,10 +207,11 @@ class FindingVerificationServiceTest {
     ReviewResponse original = response(finding("critical", "high", "Speculative"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"verdicts": [{"id": 1, "verdict": "downgraded", "risk": "medium",
             "confidence": "low", "reason": "not verifiable from the diff"}]}
-            """);
+            """));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -219,14 +224,34 @@ class FindingVerificationServiceTest {
   }
 
   @Test
+  void keepsFindingsUnchangedWhenTheVerifierResponseIsCutShort() {
+    // Characterization, not red/green: the verifier fails open on a truncation exactly as it does
+    // on malformed JSON, so this passes with detection disabled too. It is kept because that
+    // fail-open contract is what must NOT change as truncation grows its own handling — the
+    // difference detection buys here is the log line, which is not worth asserting on. The
+    // red/green proof for detection itself lives in AiResponsesTest.
+    ReviewResponse original = response(finding("critical", "high", "Speculative"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(aiTruncated("{\"verdicts\": [{\"id\": 1, \"verdict\": \"downgr"));
+
+    var result = service.verify(original, "diff", "stack", "");
+
+    // Fails open: the unverified finding survives at its original risk/confidence.
+    assertEquals(1, result.findings().size());
+    assertEquals("critical", result.findings().get(0).risk());
+    assertEquals("high", result.findings().get(0).confidence());
+  }
+
+  @Test
   void shouldTolerateRawControlCharsInVerifierResponse() {
     // The verifier sometimes echoes code in its reason with a raw tab/newline left unescaped; the
     // verdict must still be applied (the downgrade below only lands if the response parsed).
     ReviewResponse original = response(finding("critical", "high", "Speculative"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(
-            "{\"verdicts\": [{\"id\": 1, \"verdict\": \"downgraded\", \"risk\": \"medium\","
-                + " \"confidence\": \"low\", \"reason\": \"guard\tmissing\nhere\"}]}");
+            aiOk(
+                "{\"verdicts\": [{\"id\": 1, \"verdict\": \"downgraded\", \"risk\": \"medium\","
+                    + " \"confidence\": \"low\", \"reason\": \"guard\tmissing\nhere\"}]}"));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -239,10 +264,11 @@ class FindingVerificationServiceTest {
     ReviewResponse original = response(finding("medium", "low", "Already modest"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"verdicts": [{"id": 1, "verdict": "downgraded", "risk": "critical",
             "confidence": "high", "reason": "tries to escalate"}]}
-            """);
+            """));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -256,9 +282,10 @@ class FindingVerificationServiceTest {
     ReviewResponse original = response(finding("high", "medium", "Unrated downgrade"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"verdicts": [{"id": 1, "verdict": "downgraded", "reason": "no ratings given"}]}
-            """);
+            """));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -276,13 +303,14 @@ class FindingVerificationServiceTest {
             finding("critical", "high", "To high/low"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"verdicts": [
               {"id": 1, "verdict": "downgraded", "risk": "moderate", "confidence": "very low", "reason": "r"},
               {"id": 2, "verdict": "downgraded", "risk": "low", "confidence": "medium", "reason": "r"},
               {"id": 3, "verdict": "downgraded", "risk": "high", "confidence": "low", "reason": "r"}
             ]}
-            """);
+            """));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -303,9 +331,10 @@ class FindingVerificationServiceTest {
     ReviewResponse original = response(finding("high", "high", "No decision"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"verdicts": [{"id": 1, "reason": "verdict field omitted"}]}
-            """);
+            """));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -318,12 +347,13 @@ class FindingVerificationServiceTest {
         response(finding("critical", "high", "Blank risk"), finding("high", "high", "Blank conf"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"verdicts": [
               {"id": 1, "verdict": "downgraded", "risk": "", "confidence": "low", "reason": "r"},
               {"id": 2, "verdict": "downgraded", "risk": "low", "confidence": "", "reason": "r"}
             ]}
-            """);
+            """));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -341,9 +371,10 @@ class FindingVerificationServiceTest {
         response(finding("high", "high", "No verdict"), finding("low", "high", "Weird verdict"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"verdicts": [{"id": 2, "verdict": "shrug", "reason": "?"}]}
-            """);
+            """));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -355,12 +386,13 @@ class FindingVerificationServiceTest {
     ReviewResponse original = response(finding("critical", "high", "Bug"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"verdicts": [
               {"id": 1, "verdict": "rejected", "reason": "first wins"},
               {"id": 1, "verdict": "confirmed", "reason": "ignored"}
             ]}
-            """);
+            """));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -372,11 +404,12 @@ class FindingVerificationServiceTest {
     ReviewResponse original = response(finding("critical", "high", "Bug"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(
-            """
+            aiOk(
+                """
             ```json
             {"verdicts": [{"id": 1, "verdict": "rejected", "reason": "fp"}]}
             ```
-            """);
+            """));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -398,7 +431,7 @@ class FindingVerificationServiceTest {
   void shouldFailOpenWhenVerifierReturnsInvalidJson() {
     ReviewResponse original = response(finding("critical", "high", "Bug"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
-        .thenReturn("not json at all");
+        .thenReturn(aiOk("not json at all"));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -410,9 +443,10 @@ class FindingVerificationServiceTest {
     var original = new ReviewResponse(List.of(finding("critical", "high", "Bug")), List.of(), null);
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(
-            """
+            aiOk(
+                """
             {"verdicts": [{"id": 1, "verdict": "rejected", "reason": "fp"}]}
-            """);
+            """));
 
     var result = service.verify(original, "diff", "stack", "");
 
@@ -425,7 +459,7 @@ class FindingVerificationServiceTest {
     ReviewResponse original =
         response(finding("critical", "high", "Brace {bug} <<<DIFF_END>>> tail"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
-        .thenReturn("{\"verdicts\": []}");
+        .thenReturn(aiOk("{\"verdicts\": []}"));
 
     service.verify(original, "the-diff", "the-stack", "prior context");
 
@@ -446,7 +480,7 @@ class FindingVerificationServiceTest {
   void shouldPassEmptyPreviousFindingsWhenNull() {
     ReviewResponse original = response(finding("critical", "high", "Title"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
-        .thenReturn("{\"verdicts\": []}");
+        .thenReturn(aiOk("{\"verdicts\": []}"));
 
     service.verify(original, "the-diff", "the-stack", null);
 


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

> **Stacked on #495.** Base is `fix/492-truncation-detection`, not `release/v0.6.0` — this needs `AiResponseTruncatedException` from that PR. GitHub will retarget the base to `release/v0.6.0` automatically when #495 merges. **Review #495 first.**

## Description

Fixes #497.

#495 detects `finish_reason: length` on the streaming review path. Every other AI call returned a bare `String`, so a response cut at `max_tokens` reached a JSON parser and came back as "not valid JSON" — indistinguishable from a genuinely malformed body. An operator who set the cap too low saw a parse warning with nothing pointing at the cap.

Affects `/improve`, `/generate-tests`, `/add-docs`, `/describe`, `/changelog`, maintainer replies, and the finding verifier.

### Scope — this is the legibility half, not a cost fix

Worth stating so the change isn't read as bigger than it is. `max-ai-retries` is referenced in exactly two files:

```
$ grep -rln "maxAiRetries" --include=*.java src/main/java
.../config/ThrillhouseConfig.java
.../review/ai/AiReviewService.java
```

So these paths never had the ~10× retry amplification #495 removed — one call, one failure, already soft-failed. What was missing was any way to know *why*.

### Why `Result<String>` and not a `ChatModelListener`

The issue listed both. I went with `Result<String>`:

- **The compiler proves completeness.** It found all 9 assistant methods and all 9 call sites, and it will keep proving it for any method added later. A listener's correctness is an argument, not a check.
- **Correlation risk.** `OtelObservabilityListener` already exists and correlates via `ReviewSessionContext` — but that context is bound in `AiReviewService.streamOnce`, i.e. for review calls. Extending it to the command paths means new thread-correlation plumbing on exactly the parallel/virtual-thread paths, where getting it subtly wrong misattributes a truncation **silently** — the same class of failure being fixed.
- **`Result` also carries `tokenUsage()` per call**, which #499's spend ceiling needs next.

### Shape

`AiResponses.textOrThrowOnTruncation(result, what)` is the single place the decision is made. Seven of the nine sites already flowed through the `callAssistant` seam in `AbstractPrSuggestionGenerator`, so that seam changed once; `FindingVerificationService` and `MaintainerReplyService` are unwrapped individually.

Each gets a `catch (AiResponseTruncatedException)` **distinct from** the generic failure catch. That matters: "assistant call failed" sends someone hunting a provider error, when the cause is a cap they set and can raise. The message names `max-output-tokens` and the call.

A `null` result still passes through as `null` — "no response" is a different condition from "cut short", and the callers already handle it.

## Related Issues

Fixes #497

Stacked on #495 (#492). Next in the stack: #498, then #499, then #500.

## How Has This Been Tested?

- [x] Unit tests

**Red/green on the detection**, `AiResponsesTest`, with the `FinishReason.LENGTH` check disabled:

```
[ERROR] AiResponsesTest.throwsOnALengthStopRatherThanReturningTheCutBody:49 Expected
  ...AiResponseTruncatedException to be thrown, but nothing was thrown.
[ERROR] AiResponsesTest.namesTheCallSoTheOperatorKnowsWhichCommandWasCutShort:62 Expected
  ...AiResponseTruncatedException to be thrown, but nothing was thrown.
```

Green with it restored. Both truncation catch blocks are driven by tests that go through the real services — `ChangelogEntryGeneratorTest.postsNothingWhenTheAssistantResponseIsCutShortAtTheLengthCap` (the `callAssistant` seam) and `MaintainerReplyServiceTest.truncatedReplyIsSwallowedRatherThanPostedHalfWritten` (the reply path).

**One test of mine is characterization, not red/green, and is labelled as such in the source.** `FindingVerificationServiceTest.keepsFindingsUnchangedWhenTheVerifierResponseIsCutShort` passes with detection disabled too, because the verifier fails open on a truncation exactly as it does on malformed JSON — the only difference detection buys there is the log line, which isn't worth asserting on. I kept it because that fail-open contract is what must not change as truncation grows more handling, but it proves nothing about detection and shouldn't be read as if it does.

**Conversion safety.** The return-type change touched 91 `thenReturn` stubs and 9 `thenAnswer` lambdas across 7 test files. Those were rewritten mechanically with a paren-matcher that respects Java string literals and text blocks — a naive sed would have corrupted the multi-line JSON fixtures. The proof it was behaviour-preserving is that the whole pre-existing suite passes unchanged; no existing assertion was touched, and nothing was disabled or deleted.

Gates on the final tree:

- `./mvnw -B spotless:apply` / `spotless:check` — clean
- `./mvnw -B clean compile spotbugs:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — **Tests run: 2437, Failures: 0, Errors: 0, Skipped: 0**
- Coverage: `jacoco.xml` intersected with this PR's added `src/main/java` lines — **no uncovered added lines**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No behaviour change for any deployment that does not set `max-output-tokens` — no `max_tokens` is sent, so no length stop can occur. When one does occur the command still posts nothing, exactly as before; it just says why.

**Correction to something I said earlier in planning:** I expected #497 and #498 to share plumbing and be one change. They don't. This is a return-type change; #498 needs *different caps per call type*, which means named model configs or per-request parameters — a separate mechanism. #498 is its own PR in the stack.