### PR TITLE
feat(review): salvage findings from a length-capped response instead of discarding the batch

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -92,7 +92,8 @@ public class DiffBudgetPlanner {
       List<String> clippedFiles,
       boolean budgeted,
       List<String> runtimeUncoveredFiles,
-      List<String> spendCeilingSkippedFiles) {
+      List<String> spendCeilingSkippedFiles,
+      List<String> responseCutFiles) {
     public BudgetPlan {
       batches = List.copyOf(batches);
       omittedFiles = List.copyOf(omittedFiles);
@@ -105,6 +106,7 @@ public class DiffBudgetPlanner {
           spendCeilingSkippedFiles == null
               ? new CopyOnWriteArrayList<>()
               : spendCeilingSkippedFiles;
+      responseCutFiles = responseCutFiles == null ? new CopyOnWriteArrayList<>() : responseCutFiles;
     }
 
     /**
@@ -134,6 +136,24 @@ public class DiffBudgetPlanner {
           new CopyOnWriteArrayList<>());
     }
 
+    /** Back-compat convenience predating {@code responseCutFiles}; starts it empty. */
+    public BudgetPlan(
+        List<DiffBatch> batches,
+        List<String> omittedFiles,
+        List<String> clippedFiles,
+        boolean budgeted,
+        List<String> runtimeUncoveredFiles,
+        List<String> spendCeilingSkippedFiles) {
+      this(
+          batches,
+          omittedFiles,
+          clippedFiles,
+          budgeted,
+          runtimeUncoveredFiles,
+          spendCeilingSkippedFiles,
+          new CopyOnWriteArrayList<>());
+    }
+
     /** Defensive copy: the mutable runtime-gap backing must never escape the plan. */
     @Override
     public List<String> runtimeUncoveredFiles() {
@@ -144,6 +164,12 @@ public class DiffBudgetPlanner {
     @Override
     public List<String> spendCeilingSkippedFiles() {
       return List.copyOf(spendCeilingSkippedFiles);
+    }
+
+    /** Defensive copy, like {@link #runtimeUncoveredFiles()}. */
+    @Override
+    public List<String> responseCutFiles() {
+      return List.copyOf(responseCutFiles);
     }
 
     /** Records files a batch left unreviewed at runtime, ignoring nulls and duplicates. */
@@ -171,10 +197,29 @@ public class DiffBudgetPlanner {
       }
     }
 
+    /**
+     * Records files whose batch response the model cut at its length cap but whose complete leading
+     * findings were salvaged (#500) — partially reviewed, a state distinct from {@link
+     * #recordUncoveredFiles not reviewed}: the salvaged findings are kept and the disclosure says
+     * the response was cut, not that the files were never seen. Deliberately <em>not</em> folded
+     * into {@code runtimeUncoveredFiles}: these files keep their walkthrough rows and partial
+     * findings; only approval is withheld ({@link #truncated()}).
+     */
+    void recordResponseCutFiles(List<String> filenames) {
+      for (var name : filenames) {
+        if (name != null && !responseCutFiles.contains(name)) {
+          responseCutFiles.add(name);
+        }
+      }
+    }
+
     public boolean truncated() {
-      // Clipped unseen hunks and files a failed batch never covered withhold coverage like omitted
-      // files — all three hold APPROVE.
-      return !omittedFiles.isEmpty() || !clippedFiles.isEmpty() || !runtimeUncoveredFiles.isEmpty();
+      // Clipped unseen hunks, files a failed batch never covered, and files whose response was
+      // cut mid-body all withhold coverage like omitted files — each holds APPROVE.
+      return !omittedFiles.isEmpty()
+          || !clippedFiles.isEmpty()
+          || !runtimeUncoveredFiles.isEmpty()
+          || !responseCutFiles.isEmpty();
     }
 
     /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -245,41 +245,7 @@ public class FindingPipeline {
         plan.recordSpendCeilingSkippedFiles(filenamesOf(batches.get(index).files()));
         continue;
       }
-      try {
-        outcomesByIndex[index] =
-            processBatch(index, batches, session, promptInputs, plan, previousFilesById);
-        Log.infof("Batch %d/%d succeeded on retry", index + 1, batches.size());
-      } catch (TokenSpendCeilingExceededException e) {
-        // The gate above passed but a concurrent late callback (e.g. a timed-out attempt's usage)
-        // pushed the ledger over before the attempt started, or a mid-retry attempt was refused.
-        Log.warnf(
-            "Batch %d/%d retry refused at the review's token spend ceiling; disclosing its files"
-                + " as not reviewed. %s",
-            index + 1, batches.size(), e.getMessage());
-        plan.recordSpendCeilingSkippedFiles(filenamesOf(batches.get(index).files()));
-      } catch (RuntimeException e) {
-        var truncation = AiResponseTruncatedException.findIn(e);
-        if (truncation.isPresent()) {
-          // The parallel attempt failed transiently and the retry hit the length cap: same
-          // salvage-or-disclose step as a parallel-pass truncation, and no further retry (#495).
-          outcomesByIndex[index] =
-              salvageTruncatedBatch(
-                  index, batches, promptInputs, plan, previousFilesById, truncation.get());
-          continue;
-        }
-        // Soft-fail like the on-request generators (DocGenerationService / PrImprovementService):
-        // one batch that never succeeds must not discard the batches that did. Keep their
-        // findings, record this batch's files as uncovered on the shared plan so the verdict holds
-        // APPROVE and the summary discloses the gap, and let the review proceed (outcome stays
-        // null and is skipped below).
-        Log.warnf(
-            e,
-            "Batch %d/%d failed after its retry; keeping the successful batches and disclosing its"
-                + " files as not reviewed rather than failing the whole review",
-            index + 1,
-            batches.size());
-        plan.recordUncoveredFiles(filenamesOf(batches.get(index).files()));
-      }
+      retryBatch(index, batches, session, promptInputs, plan, previousFilesById, outcomesByIndex);
     }
 
     var outcomes =
@@ -399,6 +365,56 @@ public class FindingPipeline {
    */
   private static long ledgerSessionId(ReviewSession session) {
     return ReviewTokenLedger.keyFor(session);
+  }
+
+  /**
+   * One batch's sequential retry: a fresh billed attempt whose failure classifications mirror the
+   * parallel pass — a mid-retry ceiling refusal or a truncation goes to disclosure (the truncation
+   * salvaging first), anything else soft-fails the batch as not reviewed.
+   */
+  private void retryBatch(
+      int index,
+      List<DiffBudgetPlanner.DiffBatch> batches,
+      ReviewSession session,
+      AiReviewService.PromptInputs promptInputs,
+      DiffBudgetPlanner.BudgetPlan plan,
+      Map<Integer, String> previousFilesById,
+      BatchOutcome[] outcomesByIndex) {
+    try {
+      outcomesByIndex[index] =
+          processBatch(index, batches, session, promptInputs, plan, previousFilesById);
+      Log.infof("Batch %d/%d succeeded on retry", index + 1, batches.size());
+    } catch (TokenSpendCeilingExceededException e) {
+      // The gate above passed but a concurrent late callback (e.g. a timed-out attempt's usage)
+      // pushed the ledger over before the attempt started, or a mid-retry attempt was refused.
+      Log.warnf(
+          "Batch %d/%d retry refused at the review's token spend ceiling; disclosing its files"
+              + " as not reviewed. %s",
+          index + 1, batches.size(), e.getMessage());
+      plan.recordSpendCeilingSkippedFiles(filenamesOf(batches.get(index).files()));
+    } catch (RuntimeException e) {
+      var truncation = AiResponseTruncatedException.findIn(e);
+      if (truncation.isPresent()) {
+        // The parallel attempt failed transiently and the retry hit the length cap: same
+        // salvage-or-disclose step as a parallel-pass truncation, and no further retry (#495).
+        outcomesByIndex[index] =
+            salvageTruncatedBatch(
+                index, batches, promptInputs, plan, previousFilesById, truncation.get());
+        return;
+      }
+      // Soft-fail like the on-request generators (DocGenerationService / PrImprovementService):
+      // one batch that never succeeds must not discard the batches that did. Keep their
+      // findings, record this batch's files as uncovered on the shared plan so the verdict holds
+      // APPROVE and the summary discloses the gap, and let the review proceed (outcome stays
+      // null and is skipped below).
+      Log.warnf(
+          e,
+          "Batch %d/%d failed after its retry; keeping the successful batches and disclosing its"
+              + " files as not reviewed rather than failing the whole review",
+          index + 1,
+          batches.size());
+      plan.recordUncoveredFiles(filenamesOf(batches.get(index).files()));
+    }
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -29,6 +29,7 @@ import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewTokenLedger;
 import dev.thiagogonzaga.thrillhousebot.review.ai.TokenCounter;
 import dev.thiagogonzaga.thrillhousebot.review.ai.TokenSpendCeilingExceededException;
+import dev.thiagogonzaga.thrillhousebot.review.ai.TruncatedResponseSalvager;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -77,6 +78,7 @@ public class FindingPipeline {
   private final DiffBudgetPlanner budgetPlanner;
   private final TokenCounter tokenCounter;
   private final ReviewTokenLedger tokenLedger;
+  private final TruncatedResponseSalvager salvager;
 
   @Inject
   public FindingPipeline(
@@ -90,7 +92,8 @@ public class FindingPipeline {
       BotIdentity botIdentity,
       DiffBudgetPlanner budgetPlanner,
       TokenCounter tokenCounter,
-      ReviewTokenLedger tokenLedger) {
+      ReviewTokenLedger tokenLedger,
+      TruncatedResponseSalvager salvager) {
     this.aiReviewService = aiReviewService;
     this.quoteValidator = quoteValidator;
     this.frameworkFilter = frameworkFilter;
@@ -102,6 +105,7 @@ public class FindingPipeline {
     this.budgetPlanner = budgetPlanner;
     this.tokenCounter = tokenCounter;
     this.tokenLedger = tokenLedger;
+    this.salvager = salvager;
   }
 
   /**
@@ -216,7 +220,15 @@ public class FindingPipeline {
                                   i, batches, session, promptInputs, plan, previousFilesById),
                           executor))
               .toList();
-      joinBatchOutcomes(futures, batches, plan, session, outcomesByIndex, failedIndices);
+      joinBatchOutcomes(
+          futures,
+          batches,
+          promptInputs,
+          plan,
+          session,
+          previousFilesById,
+          outcomesByIndex,
+          failedIndices);
     }
 
     for (int index : failedIndices) {
@@ -246,6 +258,15 @@ public class FindingPipeline {
             index + 1, batches.size(), e.getMessage());
         plan.recordSpendCeilingSkippedFiles(filenamesOf(batches.get(index).files()));
       } catch (RuntimeException e) {
+        var truncation = AiResponseTruncatedException.findIn(e);
+        if (truncation.isPresent()) {
+          // The parallel attempt failed transiently and the retry hit the length cap: same
+          // salvage-or-disclose step as a parallel-pass truncation, and no further retry (#495).
+          outcomesByIndex[index] =
+              salvageTruncatedBatch(
+                  index, batches, promptInputs, plan, previousFilesById, truncation.get());
+          continue;
+        }
         // Soft-fail like the on-request generators (DocGenerationService / PrImprovementService):
         // one batch that never succeeds must not discard the batches that did. Keep their
         // findings, record this batch's files as uncovered on the shared plan so the verdict holds
@@ -301,6 +322,12 @@ public class FindingPipeline {
       // The gate above passed but a late usage callback (e.g. a timed-out batch attempt's
       // response) crossed the ceiling first, or a summary retry was refused mid-loop.
       return countsOnlySummary(session, refined, "summary call refused");
+    } catch (AiResponseTruncatedException e) {
+      // #500 scope A: every batch call succeeded and was billed. Losing the whole review to a
+      // truncated summary would discard exactly the paid work #495 preserved on the batch lane —
+      // salvage the summary object if it closed before the cut, else degrade to the same
+      // counts-only shape as the ceiling-tripped path above. Never re-enters the retry lane.
+      return salvagedOrCountsOnlySummary(session, refined, e);
     }
 
     var merged =
@@ -327,7 +354,40 @@ public class FindingPipeline {
         tokenLedger.ceiling(),
         what,
         refined.findings().size());
-    var merged = new ReviewResponse(refined.findings(), refined.previousFindingsStatus(), null);
+    return persistWithSummary(session, refined, null);
+  }
+
+  /**
+   * The summary degradation for a summary response the model cut at its length cap (#500 scope A):
+   * if the summary object closed before the cut it is salvaged and used as-is; otherwise the review
+   * keeps its paid findings with the {@link #countsOnlySummary counts-only} shape. Either way the
+   * truncation is disclosed in the log with the caps that apply — the summary call runs on the
+   * concise model, so both knobs are named. Statuses are never taken from the salvage: the
+   * code-blind summary call must not decide what was resolved (same rule as the parsed path).
+   */
+  private ReviewResponse salvagedOrCountsOnlySummary(
+      ReviewSession session, ReviewResponse refined, AiResponseTruncatedException truncation) {
+    var salvagedSummary = salvager.salvage(truncation.partialBody()).summary();
+    if (salvagedSummary != null) {
+      Log.warnf(
+          "Summary response for session %d was cut at the model's response-length cap"
+              + " (max-output-tokens / REVIEW_CONCISE_MAX_OUTPUT_TOKENS); the summary object"
+              + " closed before the cut and was salvaged — keeping the %d paid findings",
+          ledgerSessionId(session), refined.findings().size());
+      return persistWithSummary(session, refined, salvagedSummary);
+    }
+    Log.warnf(
+        "Summary response for session %d was cut at the model's response-length cap"
+            + " (max-output-tokens / REVIEW_CONCISE_MAX_OUTPUT_TOKENS) and no complete summary"
+            + " object could be salvaged; keeping the %d paid findings with a counts-only summary",
+        ledgerSessionId(session), refined.findings().size());
+    return persistWithSummary(session, refined, null);
+  }
+
+  /** Persists and returns the refined findings/statuses under the given (possibly null) summary. */
+  private ReviewResponse persistWithSummary(
+      ReviewSession session, ReviewResponse refined, ReviewResponse.Summary summary) {
+    var merged = new ReviewResponse(refined.findings(), refined.previousFindingsStatus(), summary);
     persistAiResponse(session, merged);
     return merged;
   }
@@ -352,24 +412,24 @@ public class FindingPipeline {
   private void joinBatchOutcomes(
       List<CompletableFuture<BatchOutcome>> futures,
       List<DiffBudgetPlanner.DiffBatch> batches,
+      AiReviewService.PromptInputs promptInputs,
       DiffBudgetPlanner.BudgetPlan plan,
       ReviewSession session,
+      Map<Integer, String> previousFilesById,
       BatchOutcome[] outcomesByIndex,
       List<Integer> failedIndices) {
     for (int i = 0; i < futures.size(); i++) {
       try {
         outcomesByIndex[i] = futures.get(i).join();
       } catch (CompletionException e) {
-        if (isResponseTruncated(e)) {
+        var truncation = AiResponseTruncatedException.findIn(e);
+        if (truncation.isPresent()) {
           // The batch's own retry below would re-send the identical prompt against the identical
-          // cap. Disclose the gap now rather than paying for a second guaranteed truncation.
-          Log.warnf(
-              e,
-              "Batch %d/%d hit the model's response-length cap; not retrying and disclosing its"
-                  + " files as not reviewed",
-              i + 1,
-              batches.size());
-          plan.recordUncoveredFiles(filenamesOf(batches.get(i).files()));
+          // cap (#495), so the failure goes straight to the disclose step — which now salvages
+          // the complete leading findings out of the buffered partial body first (#500).
+          outcomesByIndex[i] =
+              salvageTruncatedBatch(
+                  i, batches, promptInputs, plan, previousFilesById, truncation.get());
         } else if (isSpendCeilingBlocked(e)) {
           // Deterministic like a truncation: the ledger is monotonic within a review, so a retry
           // would be refused identically. Degrade like the budgeter — disclose, with the ceiling
@@ -405,14 +465,30 @@ public class FindingPipeline {
     var batchInputs = withDiff(promptInputs, PromptTemplateEscaper.fence(batch.text()), "");
     var batchResponse =
         aiReviewService.reviewBatch(session, batchInputs, index + 1, batches.size());
+    return refineBatchOutcome(index, batch, batchInputs, batchResponse, plan, previousFilesById);
+  }
+
+  /**
+   * Runs one batch's raw response through the per-batch chain — quote validation and framework
+   * filtering against the batch's own in-budget text, verification, and status scoping. Shared by
+   * the parsed path and the salvage path, so salvaged findings face exactly the checks a normally
+   * parsed batch's findings do.
+   */
+  private BatchOutcome refineBatchOutcome(
+      int index,
+      DiffBudgetPlanner.DiffBatch batch,
+      AiReviewService.PromptInputs batchInputs,
+      ReviewResponse batchResponse,
+      DiffBudgetPlanner.BudgetPlan plan,
+      Map<Integer, String> previousFilesById) {
     var validated = quoteValidator.validate(batchResponse, batch.text());
     validated = frameworkFilter.filter(validated, batch.text());
     var verified =
         findingVerificationService.verify(
             validated,
             batchInputs.diff(),
-            promptInputs.projectStack(),
-            promptInputs.previousFindings());
+            batchInputs.projectStack(),
+            batchInputs.previousFindings());
     return new BatchOutcome(
         index,
         verified.findings(),
@@ -420,37 +496,58 @@ public class FindingPipeline {
             batchResponse.previousFindingsStatus(), batch, plan, previousFilesById));
   }
 
+  /**
+   * The disclose step for a batch whose response the model cut at its length cap (#500): salvages
+   * the complete leading findings/statuses out of the buffered partial body and, when anything came
+   * back, runs them through the normal per-batch chain and discloses the batch's files as
+   * <em>partially reviewed</em> — the response was cut and the findings up to the cut were kept.
+   * When nothing salvages (the cut landed before the first element closed, or the lane carried no
+   * body), it falls back to the pre-#500 behaviour: the files are disclosed as not reviewed.
+   * Replaces disclosure only — the truncation was already refused a retry (#495), and salvage makes
+   * no AI call of its own, so #509's ceiling accounting is untouched.
+   */
+  private BatchOutcome salvageTruncatedBatch(
+      int index,
+      List<DiffBudgetPlanner.DiffBatch> batches,
+      AiReviewService.PromptInputs promptInputs,
+      DiffBudgetPlanner.BudgetPlan plan,
+      Map<Integer, String> previousFilesById,
+      AiResponseTruncatedException truncation) {
+    var batch = batches.get(index);
+    var salvaged = salvager.salvage(truncation.partialBody());
+    if (!salvaged.hasFindingsOrStatuses()) {
+      Log.warnf(
+          "Batch %d/%d hit the model's response-length cap and nothing could be salvaged from the"
+              + " partial response; not retrying and disclosing its files as not reviewed",
+          index + 1, batches.size());
+      plan.recordUncoveredFiles(filenamesOf(batch.files()));
+      return null;
+    }
+    Log.warnf(
+        "Batch %d/%d hit the model's response-length cap; not retrying — salvaged %d complete"
+            + " finding(s) and %d status(es) from the partial response and disclosing its files as"
+            + " partially reviewed",
+        index + 1,
+        batches.size(),
+        salvaged.findings().size(),
+        salvaged.previousFindingsStatus().size());
+    plan.recordResponseCutFiles(filenamesOf(batch.files()));
+    var batchInputs = withDiff(promptInputs, PromptTemplateEscaper.fence(batch.text()), "");
+    var partialResponse =
+        new ReviewResponse(salvaged.findings(), salvaged.previousFindingsStatus(), null);
+    return refineBatchOutcome(index, batch, batchInputs, partialResponse, plan, previousFilesById);
+  }
+
   private static List<String> filenamesOf(List<GitHubPullRequestClient.FileDiff> files) {
     return files.stream().map(GitHubPullRequestClient.FileDiff::filename).toList();
   }
 
   /**
-   * Whether a batch failure was the model hitting its response-length cap. Walks the cause chain
-   * because the failure arrives wrapped — {@link CompletionException} over the {@link
-   * dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewException} the service threw, so depth 2 in
-   * practice.
-   *
-   * <p>Bounded rather than walked to {@code null}: a cause chain can cycle — a {@link Throwable}
-   * overriding {@code getCause()}, or plain {@code A caused-by B caused-by A} — and an unbounded
-   * walk would spin forever on the review thread. The bound is far above any real chain, so a
-   * truncation is never missed for depth.
-   */
-  private static boolean isResponseTruncated(Throwable failure) {
-    var cause = failure;
-    for (var depth = 0;
-        cause != null && depth < MAX_CAUSE_DEPTH;
-        depth++, cause = cause.getCause()) {
-      if (cause instanceof AiResponseTruncatedException) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Whether a batch failure was the spend ceiling refusing the call before it was made. Same
-   * bounded cause walk as {@link #isResponseTruncated} and for the same reason: the refusal arrives
-   * wrapped in the parallel pass's {@link CompletionException}.
+   * Whether a batch failure was the spend ceiling refusing the call before it was made. Bounded
+   * cause walk like {@link AiResponseTruncatedException#findIn} (where the truncation flavour of
+   * this check was hoisted, so the pipeline and the orchestrator share one walk) and for the same
+   * reason: the refusal arrives wrapped in the parallel pass's {@link CompletionException}, and an
+   * unbounded walk over a cyclic chain would spin forever on the review thread.
    */
   private static boolean isSpendCeilingBlocked(Throwable failure) {
     var cause = failure;
@@ -498,7 +595,16 @@ public class FindingPipeline {
                 clampOverview(changedFilesOverview(ctx, plan), promptInputs)),
             promptInputs.previousFindings(),
             promptInputs.repoInstructions());
-    var summaryResponse = aiReviewService.summarize(session, summaryInputs);
+    ReviewResponse summaryResponse;
+    try {
+      summaryResponse = aiReviewService.summarize(session, summaryInputs);
+    } catch (AiResponseTruncatedException e) {
+      // Same degradation as the multi-call summary seam (#500 scope A): this path has no findings
+      // by construction, but the review must still post with its omission disclosures rather than
+      // fail on a deterministic truncation.
+      return salvagedOrCountsOnlySummary(
+          session, new ReviewResponse(List.of(), List.of(), null), e);
+    }
     var merged = new ReviewResponse(List.of(), List.of(), summaryResponse.summary());
     persistAiResponse(session, merged);
     return merged;
@@ -750,6 +856,10 @@ public class FindingPipeline {
     // effectiveClippedFiles drops any clipped file a failed batch left wholly uncovered, so it is
     // disclosed once, as uncovered, not also marked "partially analyzed".
     var clipped = Set.copyOf(plan.effectiveClippedFiles());
+    // Files whose batch response was cut but salvaged (#500): kept in the walkthrough with an
+    // honest caveat — checked before the clipped marker so a file in both classes is disclosed
+    // once, under the stronger (output-side) statement.
+    var responseCut = Set.copyOf(plan.responseCutFiles());
     for (var file : ctx.reviewableFiles()) {
       if (ReviewDiffFormatter.namesContain(omitted, file.filename())
           || ReviewDiffFormatter.namesContain(uncovered, file.filename())) {
@@ -762,10 +872,7 @@ public class FindingPipeline {
           .append(file.additions())
           .append(" -")
           .append(file.deletions())
-          .append(
-              ReviewDiffFormatter.namesContain(clipped, file.filename())
-                  ? " — partially analyzed: clipped to fit the review call budget"
-                  : "")
+          .append(fileCoverageMarker(file.filename(), responseCut, clipped))
           .append(")\n");
     }
     for (var name : plan.omittedFiles()) {
@@ -777,6 +884,19 @@ public class FindingPipeline {
               " (not reviewed — the review call for it did not complete; treated as uncovered)\n");
     }
     return sb.toString();
+  }
+
+  /** The per-file coverage caveat for the summary overview, or empty for full coverage. */
+  private static String fileCoverageMarker(
+      String filename, Set<String> responseCut, Set<String> clipped) {
+    if (ReviewDiffFormatter.namesContain(responseCut, filename)) {
+      return " — partially reviewed: the model's response was cut at its length cap; findings up"
+          + " to the cut were kept";
+    }
+    if (ReviewDiffFormatter.namesContain(clipped, filename)) {
+      return " — partially analyzed: clipped to fit the review call budget";
+    }
+    return "";
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -21,6 +21,7 @@ import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSessionPersistence;
 import dev.thiagogonzaga.thrillhousebot.dashboard.SessionEventBroadcaster;
 import dev.thiagogonzaga.thrillhousebot.github.*;
+import dev.thiagogonzaga.thrillhousebot.review.ai.AiResponseTruncatedException;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
@@ -36,6 +37,25 @@ public class ReviewOrchestrator {
   private static final String CHECK_STATUS_COMPLETED = "completed";
 
   private static final String CONCLUSION_FAILURE = "failure";
+
+  /** FAILED check-run title when the failure was the model's response-length cap (#500). */
+  static final String TRUNCATION_CHECK_TITLE = "Review failed: the AI response hit its length cap";
+
+  /**
+   * FAILED check-run summary for a truncation: names the cap and the knob(s) to raise, matching the
+   * PR notice, instead of the bare conclusion-only update a generic failure gets.
+   */
+  static String truncationCheckSummary(boolean conciseModelImplicated) {
+    return "The model's response was cut at its response-length cap (finish_reason=length), so the"
+        + " review output was incomplete. Retrying without changing configuration would be cut at"
+        + " the same point — raise the active model's max-output-tokens (or leave it unset to use"
+        + " the provider default)"
+        + (conciseModelImplicated
+            ? ", and REVIEW_CONCISE_MAX_OUTPUT_TOKENS (the truncated call ran on the concise"
+                + " model)"
+            : "")
+        + ", then run /review again.";
+  }
 
   private final ThrillhouseConfig config;
   private final GitHubAuthClient authClient;
@@ -438,11 +458,16 @@ public class ReviewOrchestrator {
 
   /**
    * Handles a review failure: updates the check run, posts an error comment, and updates the
-   * session.
+   * session. A failure caused by the model's response-length cap (anywhere in the cause chain) gets
+   * truncation-specific copy on both surfaces (#500 scope B): the cap is named and the {@code
+   * max-output-tokens} knob pointed at, because the generic notice's bare {@code /review} retry
+   * advice is knowably futile for a deterministic truncation — and the FAILED check run carries the
+   * same explanation instead of a bare conclusion.
    */
   void handleReviewFailure(
       String auth, ReviewRequest req, ReviewSession session, long checkRunId, RuntimeException e) {
     Log.errorf(e, "Review failed for %s/%s #%d", req.owner(), req.repo(), req.prNumber());
+    var truncation = AiResponseTruncatedException.findIn(e);
 
     if (checkRunId > 0) {
       try {
@@ -454,15 +479,22 @@ public class ReviewOrchestrator {
                 checkRunId,
                 CHECK_STATUS_COMPLETED,
                 CONCLUSION_FAILURE,
-                null,
-                null,
+                truncation.isPresent() ? TRUNCATION_CHECK_TITLE : null,
+                truncation
+                    .map(t -> truncationCheckSummary(t.conciseModelImplicated()))
+                    .orElse(null),
                 sessionUrl(session)));
       } catch (RuntimeException checkRunError) {
         Log.warnf(checkRunError, "Failed to mark check run %d as failed", checkRunId);
       }
     }
 
-    reviewPublisher.postFailureNotice(auth, req.owner(), req.repo(), req.prNumber());
+    if (truncation.isPresent()) {
+      reviewPublisher.postTruncationFailureNotice(
+          auth, req.owner(), req.repo(), req.prNumber(), truncation.get().conciseModelImplicated());
+    } else {
+      reviewPublisher.postFailureNotice(auth, req.owner(), req.repo(), req.prNumber());
+    }
 
     String errorMessage =
         e.getMessage() != null

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -206,19 +206,54 @@ public class ReviewPublisher {
    * surfaced. Best-effort: a failure to post it is logged, not propagated.
    */
   void postFailureNotice(String auth, String owner, String repo, int prNumber) {
+    postFailureNoticeComment(
+        auth,
+        owner,
+        repo,
+        prNumber,
+        """
+            ⚠️ **ThrillhouseBot review could not be completed.**
+
+            The review service encountered an error. \
+            Please reply with `/review` or `@Thrillhousebot review` to retry.""");
+  }
+
+  /**
+   * The failure notice for a review that failed because the model's response was cut at its length
+   * cap (#500 scope B). A truncation is deterministic — the generic notice's bare {@code /review}
+   * advice is exactly the knowably-futile retry #495 exists to prevent — so this variant names the
+   * cap and the knob to raise instead: the active model's {@code max-output-tokens}, plus {@code
+   * REVIEW_CONCISE_MAX_OUTPUT_TOKENS} when the truncated call ran on the concise named model (its
+   * cap is configured separately).
+   */
+  void postTruncationFailureNotice(
+      String auth, String owner, String repo, int prNumber, boolean conciseModelImplicated) {
+    var conciseClause =
+        conciseModelImplicated
+            ? " The truncated call ran on the concise model, so raise"
+                + " `REVIEW_CONCISE_MAX_OUTPUT_TOKENS` as well."
+            : "";
+    postFailureNoticeComment(
+        auth,
+        owner,
+        repo,
+        prNumber,
+        """
+            ⚠️ **ThrillhouseBot review could not be completed.**
+
+            The model's response was cut at its response-length cap (`finish_reason=length`), \
+            so the review output was incomplete. This failure is deterministic: retrying \
+            without changing configuration would be cut at the same point. Raise the active \
+            model's `max-output-tokens` (or leave it unset to use the provider default), then \
+            run `/review` again."""
+            + conciseClause);
+  }
+
+  private void postFailureNoticeComment(
+      String auth, String owner, String repo, int prNumber, String body) {
     try {
       commentClient.createComment(
-          auth,
-          ACCEPT,
-          owner,
-          repo,
-          prNumber,
-          new GitHubCommentClient.CreateCommentRequest(
-              """
-                  ⚠️ **ThrillhouseBot review could not be completed.**
-
-                  The review service encountered an error. \
-                  Please reply with `/review` or `@Thrillhousebot review` to retry."""));
+          auth, ACCEPT, owner, repo, prNumber, new GitHubCommentClient.CreateCommentRequest(body));
     } catch (RuntimeException commentError) {
       Log.warnf(
           commentError,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -121,19 +121,22 @@ public record ReviewResult(
   /**
    * Which files the review left uncovered, by name and by reason: {@code omittedFileNames} were
    * never sent because the diff exceeded the token budget, {@code clippedFileNames} were
-   * hunk-clipped and only partially analyzed, and {@code spendCeilingSkippedFileNames} had their
-   * review call skipped because the review's token spend ceiling ({@code
-   * REVIEW_MAX_TOKENS_PER_REVIEW}) was reached — a different reason with a different fix, so the
-   * rendered copy names it separately. All empty on the legacy line-cap path, where only a count is
-   * known — the rendered copy then falls back to the numeric clause.
+   * hunk-clipped and only partially analyzed, {@code spendCeilingSkippedFileNames} had their review
+   * call skipped because the review's token spend ceiling ({@code REVIEW_MAX_TOKENS_PER_REVIEW})
+   * was reached — a different reason with a different fix, so the rendered copy names it separately
+   * — and {@code responseCutFileNames} were only partially reviewed because the model's response
+   * was cut at its length cap and the findings up to the cut were kept (#500). All empty on the
+   * legacy line-cap path, where only a count is known — the rendered copy then falls back to the
+   * numeric clause.
    */
   @RegisterForReflection
   public record TruncationDetail(
       List<String> omittedFileNames,
       List<String> clippedFileNames,
-      List<String> spendCeilingSkippedFileNames) {
+      List<String> spendCeilingSkippedFileNames,
+      List<String> responseCutFileNames) {
     public static final TruncationDetail EMPTY =
-        new TruncationDetail(List.of(), List.of(), List.of());
+        new TruncationDetail(List.of(), List.of(), List.of(), List.of());
 
     public TruncationDetail {
       omittedFileNames = omittedFileNames == null ? List.of() : List.copyOf(omittedFileNames);
@@ -142,17 +145,28 @@ public record ReviewResult(
           spendCeilingSkippedFileNames == null
               ? List.of()
               : List.copyOf(spendCeilingSkippedFileNames);
+      responseCutFileNames =
+          responseCutFileNames == null ? List.of() : List.copyOf(responseCutFileNames);
     }
 
     /** Convenience for the token-budget-only surfaces, which have no spend-ceiling skips. */
     public TruncationDetail(List<String> omittedFileNames, List<String> clippedFileNames) {
-      this(omittedFileNames, clippedFileNames, List.of());
+      this(omittedFileNames, clippedFileNames, List.of(), List.of());
+    }
+
+    /** Back-compat convenience predating {@code responseCutFileNames}; starts it empty. */
+    public TruncationDetail(
+        List<String> omittedFileNames,
+        List<String> clippedFileNames,
+        List<String> spendCeilingSkippedFileNames) {
+      this(omittedFileNames, clippedFileNames, spendCeilingSkippedFileNames, List.of());
     }
 
     public boolean isEmpty() {
       return omittedFileNames.isEmpty()
           && clippedFileNames.isEmpty()
-          && spendCeilingSkippedFileNames.isEmpty();
+          && spendCeilingSkippedFileNames.isEmpty()
+          && responseCutFileNames.isEmpty();
     }
   }
 
@@ -339,6 +353,16 @@ public record ReviewResult(
               detail.spendCeilingSkippedFileNames().size(),
               nameList(detail.spendCeilingSkippedFileNames())));
     }
+    // The response-cut class is partial in a third way: the files were sent and reviewed, but the
+    // model's answer was cut at its length cap — the findings produced before the cut were kept,
+    // so "not reviewed" would understate the coverage and silence the honest caveat.
+    if (!detail.responseCutFileNames().isEmpty()) {
+      clauses.add(
+          String.format(
+              "%d file(s) were only partially reviewed because the model's response was cut at"
+                  + " its length cap (max-output-tokens) — findings up to the cut were kept (%s)",
+              detail.responseCutFileNames().size(), nameList(detail.responseCutFileNames())));
+    }
     return String.join(", and ", clauses);
   }
 
@@ -369,6 +393,12 @@ public record ReviewResult(
           String.format(
               "%d file(s) skipped at the token spend ceiling",
               truncation.spendCeilingSkippedFileNames().size()));
+    }
+    if (!truncation.responseCutFileNames().isEmpty()) {
+      parts.add(
+          String.format(
+              "%d file(s) partially reviewed (response cut at the length cap)",
+              truncation.responseCutFileNames().size()));
     }
     return String.join(", ", parts);
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -119,18 +119,24 @@ public class VerdictBuilder {
     // into the omitted set (effective*); legacy: line-cap count — never sum both. Files skipped at
     // the token spend ceiling gate approval through the same omitted set but are pulled out into
     // their own class here, so the disclosure names the ceiling — a different cause with a
-    // different fix — instead of blaming the diff budget (and never lists a file twice).
+    // different fix — instead of blaming the diff budget (and never lists a file twice). Files
+    // whose batch response was cut but salvaged (#500) are a further class: partially reviewed,
+    // holding approval like the others, disclosed with the response cut as the reason — and a file
+    // both clipped and response-cut is disclosed once, under the stronger (output-side) statement.
     var ceilingSkipped = plan.spendCeilingSkippedFiles();
+    var responseCut = plan.responseCutFiles();
+    var clipped = withoutNames(plan.effectiveClippedFiles(), responseCut);
     var truncation =
         plan.budgeted()
             ? new ReviewResult.TruncationDetail(
                 withoutNames(plan.effectiveOmittedFiles(), ceilingSkipped),
-                plan.effectiveClippedFiles(),
-                ceilingSkipped)
+                clipped,
+                ceilingSkipped,
+                responseCut)
             : ReviewResult.TruncationDetail.EMPTY;
     var omitted =
         plan.budgeted()
-            ? plan.effectiveOmittedFiles().size() + plan.effectiveClippedFiles().size()
+            ? plan.effectiveOmittedFiles().size() + clipped.size() + responseCut.size()
             : ctx.omittedFiles();
     // GitHub PR-level totals when available; ignore-glob drops can undercount diff-derived stats.
     // Pure renames are excluded from reviewableFiles for AI budget (#386) but still belong in the

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponseTruncatedException.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponseTruncatedException.java
@@ -15,6 +15,8 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
+import java.util.Optional;
+
 /**
  * Raised when the model stopped because it hit its response-length cap ({@code finish_reason:
  * length}) rather than because it finished answering. The body is cut mid-structure, so it would
@@ -29,10 +31,81 @@ package dev.thiagogonzaga.thrillhousebot.review.ai;
  * <p>Extends {@link AiReviewException} so it survives {@link
  * AiReviewService#asAiReviewException(java.util.concurrent.ExecutionException)} with its identity
  * intact — that unwrapper returns an {@code AiReviewException} cause as-is.
+ *
+ * <p>The exception also carries the {@linkplain #partialBody() buffered partial body} when the
+ * failing lane has it (the streaming review path buffers every token it received before the cut).
+ * The body is well-formed up to the cut, so the caller that decides what a truncation costs — the
+ * pipeline's disclose step — can salvage the complete leading elements instead of discarding paid
+ * output it already holds. Carrying it on the exception keeps the no-retry contract intact: the
+ * detection site still throws, nothing re-enters the retry lane, and only the disclose step gains
+ * an input it previously threw away.
  */
 public class AiResponseTruncatedException extends AiReviewException {
 
+  /** Cause-chain links inspected before giving up, so a cyclic chain cannot spin. */
+  private static final int MAX_CAUSE_DEPTH = 16;
+
+  private final String partialBody;
+  private final boolean conciseModelImplicated;
+
   public AiResponseTruncatedException(String message) {
+    this(message, null, false);
+  }
+
+  /**
+   * @param partialBody the response text received before the cut, or {@code null} when the failing
+   *     lane does not buffer it (the blocking assistants)
+   * @param conciseModelImplicated whether the truncated call ran on the {@code concise} named
+   *     model, whose cap is {@code REVIEW_CONCISE_MAX_OUTPUT_TOKENS} rather than the active model's
+   *     {@code max-output-tokens} — rendered copy names the knob that actually applies
+   */
+  public AiResponseTruncatedException(
+      String message, String partialBody, boolean conciseModelImplicated) {
     super(message, 1, null);
+    this.partialBody = partialBody;
+    this.conciseModelImplicated = conciseModelImplicated;
+  }
+
+  /** The buffered text received before the cut; {@code null} when the lane does not buffer it. */
+  public String partialBody() {
+    return partialBody;
+  }
+
+  /** Whether the truncated call ran on the {@code concise} named model. */
+  public boolean conciseModelImplicated() {
+    return conciseModelImplicated;
+  }
+
+  /**
+   * This truncation, marked as coming from the {@code concise} named model — same message, same
+   * partial body. Returns {@code this} when already marked.
+   */
+  public AiResponseTruncatedException implicatingConciseModel() {
+    if (conciseModelImplicated) {
+      return this;
+    }
+    return new AiResponseTruncatedException(getMessage(), partialBody, true);
+  }
+
+  /**
+   * The truncation inside a failure's cause chain, if any. Hoisted from {@code FindingPipeline} so
+   * every layer that reacts to a truncation — the pipeline's disclose step, the orchestrator's
+   * failure notice — shares one walk instead of each growing its own.
+   *
+   * <p>Bounded rather than walked to {@code null}: a cause chain can cycle — a {@link Throwable}
+   * overriding {@code getCause()}, or plain {@code A caused-by B caused-by A} — and an unbounded
+   * walk would spin forever on the review thread. The bound is far above any real chain (the
+   * failure arrives wrapped at depth 2 in practice), so a truncation is never missed for depth.
+   */
+  public static Optional<AiResponseTruncatedException> findIn(Throwable failure) {
+    var cause = failure;
+    for (var depth = 0;
+        cause != null && depth < MAX_CAUSE_DEPTH;
+        depth++, cause = cause.getCause()) {
+      if (cause instanceof AiResponseTruncatedException truncation) {
+        return Optional.of(truncation);
+      }
+    }
+    return Optional.empty();
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewService.java
@@ -99,16 +99,24 @@ public class AiReviewService {
    * concise cap rather than the batch review's response allowance.
    */
   public ReviewResponse summarize(ReviewSession session, SummaryInputs inputs) {
-    return runWithRetries(
-        session,
-        () ->
-            prSummarizer.summarizeStream(
-                inputs.prContext(),
-                inputs.findings(),
-                inputs.changedFiles(),
-                inputs.previousFindings(),
-                inputs.repoInstructions()),
-        false);
+    try {
+      return runWithRetries(
+          session,
+          () ->
+              prSummarizer.summarizeStream(
+                  inputs.prContext(),
+                  inputs.findings(),
+                  inputs.changedFiles(),
+                  inputs.previousFindings(),
+                  inputs.repoInstructions()),
+          false);
+    } catch (AiResponseTruncatedException e) {
+      // This call runs on the concise named model, so the cap that cut it is
+      // REVIEW_CONCISE_MAX_OUTPUT_TOKENS — mark the failure so downstream copy names that knob
+      // instead of only the active model's max-output-tokens. Rethrown outside the retry loop,
+      // which already declined to retry, so the no-retry contract is untouched.
+      throw e.implicatingConciseModel();
+    }
   }
 
   private TokenStream reviewStream(PromptInputs inputs) {
@@ -280,12 +288,17 @@ public class AiReviewService {
       // the transient-retry path below — parsing it first would surface only "not valid review
       // JSON", which is indistinguishable from a malformed response and gets retried.
       if (response.finishReason() == FinishReason.LENGTH) {
+        // The buffered partial text travels with the exception: it is well-formed up to the cut,
+        // and the disclose step can salvage its complete leading elements (#500) instead of
+        // discarding output that was already paid for.
         result.completeExceptionally(
             new AiResponseTruncatedException(
                 "Model stopped at its response-length cap (finish_reason=length) after "
                     + text.length()
                     + " characters, so the response is incomplete. Raise the active model's"
-                    + " max-output-tokens, or leave it unset to use the provider default."));
+                    + " max-output-tokens, or leave it unset to use the provider default.",
+                text,
+                false));
         return;
       }
       result.complete(parser.parse(text));

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvager.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvager.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Salvages the complete leading JSON elements out of a response the model cut at its length cap
+ * ({@link AiResponseTruncatedException#partialBody()}). The body is well-formed up to the cut, so
+ * every {@code findings} / {@code previous_findings_status} array element that closed before it —
+ * and a {@code summary} object that did — is recoverable as-is; the trailing cut-off value is
+ * dropped by construction.
+ *
+ * <p>Deliberately a separate class from {@link ReviewResponseParser}: the parser's contract is
+ * all-or-nothing on a complete body, while salvage is best-effort on a known-cut one, and the two
+ * must not blur (#508 is being fixed in the parser in parallel). The fence/noise stripping and
+ * control-character escaping are shared through {@link ReviewResponseParser#extractJson}, and the
+ * tokenization is Jackson's own streaming parser — no hand-rolled string slicing over model output.
+ *
+ * <p>Paranoid by construction, since the input is model output: the scan is a single bounded
+ * forward pass ({@link #MAX_SALVAGED_BODY_CHARS}), each array keeps at most {@link
+ * #MAX_ELEMENTS_PER_ARRAY} elements, an element that does not map onto the response schema is
+ * skipped rather than failing the salvage, and any parse error simply ends the pass with what was
+ * already collected. Salvage never throws.
+ */
+@ApplicationScoped
+public class TruncatedResponseSalvager {
+
+  /**
+   * Upper bound on the body length a salvage pass will even look at. The buffered body is already
+   * bounded by the model's output cap, so this is belt-and-braces against a runaway buffer — well
+   * above the largest configured cap's worth of characters, so a real truncation is never refused.
+   */
+  static final int MAX_SALVAGED_BODY_CHARS = 10_000_000;
+
+  /**
+   * Upper bound on elements kept per array. A real batch response carries tens of findings; a body
+   * repeating thousands of elements is runaway output, and the pass stops rather than ferrying it
+   * all into the finding chain.
+   */
+  static final int MAX_ELEMENTS_PER_ARRAY = 500;
+
+  private final ObjectMapper mapper;
+
+  @Inject
+  public TruncatedResponseSalvager(ObjectMapper mapper) {
+    this.mapper = mapper;
+  }
+
+  /**
+   * What a salvage pass recovered: the complete findings and previous-finding statuses (possibly
+   * none), and the summary object when it closed before the cut ({@code null} otherwise).
+   */
+  public record Salvaged(
+      List<ReviewResponse.Finding> findings,
+      List<ReviewResponse.PreviousFindingStatus> previousFindingsStatus,
+      ReviewResponse.Summary summary) {
+    public Salvaged {
+      findings = List.copyOf(findings);
+      previousFindingsStatus = List.copyOf(previousFindingsStatus);
+    }
+
+    static final Salvaged NOTHING = new Salvaged(List.of(), List.of(), null);
+
+    /** Whether anything a batch disclosure could honestly call "partially reviewed" came back. */
+    public boolean hasFindingsOrStatuses() {
+      return !findings.isEmpty() || !previousFindingsStatus.isEmpty();
+    }
+  }
+
+  /**
+   * Salvages the complete elements of {@code partialBody}. Returns {@link Salvaged#NOTHING} when
+   * there is nothing to work with — no body (the blocking lanes do not buffer one), a body that
+   * does not open a JSON object, or a cut that landed before the first element closed.
+   */
+  public Salvaged salvage(String partialBody) {
+    if (partialBody == null
+        || partialBody.isBlank()
+        || partialBody.length() > MAX_SALVAGED_BODY_CHARS) {
+      return Salvaged.NOTHING;
+    }
+    var json = ReviewResponseParser.extractJson(partialBody);
+    var findings = new ArrayList<ReviewResponse.Finding>();
+    var statuses = new ArrayList<ReviewResponse.PreviousFindingStatus>();
+    ReviewResponse.Summary summary = null;
+    try (JsonParser parser = mapper.createParser(json)) {
+      if (parser.nextToken() != JsonToken.START_OBJECT) {
+        return Salvaged.NOTHING;
+      }
+      while (parser.nextToken() == JsonToken.FIELD_NAME) {
+        var field = parser.currentName();
+        // Never null: inside the root object, Jackson raises JsonEOFException at the cut instead
+        // of returning null, and the catch below ends the pass.
+        var value = parser.nextToken();
+        switch (field) {
+          case "findings" ->
+              salvageArrayElements(parser, value, ReviewResponse.Finding.class, findings);
+          case "previous_findings_status" ->
+              salvageArrayElements(
+                  parser, value, ReviewResponse.PreviousFindingStatus.class, statuses);
+          case "summary" -> summary = objectOrNull(parser, value, ReviewResponse.Summary.class);
+          default -> parser.skipChildren();
+        }
+      }
+    } catch (IOException e) {
+      // The cut point (or trailing garbage): everything that closed before it is already
+      // collected, and the partial trailing value was never added. This is the expected way for
+      // a truncated body's pass to end.
+      Log.debugf("Salvage pass ended at the cut: %s", e.getMessage());
+    }
+    return new Salvaged(findings, statuses, summary);
+  }
+
+  /**
+   * Collects the array's complete elements into {@code out}, capped at {@link
+   * #MAX_ELEMENTS_PER_ARRAY}. A non-array value is skipped whole (e.g. the object-form {@code
+   * previous_findings_status} some models emit — salvage keeps only the unambiguous shape). An
+   * element that is not an object, or does not map onto {@code type}, is skipped individually.
+   */
+  private <T> void salvageArrayElements(
+      JsonParser parser, JsonToken value, Class<T> type, List<T> out) throws IOException {
+    if (value != JsonToken.START_ARRAY) {
+      parser.skipChildren();
+      return;
+    }
+    while (out.size() < MAX_ELEMENTS_PER_ARRAY) {
+      // Never null: inside the array, Jackson raises JsonEOFException at the cut instead of
+      // returning null, ending the pass with the complete leading elements kept.
+      var token = parser.nextToken();
+      if (token == JsonToken.END_ARRAY) {
+        return;
+      }
+      var element = objectOrNull(parser, token, type);
+      if (element != null) {
+        out.add(element);
+      }
+    }
+    // Element cap reached: runaway output. Stop the whole pass (the outer loop ends on the next
+    // non-FIELD_NAME token) rather than scanning the remainder.
+  }
+
+  /**
+   * Reads the value at the current token completely and maps it onto {@code type}; {@code null} for
+   * a non-object value or one that does not map. Reading always consumes the whole value, so the
+   * parser stays element-aligned — and a value the cut split throws, ending the pass with the
+   * partial value dropped.
+   */
+  private <T> T objectOrNull(JsonParser parser, JsonToken token, Class<T> type) throws IOException {
+    JsonNode node = parser.readValueAsTree();
+    if (token != JsonToken.START_OBJECT) {
+      return null;
+    }
+    try {
+      return mapper.treeToValue(node, type);
+    } catch (JsonProcessingException e) {
+      Log.debugf("Skipping a salvaged element that does not map onto %s", type.getSimpleName());
+      return null;
+    }
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvager.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvager.java
@@ -106,7 +106,11 @@ public class TruncatedResponseSalvager {
     var findings = new ArrayList<ReviewResponse.Finding>();
     var statuses = new ArrayList<ReviewResponse.PreviousFindingStatus>();
     ReviewResponse.Summary summary = null;
-    try (JsonParser parser = mapper.createParser(json)) {
+    // Deliberately not try-with-resources: the parser reads a String, holds no OS resource, and
+    // the compiler's close-on-exception desugaring adds unreachable branches for a reader that
+    // cannot fail to close. The success path closes explicitly; the cut path abandons the parser.
+    try {
+      JsonParser parser = mapper.createParser(json);
       if (parser.nextToken() != JsonToken.START_OBJECT) {
         return Salvaged.NOTHING;
       }
@@ -125,6 +129,7 @@ public class TruncatedResponseSalvager {
           default -> parser.skipChildren();
         }
       }
+      parser.close();
     } catch (IOException e) {
       // The cut point (or trailing garbage): everything that closed before it is already
       // collected, and the partial trailing value was never added. This is the expected way for
@@ -175,7 +180,7 @@ public class TruncatedResponseSalvager {
     }
     try {
       return mapper.treeToValue(node, type);
-    } catch (JsonProcessingException e) {
+    } catch (JsonProcessingException _) {
       Log.debugf("Skipping a salvaged element that does not map onto %s", type.getSimpleName());
       return null;
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvager.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvager.java
@@ -106,11 +106,9 @@ public class TruncatedResponseSalvager {
     var findings = new ArrayList<ReviewResponse.Finding>();
     var statuses = new ArrayList<ReviewResponse.PreviousFindingStatus>();
     ReviewResponse.Summary summary = null;
-    // Deliberately not try-with-resources: the parser reads a String, holds no OS resource, and
-    // the compiler's close-on-exception desugaring adds unreachable branches for a reader that
-    // cannot fail to close. The success path closes explicitly; the cut path abandons the parser.
+    JsonParser parser = null;
     try {
-      JsonParser parser = mapper.createParser(json);
+      parser = mapper.createParser(json);
       if (parser.nextToken() != JsonToken.START_OBJECT) {
         return Salvaged.NOTHING;
       }
@@ -129,12 +127,13 @@ public class TruncatedResponseSalvager {
           default -> parser.skipChildren();
         }
       }
-      parser.close();
     } catch (IOException e) {
       // The cut point (or trailing garbage): everything that closed before it is already
       // collected, and the partial trailing value was never added. This is the expected way for
       // a truncated body's pass to end.
       Log.debugf("Salvage pass ended at the cut: %s", e.getMessage());
+    } finally {
+      closeQuietly(parser);
     }
     return new Salvaged(findings, statuses, summary);
   }
@@ -173,6 +172,22 @@ public class TruncatedResponseSalvager {
    * parser stays element-aligned — and a value the cut split throws, ending the pass with the
    * partial value dropped.
    */
+  /**
+   * Closes the parser without letting a close-time failure mask the salvage result. A string-backed
+   * parser cannot fail to close in practice — the null guard and the swallow exist for the
+   * contract, and are exercised directly by tests because no production input reaches them.
+   */
+  static void closeQuietly(JsonParser parser) {
+    if (parser == null) {
+      return;
+    }
+    try {
+      parser.close();
+    } catch (IOException e) {
+      Log.debugf("Ignoring a close failure on a string-backed parser: %s", e.getMessage());
+    }
+  }
+
   private <T> T objectOrNull(JsonParser parser, JsonToken token, Class<T> type) throws IOException {
     JsonNode node = parser.readValueAsTree();
     if (token != JsonToken.START_OBJECT) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -360,6 +360,35 @@ class DiffBudgetPlannerTest {
   }
 
   @Test
+  void responseCutFilesStayOutOfTheUncoveredSetButHoldTruncation() {
+    // #500: a salvaged batch's files are partially reviewed — they must trip the truncation gate
+    // (approval held, disclosure rendered) without joining the not-reviewed sets, keep dedupe/null
+    // hygiene like the other recorders, and stay behind a defensive copy.
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+
+    plan.recordResponseCutFiles(Arrays.asList("a.java", null, "a.java", "b.java"));
+
+    assertEquals(List.of("a.java", "b.java"), plan.responseCutFiles());
+    assertTrue(plan.runtimeUncoveredFiles().isEmpty());
+    assertTrue(plan.effectiveOmittedFiles().isEmpty());
+    assertTrue(plan.truncated());
+    assertThrows(
+        UnsupportedOperationException.class, () -> plan.responseCutFiles().add("escaped.java"));
+  }
+
+  @Test
+  void aPlanBuiltWithANullResponseCutListStillAcceptsRecords() {
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true, null, null, null);
+
+    assertTrue(plan.responseCutFiles().isEmpty());
+
+    plan.recordResponseCutFiles(List.of("src/Cut.java"));
+
+    assertEquals(List.of("src/Cut.java"), plan.responseCutFiles());
+  }
+
+  @Test
   void clippedFilesAreReportedUnchangedWhenNoBatchFailed() {
     // No runtime gap: the clipped list passes through, so a partially analyzed file keeps its
     // "clipped" meaning rather than being reported as wholly uncovered.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -372,8 +372,8 @@ class DiffBudgetPlannerTest {
     assertTrue(plan.runtimeUncoveredFiles().isEmpty());
     assertTrue(plan.effectiveOmittedFiles().isEmpty());
     assertTrue(plan.truncated());
-    assertThrows(
-        UnsupportedOperationException.class, () -> plan.responseCutFiles().add("escaped.java"));
+    var cutFiles = plan.responseCutFiles();
+    assertThrows(UnsupportedOperationException.class, () -> cutFiles.add("escaped.java"));
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -87,7 +87,9 @@ class FindingPipelineTest {
             BotIdentity.from(List.of("thrillhousebot[bot]")),
             budgetPlanner,
             new TokenCounter(),
-            tokenLedger);
+            tokenLedger,
+            new dev.thiagogonzaga.thrillhousebot.review.ai.TruncatedResponseSalvager(
+                new ObjectMapper()));
     when(quoteValidator.validate(any(), any())).thenAnswer(inv -> inv.getArgument(0));
     when(frameworkFilter.filter(any(), any())).thenAnswer(inv -> inv.getArgument(0));
     when(deduplicator.dedupe(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -236,6 +238,197 @@ class FindingPipelineTest {
     assertEquals(List.of("a.java"), plan.runtimeUncoveredFiles());
     assertTrue(plan.truncated());
     assertTrue(captor.getValue().changedFiles().contains("a.java (not reviewed"));
+  }
+
+  /** One complete finding element for a stubbed partial body, anchored in batch 1's file. */
+  private static String bodyFinding(String title) {
+    return "{\"risk\":\"medium\",\"confidence\":\"high\",\"file\":\"a.java\",\"line\":1,"
+        + ("\"title\":\"" + title + "\",\"description\":\"desc\",")
+        + "\"suggestion_old\":\"old line\",\"suggestion_new\":\"new line\"}";
+  }
+
+  /** A batch response cut at the length cap: 3 complete findings, 1 complete status, then a cut. */
+  private static String partialBatchBody() {
+    return "{\"findings\":["
+        + bodyFinding("S1")
+        + ","
+        + bodyFinding("S2")
+        + ","
+        + bodyFinding("S3")
+        + "],\"previous_findings_status\":[{\"id\":1,\"status\":\"unresolved\",\"note\":\"n\"},"
+        + "{\"id\":2,\"status\":\"resol";
+  }
+
+  @Test
+  void multiCallSalvagesTheCompleteFindingsFromATruncatedBatchResponse() {
+    // #500(a): the partial body travels with the truncation and is well-formed up to the cut. The
+    // complete leading findings must be salvaged through the normal validate/verify chain and the
+    // batch's files disclosed as PARTIALLY reviewed — not dropped and disclosed as not reviewed.
+    var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt()))
+        .thenThrow(
+            new AiResponseTruncatedException("finish_reason=length", partialBatchBody(), false));
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(2), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("b.java", "B")), List.of(), null));
+    var summary = new ReviewResponse.Summary(4, 0, 0, 4, 0, "ok", "does things", List.of());
+    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
+    when(aiReviewService.summarize(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), summary));
+
+    var plan = multiBatchPlan();
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    // #495's no-retry stands: salvage replaces the disclose step, never re-enters the retry lane.
+    verify(aiReviewService, times(1)).reviewBatch(eq(session), any(), eq(1), anyInt());
+    // The salvaged findings run the same validate/verify chain as any batch's.
+    verify(findingVerificationService, times(2)).verify(any(), any(), any(), any());
+
+    assertEquals(4, result.findings().size());
+    assertEquals("S1", result.findings().get(0).title());
+    assertEquals("S3", result.findings().get(2).title());
+    assertEquals("B", result.findings().get(3).title());
+    // The complete status before the cut is kept too; the cut-off one is dropped.
+    assertEquals(1, result.previousFindingsStatus().size());
+    assertEquals(1, result.previousFindingsStatus().get(0).id());
+
+    // Partially reviewed — a distinct, honest state: not in the not-reviewed set, named in the
+    // response-cut set, still holding APPROVE back.
+    assertEquals(List.of("a.java"), plan.responseCutFiles());
+    assertTrue(plan.runtimeUncoveredFiles().isEmpty());
+    assertTrue(plan.truncated());
+    var changedFiles = captor.getValue().changedFiles();
+    assertTrue(changedFiles.contains("a.java (modified"), changedFiles);
+    assertTrue(
+        changedFiles.contains("partially reviewed: the model's response was cut"), changedFiles);
+    assertFalse(changedFiles.contains("a.java (not reviewed"), changedFiles);
+  }
+
+  @Test
+  void multiCallFallsBackToNotReviewedWhenTheCutPrecedesTheFirstCompleteFinding() {
+    // #500(b): a cut before the first element closed leaves nothing to salvage — the batch falls
+    // back to today's behaviour, disclosed as not reviewed. Green-only by necessity: this IS the
+    // pre-#500 disclosure, so no assertion here could have failed before the change; the guard
+    // pins that salvage never invents a "partially reviewed" claim out of an empty salvage.
+    var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt()))
+        .thenThrow(
+            new AiResponseTruncatedException(
+                "finish_reason=length", "{\"findings\":[{\"risk\":\"hi", false));
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(2), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("b.java", "B")), List.of(), null));
+    var summary = new ReviewResponse.Summary(1, 0, 0, 1, 0, "ok", "does things", List.of());
+    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
+    when(aiReviewService.summarize(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), summary));
+
+    var plan = multiBatchPlan();
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    verify(aiReviewService, times(1)).reviewBatch(eq(session), any(), eq(1), anyInt());
+    assertEquals(1, result.findings().size());
+    assertEquals(List.of("a.java"), plan.runtimeUncoveredFiles());
+    assertTrue(plan.responseCutFiles().isEmpty());
+    assertTrue(captor.getValue().changedFiles().contains("a.java (not reviewed"));
+  }
+
+  @Test
+  void multiCallSalvagesATruncationThrownOnTheSequentialRetry() {
+    // A batch can fail transiently in the parallel pass and then truncate on its sequential retry.
+    // The retry's truncation must land in the same salvage-or-disclose step, not the generic
+    // soft-fail that discards the partial output.
+    var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt()))
+        .thenThrow(new AiReviewException("transient", 1, null))
+        .thenThrow(
+            new AiResponseTruncatedException("finish_reason=length", partialBatchBody(), false));
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(2), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("b.java", "B")), List.of(), null));
+    var summary = new ReviewResponse.Summary(4, 0, 0, 4, 0, "ok", "does things", List.of());
+    when(aiReviewService.summarize(eq(session), any()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), summary));
+
+    var plan = multiBatchPlan();
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    verify(aiReviewService, times(2)).reviewBatch(eq(session), any(), eq(1), anyInt());
+    assertEquals(4, result.findings().size());
+    assertEquals(List.of("a.java"), plan.responseCutFiles());
+    assertTrue(plan.runtimeUncoveredFiles().isEmpty());
+  }
+
+  @Test
+  void multiCallKeepsTheFindingsWhenTheSummaryResponseIsTruncated() {
+    // #500 scope A: every batch call succeeded and was billed; a summary truncated at the concise
+    // cap must degrade to the counts-only summary (the same shape as the ceiling-tripped path),
+    // with the findings persisted — not throw the whole paid review away.
+    var session = persistedSession();
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("a.java", "A")), List.of(), null));
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(2), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("b.java", "B")), List.of(), null));
+    when(aiReviewService.summarize(eq(session), any()))
+        .thenThrow(new AiResponseTruncatedException("finish_reason=length", "{\"summ", true));
+
+    var result =
+        pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+
+    verify(aiReviewService, times(1)).summarize(eq(session), any());
+    assertEquals(2, result.findings().size());
+    assertNull(result.summary());
+    assertNotNull(session.getAiResponseJson(), "the paid findings must still be persisted");
+  }
+
+  @Test
+  void multiCallSalvagesTheSummaryObjectWhenItClosedBeforeTheCut() {
+    // Scope A's better half: when the summary object itself completed before the cut, it is
+    // salvaged rather than degraded to counts-only.
+    var session = persistedSession();
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("a.java", "A")), List.of(), null));
+    var partial =
+        "{\"findings\":[],\"summary\":{\"total_findings\":2,\"critical\":0,\"high\":1,"
+            + "\"medium\":1,\"low\":0,\"overall_assessment\":\"solid\",\"pr_purpose\":\"adds\","
+            + "\"description_gaps\":[]},\"previous_findings_status\":[{\"id\":7,\"status\":\"res";
+    when(aiReviewService.summarize(eq(session), any()))
+        .thenThrow(new AiResponseTruncatedException("finish_reason=length", partial, true));
+
+    var result =
+        pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+
+    assertEquals(2, result.findings().size());
+    assertNotNull(result.summary());
+    assertEquals("solid", result.summary().overallAssessment());
+    assertNotNull(session.getAiResponseJson());
+  }
+
+  @Test
+  void summarizeWithoutReviewDegradesToCountsOnlyWhenTheSummaryIsTruncated() {
+    // The degenerate all-omitted plan makes exactly one AI call — the summary. A truncation there
+    // must not fail the review either: same counts-only degradation, empty findings, persisted.
+    var session = persistedSession();
+    var template =
+        new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(List.of(), List.of("a.java", "b.java"), List.of(), true);
+    when(aiReviewService.summarize(eq(session), any()))
+        .thenThrow(new AiResponseTruncatedException("finish_reason=length", null, true));
+
+    var result =
+        pipeline.run(session, template, reviewContext(), plan, new DiffLineResolver(Map.of()));
+
+    assertTrue(result.findings().isEmpty());
+    assertNull(result.summary());
+    assertNotNull(session.getAiResponseJson());
   }
 
   @Test
@@ -1076,7 +1269,9 @@ class FindingPipelineTest {
             BotIdentity.from(List.of("thrillhousebot[bot]")),
             budgetPlanner,
             new TokenCounter(),
-            realLedger);
+            realLedger,
+            new dev.thiagogonzaga.thrillhousebot.review.ai.TruncatedResponseSalvager(
+                new ObjectMapper()));
     var session = persistedSession();
     var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
     when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
@@ -1189,7 +1384,9 @@ class FindingPipelineTest {
             BotIdentity.from(List.of("thrillhousebot[bot]")),
             budgetPlanner,
             new TokenCounter(),
-            tokenLedger);
+            tokenLedger,
+            new dev.thiagogonzaga.thrillhousebot.review.ai.TruncatedResponseSalvager(
+                new ObjectMapper()));
     var session = ReviewSession.create("owner/repo", 1, "PR", "sha");
     var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
     when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -150,7 +150,8 @@ class ReviewOrchestratorTest {
             new DiffBudgetPlanner(
                 diffFormatter, new TokenCounter(), config, new ActiveModelSettings(config, "m")),
             new TokenCounter(),
-            mock(ReviewTokenLedger.class));
+            mock(ReviewTokenLedger.class),
+            new dev.thiagogonzaga.thrillhousebot.review.ai.TruncatedResponseSalvager(mapper));
     orchestrator = newOrchestrator();
     when(config.review()).thenReturn(reviewConfig);
     when(reviewConfig.maxReviewComments()).thenReturn(10);
@@ -2986,6 +2987,188 @@ class ReviewOrchestratorTest {
           .createComment(eq("Bearer tok"), anyString(), eq("owner"), eq("repo"), eq(42), any());
       verify(sessionPersistence).update(eq(2L), any());
     }
+
+    private ReviewSession failureSession() {
+      var session = new ReviewSession();
+      session.id = 5L;
+      session.setRepository("owner/repo");
+      session.setPrNumber(42);
+      session.setPrTitle("Test PR");
+      session.setCommitSha("abcdefgh");
+      session.setTimestamp(java.time.Instant.parse("2025-06-01T12:00:00Z"));
+      return session;
+    }
+
+    @Test
+    void aTruncationFailurePostsTheCapNamingNoticeInsteadOfTheBareRetryAdvice() {
+      // #500 scope B: a truncation is deterministic — advising a bare `/review` retry is exactly
+      // the knowably-futile call #495 exists to prevent. The notice must name the cap and the
+      // max-output-tokens knob instead.
+      var session = failureSession();
+
+      orchestrator.handleReviewFailure(
+          "Bearer tok",
+          reviewRequest(),
+          session,
+          99L,
+          new dev.thiagogonzaga.thrillhousebot.review.ai.AiResponseTruncatedException(
+              "Model stopped at its response-length cap (finish_reason=length)"));
+
+      var commentCaptor = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+      verify(commentClient)
+          .createComment(
+              eq("Bearer tok"),
+              anyString(),
+              eq("owner"),
+              eq("repo"),
+              eq(42),
+              commentCaptor.capture());
+      var body = commentCaptor.getValue().body();
+      assertTrue(body.contains("response-length cap"), body);
+      assertTrue(body.contains("max-output-tokens"), body);
+      assertFalse(body.contains("reply with `/review`"), body);
+
+      // The FAILED check run must say the same instead of the null title/summary it sends today.
+      var checkCaptor = ArgumentCaptor.forClass(GitHubCheckRunClient.UpdateCheckRunRequest.class);
+      verify(checkRunClient)
+          .updateCheckRun(
+              eq("Bearer tok"),
+              anyString(),
+              eq("owner"),
+              eq("repo"),
+              eq(99L),
+              checkCaptor.capture());
+      var output = checkCaptor.getValue().output();
+      assertNotNull(output, "the FAILED check run must carry a truncation title/summary");
+      assertTrue(output.title().contains("length cap"), output.title());
+      assertTrue(output.summary().contains("max-output-tokens"), output.summary());
+    }
+
+    @Test
+    void aConciseModelTruncationFailureNamesTheConciseKnobToo() {
+      var session = failureSession();
+
+      orchestrator.handleReviewFailure(
+          "Bearer tok",
+          reviewRequest(),
+          session,
+          99L,
+          new dev.thiagogonzaga.thrillhousebot.review.ai.AiResponseTruncatedException(
+                  "Model stopped at its response-length cap (finish_reason=length)")
+              .implicatingConciseModel());
+
+      var commentCaptor = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+      verify(commentClient)
+          .createComment(
+              eq("Bearer tok"),
+              anyString(),
+              eq("owner"),
+              eq("repo"),
+              eq(42),
+              commentCaptor.capture());
+      assertTrue(
+          commentCaptor.getValue().body().contains("REVIEW_CONCISE_MAX_OUTPUT_TOKENS"),
+          commentCaptor.getValue().body());
+
+      var checkCaptor = ArgumentCaptor.forClass(GitHubCheckRunClient.UpdateCheckRunRequest.class);
+      verify(checkRunClient)
+          .updateCheckRun(
+              eq("Bearer tok"),
+              anyString(),
+              eq("owner"),
+              eq("repo"),
+              eq(99L),
+              checkCaptor.capture());
+      assertNotNull(checkCaptor.getValue().output());
+      assertTrue(
+          checkCaptor.getValue().output().summary().contains("REVIEW_CONCISE_MAX_OUTPUT_TOKENS"),
+          checkCaptor.getValue().output().summary());
+    }
+
+    @Test
+    void aTruncationBuriedInTheCauseChainStillGetsTheCapNamingNotice() {
+      // The single-call lane can wrap the truncation (e.g. IllegalStateException over it); the
+      // orchestrator must walk the cause chain, not instanceof-check the top failure.
+      var session = failureSession();
+
+      orchestrator.handleReviewFailure(
+          "Bearer tok",
+          reviewRequest(),
+          session,
+          0L,
+          new IllegalStateException(
+              "wrapped",
+              new dev.thiagogonzaga.thrillhousebot.review.ai.AiResponseTruncatedException(
+                  "Model stopped at its response-length cap (finish_reason=length)")));
+
+      var commentCaptor = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+      verify(commentClient)
+          .createComment(
+              eq("Bearer tok"),
+              anyString(),
+              eq("owner"),
+              eq("repo"),
+              eq(42),
+              commentCaptor.capture());
+      assertTrue(
+          commentCaptor.getValue().body().contains("max-output-tokens"),
+          commentCaptor.getValue().body());
+    }
+
+    @Test
+    void aFailedTruncationNoticePostIsSwallowedAndTheFailureFlowCompletes() {
+      // The truncation notice shares the generic notice's best-effort contract: a comment API
+      // failure is logged, and the session still lands in FAILED.
+      var session = failureSession();
+      when(commentClient.createComment(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), any()))
+          .thenThrow(new RuntimeException("comment 500"));
+
+      orchestrator.handleReviewFailure(
+          "Bearer tok",
+          reviewRequest(),
+          session,
+          0L,
+          new dev.thiagogonzaga.thrillhousebot.review.ai.AiResponseTruncatedException(
+              "Model stopped at its response-length cap (finish_reason=length)"));
+
+      verify(sessionPersistence).update(eq(5L), any());
+      assertEquals(ReviewSession.STATUS_FAILED, session.getStatus());
+    }
+
+    @Test
+    void aGenericFailureKeepsTheGenericRetryNoticeAndBareCheckRun() {
+      // Every other failure is (potentially) transient: the `/review` retry advice stays, and the
+      // check run keeps its bare conclusion-only shape.
+      var session = failureSession();
+
+      orchestrator.handleReviewFailure(
+          "Bearer tok", reviewRequest(), session, 99L, new RuntimeException("boom"));
+
+      var commentCaptor = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+      verify(commentClient)
+          .createComment(
+              eq("Bearer tok"),
+              anyString(),
+              eq("owner"),
+              eq("repo"),
+              eq(42),
+              commentCaptor.capture());
+      var body = commentCaptor.getValue().body();
+      assertTrue(body.contains("reply with `/review`"), body);
+      assertFalse(body.contains("max-output-tokens"), body);
+
+      var checkCaptor = ArgumentCaptor.forClass(GitHubCheckRunClient.UpdateCheckRunRequest.class);
+      verify(checkRunClient)
+          .updateCheckRun(
+              eq("Bearer tok"),
+              anyString(),
+              eq("owner"),
+              eq("repo"),
+              eq(99L),
+              checkCaptor.capture());
+      assertNull(checkCaptor.getValue().output(), "generic failures keep the bare check run");
+    }
   }
 
   @Nested
@@ -4207,7 +4390,8 @@ class ReviewOrchestratorTest {
               new DiffBudgetPlanner(
                   diffFormatter, new TokenCounter(), config, new ActiveModelSettings(config, "m")),
               new TokenCounter(),
-              mock(ReviewTokenLedger.class));
+              mock(ReviewTokenLedger.class),
+              new dev.thiagogonzaga.thrillhousebot.review.ai.TruncatedResponseSalvager(mapper));
 
       var response = new ReviewResponse(List.of(), List.of(), null);
       failingPipeline.persistAiResponse(session, response);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -265,9 +265,65 @@ class ReviewResultTest {
 
   @Test
   void truncationDetailNormalizesNullListsToEmpty() {
-    var detail = new ReviewResult.TruncationDetail(null, null, null);
+    var detail = new ReviewResult.TruncationDetail(null, null, null, null);
     assertTrue(detail.isEmpty());
     assertEquals(List.of(), detail.spendCeilingSkippedFileNames());
+    assertEquals(List.of(), detail.responseCutFileNames());
+  }
+
+  @Test
+  void coverageGapClauseNamesTheResponseCutClassWithTheCapAndTheKeptFindings() {
+    // #500: a salvaged batch's files were reviewed up to the cut — the clause must say the
+    // response was cut (naming the cap) and that the findings up to the cut were kept, not fold
+    // them into the budget or ceiling wording.
+    var detail =
+        new ReviewResult.TruncationDetail(
+            List.of("a.java"), List.of(), List.of(), List.of("cut.java"));
+
+    var clause = ReviewResult.coverageGapClause(2, detail);
+
+    assertTrue(clause.contains("1 file(s) were omitted entirely (a.java)"), clause);
+    assertTrue(
+        clause.contains(
+            "1 file(s) were only partially reviewed because the model's response was cut at its"
+                + " length cap (max-output-tokens) — findings up to the cut were kept (cut.java)"),
+        clause);
+  }
+
+  @Test
+  void coverageGapBriefCountsResponseCutFilesAsTheirOwnClass() {
+    var result =
+        new ReviewResult(
+            List.of(),
+            0,
+            0,
+            0,
+            0,
+            null,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            1,
+            false,
+            true,
+            new ReviewResult.TruncationDetail(
+                List.of(), List.of(), List.of(), List.of("cut.java")));
+
+    var brief = result.coverageGapBrief();
+
+    assertTrue(
+        brief.contains("1 file(s) partially reviewed (response cut at the length cap)"), brief);
+  }
+
+  @Test
+  void truncationDetailWithOnlyResponseCutFilesIsNotEmpty() {
+    var detail =
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of("cut.java"));
+    assertFalse(detail.isEmpty());
+    // The three-list convenience constructor keeps the pre-#500 shape: no response-cut files.
+    assertTrue(new ReviewResult.TruncationDetail(List.of(), List.of(), List.of()).isEmpty());
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -219,6 +219,51 @@ class VerdictBuilderTest {
   }
 
   @Test
+  void responseCutFilesAreDisclosedAsPartiallyReviewedAndHoldApproval() {
+    // #500: a batch whose response was cut but salvaged is a third kind of partial coverage — the
+    // files were reviewed up to the cut and the findings kept, so the disclosure must say the
+    // response was cut (naming the cap), hold approval, and NOT list the files as "not reviewed".
+    var ctx = contextWithLineCapOmissions(0);
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    plan.recordResponseCutFiles(List.of("cut.java"));
+
+    var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    assertEquals(1, result.omittedFiles());
+    assertTrue(result.truncated());
+    assertEquals(ReviewState.COMMENT, result.reviewState());
+    assertEquals(List.of("cut.java"), result.truncation().responseCutFileNames());
+    assertTrue(
+        result
+            .summaryMarkdown()
+            .contains(
+                "1 file(s) were only partially reviewed because the model's response was cut at"
+                    + " its length cap (max-output-tokens) — findings up to the cut were kept"
+                    + " (cut.java)"),
+        result.summaryMarkdown());
+    var checkSummary = VerdictBuilder.checkSummaryForResult(result);
+    assertTrue(
+        checkSummary.contains("1 file(s) partially reviewed (response cut at the length cap)"),
+        checkSummary);
+  }
+
+  @Test
+  void aResponseCutFileThatWasAlsoClippedIsDisclosedOnceAsPartiallyReviewed() {
+    // A clipped file's batch can also have its response cut. One file, one disclosure: the
+    // stronger (output-side) statement wins, and the file is never counted twice.
+    var ctx = contextWithLineCapOmissions(0);
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of("c.java"), true);
+    plan.recordResponseCutFiles(List.of("c.java"));
+
+    var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    assertEquals(1, result.omittedFiles());
+    assertEquals(List.of(), result.truncation().clippedFileNames());
+    assertEquals(List.of("c.java"), result.truncation().responseCutFileNames());
+    assertFalse(result.summaryMarkdown().contains("partially analyzed"), result.summaryMarkdown());
+  }
+
+  @Test
   void clippedOnlyReviewIsDisclosedAsPartialAndHoldsApproval() {
     var ctx = contextWithLineCapOmissions(0);
     var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of("huge.java"), true);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponseTruncatedExceptionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponseTruncatedExceptionTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link AiResponseTruncatedException}'s carried state and cause-chain finder. */
+class AiResponseTruncatedExceptionTest {
+
+  @Test
+  void theSingleArgumentConstructorCarriesNoBodyAndNoConciseMark() {
+    var e = new AiResponseTruncatedException("cap");
+
+    assertNull(e.partialBody());
+    assertFalse(e.conciseModelImplicated());
+  }
+
+  @Test
+  void implicatingConciseModelKeepsMessageAndBodyAndIsIdempotent() {
+    var e = new AiResponseTruncatedException("cap", "{\"findings\":[", false);
+
+    var marked = e.implicatingConciseModel();
+
+    assertTrue(marked.conciseModelImplicated());
+    assertEquals("cap", marked.getMessage());
+    assertEquals("{\"findings\":[", marked.partialBody());
+    // Already marked: no fresh copy, so the identity a caller logged stays stable.
+    assertSame(marked, marked.implicatingConciseModel());
+  }
+
+  @Test
+  void findInWalksTheCauseChainAndReturnsTheTruncation() {
+    var truncation = new AiResponseTruncatedException("cap", "body", false);
+    var wrapped = new CompletionException(new IllegalStateException("wrap", truncation));
+
+    var found = AiResponseTruncatedException.findIn(wrapped);
+
+    assertTrue(found.isPresent());
+    assertSame(truncation, found.get());
+    assertEquals("body", found.get().partialBody());
+  }
+
+  @Test
+  void findInReturnsEmptyForANonTruncationFailure() {
+    assertTrue(
+        AiResponseTruncatedException.findIn(new RuntimeException("boom", new Exception("t")))
+            .isEmpty());
+  }
+
+  @Test
+  void findInSurvivesACyclicCauseChain() {
+    // A caused-by B caused-by A: an unbounded walk would spin forever on the review thread.
+    var forward = new AtomicReference<Throwable>();
+    var a =
+        new RuntimeException("a") {
+          @Override
+          public synchronized Throwable getCause() {
+            return forward.get();
+          }
+        };
+    var b =
+        new RuntimeException("b") {
+          @Override
+          public synchronized Throwable getCause() {
+            return a;
+          }
+        };
+    forward.set(b);
+
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5), () -> assertTrue(AiResponseTruncatedException.findIn(a).isEmpty()));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewServiceTest.java
@@ -1133,6 +1133,56 @@ class AiReviewServiceTest {
                             event.type())));
   }
 
