### PR TITLE
fix(review): tolerate mis-shaped summary fields instead of failing the whole review

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -78,7 +79,7 @@ public class ReviewResponseParser {
                 + " kept %d finding(s). Mapping error: %s",
             salvaged.findings().size(), cause.getMessage());
         return salvaged;
-      } catch (JsonProcessingException stillFailing) {
+      } catch (JsonProcessingException _) {
         // The failure was not confined to the summary — fall through to the original error.
       }
     }
@@ -167,16 +168,7 @@ public class ReviewResponseParser {
     }
     var normalized = mapper.createArrayNode();
     if (gaps.isArray()) {
-      var changed = false;
-      for (var gap : gaps) {
-        if (gap.isTextual() || gap.isNull()) {
-          normalized.add(gap);
-        } else {
-          normalized.add(flattenGap(gap));
-          changed = true;
-        }
-      }
-      if (!changed) {
+      if (!flattenInto(normalized, gaps)) {
         // Already-conforming arrays stay untouched
         return;
       }
@@ -186,6 +178,24 @@ public class ReviewResponseParser {
       normalized.add(flattenGap(gaps));
     }
     summary.set(DESCRIPTION_GAPS, normalized);
+  }
+
+  /**
+   * Copies {@code gaps} into {@code normalized}, flattening every non-string element. Returns
+   * whether anything needed flattening — {@code false} means the array already conformed and the
+   * caller should keep the original node untouched.
+   */
+  private static boolean flattenInto(ArrayNode normalized, JsonNode gaps) {
+    var changed = false;
+    for (var gap : gaps) {
+      if (gap.isTextual() || gap.isNull()) {
+        normalized.add(gap);
+      } else {
+        normalized.add(flattenGap(gap));
+        changed = true;
+      }
+    }
+    return changed;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
@@ -15,17 +15,23 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.io.IOException;
+import java.util.ArrayList;
 
 @ApplicationScoped
 public class ReviewResponseParser {
 
   private static final String PREVIOUS_FINDINGS_STATUS = "previous_findings_status";
+  private static final String SUMMARY = "summary";
+  private static final String DESCRIPTION_GAPS = "description_gaps";
 
   private final ObjectMapper mapper;
 
@@ -38,13 +44,61 @@ public class ReviewResponseParser {
     if (raw == null || raw.isBlank()) {
       throw new IllegalArgumentException("Model returned an empty response");
     }
+    JsonNode root;
     try {
-      var root = mapper.readTree(extractJson(raw));
-      normalizePreviousFindingsStatus(root);
-      return mapper.treeToValue(root, ReviewResponse.class);
+      root = mapper.readTree(extractJson(raw));
     } catch (IOException e) {
       throw new IllegalArgumentException("Model response is not valid review JSON", e);
     }
+    normalizePreviousFindingsStatus(root);
+    normalizeDescriptionGaps(root);
+    try {
+      return mapper.treeToValue(root, ReviewResponse.class);
+    } catch (JsonProcessingException e) {
+      return parseWithoutSummary(root, e);
+    }
+  }
+
+  /**
+   * Last-resort salvage for valid JSON that still fails schema mapping after normalization: a
+   * mapping failure confined to the {@code summary} node must not discard findings (and previous
+   * finding statuses) that mapped cleanly — that would throw away a fully paid review and force a
+   * full-cost retry. Retry the mapping with {@code summary} removed; every consumer of {@link
+   * ReviewResponse#summary()} null-guards it. If the failure was not confined to the summary,
+   * report the original mapping error.
+   */
+  private ReviewResponse parseWithoutSummary(JsonNode root, JsonProcessingException cause) {
+    if (root instanceof ObjectNode rootObject && rootObject.hasNonNull(SUMMARY)) {
+      var withoutSummary = rootObject.deepCopy();
+      withoutSummary.remove(SUMMARY);
+      try {
+        var salvaged = mapper.treeToValue(withoutSummary, ReviewResponse.class);
+        Log.warnf(
+            "Review response summary did not match the schema — dropped the 'summary' node and"
+                + " kept %d finding(s). Mapping error: %s",
+            salvaged.findings().size(), cause.getMessage());
+        return salvaged;
+      } catch (JsonProcessingException stillFailing) {
+        // The failure was not confined to the summary — fall through to the original error.
+      }
+    }
+    throw schemaMismatch(cause);
+  }
+
+  /**
+   * A Jackson databind failure means the JSON itself was valid but did not fit the review schema —
+   * a (near-)deterministic model-output shape problem, not a transient parse failure. Keep the
+   * exception type callers catch, but say so in the message (with the failing path) so the two
+   * failure classes are distinguishable in the logs.
+   */
+  static IllegalArgumentException schemaMismatch(JsonProcessingException cause) {
+    if (cause instanceof JsonMappingException mapping) {
+      return new IllegalArgumentException(
+          "Model response was valid JSON but did not match the review schema at "
+              + mapping.getPathReference(),
+          cause);
+    }
+    return new IllegalArgumentException("Model response is not valid review JSON", cause);
   }
 
   /**
@@ -92,6 +146,70 @@ public class ReviewResponseParser {
   private static int parseFindingId(String key) {
     var digits = key.replaceAll("\\D", "");
     return digits.isEmpty() ? 0 : Integer.parseInt(digits);
+  }
+
+  /**
+   * Models sometimes emit {@code summary.description_gaps} elements as objects — e.g. {@code
+   * {"claim": …, "code": …}} — instead of the plain strings the schema asks for. Normalize each
+   * element to a string so the shape mismatch does not fail the whole review (and force a full-cost
+   * retry). Elements that are already strings (or null, which the {@code Summary} constructor
+   * drops) pass through unchanged; a bare string or single object in place of the array is wrapped
+   * into a one-element array.
+   */
+  private void normalizeDescriptionGaps(JsonNode root) {
+    if (!(root instanceof ObjectNode rootObject)
+        || !(rootObject.get(SUMMARY) instanceof ObjectNode summary)) {
+      return;
+    }
+    var gaps = summary.get(DESCRIPTION_GAPS);
+    if (gaps == null || gaps.isNull()) {
+      return;
+    }
+    var normalized = mapper.createArrayNode();
+    if (gaps.isArray()) {
+      var changed = false;
+      for (var gap : gaps) {
+        if (gap.isTextual() || gap.isNull()) {
+          normalized.add(gap);
+        } else {
+          normalized.add(flattenGap(gap));
+          changed = true;
+        }
+      }
+      if (!changed) {
+        // Already-conforming arrays stay untouched
+        return;
+      }
+    } else if (gaps.isTextual()) {
+      normalized.add(gaps);
+    } else {
+      normalized.add(flattenGap(gaps));
+    }
+    summary.set(DESCRIPTION_GAPS, normalized);
+  }
+
+  /**
+   * Flattens one mis-shaped gap element to a string: objects join their string-valued fields {@code
+   * ": "}-separated in a stable order — {@code "claim"} first when present (the field the
+   * production shape led with), then the rest in emission order; non-string scalars flatten via
+   * {@code asText()}; arrays, and objects without any string-valued field, degrade to their JSON
+   * text so no content is silently lost.
+   */
+  private static String flattenGap(JsonNode gap) {
+    if (!gap.isObject()) {
+      return gap.isValueNode() ? gap.asText() : gap.toString();
+    }
+    var parts = new ArrayList<String>();
+    var claim = gap.get("claim");
+    if (claim != null && claim.isTextual()) {
+      parts.add(claim.asText());
+    }
+    for (var entry : gap.properties()) {
+      if (entry.getValue().isTextual() && !"claim".equals(entry.getKey())) {
+        parts.add(entry.getValue().asText());
+      }
+    }
+    return parts.isEmpty() ? gap.toString() : String.join(": ", parts);
   }
 
   /** Strips optional markdown fences and leading noise before the JSON object/array. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParserTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParserTest.java
@@ -269,6 +269,40 @@ class ReviewResponseParserTest {
   }
 
   @Test
+  void shouldPassThroughALiteralNullDescriptionGaps() {
+    // A model may emit "description_gaps": null rather than omitting the field. The normalizer
+    // must leave it alone (the Summary constructor already drops nulls), not wrap it in an array.
+    var response =
+        parser.parse(
+            """
+            {"findings": [],
+             "summary": {"total_findings": 0, "critical": 0, "high": 0, "medium": 0, "low": 0,
+               "overall_assessment": "fine", "pr_purpose": "p", "description_gaps": null}}
+            """);
+
+    assertNotNull(response.summary());
+    assertEquals(java.util.List.of(), response.summary().descriptionGaps());
+  }
+
+  @Test
+  void shouldSkipANonTextualClaimWhenFlatteningAGapObject() {
+    // The "claim"-first ordering guard must not blow up (or emit "42") when a model puts a
+    // non-string value under "claim" — the remaining string-valued fields still carry the gap.
+    var response =
+        parser.parse(
+            """
+            {"findings": [],
+             "summary": {"total_findings": 0, "critical": 0, "high": 0, "medium": 0, "low": 0,
+               "overall_assessment": "fine", "pr_purpose": "p",
+               "description_gaps": [{"claim": 42, "code": "the stated cap is never sent"}]}}
+            """);
+
+    assertNotNull(response.summary());
+    assertEquals(
+        java.util.List.of("the stated cap is never sent"), response.summary().descriptionGaps());
+  }
+
+  @Test
   void shouldFlattenObjectDescriptionGapsToStrings() {
     // The exact production shape from issue #508: deepseek-v4-flash emitted description_gaps
     // elements as {"claim": …, "code": …} objects instead of the strings the schema asks for,

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParserTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParserTest.java
@@ -267,4 +267,186 @@ class ReviewResponseParserTest {
     var in = "{\"d\":\"a\\nb\\\"c\\\\d\"}";
     assertEquals(in, ReviewResponseParser.extractJson(in));
   }
+
+  @Test
+  void shouldFlattenObjectDescriptionGapsToStrings() {
+    // The exact production shape from issue #508: deepseek-v4-flash emitted description_gaps
+    // elements as {"claim": …, "code": …} objects instead of the strings the schema asks for,
+    // failing the whole (paid) review 5/5 times.
+    var response =
+        parser.parse(
+            """
+            {"findings": [{"risk": "low", "confidence": "low", "file": "f", "line": 1,
+              "title": "t", "description": "d"}],
+             "previous_findings_status": [{"id": 1, "status": "resolved", "note": "ok"}],
+             "summary": {"total_findings": 1, "critical": 0, "high": 0, "medium": 0, "low": 1,
+               "overall_assessment": "fine", "pr_purpose": "purpose",
+               "description_gaps": [{"claim": "Additional Notes: 'no max_tokens is sent'",
+                                     "code": "maxTokens is always set"}]}}
+            """);
+
+    assertEquals(1, response.findings().size());
+    assertEquals(1, response.previousFindingsStatus().size());
+    assertNotNull(response.summary());
+    assertEquals(
+        java.util.List.of("Additional Notes: 'no max_tokens is sent': maxTokens is always set"),
+        response.summary().descriptionGaps());
+    // Nothing else about the summary changed
+    assertEquals(1, response.summary().totalFindings());
+    assertEquals("fine", response.summary().overallAssessment());
+    assertEquals("purpose", response.summary().prPurpose());
+  }
+
+  @Test
+  void shouldFlattenGapObjectFieldsWithClaimFirstRegardlessOfEmissionOrder() {
+    var response =
+        parser.parse(
+            """
+            {"findings": [], "summary": {"total_findings": 0,
+              "description_gaps": [{"code": "the code", "claim": "the claim"}]}}
+            """);
+
+    assertEquals(java.util.List.of("the claim: the code"), response.summary().descriptionGaps());
+  }
+
+  @Test
+  void shouldFlattenMixedGapElementShapes() {
+    // Non-string scalars flatten via asText(); arrays and objects without string-valued
+    // fields degrade to their JSON text; plain strings pass through unchanged.
+    var response =
+        parser.parse(
+            """
+            {"findings": [], "summary": {"total_findings": 0,
+              "description_gaps": ["already a string", 42, ["a", "b"], {"n": 7}]}}
+            """);
+
+    assertEquals(
+        java.util.List.of("already a string", "42", "[\"a\",\"b\"]", "{\"n\":7}"),
+        response.summary().descriptionGaps());
+  }
+
+  @Test
+  void shouldWrapSingleObjectDescriptionGaps() {
+    var response =
+        parser.parse(
+            """
+            {"findings": [], "summary": {"total_findings": 0,
+              "description_gaps": {"claim": "c1", "code": "c2"}}}
+            """);
+
+    assertEquals(java.util.List.of("c1: c2"), response.summary().descriptionGaps());
+  }
+
+  @Test
+  void shouldWrapBareStringDescriptionGaps() {
+    var response =
+        parser.parse(
+            """
+            {"findings": [], "summary": {"total_findings": 0,
+              "description_gaps": "just one gap"}}
+            """);
+
+    assertEquals(java.util.List.of("just one gap"), response.summary().descriptionGaps());
+  }
+
+  @Test
+  void shouldSalvageFindingsWhenSummaryStillDoesNotMap() {
+    // A mapping failure confined to the summary must not discard findings that mapped
+    // cleanly — the summary degrades to null (every consumer null-guards it).
+    var response =
+        parser.parse(
+            """
+            {"findings": [{"risk": "high", "confidence": "high", "file": "f", "line": 2,
+              "title": "t", "description": "d"}],
+             "previous_findings_status": [{"id": 4, "status": "unresolved", "note": "n"}],
+             "summary": {"total_findings": {"oops": "an object"}}}
+            """);
+
+    assertEquals(1, response.findings().size());
+    assertEquals("high", response.findings().get(0).risk());
+    assertEquals(1, response.previousFindingsStatus().size());
+    assertEquals(4, response.previousFindingsStatus().get(0).id());
+    assertNull(response.summary());
+  }
+
+  @Test
+  void shouldReportSchemaPathWhenMappingFailsOutsideSummary() {
+    // Valid JSON whose failure is NOT confined to the summary is a schema mismatch, not a
+    // parse failure — the message must say so and name the failing path.
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                parser.parse(
+                    """
+                    {"findings": [{"risk": "low", "file": "f", "line": {"bad": true},
+                      "title": "t", "description": "d"}]}
+                    """));
+
+    assertTrue(ex.getMessage().contains("did not match the review schema"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("findings"), ex.getMessage());
+    assertFalse(ex.getMessage().contains("not valid review JSON"));
+  }
+
+  @Test
+  void shouldNotSalvageWhenFailureIsOutsideSummaryEvenIfSummaryPresent() {
+    // Findings themselves are broken: dropping the summary cannot save the mapping, so the
+    // original schema-mismatch error must surface instead of a silently degraded response.
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                parser.parse(
+                    """
+                    {"findings": [{"risk": "low", "file": "f", "line": {"bad": true},
+                      "title": "t", "description": "d"}],
+                     "summary": {"total_findings": 0}}
+                    """));
+
+    assertTrue(ex.getMessage().contains("did not match the review schema"), ex.getMessage());
+  }
+
+  @Test
+  void shouldKeepParseFailureMessageForNonDatabindProcessingErrors() {
+    // Defensive fallback: a JsonProcessingException that is not a databind failure keeps the
+    // parse-failure message.
+    var ex =
+        ReviewResponseParser.schemaMismatch(
+            new com.fasterxml.jackson.core.JsonParseException(null, "stream broke"));
+
+    assertTrue(ex.getMessage().contains("not valid review JSON"), ex.getMessage());
+  }
+
+  @Test
+  void shouldStillRejectInvalidJsonWithParseFailureMessage() {
+    // Guard: a true parse failure keeps the existing message, distinct from schema mismatch.
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("{\"findings\": [truncat"));
+    assertTrue(ex.getMessage().contains("not valid review JSON"), ex.getMessage());
+    assertFalse(ex.getMessage().contains("did not match the review schema"));
+  }
+
+  @Test
+  void shouldLeaveFullyValidResponseUnchanged() throws Exception {
+    var raw =
+        """
+        {"findings": [{"risk": "medium", "confidence": "high", "file": "src/A.java",
+          "line": 12, "title": "t", "description": "d",
+          "suggestion_old": "a", "suggestion_new": "b"}],
+         "previous_findings_status": [{"id": 2, "status": "justified", "note": "why"}],
+         "summary": {"total_findings": 1, "critical": 0, "high": 0, "medium": 1, "low": 0,
+           "overall_assessment": "ok", "pr_purpose": "p",
+           "description_gaps": ["gap one", "gap two"],
+           "suggested_labels": ["bug"],
+           "file_summaries": [{"path": "src/A.java", "summary": "changed"}],
+           "walkthrough_diagram": "graph TD; A-->B"}}
+        """;
+
+    var response = parser.parse(raw);
+    var direct = new ObjectMapper().readValue(raw, ReviewResponse.class);
+
+    // Normalization must be a no-op on a conforming response — identical to a plain mapping.
+    assertEquals(direct, response);
+    assertEquals(java.util.List.of("gap one", "gap two"), response.summary().descriptionGaps());
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Makes `ReviewResponseParser` tolerant of the summary-shape drift that killed 2 of the 4 reviews in the v0.5.0 production log window (PRs #495 and #504, sessions 2302/2309) — the parser half of #508 only.

**Production evidence.** deepseek-v4-flash (reasoning effort=high) returned valid JSON with the right top-level keys, but `summary.description_gaps` — schema `List<String>` — came back as objects:

```json
"description_gaps": [{"claim": "Additional Notes: 'no max_tokens is sent…'", "code": "…"}]
```

Jackson mapping then failed:

```
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException:
  Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)
  at ... StringCollectionDeserializer.deserialize ...
  at ReviewResponseParser.parse(ReviewResponseParser.java:44)
```

`findings` and `previous_findings_status` mapped fine — one mis-shaped summary sub-field discarded the complete, paid review, was reported as "Model response is not valid review JSON", and burned 5 full-price retries (~53K tokens each, 5/5 identical failure at temperature 1.0).

**Three changes, all inside the parser** (mirroring the existing `normalizePreviousFindingsStatus` pattern):

1. **Normalize `summary.description_gaps`**: object elements flatten to strings — the object's string-valued fields joined `": "`-separated, `"claim"` first when present, then the rest in emission order; non-string scalars via `asText()`; arrays and string-field-less objects degrade to their JSON text. A bare string or single object in place of the array is wrapped into a one-element array. Conforming arrays pass through untouched.
2. **Salvage over discard**: if `treeToValue` still fails after normalization, the mapping is retried with the `summary` node removed — findings and previous-finding statuses survive, summary degrades to `null` (every consumer null-guards it: `PrSummaryGenerator`'s `aiSummary == null` guards, `ReviewPublisher`'s `summary() != null` check, `FindingVerificationService.recount`'s `original == null → null`). A WARN names the dropped node and the mapping error.
3. **Honest classification in the log**: a Jackson databind failure now reads `Model response was valid JSON but did not match the review schema at <path>` (path from `JsonMappingException.getPathReference()`), distinct from the existing `not valid review JSON` for true parse failures. Same exception type as before — callers' catch sites are unchanged.

**Red (before the fix), verbatim** — the exact production shape and the summary-salvage case both die with the misleading parse-failure message:

```
[ERROR]   ReviewResponseParserTest.shouldFlattenObjectDescriptionGapsToStrings:277 ? IllegalArgument Model response is not valid review JSON
[ERROR]   ReviewResponseParserTest.shouldSalvageFindingsWhenSummaryStillDoesNotMap:357 ? IllegalArgument Model response is not valid review JSON
...
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse["summary"]->dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse$Summary["description_gaps"]->java.util.ArrayList[0])
	at com.fasterxml.jackson.databind.deser.std.StringCollectionDeserializer.deserialize(StringCollectionDeserializer.java:217)
	at dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponseParser.parse(ReviewResponseParser.java:44)
[ERROR] Tests run: 34, Failures: 1, Errors: 6, Skipped: 0
```

## Scope

Strictly the parser (`ReviewResponseParser` + its test). **Retry classification in `AiReviewService` is deliberately out of scope**: the blast radius of the remaining misclassification is bounded by #509's spend ceiling, and the misreport itself is fixed here by the message change — a schema mismatch no longer masquerades as unparseable output in the logs. `FindingPipeline`/`AiReviewService`/salvager work from the same log window is in flight separately.

## Related Issues

Fixes #508

## How Has This Been Tested?

- [x] Unit tests

Red/green on the exact production shape (`description_gaps` as `[{"claim": …, "code": …}]`), summary-confined mapping failure salvage (findings survive, summary null, WARN logged), guard tests that true parse failures keep the existing message, and a fully-valid-response identity test (parser output equals a plain `ObjectMapper.readValue` of the same payload). Full suite green; spotless and SpotBugs clean; patch coverage of added main lines vs `origin/release/v0.6.0` has zero uncovered lines.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Salvage WARN as emitted:

```
WARN  [dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponseParser] (main) Review response summary did not match the schema — dropped the 'summary' node and kept 1 finding(s). Mapping error: Cannot deserialize value of type `int` from Object value (token `JsonToken.START_OBJECT`)
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse["summary"]->dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse$Summary["total_findings"])
```

## Additional Notes

The related observations in #508 (verifier NPE on null content, AI timeout at 300s, empty head sha dispatch) are out of this PR's scope.