### PR TITLE
feat(ai): give the fixed-shape calls their own response cap via a concise named model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,7 +133,10 @@ AI_TIMEOUT=300s
 # reserves output-buffer-tokens out of the input budget and max-output-tokens may not exceed that
 # reservation (boot fails if it does). Set it true for a model that publishes its output allowance
 # on top of the input window — e.g. deepseek-v4-flash at 1M in and 384000 out, which ships that way
-# by default. Marking such a model shared silently costs ~40% of every call's diff budget:
+# by default. Getting the flag wrong is loud in one direction and quiet in the other: marking a
+# separate-budget model shared refuses to boot when its max-output-tokens exceeds the buffer
+# (deepseek-v4-flash's shipped pair does), while a model without a response cap silently loses
+# output-buffer-tokens of diff budget per call to a reservation its responses never draw on:
 #THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_FLASH_SEPARATE_OUTPUT_BUDGET=true
 #
 # Env form: the underscores depend on whether the key needs quoting in application.properties.

--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,13 @@ GITHUB_WEBHOOK_SECRET=your_webhook_secret
 #REVIEW_OUTPUT_BUFFER_TOKENS=8192
 #REVIEW_MAX_AI_CALLS=6
 #REVIEW_TOKEN_SAFETY_MARGIN=0.9
+# Optional: response cap (max_tokens) for the fixed-shape/short AI calls — the final summary of a
+# multi-call review, the finding verifier, and maintainer replies — which run on the "concise"
+# named model so they never share a cap sized for batch review output. The review itself and the
+# command generators (/describe, /changelog, /add-docs, /improve, /generate-tests) stay on the
+# default model's max-output-tokens (their responses scale with the diff). Hitting this cap
+# surfaces as a truncation error naming the variable; set it empty to use the provider default.
+#REVIEW_CONCISE_MAX_OUTPUT_TOKENS=8192
 # Optional: line cap on single-call diff renders (/add-docs, replies, base comparison,
 # budgeting-disabled review). Token-budgeted reviews and the batched commands — /improve,
 # /describe, /changelog, /generate-tests — ignore it (DiffBudgetPlanner owns coverage by

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ will change per provider:
 | `REVIEW_LARGE_PR_NUDGE_MIN_CHANGED_LINES` | Changed lines (additions + deletions) at or above which the nudge applies; either dimension triggers it on its own. `0` switches this dimension off — with both at `0` the nudge never fires | `1000` |
 | `REVIEW_MAX_INPUT_TOKENS` | Per-call input-token budget for review, `/improve`, `/describe` and `/changelog` calls; large PRs are split into batches that each fit it. Bounded by the active model's input cap (see [Per-model AI settings](#per-model-ai-settings)). `0` disables token budgeting | `48000` |
 | `REVIEW_OUTPUT_BUFFER_TOKENS` | Tokens reserved out of the input budget for the model's response | `8192` |
+| `REVIEW_CONCISE_MAX_OUTPUT_TOKENS` | Response cap (`max_tokens`) for the fixed-shape/short AI calls — the final summary of a multi-call review, the finding verifier, and maintainer replies — which run on the `concise` named model so they don't share a cap sized for batch review output (see [Per-model AI settings](#per-model-ai-settings)). Hitting it surfaces as a truncation error naming this variable, never as a silently cut summary; set it empty to drop the cap and use the provider default | `8192` |
 | `REVIEW_MAX_AI_CALLS` | Cap on AI calls per review (batch calls plus the final summary call), per `/describe` and `/changelog` run (batch calls plus one reduce call, spent only when the PR needed more than one batch), and per `/improve`, `/generate-tests` or `/add-docs` run (batch calls only — their results are merged locally); files that still don't fit are reported by name as omitted | `6` |
 | `REVIEW_TOKEN_SAFETY_MARGIN` | Fraction of the input budget actually used, absorbing token-estimate error | `0.9` |
 | `REVIEW_MAX_DIFF_LINES` | Line cap on single-call diff renders (replies, base comparison, budgeting-disabled review). Token-budgeted reviews and the batched commands — `/improve`, `/describe`, `/changelog`, `/generate-tests`, `/add-docs` — ignore it (the planner owns coverage by tokens); `0` disables the cap | `5000` |
@@ -457,6 +458,18 @@ Notes:
   `application.properties` or `-D`) alongside the env var.
 - **`top_k` is not available** on the OpenAI-compatible wire; it becomes
   relevant only with native provider integrations.