+  @Test
+  void aTruncationCarriesTheBufferedPartialBody() {
+    // #500: the streamed text received before the cut is the salvage input — well-formed JSON up
+    // to the cut point. It must travel on the typed exception; today it is buffered and then
+    // discarded, leaving the disclose step nothing to salvage from.
+    var starts = new java.util.concurrent.atomic.AtomicInteger();
+    ReviewSession session = reviewSession();
+    var partial = "{\"findings\":[{\"file\":\"A";
+    when(prReviewer.reviewStream(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString()))
+        .thenAnswer(invocation -> new TruncatedTokenStream(partial, starts));
+
+    var thrown =
+        assertThrows(
+            AiResponseTruncatedException.class, () -> service.review(session, PROMPT_INPUTS));
+
+    assertEquals(partial, thrown.partialBody());
+    assertFalse(thrown.conciseModelImplicated(), "the single-call review runs on the active model");
+  }
+
+  @Test
+  void aTruncatedSummaryImplicatesTheConciseModel() {
+    // #500 scope B: the summary call runs on the concise named model, whose cap is
+    // REVIEW_CONCISE_MAX_OUTPUT_TOKENS — downstream copy must be able to name that knob rather
+    // than only the active model's max-output-tokens.
+    var starts = new java.util.concurrent.atomic.AtomicInteger();
+    ReviewSession session = reviewSession();
+    var partial = "{\"summary\":{\"total_findings\":2,\"cri";
+    when(prSummarizer.summarizeStream(
+            anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenAnswer(invocation -> new TruncatedTokenStream(partial, starts));
+
+    var thrown =
+        assertThrows(
+            AiResponseTruncatedException.class,
+            () ->
+                service.summarize(
+                    session, new AiReviewService.SummaryInputs("ctx", "[]", "files", "", "")));
+
+    assertEquals(1, starts.get(), "no-retry must hold on the summary lane too");
+    assertTrue(thrown.conciseModelImplicated());
+    assertEquals(partial, thrown.partialBody(), "the marked copy must keep the salvage input");
+  }
+
   private static ReviewSession reviewSession() {
     var session = new ReviewSession();
     session.id = 42L;

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewServiceTest.java
@@ -1171,12 +1171,9 @@ class AiReviewServiceTest {
             anyString(), anyString(), anyString(), anyString(), anyString()))
         .thenAnswer(invocation -> new TruncatedTokenStream(partial, starts));
 
+    var inputs = new AiReviewService.SummaryInputs("ctx", "[]", "files", "", "");
     var thrown =
-        assertThrows(
-            AiResponseTruncatedException.class,
-            () ->
-                service.summarize(
-                    session, new AiReviewService.SummaryInputs("ctx", "[]", "files", "", "")));
+        assertThrows(AiResponseTruncatedException.class, () -> service.summarize(session, inputs));
 
     assertEquals(1, starts.get(), "no-retry must hold on the summary lane too");
     assertTrue(thrown.conciseModelImplicated());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvagerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvagerTest.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -278,5 +279,22 @@ class TruncatedResponseSalvagerTest {
     assertEquals(1, salvaged.findings().size());
     assertEquals(1, salvaged.previousFindingsStatus().size());
     assertTrue(salvaged.hasFindingsOrStatuses());
+  }
+
+  @Test
+  void closeQuietlyToleratesANullParser() {
+    // Reached only if createParser itself threw; the guard is contract, tested directly.
+    assertDoesNotThrow(() -> TruncatedResponseSalvager.closeQuietly(null));
+  }
+
+  @Test
+  void closeQuietlySwallowsACloseFailure() throws Exception {
+    // A string-backed parser cannot fail to close; the swallow is contract, tested directly so
+    // the finally block can never mask a salvage result with a close-time surprise.
+    var parser = org.mockito.Mockito.mock(com.fasterxml.jackson.core.JsonParser.class);
+    org.mockito.Mockito.doThrow(new java.io.IOException("boom")).when(parser).close();
+
+    assertDoesNotThrow(() -> TruncatedResponseSalvager.closeQuietly(parser));
+    org.mockito.Mockito.verify(parser).close();
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvagerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvagerTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TruncatedResponseSalvager}: the complete leading elements of a length-cut
+ * body are recovered, the trailing cut-off value is dropped, and every paranoia bound holds.
+ */
+class TruncatedResponseSalvagerTest {
+
+  private final TruncatedResponseSalvager salvager =
+      new TruncatedResponseSalvager(new ObjectMapper());
+
+  private static String finding(String title) {
+    return """
+        {"risk":"medium","confidence":"high","file":"a.java","line":3,"title":"%s",\
+        "description":"d","suggestion_old":"old","suggestion_new":"new"}"""
+        .formatted(title);
+  }
+
+  @Test
+  void keepsTheCompleteFindingsAndDropsTheCutTrailingElement() {
+    var body =
+        "{\"findings\":["
+            + finding("F1")
+            + ","
+            + finding("F2")
+            + ","
+            + finding("F3")
+            + ",{\"risk\":\"high\",\"confidence\":\"high\",\"file\":\"b.java\",\"line\":9,\"ti";
+
+    var salvaged = salvager.salvage(body);
+
+    assertEquals(3, salvaged.findings().size());
+    assertEquals("F1", salvaged.findings().get(0).title());
+    assertEquals("F3", salvaged.findings().get(2).title());
+    assertTrue(salvaged.previousFindingsStatus().isEmpty());
+    assertNull(salvaged.summary());
+    assertTrue(salvaged.hasFindingsOrStatuses());
+  }
+
+  @Test
+  void keepsTheStatusesThatClosedBeforeTheCut() {
+    var body =
+        "{\"findings\":["
+            + finding("F1")
+            + "],\"previous_findings_status\":[{\"id\":1,\"status\":\"resolved\",\"note\":\"ok\"},"
+            + "{\"id\":2,\"status\":\"unres";
+
+    var salvaged = salvager.salvage(body);
+
+    assertEquals(1, salvaged.findings().size());
+    assertEquals(1, salvaged.previousFindingsStatus().size());
+    assertEquals("resolved", salvaged.previousFindingsStatus().get(0).status());
+  }
+
+  @Test
+  void keepsTheSummaryObjectWhenItClosedBeforeTheCut() {
+    // A summary-call response cut after the summary object completed — the paid-for summary is
+    // recoverable even though the body as a whole is unparseable.
+    var body =
+        """
+        {"findings":[],"summary":{"total_findings":2,"critical":0,"high":1,"medium":1,"low":0,\
+        "overall_assessment":"solid","pr_purpose":"adds things","description_gaps":[]},\
+        "previous_findings_status":[{"id":7,"status":"resol""";
+
+    var salvaged = salvager.salvage(body);
+
+    assertNotNull(salvaged.summary());
+    assertEquals(2, salvaged.summary().totalFindings());
+    assertEquals("solid", salvaged.summary().overallAssessment());
+    assertTrue(salvaged.previousFindingsStatus().isEmpty());
+    assertFalse(salvaged.hasFindingsOrStatuses());
+  }
+
+  @Test
+  void returnsNothingWhenTheCutPrecedesTheFirstCompleteElement() {
+    var salvaged = salvager.salvage("{\"findings\":[{\"risk\":\"high\",\"confidence\":\"hi");
+
+    assertFalse(salvaged.hasFindingsOrStatuses());
+    assertNull(salvaged.summary());
+  }
+
+  @Test
+  void returnsNothingForBodiesThatCannotCarryElements() {
+    assertFalse(salvager.salvage(null).hasFindingsOrStatuses());
+    assertFalse(salvager.salvage("   ").hasFindingsOrStatuses());
+    // Prose with no JSON opener, and a root that is not an object.
+    assertFalse(
+        salvager.salvage("the model rambled instead of emitting JSON").hasFindingsOrStatuses());
+    assertFalse(salvager.salvage("[1,2").hasFindingsOrStatuses());
+  }
+
+  @Test
+  void stripsTheOpeningFenceAndLeadingProseLikeTheParserDoes() {
+    // A cut body has an opening fence but no closing one; extractJson's noise stripping must
+    // still land on the object so the elements before the cut are reachable.
+    var body = "Here is my review:\n```json\n{\"findings\":[" + finding("F1") + ",{\"risk\":\"lo";
+
+    var salvaged = salvager.salvage(body);
+
+    assertEquals(1, salvaged.findings().size());
+    assertEquals("F1", salvaged.findings().get(0).title());
+  }
+
+  @Test
+  void escapesRawControlCharactersInsideStringsLikeTheParserDoes() {
+    var body =
+        "{\"findings\":[{\"risk\":\"low\",\"confidence\":\"high\",\"file\":\"a.java\",\"line\":1,"
+            + "\"title\":\"T\",\"description\":\"has a raw\ttab\",\"suggestion_old\":\"o\","
+            + "\"suggestion_new\":\"n\"},{\"risk\":\"hi";
+
+    var salvaged = salvager.salvage(body);
+
+    assertEquals(1, salvaged.findings().size());
+    assertEquals("has a raw\ttab", salvaged.findings().get(0).description());
+  }
+
+  @Test
+  void skipsAnElementThatDoesNotMapOntoTheSchemaAndKeepsTheRest() {
+    // risk as an object cannot map onto Finding; the element is dropped individually instead of
+    // poisoning the whole salvage.
+    var body =
+        "{\"findings\":[{\"risk\":{\"nested\":true},\"file\":\"a.java\"},"
+            + finding("F2")
+            + ",{\"risk\":\"hi";
+
+    var salvaged = salvager.salvage(body);
+
+    assertEquals(1, salvaged.findings().size());
+    assertEquals("F2", salvaged.findings().get(0).title());
+  }
+
+  @Test
+  void skipsScalarArrayElementsAndKeepsTheObjects() {
+    var body = "{\"findings\":[\"not a finding\"," + finding("F2") + ",{\"risk\":\"hi";
+
+    var salvaged = salvager.salvage(body);
+
+    assertEquals(1, salvaged.findings().size());
+    assertEquals("F2", salvaged.findings().get(0).title());
+  }
+
+  @Test
+  void skipsANonArrayFindingsValueAndStillSalvagesLaterFields() {
+    // Some malformed bodies emit findings as an object; salvage keeps only the unambiguous array
+    // shape but must stay aligned and recover what follows.
+    var body =
+        "{\"findings\":{\"oops\":true},\"previous_findings_status\":"
+            + "[{\"id\":3,\"status\":\"unresolved\",\"note\":\"n\"},{\"id\":4,\"status\":\"ju";
+
+    var salvaged = salvager.salvage(body);
+
+    assertTrue(salvaged.findings().isEmpty());
+    assertEquals(1, salvaged.previousFindingsStatus().size());
+    assertEquals(3, salvaged.previousFindingsStatus().get(0).id());
+  }
+
+  @Test
+  void skipsTheObjectFormPreviousFindingsStatusConservatively() {
+    // The object-form statuses ReviewResponseParser normalizes on the complete-body path are not
+    // salvaged — a cut body's object form is ambiguous, and salvage keeps only what is provably
+    // whole. Later fields still salvage.
+    var body =
+        "{\"previous_findings_status\":{\"1\":\"resolved\"},\"findings\":["
+            + finding("F1")
+            + ",{\"risk\":\"hi";
+
+    var salvaged = salvager.salvage(body);
+
+    assertTrue(salvaged.previousFindingsStatus().isEmpty());
+    assertEquals(1, salvaged.findings().size());
+  }
+
+  @Test
+  void skipsUnknownFieldsWhole() {
+    var body = "{\"chatter\":{\"deep\":[1,2,3]},\"findings\":[" + finding("F1") + ",{\"risk\":\"hi";
+
+    var salvaged = salvager.salvage(body);
+
+    assertEquals(1, salvaged.findings().size());
+  }
+
+  @Test
+  void salvagesEverythingFromABodyThatCompletedDespiteTheLengthStop() {
+    // #508 flavor: finish_reason=length can arrive after the JSON completed. Salvage then simply
+    // recovers the whole response.
+    var body =
+        "```json\n{\"findings\":["
+            + finding("F1")
+            + "],\"previous_findings_status\":[{\"id\":1,\"status\":\"resolved\",\"note\":\"ok\"}]}\n```";
+
+    var salvaged = salvager.salvage(body);
+
+    assertEquals(1, salvaged.findings().size());
+    assertEquals(1, salvaged.previousFindingsStatus().size());
+  }
+
+  @Test
+  void capsTheElementsKeptPerArray() {
+    var sb = new StringBuilder("{\"findings\":[");
+    for (var i = 0; i <= TruncatedResponseSalvager.MAX_ELEMENTS_PER_ARRAY; i++) {
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append(finding("F" + i));
+    }
+    sb.append(
+        "],\"previous_findings_status\":[{\"id\":1,\"status\":\"resolved\",\"note\":\"n\"}]}");
+
+    var salvaged = salvager.salvage(sb.toString());
+
+    assertEquals(TruncatedResponseSalvager.MAX_ELEMENTS_PER_ARRAY, salvaged.findings().size());
+    // Runaway output: the pass stops at the cap instead of scanning the remainder, so the later
+    // field is deliberately not reached.
+    assertTrue(salvaged.previousFindingsStatus().isEmpty());
+  }
+
+  @Test
+  void refusesARunawayBodyOutright() {
+    var runaway =
+        "{\"findings\":[" + " ".repeat(TruncatedResponseSalvager.MAX_SALVAGED_BODY_CHARS) + "]";
+
+    assertFalse(salvager.salvage(runaway).hasFindingsOrStatuses());
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvagerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvagerTest.java
@@ -245,4 +245,38 @@ class TruncatedResponseSalvagerTest {
 
     assertFalse(salvager.salvage(runaway).hasFindingsOrStatuses());
   }
+
+  @Test
+  void statusesAloneMakeTheSalvageWorthDisclosing() {
+    // A body cut after the statuses but before any finding closed: findings stay empty, yet the
+    // salvage is still worth a partially-reviewed disclosure — the right-hand side of
+    // hasFindingsOrStatuses carries it.
+    var salvaged =
+        salvager.salvage(
+            """
+            {"findings": [],
+             "previous_findings_status": [{"id": 1, "status": "resolved", "note": "done"}],
+             "summary": {"total_findi""");
+
+    assertTrue(salvaged.findings().isEmpty());
+    assertEquals(1, salvaged.previousFindingsStatus().size());
+    assertTrue(salvaged.hasFindingsOrStatuses());
+  }
+
+  @Test
+  void aLengthStoppedButCompleteBodySalvagesEverythingWithoutHittingACut() {
+    // finish_reason=length does not guarantee a syntactic cut: production has produced complete
+    // JSON that still stopped on the cap. The salvage pass must run to the body's natural end —
+    // the no-IOException side of the cut handling — and keep everything.
+    var salvaged =
+        salvager.salvage(
+            """
+            {"findings": [{"risk": "low", "confidence": "low", "file": "f", "line": 1,
+              "title": "t", "description": "d"}],
+             "previous_findings_status": [{"id": 2, "status": "unresolved", "note": "n"}]}""");
+
+    assertEquals(1, salvaged.findings().size());
+    assertEquals(1, salvaged.previousFindingsStatus().size());
+    assertTrue(salvaged.hasFindingsOrStatuses());
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature

> **Stacked on #509.** Base is `feat/499-token-spend-ceiling`, not `release/v0.6.0` — both PRs touch `FindingPipeline`/`AiReviewService`, and this one builds directly on #509's counts-only summary degradation and ceiling gates. GitHub will retarget the base to `release/v0.6.0` automatically when #509 merges — but this repo squash-merges, so after that retarget this branch still carries #509's original commit and needs `git rebase --onto release/v0.6.0 9b9031e` before its own merge. **Review #509 first.**

## Description

#495 made a response truncated at `max_tokens` detected, typed, and never retried — but the batch's findings were still lost: the streaming path buffers every token the model produced before the cut, then discarded that buffer with the exception and disclosed the batch's files as "not reviewed". Capping output is supposed to trade *some* findings for bounded spend; it traded *all of that batch's* findings.

### Strategy decision: salvage the partial, not re-split-and-re-run

The issue names both candidates; this PR deliberately implements **salvage**:

1. The issue itself flags that re-splitting mid-flight duplicates `DiffBudgetPlanner`'s planning logic unless the planner grows a re-entry point — the main design hazard it calls out.
2. Re-split's extra calls would land on top of #509's brand-new spend ceiling: every re-split call would need its own gate and ledger interaction, compounding two just-shipped mechanisms.
3. Salvage recovers most of the findings for **zero extra calls** — the right trade under a spend ceiling.
4. Production evidence (#508) shows `finish_reason=length` also arrives on responses that *completed* — the tolerant partial parsing built here is the reusable half under either strategy (a completed-but-length-stopped body simply salvages whole).

Re-split remains a future option if salvage proves insufficient; nothing here forecloses it.

### What changed

- **The partial body travels with the exception.** `AiResponseTruncatedException` gains a `partialBody` (the streamed buffer, attached at the mint site in `AiReviewService.handleCompleteResponse`) and a `conciseModelImplicated` mark (`summarize` rethrows its truncations marked, since that call runs on the `concise` named model). This is the cleanest seam: the detection site already holds the buffer, the disclose site is the only consumer, and nothing about #495's no-retry classification changes — the type still short-circuits every retry layer, and the marked rethrow happens *outside* the retry loop.
- **New `review/ai/TruncatedResponseSalvager`** (deliberately a separate class — `ReviewResponseParser` is untouched, since #508 is being fixed there in parallel; the salvager *calls* the existing `extractJson` for fence/noise stripping and control-char escaping, then tokenizes with Jackson's streaming `JsonParser` — no hand-rolled string slicing). Paranoid by construction: single bounded forward pass (10M-char refusal bound over an already-cap-bounded buffer), ≤500 elements kept per array, per-element schema mapping with individual skip, any parse error ends the pass with what already closed. The trailing cut-off element is dropped by construction; only the unambiguous array form of `previous_findings_status` is salvaged.
- **Batch salvage** (`FindingPipeline.salvageTruncatedBatch`, reached from both the parallel-pass truncation branch and a truncation thrown on the sequential retry): salvaged findings/statuses run the *identical* per-batch chain as a parsed response (`refineBatchOutcome`, extracted from `processBatch` — quote validation and framework filtering against the batch's own text, verification, status scoping), then the batch's files are disclosed under a **new honest state: partially reviewed** — "the model's response was cut at its length cap; findings up to the cut were kept" — modeled alongside the existing classes (`BudgetPlan.responseCutFiles` accumulator following `recordSpendCeilingSkippedFiles`' pattern, `TruncationDetail.responseCutFileNames`, its own clause in `coverageGapClause`/`coverageGapBrief`, its own row marker in the summary overview). The files keep their walkthrough rows and their findings; approval is held (`truncated()`), like every other coverage gap. A file both hunk-clipped and response-cut is disclosed once, under the stronger output-side statement. If **nothing** salvages (cut before the first element closed, or no buffered body), behavior falls back to today's: not-reviewed disclosure via `recordUncoveredFiles`.
- **Scope addition A — a truncated summary no longer discards the paid review.** The `summarize()` call in `runMultiCall` (and in `summarizeWithoutReview`, the degenerate all-omitted path that shares the seam) now catches the truncation: if the `summary` object closed before the cut it is salvaged and used; otherwise the review degrades to **the same counts-only shape #509 built for the ceiling-tripped summary** (shared `persistWithSummary` core — no third mechanism), findings persisted, review posted, truncation disclosed in the warn log naming both caps. Batch statuses stay authoritative either way — the code-blind summary call never decides what was resolved.
- **Scope addition B — the failure notice names the cap.** `ReviewOrchestrator.handleReviewFailure` walks the cause chain via `AiResponseTruncatedException.findIn` (the bounded walk **hoisted** from `FindingPipeline.isResponseTruncated`, now shared instead of duplicated — the pipeline's ceiling walk keeps its own bound). On a truncation: the PR notice (`ReviewPublisher.postTruncationFailureNotice`) says the failure is deterministic, does **not** advise a bare `/review` retry, and names `max-output-tokens` — plus `REVIEW_CONCISE_MAX_OUTPUT_TOKENS` when the concise model made the truncated call; the FAILED check run carries a matching title/summary instead of the nulls it sent before. Every other failure keeps the generic notice and the bare check run, byte-identical.

### Constraint compliance

- **#495 no-retry:** salvage replaces the *disclose* step only. The truncation still short-circuits `runWithRetries`, still skips the sequential batch retry (`times(1)` pinned), and the summary rethrow is outside the retry loop.
- **#509 ceiling:** salvage makes no AI call, so nothing new is gated or ledgered; the ceiling classification branches are untouched and their tests unchanged. The truncation branch is checked before the ceiling branch, as before.
- **`ReviewResponseParser.java`: zero edits** (verified by diff) — salvage lives in the new class and only calls the existing package-private `extractJson`.

## Related Issues

Fixes #500

Stacked on #509 (#499). Earlier in the stack: #495 (#492), #504 (#497), #507 (#498).

## How Has This Been Tested?

- [x] Unit tests

**Red/green per behavior; red captured verbatim before the production change** (scaffolding only — exception accessors, plan/detail fields, constructor param — was in place so the tests compile; no behavior wired).

(a) truncated batch with 3 complete findings + 1 cut → salvaged through the chain, partially-reviewed disclosure (red: today the batch contributes 0 findings and the verify chain runs only for the healthy batch), plus the retry-lane variant:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.multiCallSalvagesTheCompleteFindingsFromATruncatedBatchResponse -- Time elapsed: 0.262 s <<< FAILURE!
org.mockito.exceptions.verification.TooFewActualInvocations:
findingVerificationService.verify(
    <any>,
    <any>,
    <any>,
    <any>
);
Wanted 2 times:
-> at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService.verify(FindingVerificationService.java:69)
But was 1 time:
-> at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.processBatch(FindingPipeline.java:414)

[ERROR]   FindingPipelineTest.multiCallSalvagesATruncationThrownOnTheSequentialRetry:360 expected: <4> but was: <1>
```

(b) cut mid-first-element → falls back to not-reviewed. **Green-only by necessity**: the fallback IS the pre-#500 behavior, so no assertion in `multiCallFallsBackToNotReviewedWhenTheCutPrecedesTheFirstCompleteFinding` could have failed before the change — it pins that salvage never invents a "partially reviewed" claim from an empty salvage (and it passed in the same pre-wiring run where the five tests below failed).

(c) summary truncation → findings persisted + counts-only (or salvaged) summary. Red is exactly the audit's characterization: the exception escapes `pipeline.run` (so `session.getAiResponseJson()` was never written — the assertion is unreached because the whole review is lost):

```
[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.multiCallKeepsTheFindingsWhenTheSummaryResponseIsTruncated -- Time elapsed: 0.226 s <<< ERROR!
dev.thiagogonzaga.thrillhousebot.review.ai.AiResponseTruncatedException: finish_reason=length
	at dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewService.summarize(AiReviewService.java:103)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.runMultiCall(FindingPipeline.java:355)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.runWithLedger(FindingPipeline.java:143)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.run(FindingPipeline.java:130)
[ERROR]   FindingPipelineTest.multiCallSalvagesTheSummaryObjectWhenItClosedBeforeTheCut:406 ? AiResponseTruncated finish_reason=length
[ERROR]   FindingPipelineTest.summarizeWithoutReviewDegradesToCountsOnlyWhenTheSummaryIsTruncated:427 ? AiResponseTruncated finish_reason=length
```

(d) failure notice — truncation half red (the generic notice was posted; the cap-naming assertions failed against it), generic half green-unchanged in the same run:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestratorTest.aTruncationFailurePostsTheCapNamingNoticeInsteadOfTheBareRetryAdvice -- Time elapsed: 0.553 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
?? **ThrillhouseBot review could not be completed.**

The review service encountered an error. Please reply with `/review` or `@Thrillhousebot review` to retry. ==> expected: <true> but was: <false>
[ERROR]   ReviewOrchestratorTest.aConciseModelTruncationFailureNamesTheConciseKnobToo ... ==> expected: <true> but was: <false>
[ERROR]   ReviewOrchestratorTest.aTruncationBuriedInTheCauseChainStillGetsTheCapNamingNotice ... ==> expected: <true> but was: <false>
[ERROR] Tests run: 7, Failures: 3, Errors: 0, Skipped: 0
```

Supporting seams, also red-first: the exception carrying the buffer and the concise mark —

```
[ERROR]   AiReviewServiceTest.aTruncatedSummaryImplicatesTheConciseModel:1182 expected: <true> but was: <false>
[ERROR]   AiReviewServiceTest.aTruncationCarriesTheBufferedPartialBody:1158 expected: <{"findings":[{"file":"A> but was: <null>
```

— and the verdict folding the new class into the disclosure:

```
[ERROR]   VerdictBuilderTest.aResponseCutFileThatWasAlsoClippedIsDisclosedOnceAsPartiallyReviewed:261 expected: <[]> but was: <[c.java]>
[ERROR]   VerdictBuilderTest.responseCutFilesAreDisclosedAsPartiallyReviewedAndHoldApproval:232 expected: <1> but was: <0>
```

New-machinery tests (green from creation, no red possible for a new pure class): `TruncatedResponseSalvagerTest` (15 cases — complete-element keep / trailing-cut drop, statuses, summary object, fence + control-char reuse of `extractJson`, non-object roots, object-form statuses skipped conservatively, malformed/scalar element skip, element cap, runaway-body refusal, completed-body #508 flavor) and `AiResponseTruncatedExceptionTest` (carried state, `findIn` walk incl. cyclic-chain bound).

Gates on the final tree:

- `./mvnw spotless:apply` / check — clean
- `./mvnw verify` — SpotBugs **BugInstance size is 0**, jacoco checks met, BUILD SUCCESS
- `./mvnw verify` test total — **Tests run: 2537, Failures: 0, Errors: 0, Skipped: 0** (baseline 2497 at `origin/feat/499-token-spend-ceiling` + 40 new)
- Patch coverage (`jacoco.xml` ∩ `git diff origin/feat/499-token-spend-ceiling` added lines in `src/main/java`, 8 files): **0 uncovered added executable lines**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Salvage log line: `Batch %d/%d hit the model's response-length cap; not retrying — salvaged %d complete finding(s) and %d status(es) from the partial response and disclosing its files as partially reviewed`. User-visible disclosure clause: `N file(s) were only partially reviewed because the model's response was cut at its length cap (max-output-tokens) — findings up to the cut were kept (…)`; check-run brief: `N file(s) partially reviewed (response cut at the length cap)`. Truncation failure notice: names `finish_reason=length`, `max-output-tokens`, and (when the concise model is implicated) `REVIEW_CONCISE_MAX_OUTPUT_TOKENS`, and explicitly does not advise a bare retry.

## Additional Notes

- **No new configuration** — salvage is unconditional behavior. The issue floated "configurable if the strategies differ in cost"; salvage costs zero extra calls, so there is no cost dimension for an operator to pick between, and a knob would only add a way to turn honesty off. README/`.env.example`/`application.properties` therefore untouched.
- **Deviations from a literal issue reading:** the issue's "bound the recovery" concern is met structurally (salvage makes no calls, so a repeatedly-truncating batch costs exactly one call per review — #495's guarantee); the salvager's bounds cap the parsing work itself.
- Reviewer scrutiny suggestions: (1) salvaged "resolved" statuses are trusted through the normal `scopeStatusesToBatch` scoping — the batch saw its full input slice; the cut was on output, and only elements that closed are kept — but a reviewer may prefer demoting closing claims from cut responses entirely; (2) the "partially reviewed" class deliberately does *not* join `effectiveOmittedFiles`, so salvaged files keep their walkthrough rows — check the disclosure surfaces read right in combination (banner + overview marker + check-run brief); (3) `Salvaged.hasFindingsOrStatuses()` is the salvage-success predicate — a body whose `findings` array closed cleanly *empty* before the cut falls back to not-reviewed (conservative; arguably it proves "no findings up to the cut"); (4) the concise mark is only minted in `summarize` — after this PR no concise-lane truncation should reach `handleReviewFailure` at all (they all degrade), so the mark is defense-in-depth for future propagation paths; (5) the element cap stops the whole salvage pass (later fields are not scanned) rather than draining the runaway array.