### PR TITLE
fix(config): align log and docs with the separate-output-budget arithmetic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,7 +133,10 @@ AI_TIMEOUT=300s
 # reserves output-buffer-tokens out of the input budget and max-output-tokens may not exceed that
 # reservation (boot fails if it does). Set it true for a model that publishes its output allowance
 # on top of the input window — e.g. deepseek-v4-flash at 1M in and 384000 out, which ships that way
-# by default. Marking such a model shared silently costs ~40% of every call's diff budget:
+# by default. Getting the flag wrong is loud in one direction and quiet in the other: marking a
+# separate-budget model shared refuses to boot when its max-output-tokens exceeds the buffer
+# (deepseek-v4-flash's shipped pair does), while a model without a response cap silently loses
+# output-buffer-tokens of diff budget per call to a reservation its responses never draw on:
 #THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_FLASH_SEPARATE_OUTPUT_BUDGET=true
 #
 # Env form: the underscores depend on whether the key needs quoting in application.properties.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -378,12 +378,15 @@ public class StartupConfigValidator {
       var presencePenalty = orProviderDefault(activeModel.presencePenalty());
       var seed = activeModel.seed().map(String::valueOf).orElse("none");
       log.info(
-          "Per-model AI settings active for '{}': max-input-tokens={}, output-buffer-tokens={},"
-              + " token-safety-margin={}, temperature={}, top-p={}, max-output-tokens={},"
-              + " frequency-penalty={}, presence-penalty={}, seed={}",
+          "Per-model AI settings active for '{}': max-input-tokens={}, output-buffer-tokens={}"
+              + " (reserved={}), separate-output-budget={}, token-safety-margin={}, temperature={},"
+              + " top-p={}, max-output-tokens={}, frequency-penalty={}, presence-penalty={},"
+              + " seed={}",
           activeModel.modelName(),
           activeModel.maxInputTokens(),
           activeModel.outputBufferTokens(),
+          activeModel.reservedOutputTokens(),
+          activeModel.separateOutputBudget(),
           activeModel.tokenSafetyMargin(),
           temperature,
           topP,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -165,8 +165,10 @@ public interface ThrillhouseConfig {
     /**
      * Per-call input-token budget for the review prompt. The diff is split into batches that each
      * fit this budget after the shared prompt overhead and {@link #outputBufferTokens()} are
-     * subtracted; a PR whose diff exceeds one batch is reviewed in multiple calls. Sized for the
-     * model's context window — keep headroom for output. 0 disables token budgeting (single call).
+     * subtracted (the buffer only on a shared window — a model marked {@code
+     * separate-output-budget} reserves nothing); a PR whose diff exceeds one batch is reviewed in
+     * multiple calls. Sized for the model's context window — keep headroom for output. 0 disables
+     * token budgeting (single call).
      */
     @WithDefault("48000")
     @WithName("max-input-tokens")

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -201,11 +201,13 @@ public class DiffBudgetPlanner {
 
   /**
    * The per-call input-token budget every review-path AI call must fit — {@code max-input-tokens *
-   * token-safety-margin - output-buffer-tokens} — or {@link Integer#MAX_VALUE} when budgeting is
+   * token-safety-margin - reserved-output-tokens} — or {@link Integer#MAX_VALUE} when budgeting is
    * disabled. Each term is the active model's effective value ({@link ActiveModelSettings}): the
-   * max input tokens are the global budget bounded by the model's input cap, and the margin and
-   * output buffer honor per-model overrides. Shared with the pipeline so the summary call is
-   * bounded by the same ceiling as the batch calls.
+   * max input tokens are the global budget bounded by the model's input cap, the margin honors the
+   * per-model override, and the reservation is the (per-model-overridable) output buffer on a
+   * shared window but zero for a model marked {@code separate-output-budget} — its response never
+   * draws on this pool. Shared with the pipeline so the summary call is bounded by the same ceiling
+   * as the batch calls.
    */
   public int perCallInputBudget() {
     var maxInputTokens = activeModel.maxInputTokens();


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 📝 Documentation

## Description

Fixes #505 — the three confirmed findings from deep-audit round 2 (`264bcae..3595bc0`). The audit found **no functional defects** in the five merged commits; these are the places where #496 changed the budget arithmetic and left the surrounding words behind. All were introduced this cycle (`rework`).

**1. Boot log** (`StartupConfigValidator.logActiveModelStatus`) — printed `output-buffer-tokens=8192` for a model whose budgeter reserves **0**, and never logged `separate-output-budget` at all. Two auditors flagged this line independently. It now reads:

```
... output-buffer-tokens=8192 (reserved=0), separate-output-budget=true, ...
```

so the boot an operator debugs is the boot the log describes.

**2. Javadoc drift** — `DiffBudgetPlanner.perCallInputBudget`'s own contract comment still stated the unconditional `- output-buffer-tokens` formula; `ThrillhouseConfig.maxInputTokens()` had the same unconditional reference. Both now name the reservation and its zero case.

**3. `.env.example` false claim** — "Marking such a model shared silently costs ~40% of every call's diff budget". For the sentence's own example (`deepseek-v4-flash`, shipped `max-output-tokens=384000`), the real outcome is a **refused boot** — the validator rule is pinned by `stillRejectsAResponseCapAboveTheBufferOnASharedWindow`. The silent-cost case exists only for a model without a response cap, and its size is the buffer, not 40%. The comment now states both directions correctly.

## Related Issues

Fixes #505

The audit's two other confirmed findings (truncated summary call discards a paid multi-call review; generic failure notice advises a futile retry) are latent, pre-existing shapes folded into #500's scope — deliberately not part of this PR.

## How Has This Been Tested?

- [x] Unit tests

Log-format and comment changes — no behaviour to red/green. The full suite pins that nothing else moved:

- `./mvnw -B spotless:apply` / `spotless:check` — clean
- `./mvnw -B clean compile spotbugs:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — **Tests run: 2454, Failures: 0, Errors: 0, Skipped: 0**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No functional change anywhere: the log line gains two fields, and every other edit is comment text.