+- **`max-output-tokens` no longer caps every call.** The final summary of a
+  multi-call review, the finding verifier, and maintainer replies run on a
+  second model binding — the `concise` named model
+  (`quarkus.langchain4j.openai.concise.*`) — that points at the same provider,
+  credentials, and model through the same `AI_*` variables and follows the
+  active model's temperature/reasoning tuning, but carries its own response
+  cap, `REVIEW_CONCISE_MAX_OUTPUT_TOKENS` (default `8192`). Those responses are
+  fixed-shape or short, so they don't need — and shouldn't be licensed to
+  spend — a cap sized for batch review output. The review itself and the
+  command generators (`/describe`, `/changelog`, `/add-docs`, `/improve`,
+  `/generate-tests`), whose outputs scale with the diff, stay on the default
+  model and its `max-output-tokens`.
 - **`max-output-tokens` vs `output-buffer-tokens`**: `max-output-tokens` is the
   hard response-length cap sent to the provider; `output-buffer-tokens` only
   reserves input-budget headroom for the map-reduce budgeter. On a shared-window

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -378,12 +378,15 @@ public class StartupConfigValidator {
       var presencePenalty = orProviderDefault(activeModel.presencePenalty());
       var seed = activeModel.seed().map(String::valueOf).orElse("none");
       log.info(
-          "Per-model AI settings active for '{}': max-input-tokens={}, output-buffer-tokens={},"
-              + " token-safety-margin={}, temperature={}, top-p={}, max-output-tokens={},"
-              + " frequency-penalty={}, presence-penalty={}, seed={}",
+          "Per-model AI settings active for '{}': max-input-tokens={}, output-buffer-tokens={}"
+              + " (reserved={}), separate-output-budget={}, token-safety-margin={}, temperature={},"
+              + " top-p={}, max-output-tokens={}, frequency-penalty={}, presence-penalty={},"
+              + " seed={}",
           activeModel.modelName(),
           activeModel.maxInputTokens(),
           activeModel.outputBufferTokens(),
+          activeModel.reservedOutputTokens(),
+          activeModel.separateOutputBudget(),
           activeModel.tokenSafetyMargin(),
           temperature,
           topP,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -51,21 +51,28 @@ public class StartupConfigValidator {
   private final ThrillhouseConfig config;
   private final String aiApiKey;
   private final ActiveModelSettings activeModel;
+  private final Optional<Integer> conciseMaxOutputTokens;
 
   @Inject
   public StartupConfigValidator(
       ThrillhouseConfig config,
       @ConfigProperty(name = "quarkus.langchain4j.openai.api-key") Optional<String> aiApiKey,
-      ActiveModelSettings activeModel) {
-    this(config, aiApiKey.orElse(""), activeModel);
+      ActiveModelSettings activeModel,
+      @ConfigProperty(name = "quarkus.langchain4j.openai.concise.chat-model.max-tokens")
+          Optional<Integer> conciseMaxOutputTokens) {
+    this(config, aiApiKey.orElse(""), activeModel, conciseMaxOutputTokens);
   }
 
   /** Visible for tests: exercises validation outcomes without booting the CDI container. */
   StartupConfigValidator(
-      ThrillhouseConfig config, String aiApiKey, ActiveModelSettings activeModel) {
+      ThrillhouseConfig config,
+      String aiApiKey,
+      ActiveModelSettings activeModel,
+      Optional<Integer> conciseMaxOutputTokens) {
     this.config = config;
     this.aiApiKey = aiApiKey;
     this.activeModel = activeModel;
+    this.conciseMaxOutputTokens = conciseMaxOutputTokens;
   }
 
   void onStart(@Observes StartupEvent event) {
@@ -95,6 +102,7 @@ public class StartupConfigValidator {
     validateModelSettings(problems, config.ai().models());
     validateEffectiveBudget(problems);
     validateReasoningEffort(problems, config.ai().reasoning());
+    validateConciseResponseCap(problems);
 
     if (!problems.isEmpty()) {
       throw new ConfigValidationException(formatMessage(problems));
@@ -104,6 +112,7 @@ public class StartupConfigValidator {
     logReasoningStatus();
     logCiGatingStatus();
     logActiveModelStatus();
+    logConciseModelStatus();
     warnUnmappedModelEnvVars(System.getenv());
     log.info(
         "Configuration validated: GitHub App id, private key, webhook secret, and AI API key are"
@@ -323,6 +332,23 @@ public class StartupConfigValidator {
   }
 
   /**
+   * Rejects a degenerate response cap for the {@code concise} named model (the summary, verifier,
+   * and reply calls — #498) at boot, the same fail-fast contract as the other budget keys. Empty is
+   * allowed: an operator who clears {@code REVIEW_CONCISE_MAX_OUTPUT_TOKENS} drops the cap and the
+   * provider default applies.
+   */
+  private void validateConciseResponseCap(List<String> problems) {
+    conciseMaxOutputTokens
+        .filter(v -> v < 1)
+        .ifPresent(
+            v ->
+                problems.add(
+                    "REVIEW_CONCISE_MAX_OUTPUT_TOKENS must be >= 1"
+                        + " (quarkus.langchain4j.openai.concise.chat-model.max-tokens): "
+                        + v));
+  }
+
+  /**
    * Rejects an unrecognized {@code REVIEW_CI_GATING} value at boot so a typo never silently falls
    * through to the fail-closed default.
    */
@@ -395,6 +421,20 @@ public class StartupConfigValidator {
           presencePenalty,
           seed);
     }
+  }
+
+  /**
+   * Mirrors {@link #logActiveModelStatus}'s per-model line for the {@code concise} named model, so
+   * the boot log states which response cap the summary/verifier/reply calls run under — including
+   * the shipped 8192 default, which applies without any operator action.
+   */
+  private void logConciseModelStatus() {
+    log.info(
+        "Concise model active for summary/verifier/reply calls: max-output-tokens={}"
+            + " (REVIEW_CONCISE_MAX_OUTPUT_TOKENS); other generation parameters follow the active"
+            + " model '{}'.",
+        orProviderDefault(conciseMaxOutputTokens),
+        activeModel.modelName());
   }
 
   /** Env-var prefix every per-model setting shares. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -165,8 +165,10 @@ public interface ThrillhouseConfig {
     /**
      * Per-call input-token budget for the review prompt. The diff is split into batches that each
      * fit this budget after the shared prompt overhead and {@link #outputBufferTokens()} are
-     * subtracted; a PR whose diff exceeds one batch is reviewed in multiple calls. Sized for the
-     * model's context window — keep headroom for output. 0 disables token budgeting (single call).
+     * subtracted (the buffer only on a shared window — a model marked {@code
+     * separate-output-budget} reserves nothing); a PR whose diff exceeds one batch is reviewed in
+     * multiple calls. Sized for the model's context window — keep headroom for output. 0 disables
+     * token budgeting (single call).
      */
     @WithDefault("48000")
     @WithName("max-input-tokens")

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -201,11 +201,13 @@ public class DiffBudgetPlanner {
 
   /**
    * The per-call input-token budget every review-path AI call must fit — {@code max-input-tokens *
-   * token-safety-margin - output-buffer-tokens} — or {@link Integer#MAX_VALUE} when budgeting is
+   * token-safety-margin - reserved-output-tokens} — or {@link Integer#MAX_VALUE} when budgeting is
    * disabled. Each term is the active model's effective value ({@link ActiveModelSettings}): the
-   * max input tokens are the global budget bounded by the model's input cap, and the margin and
-   * output buffer honor per-model overrides. Shared with the pipeline so the summary call is
-   * bounded by the same ceiling as the batch calls.
+   * max input tokens are the global budget bounded by the model's input cap, the margin honors the
+   * per-model override, and the reservation is the (per-model-overridable) output buffer on a
+   * shared window but zero for a model marked {@code separate-output-budget} — its response never
+   * draws on this pool. Shared with the pipeline so the summary call is bounded by the same ceiling
+   * as the batch calls.
    */
   public int perCallInputBudget() {
     var maxInputTokens = activeModel.maxInputTokens();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewService.java
@@ -48,6 +48,7 @@ public class AiReviewService {
   private static final int STREAM_FLUSH_MIN_CHARS = 512;
 
   private final PrReviewer prReviewer;
+  private final PrSummarizer prSummarizer;
   private final ReviewResponseParser parser;
   private final ThrillhouseConfig config;
 
@@ -56,10 +57,12 @@ public class AiReviewService {
   @Inject
   public AiReviewService(
       PrReviewer prReviewer,
+      PrSummarizer prSummarizer,
       ReviewResponseParser parser,
       ThrillhouseConfig config,
       SessionEventBroadcaster broadcaster) {
     this.prReviewer = prReviewer;
+    this.prSummarizer = prSummarizer;
     this.parser = parser;
     this.config = config;
     this.broadcaster = broadcaster;
@@ -87,13 +90,15 @@ public class AiReviewService {
   /**
    * Final summary call of a large multi-call review: rolls the aggregated findings up into the
    * PR-level summary object + previous_findings_status. Blocking, no token stream; the returned
-   * response carries the summary and previous-findings status (its findings list is empty).
+   * response carries the summary and previous-findings status (its findings list is empty). Runs on
+   * the {@code concise} named model — the response is one fixed-shape object, so it carries the
+   * concise cap rather than the batch review's response allowance.
    */
   public ReviewResponse summarize(ReviewSession session, SummaryInputs inputs) {
     return runWithRetries(
         session,
         () ->
-            prReviewer.summarizeStream(
+            prSummarizer.summarizeStream(
                 inputs.prContext(),
                 inputs.findings(),
                 inputs.changedFiles(),

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelCustomizers.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelCustomizers.java
@@ -20,6 +20,7 @@ import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 import dev.thiagogonzaga.thrillhousebot.config.ActiveModelSettings;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
+import io.quarkiverse.langchain4j.ModelName;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Optional;
 
@@ -36,6 +37,17 @@ import java.util.Optional;
  * only applied to the blocking {@code ChatModel} — the streaming builder never reads them, which
  * would silently skip the main review call ({@link PrReviewer#reviewStream}). Setting the builders'
  * own parameters covers both models and leaves every other default request parameter untouched.
+ *
+ * <p>Customizers bind to models by CDI qualifier: {@code ModelBuilderCustomizer.applyCustomizers}
+ * selects {@code @Default}-qualified beans for the default model and {@code @ModelName}-qualified
+ * beans for a named one, with no inheritance either way, and runs them after the extension's config
+ * properties, immediately before {@code build()} — so a customizer wins over config. That is why
+ * the {@code concise} named model (#498: summary, verifier, replies) has customizers of its own:
+ * without them it would silently lose the reasoning/temperature tuning, and with the unqualified
+ * ones it would have its response cap ({@code
+ * quarkus.langchain4j.openai.concise.chat-model.max-tokens}, aliased to {@code
+ * REVIEW_CONCISE_MAX_OUTPUT_TOKENS}) stomped by the active model's {@code max-output-tokens}. The
+ * concise pair therefore applies every shared parameter except the response cap.
  */
 public final class ChatModelCustomizers {
 
@@ -97,6 +109,65 @@ public final class ChatModelCustomizers {
       activeModel.temperature().ifPresent(builder::temperature);
       activeModel.topP().ifPresent(builder::topP);
       activeModel.maxOutputTokens().ifPresent(builder::maxTokens);
+      activeModel.frequencyPenalty().ifPresent(builder::frequencyPenalty);
+      activeModel.presencePenalty().ifPresent(builder::presencePenalty);
+      activeModel.seed().ifPresent(builder::seed);
+    }
+  }
+
+  /**
+   * Tuning for the concise named model's blocking bean (verifier, replies). Applies the same
+   * reasoning and generation parameters as the default model's customizer, but never {@code
+   * maxTokens}: the concise response cap comes from the named config block and applying the active
+   * model's {@code max-output-tokens} here would overwrite it — customizers run after config
+   * properties.
+   */
+  @ApplicationScoped
+  @ModelName("concise")
+  static class ConciseChatModelCustomizer
+      implements ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder> {
+
+    private final ThrillhouseConfig config;
+    private final ActiveModelSettings activeModel;
+
+    ConciseChatModelCustomizer(ThrillhouseConfig config, ActiveModelSettings activeModel) {
+      this.config = config;
+      this.activeModel = activeModel;
+    }
+
+    @Override
+    public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
+      reasoningEffort(config).ifPresent(builder::reasoningEffort);
+      activeModel.temperature().ifPresent(builder::temperature);
+      activeModel.topP().ifPresent(builder::topP);
+      activeModel.frequencyPenalty().ifPresent(builder::frequencyPenalty);
+      activeModel.presencePenalty().ifPresent(builder::presencePenalty);
+      activeModel.seed().ifPresent(builder::seed);
+    }
+  }
+
+  /**
+   * Tuning for the concise named model's streaming bean (the final summary call). Same contract as
+   * {@link ConciseChatModelCustomizer}: everything shared, never {@code maxTokens}.
+   */
+  @ApplicationScoped
+  @ModelName("concise")
+  static class ConciseStreamingChatModelCustomizer
+      implements ModelBuilderCustomizer<OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder> {
+
+    private final ThrillhouseConfig config;
+    private final ActiveModelSettings activeModel;
+
+    ConciseStreamingChatModelCustomizer(ThrillhouseConfig config, ActiveModelSettings activeModel) {
+      this.config = config;
+      this.activeModel = activeModel;
+    }
+
+    @Override
+    public void customize(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder builder) {
+      reasoningEffort(config).ifPresent(builder::reasoningEffort);
+      activeModel.temperature().ifPresent(builder::temperature);
+      activeModel.topP().ifPresent(builder::topP);
       activeModel.frequencyPenalty().ifPresent(builder::frequencyPenalty);
       activeModel.presencePenalty().ifPresent(builder::presencePenalty);
       activeModel.seed().ifPresent(builder::seed);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifier.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifier.java
@@ -24,10 +24,13 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * Second-pass AI call that audits candidate findings; returns raw JSON parsed by the caller.
- * Application-scoped (no chat memory) so parallel map-reduce batch threads can invoke it.
+ * Application-scoped (no chat memory) so parallel map-reduce batch threads can invoke it. Bound to
+ * the {@code concise} named model: the response is one verdict per finding, so it carries the
+ * concise response cap ({@code REVIEW_CONCISE_MAX_OUTPUT_TOKENS}) instead of the batch review's
+ * allowance.
  */
 @ApplicationScoped
-@RegisterAiService
+@RegisterAiService(modelName = "concise")
 public interface FindingVerifier {
 
   // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrSummarizer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrSummarizer.java
@@ -23,30 +23,27 @@ import io.quarkiverse.langchain4j.RegisterAiService;
 import jakarta.enterprise.context.ApplicationScoped;
 
 /**
- * Stateless streaming AI service for the PR review call, whose response scales with finding count
- * and therefore carries the default model's response cap. The final summary call lives on {@link
- * PrSummarizer}, bound to the {@code concise} named model, so its fixed-shape response gets a
- * tighter cap. Application-scoped because there is no chat memory / {@code @MemoryId} — request
- * scope would break parallel map-reduce batches that run on virtual threads without an inherited
- * CDI request context.
+ * Stateless streaming AI service for the final summary call of a multi-call review. Split out of
+ * {@link PrReviewer} because one {@code @RegisterAiService} interface is one model binding, and the
+ * summary must not share the batch review's response cap: a batch response scales with finding
+ * count, while the summary returns one fixed-shape object plus {@code previous_findings_status}, so
+ * it binds to the {@code concise} named model whose {@code max-tokens} is sized for fixed-shape
+ * output ({@code REVIEW_CONCISE_MAX_OUTPUT_TOKENS}). Application-scoped for the same reason as
+ * {@link PrReviewer}: there is no chat memory / {@code @MemoryId}, and request scope would break
+ * callers on virtual threads without an inherited CDI request context.
  */
 @ApplicationScoped
-@RegisterAiService
-public interface PrReviewer {
+@RegisterAiService(modelName = "concise")
+public interface PrSummarizer {
 
-  // {{repoInstructions}} carries the pre-rendered trailing guidance: available repository labels
-  // (when labelling is on) followed by any repo instructions file.
-  //
   // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that
   // parameter's raw value and silently drops every other @V.
-  @SystemMessage(PrReviewPrompts.SYSTEM)
-  @UserMessage(PrReviewPrompts.USER)
-  TokenStream reviewStream(
-      @V("diff") String diff,
+  @SystemMessage(PrReviewPrompts.SUMMARY_SYSTEM)
+  @UserMessage(PrReviewPrompts.SUMMARY_USER)
+  TokenStream summarizeStream(
       @V("prContext") String prContext,
-      @V("baseComparison") String baseComparison,
-      @V("projectStack") String projectStack,
-      @V("relatedTests") String relatedTests,
+      @V("findings") String findings,
+      @V("changedFiles") String changedFiles,
       @V("previousFindings") String previousFindings,
       @V("repoInstructions") String repoInstructions);
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReplyAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReplyAssistant.java
@@ -23,9 +23,11 @@ import io.quarkiverse.langchain4j.RegisterAiService;
 
 /**
  * Conversational reply to a maintainer's question or pushback in a PR thread. Returns the reply as
- * plain Markdown — unlike the review call, there is no JSON schema to parse.
+ * plain Markdown — unlike the review call, there is no JSON schema to parse. Bound to the {@code
+ * concise} named model: a reply is short prose, so it carries the concise response cap ({@code
+ * REVIEW_CONCISE_MAX_OUTPUT_TOKENS}) instead of the batch review's allowance.
  */
-@RegisterAiService
+@RegisterAiService(modelName = "concise")
 public interface ReplyAssistant {
 
   // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -121,6 +121,31 @@ quarkus.langchain4j.openai.chat-model.log-responses=false
 %dev.quarkus.langchain4j.openai.chat-model.log-requests=true
 %dev.quarkus.langchain4j.openai.chat-model.log-responses=true
 
+# Named "concise" model (#498) — the same provider, credentials, and model as the default block,
+# but with its own response cap for the calls whose output is fixed-shape or short: the multi-call
+# review's final summary (PrSummarizer), the finding verifier (FindingVerifier), and maintainer
+# replies (ReplyAssistant). A batch review response scales with finding count and keeps the default
+# model's allowance; these calls do not, so sizing one shared cap for the batch call would license
+# them to run far longer than they ever should. quarkus-langchain4j named configs inherit NOTHING
+# from the default block (OpenAiRecorder resolves namedConfig().get(name) with no fallback), so
+# every connection setting aliases the SAME env vars — operators configure one provider and both
+# models follow it.
+quarkus.langchain4j.openai.concise.api-key=${AI_API_KEY:}
+quarkus.langchain4j.openai.concise.base-url=${AI_BASE_URL:https://api.deepseek.com/v1}
+quarkus.langchain4j.openai.concise.chat-model.model-name=${AI_MODEL:deepseek-chat}
+quarkus.langchain4j.openai.concise.timeout=${AI_TIMEOUT:300s}
+# The concise response cap. 8192 tokens is roomy for these calls — a summary is one object plus
+# previous_findings_status, a verifier response is one verdict per finding (a 50-finding review
+# verifies in well under 4k tokens), a reply is a few paragraphs — while still an order of
+# magnitude under caps sized for batch review output (e.g. deepseek-v4-flash's 384000). Hitting it
+# surfaces as the #492/#495 truncation error naming this knob, never as a silently cut summary.
+# Set the env var empty to drop the cap and use the provider default.
+quarkus.langchain4j.openai.concise.chat-model.max-tokens=${REVIEW_CONCISE_MAX_OUTPUT_TOKENS:8192}
+quarkus.langchain4j.openai.concise.chat-model.log-requests=false
+quarkus.langchain4j.openai.concise.chat-model.log-responses=false
+%dev.quarkus.langchain4j.openai.concise.chat-model.log-requests=true
+%dev.quarkus.langchain4j.openai.concise.chat-model.log-responses=true
+
 # Logging — plain text in all profiles (JSON extension removed due to stack-trace formatting bug)
 
 # OpenTelemetry

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -78,6 +78,7 @@ class StartupConfigValidatorTest {
     private String reasoningEffort = "low";
     private String blockingStrictness = "balanced";
     private String modelName = "deepseek-chat";
+    private Optional<Integer> conciseMaxOutputTokens = Optional.of(8192);
     private final Map<String, ThrillhouseConfig.AiPricingConfig.ModelSettings> models =
         new HashMap<>();
 
@@ -151,6 +152,11 @@ class StartupConfigValidatorTest {
       return this;
     }
 
+    ConfigBuilder conciseMaxOutputTokens(Optional<Integer> v) {
+      this.conciseMaxOutputTokens = v;
+      return this;
+    }
+
     ConfigBuilder model(String name, ThrillhouseConfig.AiPricingConfig.ModelSettings settings) {
       this.models.put(name, settings);
       return this;
@@ -183,7 +189,7 @@ class StartupConfigValidatorTest {
       lenient().when(review.blockingStrictness()).thenReturn(blockingStrictness);
       lenient().when(ai.models()).thenReturn(models);
       return new StartupConfigValidator(
-          config, aiApiKey, new ActiveModelSettings(config, modelName));
+          config, aiApiKey, new ActiveModelSettings(config, modelName), conciseMaxOutputTokens);
     }
   }
 
@@ -283,6 +289,27 @@ class StartupConfigValidatorTest {
   void failsFastWhenMaxAiCallsBelowOne() {
     var ex = assertFailsValidation(new ConfigBuilder().maxAiCalls(0).build());
     assertTrue(ex.getMessage().contains("REVIEW_MAX_AI_CALLS"), ex.getMessage());
+  }
+
+  @Test
+  void failsFastWhenConciseResponseCapBelowOne() {
+    // Same fail-fast contract as the other budget keys: a degenerate cap on the concise model
+    // (summary/verifier/replies) must be rejected at boot, naming the env var.
+    for (var cap : new int[] {0, -1}) {
+      var ex =
+          assertFailsValidation(
+              new ConfigBuilder().conciseMaxOutputTokens(Optional.of(cap)).build());
+      assertTrue(
+          ex.getMessage().contains("REVIEW_CONCISE_MAX_OUTPUT_TOKENS must be >= 1"),
+          ex.getMessage());
+    }
+  }
+
+  @Test
+  void bootsWhenTheConciseResponseCapIsUnset() {
+    // An operator may clear REVIEW_CONCISE_MAX_OUTPUT_TOKENS (empty value) so the concise calls
+    // fall back to the provider default; absence is not a misconfiguration.
+    new ConfigBuilder().conciseMaxOutputTokens(Optional.empty()).build().validate();
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewServiceTest.java
@@ -44,6 +44,8 @@ class AiReviewServiceTest {
 
   @Mock private PrReviewer prReviewer;
 
+  @Mock private PrSummarizer prSummarizer;
+
   @Mock private ReviewResponseParser parser;
 
   @Mock private ThrillhouseConfig config;
@@ -181,7 +183,7 @@ class AiReviewServiceTest {
   @Test
   void summarizeCallsSummaryStreamBlockingAndReturnsParsedResponse() {
     ReviewSession session = reviewSession();
-    when(prReviewer.summarizeStream(
+    when(prSummarizer.summarizeStream(
             anyString(), anyString(), anyString(), anyString(), anyString()))
         .thenReturn(new FakeTokenStream("{\"findings\":[]}"));
     when(parser.parse(anyString())).thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -190,7 +192,7 @@ class AiReviewServiceTest {
         service.summarize(session, new AiReviewService.SummaryInputs("ctx", "[]", "files", "", ""));
 
     assertNotNull(response);
-    verify(prReviewer)
+    verify(prSummarizer)
         .summarizeStream(anyString(), anyString(), anyString(), anyString(), anyString());
     var captor = ArgumentCaptor.forClass(SessionEventBroadcaster.SessionEvent.class);
     verify(broadcaster, atLeast(0)).broadcast(captor.capture());
@@ -851,7 +853,7 @@ class AiReviewServiceTest {
         .thenReturn(new HangingTokenStream());
     StreamingHandle handle = mock(StreamingHandle.class);
     var cancellableService =
-        new AiReviewService(prReviewer, parser, config, broadcaster) {
+        new AiReviewService(prReviewer, prSummarizer, parser, config, broadcaster) {
           @Override
           StreamingHandle streamingHandleOf(TokenStream stream) {
             return handle;
@@ -903,7 +905,7 @@ class AiReviewServiceTest {
     StreamingHandle handle = mock(StreamingHandle.class);
     doThrow(new IllegalStateException("already closed")).when(handle).cancel();
     var cancellableService =
-        new AiReviewService(prReviewer, parser, config, broadcaster) {
+        new AiReviewService(prReviewer, prSummarizer, parser, config, broadcaster) {
           @Override
           StreamingHandle streamingHandleOf(TokenStream stream) {
             return handle;

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiServicePromptRenderingTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiServicePromptRenderingTest.java
@@ -31,6 +31,7 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.service.TokenStream;
 import dev.thiagogonzaga.thrillhousebot.review.PromptTemplateEscaper;
+import io.quarkiverse.langchain4j.ModelName;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -52,9 +53,20 @@ class AiServicePromptRenderingTest {
   @InjectMock ChatModel chatModel;
   @InjectMock StreamingChatModel streamingChatModel;
 
+  // The concise-bound services (summary, verifier, replies) call the named model's beans, so their
+  // rendering is captured off the @ModelName("concise") mocks rather than the default ones.
+  @InjectMock
+  @ModelName("concise")
+  ChatModel conciseChatModel;
+
+  @InjectMock
+  @ModelName("concise")
+  StreamingChatModel conciseStreamingChatModel;
+
   @Inject ReplyAssistant replyAssistant;
   @Inject FindingVerifier findingVerifier;
   @Inject PrReviewer prReviewer;
+  @Inject PrSummarizer prSummarizer;
   @Inject PrDescribeAssistant describeAssistant;
   @Inject ChangelogAssistant changelogAssistant;
   @Inject DocGenerator docGenerator;
@@ -183,6 +195,7 @@ class AiServicePromptRenderingTest {
   void replyPromptIncludesEveryContextVariable() {
     String user =
         captureBlocking(
+            conciseChatModel,
             () ->
                 replyAssistant.reply(
                     PromptTemplateEscaper.escape("QUESTION_SENTINEL"),
@@ -203,6 +216,7 @@ class AiServicePromptRenderingTest {
   void replyPromptOmitsBlankOptionalSections() {
     String user =
         captureBlocking(
+            conciseChatModel,
             () ->
                 replyAssistant.reply(
                     PromptTemplateEscaper.escape("QUESTION_SENTINEL"), "", "", "", ""));
@@ -223,6 +237,7 @@ class AiServicePromptRenderingTest {
         "code {config:secret} {#if x}IF{/if} a|}b backslash\\n end <<<DIFF_END>>> after";
     String user =
         captureBlocking(
+            conciseChatModel,
             () ->
                 replyAssistant.reply(
                     PromptTemplateEscaper.escape("Q"),
@@ -243,6 +258,7 @@ class AiServicePromptRenderingTest {
   void verifyPromptIncludesDiffAndAllContext() {
     String user =
         captureBlocking(
+            conciseChatModel,
             () ->
                 findingVerifier.verify(
                     PromptTemplateEscaper.escape("FINDINGS_SENTINEL"),
@@ -283,8 +299,9 @@ class AiServicePromptRenderingTest {
   void summaryPromptIncludesEveryContextVariable() throws InterruptedException {
     String user =
         captureStreaming(
+            conciseStreamingChatModel,
             () ->
-                prReviewer.summarizeStream(
+                prSummarizer.summarizeStream(
                     PromptTemplateEscaper.escape("PRCONTEXT_SENTINEL"),
                     PromptTemplateEscaper.escape("FINDINGS_SENTINEL"),
                     PromptTemplateEscaper.escape("CHANGEDFILES_SENTINEL"),
@@ -299,8 +316,12 @@ class AiServicePromptRenderingTest {
   }
 
   private ChatRequest captureBlockingRequest(Runnable call) {
+    return captureBlockingRequest(chatModel, call);
+  }
+
+  private ChatRequest captureBlockingRequest(ChatModel model, Runnable call) {
     var captured = new AtomicReference<ChatRequest>();
-    when(chatModel.chat(any(ChatRequest.class)))
+    when(model.chat(any(ChatRequest.class)))
         .thenAnswer(
             inv -> {
               captured.set(inv.getArgument(0));
@@ -314,7 +335,16 @@ class AiServicePromptRenderingTest {
     return userText(captureBlockingRequest(call));
   }
 
+  private String captureBlocking(ChatModel model, Runnable call) {
+    return userText(captureBlockingRequest(model, call));
+  }
+
   private String captureStreaming(Supplier<TokenStream> call) throws InterruptedException {
+    return captureStreaming(streamingChatModel, call);
+  }
+
+  private String captureStreaming(StreamingChatModel model, Supplier<TokenStream> call)
+      throws InterruptedException {
     var captured = new AtomicReference<ChatRequest>();
     doAnswer(
             inv -> {
@@ -324,7 +354,7 @@ class AiServicePromptRenderingTest {
                   ChatResponse.builder().aiMessage(AiMessage.from("{}")).build());
               return null;
             })
-        .when(streamingChatModel)
+        .when(model)
         .chat(any(ChatRequest.class), any(StreamingChatResponseHandler.class));
 
     var done = new CountDownLatch(1);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiServiceUserMessagePlacementTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiServiceUserMessagePlacementTest.java
@@ -42,6 +42,11 @@ class AiServiceUserMessagePlacementTest {
   }
 
   @Test
+  void prSummarizerPutsUserMessageOnTheMethod() {
+    assertUserMessageOnMethodNotParameter(PrSummarizer.class);
+  }
+
+  @Test
   void findingVerifierPutsUserMessageOnTheMethod() {
     assertUserMessageOnMethodNotParameter(FindingVerifier.class);
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelCustomizersTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelCustomizersTest.java
@@ -183,6 +183,66 @@ class ChatModelCustomizersTest {
   }
 
   @Test
+  void conciseChatModelGetsSharedTuningButNeverAResponseCap() {
+    // The concise model's cap comes from its named config block
+    // (quarkus.langchain4j.openai.concise.chat-model.max-tokens); customizers run after config
+    // properties, so a maxTokens call here would stomp the cap the named model exists to carry.
+    var builder = mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+    var config =
+        config(
+            true,
+            "Medium",
+            Map.of(MODEL, settings(Optional.of(0.2), Optional.of(0.95), Optional.of(384_000))));
+
+    new ChatModelCustomizers.ConciseChatModelCustomizer(config, activeModel(config))
+        .customize(builder);
+
+    verify(builder).reasoningEffort("medium");
+    verify(builder).temperature(0.2);
+    verify(builder).topP(0.95);
+    verifyNoMoreInteractions(builder);
+  }
+
+  @Test
+  void conciseStreamingModelGetsSharedTuningButNeverAResponseCap() {
+    var builder = mock(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder.class);
+    var config =
+        config(
+            true,
+            "Medium",
+            Map.of(MODEL, settings(Optional.of(0.2), Optional.of(0.95), Optional.of(384_000))));
+
+    new ChatModelCustomizers.ConciseStreamingChatModelCustomizer(config, activeModel(config))
+        .customize(builder);
+
+    verify(builder).reasoningEffort("medium");
+    verify(builder).temperature(0.2);
+    verify(builder).topP(0.95);
+    verifyNoMoreInteractions(builder);
+  }
+
+  @Test
+  void conciseCustomizersApplyPenaltiesAndSeed() {
+    var blocking = mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+    var streaming = mock(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder.class);
+    var config = config(false, "low", Map.of(MODEL, settingsWithPenaltiesAndSeed(0.5, -0.5, 42)));
+
+    new ChatModelCustomizers.ConciseChatModelCustomizer(config, activeModel(config))
+        .customize(blocking);
+    new ChatModelCustomizers.ConciseStreamingChatModelCustomizer(config, activeModel(config))
+        .customize(streaming);
+
+    verify(blocking).frequencyPenalty(0.5);
+    verify(blocking).presencePenalty(-0.5);
+    verify(blocking).seed(42);
+    verifyNoMoreInteractions(blocking);
+    verify(streaming).frequencyPenalty(0.5);
+    verify(streaming).presencePenalty(-0.5);
+    verify(streaming).seed(42);
+    verifyNoMoreInteractions(streaming);
+  }
+
+  @Test
   void anotherModelsEntryIsNotAppliedToTheActiveModel() {
     // A tuning entry keyed to a different model name must not leak into the active model's calls.
     var builder = mock(OpenAiChatModel.OpenAiChatModelBuilder.class);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelDefaultOffTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelDefaultOffTest.java
@@ -22,21 +22,32 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
+import io.quarkiverse.langchain4j.ModelName;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 /**
  * Default profile: reasoning is off and no per-model settings entry exists, so no {@code
- * reasoning_effort} and no {@code max_tokens} reach either model, and temperature/top-p stay at the
- * quarkus-langchain4j extension defaults (1.0/1.0) — today's behavior is preserved for untuned
- * deployments.
+ * reasoning_effort} and no {@code max_tokens} reach either default model, and temperature/top-p
+ * stay at the quarkus-langchain4j extension defaults (1.0/1.0) — today's behavior is preserved for
+ * untuned deployments. The {@code concise} named model differs in exactly one way: it always
+ * carries its response cap ({@code REVIEW_CONCISE_MAX_OUTPUT_TOKENS}, default 8192), because the
+ * summary/verifier/reply responses are fixed-shape and must not run unbounded.
  */
 @QuarkusTest
 class ChatModelDefaultOffTest {
 
   @Inject ChatModel chatModel;
   @Inject StreamingChatModel streamingChatModel;
+
+  @Inject
+  @ModelName("concise")
+  ChatModel conciseChatModel;
+
+  @Inject
+  @ModelName("concise")
+  StreamingChatModel conciseStreamingChatModel;
 
   @Test
   void noTuningIsSentByDefault() {
@@ -52,6 +63,26 @@ class ChatModelDefaultOffTest {
             OpenAiChatRequestParameters.class, streamingChatModel.defaultRequestParameters());
     assertNull(streaming.reasoningEffort());
     assertNull(streaming.maxOutputTokens());
+    assertEquals(1.0, streaming.temperature());
+    assertEquals(1.0, streaming.topP());
+  }
+
+  @Test
+  void conciseModelsCarryOnlyTheirResponseCapByDefault() {
+    var blocking =
+        assertInstanceOf(
+            OpenAiChatRequestParameters.class, conciseChatModel.defaultRequestParameters());
+    assertEquals(8192, blocking.maxOutputTokens(), "the concise default cap must apply");
+    assertNull(blocking.reasoningEffort());
+    assertEquals(1.0, blocking.temperature());
+    assertEquals(1.0, blocking.topP());
+
+    var streaming =
+        assertInstanceOf(
+            OpenAiChatRequestParameters.class,
+            conciseStreamingChatModel.defaultRequestParameters());
+    assertEquals(8192, streaming.maxOutputTokens(), "the concise default cap must apply");
+    assertNull(streaming.reasoningEffort());
     assertEquals(1.0, streaming.temperature());
     assertEquals(1.0, streaming.topP());
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelWiringTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelWiringTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
+import io.quarkiverse.langchain4j.ModelName;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -38,6 +39,13 @@ import org.junit.jupiter.api.Test;
  * quarkus.langchain4j.openai.chat-model.*} properties are applied to the blocking model only, so
  * this test pins that the {@link ChatModelCustomizers} route reaches the streaming model used by
  * the main PR review call. It would fail if the wiring ever regressed to the config properties.
+ *
+ * <p>The {@code concise} named model (summary, verifier, replies — #498) is pinned separately:
+ * customizers bind by CDI qualifier ({@code applyCustomizers} selects {@code @Default} beans for
+ * the default model and {@code @ModelName}-qualified beans for a named one), so these assertions
+ * prove the named model carries its own response cap ({@code REVIEW_CONCISE_MAX_OUTPUT_TOKENS}
+ * default 8192) instead of the active model's {@code max-output-tokens}, while still receiving the
+ * shared reasoning/temperature tuning — and that the batch-review models keep theirs.
  */
 @QuarkusTest
 @TestProfile(ChatModelWiringTest.TuningEnabled.class)
@@ -45,6 +53,14 @@ class ChatModelWiringTest {
 
   @Inject ChatModel chatModel;
   @Inject StreamingChatModel streamingChatModel;
+
+  @Inject
+  @ModelName("concise")
+  ChatModel conciseChatModel;
+
+  @Inject
+  @ModelName("concise")
+  StreamingChatModel conciseStreamingChatModel;
 
   @Test
   void blockingModelCarriesConfiguredTuning() {
@@ -65,6 +81,42 @@ class ChatModelWiringTest {
     assertEquals(0.3, params.temperature());
     assertEquals(0.95, params.topP());
     assertEquals(4096, params.maxOutputTokens());
+  }
+
+  @Test
+  void conciseBlockingModelCarriesTheConciseCapAndTheSharedTuning() {
+    var params =
+        assertInstanceOf(
+            OpenAiChatRequestParameters.class, conciseChatModel.defaultRequestParameters());
+    assertEquals(
+        8192,
+        params.maxOutputTokens(),
+        "the concise response cap must apply, not the active model's max-output-tokens");
+    assertEquals(
+        "medium",
+        params.reasoningEffort(),
+        "the concise model must not silently lose the reasoning setting");
+    assertEquals(0.3, params.temperature());
+    assertEquals(0.95, params.topP());
+  }
+
+  @Test
+  void conciseStreamingModelCarriesTheConciseCapAndTheSharedTuning() {
+    // The summary call streams, so the named model's streaming bean is the one that matters.
+    var params =
+        assertInstanceOf(
+            OpenAiChatRequestParameters.class,
+            conciseStreamingChatModel.defaultRequestParameters());
+    assertEquals(
+        8192,
+        params.maxOutputTokens(),
+        "the concise response cap must apply, not the active model's max-output-tokens");
+    assertEquals(
+        "medium",
+        params.reasoningEffort(),
+        "the concise model must not silently lose the reasoning setting");
+    assertEquals(0.3, params.temperature());
+    assertEquals(0.95, params.topP());
   }
 
   public static class TuningEnabled implements QuarkusTestProfile {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ConciseModelTruncationTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ConciseModelTruncationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
+import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
+import io.quarkiverse.langchain4j.ModelName;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins that moving the summary, verifier, and reply calls onto the {@code concise} named model
+ * (#498) did not detach them from the truncation detection of #492/#495/#497: a {@code
+ * finish_reason: length} stop on a concise-bound call must still surface as {@link
+ * AiResponseTruncatedException} — naming the cap — rather than as an unparseable or half-posted
+ * body. Drives the real AI services against mocked {@code @ModelName("concise")} model beans, so
+ * the test also fails if a service silently rebinds to the default model.
+ */
+@QuarkusTest
+class ConciseModelTruncationTest {
+
+  @InjectMock
+  @ModelName("concise")
+  ChatModel conciseChatModel;
+
+  @InjectMock
+  @ModelName("concise")
+  StreamingChatModel conciseStreamingChatModel;
+
+  @Inject AiReviewService aiReviewService;
+  @Inject FindingVerifier findingVerifier;
+  @Inject ReplyAssistant replyAssistant;
+
+  @Test
+  void aLengthStopOnTheConciseSummaryCallRaisesTheTruncationError() {
+    doAnswer(
+            inv -> {
+              StreamingChatResponseHandler handler = inv.getArgument(1);
+              handler.onCompleteResponse(lengthStoppedResponse("{\"summary\":\"cut mid-obj"));
+              return null;
+            })
+        .when(conciseStreamingChatModel)
+        .chat(any(ChatRequest.class), any(StreamingChatResponseHandler.class));
+
+    var thrown =
+        assertThrows(
+            AiResponseTruncatedException.class,
+            () ->
+                aiReviewService.summarize(
+                    reviewSession(),
+                    new AiReviewService.SummaryInputs("ctx", "[]", "files", "", "")));
+
+    assertTrue(
+        thrown.getMessage().contains("max-output-tokens"),
+        "the message must name the knob an operator has to change: " + thrown.getMessage());
+  }
+
+  @Test
+  void aLengthStopOnTheConciseVerifierCallRaisesTheTruncationError() {
+    when(conciseChatModel.chat(any(ChatRequest.class)))
+        .thenReturn(lengthStoppedResponse("[{\"id\":1,\"verdi"));
+
+    var result = findingVerifier.verify("[]", "diff", "", "");
+
+    assertThrows(
+        AiResponseTruncatedException.class,
+        () -> AiResponses.textOrThrowOnTruncation(result, "Finding verification"));
+  }
+
+  @Test
+  void aLengthStopOnTheConciseReplyCallRaisesTheTruncationError() {
+    when(conciseChatModel.chat(any(ChatRequest.class)))
+        .thenReturn(lengthStoppedResponse("A reply cut mid-sen"));
+
+    var result = replyAssistant.reply("question", "", "", "", "");
+
+    assertThrows(
+        AiResponseTruncatedException.class,
+        () -> AiResponses.textOrThrowOnTruncation(result, "Maintainer reply"));
+  }
+
+  private static ChatResponse lengthStoppedResponse(String partialText) {
+    return ChatResponse.builder()
+        .aiMessage(AiMessage.from(partialText))
+        .finishReason(FinishReason.LENGTH)
+        .build();
+  }
+
+  private static ReviewSession reviewSession() {
+    var session = new ReviewSession();
+    session.id = 4242L;
+    session.setRepository("owner/repo");
+    session.setPrNumber(1);
+    session.setPrTitle("Concise truncation");
+    session.setCommitSha("abc");
+    session.setTimestamp(Instant.parse("2025-06-01T12:00:00Z"));
+    return session;
+  }
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature

> **Stacked on #506.** Base is `fix/505-audit2-drift`, not `release/v0.6.0` — purely to keep the stack ordered; #506 is docs/log-only and nothing here depends on it functionally. GitHub will retarget the base to `release/v0.6.0` automatically when #506 merges — but this repo squash-merges, so after that retarget this branch still carries #506's original commit and needs `git rebase --onto release/v0.6.0 a7b7fa6` before its own merge. **Review #506 first.**

## Description

Fixes #498.

`max-output-tokens` was applied once, on the model builders, so every AI call shared one response cap. That is the wrong granularity: a **batch review** response scales with finding count and is the call that legitimately needs a large allowance; the **summary** returns one fixed-shape object plus `previous_findings_status`; the **verifier** returns a verdict per finding; a **maintainer reply** is short prose. Sizing the shared cap for the batch call licensed every other call to run orders of magnitude longer than it should — e.g. the shipped `deepseek-v4-flash` entry sets `max-output-tokens=384000`, and until now the summary call carried all of it.

### Shape: one named model, `concise`

The summary, verifier, and reply calls now bind to a `concise` named model:

- **`PrSummarizer`** (new interface, `@RegisterAiService(modelName = "concise")`) — `summarizeStream` moved verbatim from `PrReviewer` (same `PrReviewPrompts.SUMMARY_*` constants, same `@V` slots), because one `@RegisterAiService` interface is one model binding.
- **`FindingVerifier`** and **`ReplyAssistant`** — rebound with `modelName = "concise"`; no signature change, so their callers are untouched.
- **`quarkus.langchain4j.openai.concise.*`** aliases the **same** `AI_*` env vars (api-key, base-url, model-name, timeout, log flags) — named configs inherit nothing from the default block (`OpenAiRecorder.correspondingOpenAiConfig` is `isDefault(name) ? defaultConfig() : namedConfig().get(name)`, no fallback), so the aliases are what keep operators configuring one provider. Note the namespace is provider-first: a first boot attempt with `quarkus.langchain4j.concise.openai.*` failed with `SRCFG00014: The config property quarkus.langchain4j.openai.concise.api-key is required`.
- **`REVIEW_CONCISE_MAX_OUTPUT_TOKENS`** (default **8192**) feeds `quarkus.langchain4j.openai.concise.chat-model.max-tokens`. 8192 is roomy for these calls — a 50-finding review verifies in well under 4k tokens, a summary is one object, a reply a few paragraphs — while an order of magnitude under batch-sized caps. Empty drops the cap (provider default).

**Deliberately NOT moved:** the review call and the command generators (`/describe`, `/changelog`, `/add-docs`, `/improve`, `/generate-tests`, including the describe/changelog reduce steps). Their outputs scale with the diff — a large PR legitimately produces a long description, changelog, docstring set, or test file — so capping them at a fixed "concise" size would trade one wrong granularity for another. They stay on the default model's `max-output-tokens`.

### The customizer-binding question, settled with evidence

Whether the existing `ChatModelCustomizers` would reach (and stomp) the named model was verified against the deployed 1.12.2 jars (`javap -c` on `ModelBuilderCustomizer` and the `OpenAiRecorder` apply-functions):

- `applyCustomizers(instance, builder, name)` selects customizer beans **by CDI qualifier**: `Default.Literal` for the default model, `ModelName.Literal.of(name)` for a named one. **No inheritance in either direction.**
- The recorder runs customizers **after** the config properties, immediately before `build()` — a customizer wins over config.
- In 1.12.2 both the blocking **and** streaming recorders apply `ChatModelConfig.maxTokens()`, so the named block's `chat-model.max-tokens` reaches both concise beans (the 1.11.2 blocking-only gap that motivated the customizer route does not bite here).

Consequences implemented: the unqualified customizers **cannot** stomp the concise cap (they never run for the named model), but the named model would silently lose reasoning-effort/temperature/top-p/penalties/seed. So `ChatModelCustomizers` gains a `@ModelName("concise")` pair that applies every shared parameter **except** `maxTokens` — applying the active model's `max-output-tokens` there would overwrite the concise cap, since customizers run last. `ChatModelWiringTest` pins all of it end-to-end.

### Boot-time validation and log

`StartupConfigValidator` rejects `REVIEW_CONCISE_MAX_OUTPUT_TOKENS < 1` at boot (fail-fast, naming the env var, like the other budget keys; empty = uncapped is allowed) and logs the concise cap next to the per-model settings line, so the boot an operator debugs states which cap the summary/verifier/reply calls run under.

## Related Issues

Fixes #498

Stacked on #506 (#505). Earlier in the stack: #495 (#492), #504 (#497). Next: #499, then #500.

## How Has This Been Tested?

- [x] Unit tests

**Red/green.** All test changes were written against the structural move only (interfaces split and rebound, named block aliased — no cap property, no concise customizers, no validation), then the behavior was added. Red, verbatim:

```
[ERROR] Failures:
[ERROR]   StartupConfigValidatorTest.failsFastWhenConciseResponseCapBelowOne:300->assertFailsValidation:213 Expected dev.thiagogonzaga.thrillhousebot.config.ConfigValidationException to be thrown, but nothing was thrown.
[ERROR]   ChatModelDefaultOffTest.conciseModelsCarryOnlyTheirResponseCapByDefault:75 the concise default cap must apply ==> expected: <8192> but was: <null>
[ERROR]   ChatModelWiringTest.conciseBlockingModelCarriesTheConciseCapAndTheSharedTuning:91 the concise response cap must apply, not the active model's max-output-tokens ==> expected: <8192> but was: <null>
[ERROR]   ChatModelWiringTest.conciseStreamingModelCarriesTheConciseCapAndTheSharedTuning:110 the concise response cap must apply, not the active model's max-output-tokens ==> expected: <8192> but was: <null>
[ERROR] Tests run: 72, Failures: 4, Errors: 0, Skipped: 0
```

Green with the cap property + concise customizers + validator rule in place. The wiring tests also assert the default models still carry the per-model `max-output-tokens` (4096 in the profile) while the concise beans show 8192 plus the shared `reasoning_effort`/temperature/top-p — "summary/verifier/reply carry the concise cap while batch review keeps the model cap" pinned in one class.

**Truncation detection survives the rebinding** (`ConciseModelTruncationTest`, new; green-only guard — detection itself is #495/#504 behavior and was never red here): drives the real `AiReviewService.summarize`, `FindingVerifier.verify`, and `ReplyAssistant.reply` against `@InjectMock @ModelName("concise")` model beans returning `finish_reason: length`, and asserts `AiResponseTruncatedException` naming the knob. Because the mocks are the **concise-qualified** beans, these tests double as proof the services really bind to the named model — a silent fallback to the default model would leave the stubs unhit and fail.

**Existing test files touched, and why** (every prior assertion preserved; nothing disabled or deleted):

- `AiReviewServiceTest` — `AiReviewService` gained the `PrSummarizer` dependency: new `@Mock`, the summarize test stubs/verifies `prSummarizer` instead of `prReviewer`, and the two explicit `new AiReviewService(...)` constructions gained the argument. Mechanical.
- `AiServicePromptRenderingTest` — reply/verify/summary rendering is now captured off `@InjectMock @ModelName("concise")` model mocks (the default-model mocks no longer see those calls); the capture helpers gained a model parameter, with the old single-argument overloads delegating for the unchanged services. Assertions untouched.
- `AiServiceUserMessagePlacementTest` — added the `PrSummarizer` structural check (same guard every other AI service has).
- `ChatModelWiringTest` / `ChatModelDefaultOffTest` — extended with the concise-bean assertions above (the red phase); the existing default-model assertions are unchanged.
- `ChatModelCustomizersTest` — new cases for the concise customizer pair: shared tuning applied, `maxTokens` never called (`verifyNoMoreInteractions` with a per-model `max-output-tokens=384000` present in settings).
- `StartupConfigValidatorTest` — `ConfigBuilder` passes the new constructor argument (default `Optional.of(8192)`); new red/green case for `< 1` rejection plus an empty-allowed case.

Gates on the final tree:

- `./mvnw -B spotless:apply` / `spotless:check` — clean
- `./mvnw -B clean compile spotbugs:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — **Tests run: 2466, Failures: 0, Errors: 0, Skipped: 0** (baseline 2454 + 12 new)
- Coverage: `jacoco.xml` intersected with this PR's added `src/main/java` lines — **no uncovered added lines**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

- **Behavior change for every deployment:** the summary/verifier/reply calls now send `max_tokens: 8192` even where nothing was configured before (previously they were uncapped unless `max-output-tokens` was set). That is the point of the issue — the cap exists for the runaway case — and 8192 is far above what these calls produce; if it is ever hit it surfaces loudly as the #492-style truncation error naming `REVIEW_CONCISE_MAX_OUTPUT_TOKENS`, and setting the variable empty restores the uncapped behavior.
- The issue sketched per-request parameters as one possible mechanism. #504 already established that #497's `Result` plumbing and per-request parameters don't fall out of one change; the named-model route gets per-call-class caps entirely in configuration and bindings (no signature churn through the assistants), at the cost of one extra model bean pair — and the config block documents the no-inheritance trap it steps around.
- The issue asked for "the per-model `max-output-tokens` as the default when a call-specific value is not set". With a named model that exact fallback would mean conditionally re-applying the active model's cap in the concise customizer when the env var is unset — reintroducing the stomping hazard for the configured case. The shipped shape instead gives the concise cap its own always-present default (8192) and a documented empty-to-uncap escape; the operator-visible contract (batch cap never leaks onto the summary; no hardcoded per-call numbers in code) is preserved, and the boot log states the effective value.
- `website/` versioned docs (0.4.0) deliberately untouched; README, `.env.example`, and `application.properties` are the living config surface.