### PR TITLE
fix(review): disclose a summary-response cut in the posted review

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -93,7 +93,8 @@ public class DiffBudgetPlanner {
       boolean budgeted,
       List<String> runtimeUncoveredFiles,
       List<String> spendCeilingSkippedFiles,
-      List<String> responseCutFiles) {
+      List<String> responseCutFiles,
+      java.util.concurrent.atomic.AtomicBoolean summaryResponseCut) {
     public BudgetPlan {
       batches = List.copyOf(batches);
       omittedFiles = List.copyOf(omittedFiles);
@@ -107,6 +108,20 @@ public class DiffBudgetPlanner {
               ? new CopyOnWriteArrayList<>()
               : spendCeilingSkippedFiles;
       responseCutFiles = responseCutFiles == null ? new CopyOnWriteArrayList<>() : responseCutFiles;
+      summaryResponseCut =
+          summaryResponseCut == null
+              ? new java.util.concurrent.atomic.AtomicBoolean(false)
+              : summaryResponseCut;
+    }
+
+    /** Marks the review's summary response as cut at the model's length cap (#500 scope A). */
+    void recordSummaryResponseCut() {
+      summaryResponseCut.set(true);
+    }
+
+    /** Whether the summary response was cut — salvaged or degraded, the disclosure names it. */
+    public boolean summaryWasCut() {
+      return summaryResponseCut.get();
     }
 
     /**
@@ -151,7 +166,28 @@ public class DiffBudgetPlanner {
           budgeted,
           runtimeUncoveredFiles,
           spendCeilingSkippedFiles,
-          new CopyOnWriteArrayList<>());
+          new CopyOnWriteArrayList<>(),
+          null);
+    }
+
+    /** Back-compat convenience predating {@code summaryResponseCut}; starts it unset. */
+    public BudgetPlan(
+        List<DiffBatch> batches,
+        List<String> omittedFiles,
+        List<String> clippedFiles,
+        boolean budgeted,
+        List<String> runtimeUncoveredFiles,
+        List<String> spendCeilingSkippedFiles,
+        List<String> responseCutFiles) {
+      this(
+          batches,
+          omittedFiles,
+          clippedFiles,
+          budgeted,
+          runtimeUncoveredFiles,
+          spendCeilingSkippedFiles,
+          responseCutFiles,
+          null);
     }
 
     /** Defensive copy: the mutable runtime-gap backing must never escape the plan. */
@@ -170,6 +206,15 @@ public class DiffBudgetPlanner {
     @Override
     public List<String> responseCutFiles() {
       return List.copyOf(responseCutFiles);
+    }
+
+    /**
+     * Defensive snapshot, like {@link #runtimeUncoveredFiles()}: the live flag is only written
+     * through {@link #recordSummaryResponseCut()} and read through {@link #summaryWasCut()}.
+     */
+    @Override
+    public java.util.concurrent.atomic.AtomicBoolean summaryResponseCut() {
+      return new java.util.concurrent.atomic.AtomicBoolean(summaryResponseCut.get());
     }
 
     /** Records files a batch left unreviewed at runtime, ignoring nulls and duplicates. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -293,7 +293,7 @@ public class FindingPipeline {
       // truncated summary would discard exactly the paid work #495 preserved on the batch lane —
       // salvage the summary object if it closed before the cut, else degrade to the same
       // counts-only shape as the ceiling-tripped path above. Never re-enters the retry lane.
-      return salvagedOrCountsOnlySummary(session, refined, e);
+      return salvagedOrCountsOnlySummary(session, refined, plan, e);
     }
 
     var merged =
@@ -328,11 +328,17 @@ public class FindingPipeline {
    * if the summary object closed before the cut it is salvaged and used as-is; otherwise the review
    * keeps its paid findings with the {@link #countsOnlySummary counts-only} shape. Either way the
    * truncation is disclosed in the log with the caps that apply — the summary call runs on the
-   * concise model, so both knobs are named. Statuses are never taken from the salvage: the
-   * code-blind summary call must not decide what was resolved (same rule as the parsed path).
+   * concise model, so both knobs are named — and recorded on the plan so the posted review carries
+   * the same disclosure instead of leaving it log-only (the sibling spend-ceiling degradation of
+   * this lane already discloses itself). Statuses are never taken from the salvage: the code-blind
+   * summary call must not decide what was resolved (same rule as the parsed path).
    */
   private ReviewResponse salvagedOrCountsOnlySummary(
-      ReviewSession session, ReviewResponse refined, AiResponseTruncatedException truncation) {
+      ReviewSession session,
+      ReviewResponse refined,
+      DiffBudgetPlanner.BudgetPlan plan,
+      AiResponseTruncatedException truncation) {
+    plan.recordSummaryResponseCut();
     var salvagedSummary = salvager.salvage(truncation.partialBody()).summary();
     if (salvagedSummary != null) {
       Log.warnf(
@@ -619,7 +625,7 @@ public class FindingPipeline {
       // by construction, but the review must still post with its omission disclosures rather than
       // fail on a deterministic truncation.
       return salvagedOrCountsOnlySummary(
-          session, new ReviewResponse(List.of(), List.of(), null), e);
+          session, new ReviewResponse(List.of(), List.of(), null), plan, e);
     }
     var merged = new ReviewResponse(List.of(), List.of(), summaryResponse.summary());
     persistAiResponse(session, merged);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -125,18 +125,21 @@ public record ReviewResult(
    * call skipped because the review's token spend ceiling ({@code REVIEW_MAX_TOKENS_PER_REVIEW})
    * was reached — a different reason with a different fix, so the rendered copy names it separately
    * — and {@code responseCutFileNames} were only partially reviewed because the model's response
-   * was cut at its length cap and the findings up to the cut were kept (#500). All empty on the
-   * legacy line-cap path, where only a count is known — the rendered copy then falls back to the
-   * numeric clause.
+   * was cut at its length cap and the findings up to the cut were kept (#500). {@code
+   * summaryResponseCut} marks the same length-cap cut on the summary call: the findings are
+   * complete, but the prose summary was salvaged from a cut response or replaced by the counts-only
+   * fallback. All empty on the legacy line-cap path, where only a count is known — the rendered
+   * copy then falls back to the numeric clause.
    */
   @RegisterForReflection
   public record TruncationDetail(
       List<String> omittedFileNames,
       List<String> clippedFileNames,
       List<String> spendCeilingSkippedFileNames,
-      List<String> responseCutFileNames) {
+      List<String> responseCutFileNames,
+      boolean summaryResponseCut) {
     public static final TruncationDetail EMPTY =
-        new TruncationDetail(List.of(), List.of(), List.of(), List.of());
+        new TruncationDetail(List.of(), List.of(), List.of(), List.of(), false);
 
     public TruncationDetail {
       omittedFileNames = omittedFileNames == null ? List.of() : List.copyOf(omittedFileNames);
@@ -151,7 +154,7 @@ public record ReviewResult(
 
     /** Convenience for the token-budget-only surfaces, which have no spend-ceiling skips. */
     public TruncationDetail(List<String> omittedFileNames, List<String> clippedFileNames) {
-      this(omittedFileNames, clippedFileNames, List.of(), List.of());
+      this(omittedFileNames, clippedFileNames, List.of(), List.of(), false);
     }
 
     /** Back-compat convenience predating {@code responseCutFileNames}; starts it empty. */
@@ -159,14 +162,29 @@ public record ReviewResult(
         List<String> omittedFileNames,
         List<String> clippedFileNames,
         List<String> spendCeilingSkippedFileNames) {
-      this(omittedFileNames, clippedFileNames, spendCeilingSkippedFileNames, List.of());
+      this(omittedFileNames, clippedFileNames, spendCeilingSkippedFileNames, List.of(), false);
+    }
+
+    /** Back-compat convenience predating {@code summaryResponseCut}; starts it unset. */
+    public TruncationDetail(
+        List<String> omittedFileNames,
+        List<String> clippedFileNames,
+        List<String> spendCeilingSkippedFileNames,
+        List<String> responseCutFileNames) {
+      this(
+          omittedFileNames,
+          clippedFileNames,
+          spendCeilingSkippedFileNames,
+          responseCutFileNames,
+          false);
     }
 
     public boolean isEmpty() {
       return omittedFileNames.isEmpty()
           && clippedFileNames.isEmpty()
           && spendCeilingSkippedFileNames.isEmpty()
-          && responseCutFileNames.isEmpty();
+          && responseCutFileNames.isEmpty()
+          && !summaryResponseCut;
     }
   }
 
@@ -282,6 +300,22 @@ public record ReviewResult(
   static final String TRUNCATION_NOTICE_LEAD_IN = "> ⚠️ **Large PR — partial review.**";
 
   /**
+   * Banner prepended to the summary when only the summary response was cut at the model's length
+   * cap — no file-coverage gap exists, so the partial-review banner (whose framing says the
+   * findings cover only part of the diff) would overstate the damage: here the findings are
+   * complete and only the prose summary was salvaged or degraded. When a file-coverage gap exists
+   * too, {@link #coverageGapClause(int, TruncationDetail)} folds the summary cut in as one more
+   * clause instead and this banner is not used.
+   */
+  static final String SUMMARY_CUT_NOTICE =
+      """
+      > ⚠️ **Summary shortened.** The model's summary response was cut at its length cap\
+       (max-output-tokens / REVIEW_CONCISE_MAX_OUTPUT_TOKENS) — the findings themselves are\
+       complete.
+
+      """;
+
+  /**
    * The shared "N file(s) were omitted …" clause, so the review banner and the on-demand-command
    * disclosure never drift on the omitted count and the reason — only the surrounding framing
    * differs between the two surfaces.
@@ -363,6 +397,16 @@ public record ReviewResult(
                   + " its length cap (max-output-tokens) — findings up to the cut were kept (%s)",
               detail.responseCutFileNames().size(), nameList(detail.responseCutFileNames())));
     }
+    // The summary-cut class affects prose, not findings: the findings are complete, but the
+    // summary call's response hit the same length cap and was salvaged (or replaced by the
+    // counts-only fallback) — the sibling spend-ceiling degradation of the same lane already
+    // discloses itself, so staying silent here would make the two lanes inconsistent.
+    if (detail.summaryResponseCut()) {
+      clauses.add(
+          "the summary was shortened because the model's response was cut at its length cap"
+              + " (max-output-tokens / REVIEW_CONCISE_MAX_OUTPUT_TOKENS) — the findings themselves"
+              + " are complete");
+    }
     return String.join(", and ", clauses);
   }
 
@@ -399,6 +443,9 @@ public record ReviewResult(
           String.format(
               "%d file(s) partially reviewed (response cut at the length cap)",
               truncation.responseCutFileNames().size()));
+    }
+    if (truncation.summaryResponseCut()) {
+      parts.add("summary shortened (response cut at the length cap)");
     }
     return String.join(", ", parts);
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -132,7 +132,8 @@ public class VerdictBuilder {
                 withoutNames(plan.effectiveOmittedFiles(), ceilingSkipped),
                 clipped,
                 ceilingSkipped,
-                responseCut)
+                responseCut,
+                plan.summaryWasCut())
             : ReviewResult.TruncationDetail.EMPTY;
     var omitted =
         plan.budgeted()
@@ -227,12 +228,7 @@ public class VerdictBuilder {
   }
 
   static String checkSummaryForResult(ReviewResult result) {
-    var truncationSuffix =
-        result.truncated()
-            ? " The diff was also too large to review in full ("
-                + result.coverageGapBrief()
-                + ") — partial review."
-            : "";
+    var truncationSuffix = truncationSuffixFor(result);
     if (result.hasIssues()) {
       return String.format(
               "%d findings: %d critical, %d high, %d medium, %d low",
@@ -282,9 +278,26 @@ public class VerdictBuilder {
     }
     var unresolved = result.unresolvedPreviousCount();
     if (unresolved == 0) {
-      return PrSummaryGenerator.ZERO_ISSUES_MESSAGE;
+      return PrSummaryGenerator.ZERO_ISSUES_MESSAGE + truncationSuffix;
     }
-    return ReviewResult.unresolvedPreviousMessage(unresolved);
+    return ReviewResult.unresolvedPreviousMessage(unresolved) + truncationSuffix;
+  }
+
+  /**
+   * The coverage suffix of the check-run summary: the partial-review brief when file coverage was
+   * truncated (that brief already folds a summary cut in as one of its counts), the summary-only
+   * marker when just the summary response was cut, empty otherwise.
+   */
+  private static String truncationSuffixFor(ReviewResult result) {
+    if (result.truncated()) {
+      return " The diff was also too large to review in full ("
+          + result.coverageGapBrief()
+          + ") — partial review.";
+    }
+    if (result.truncation().summaryResponseCut()) {
+      return " The summary was shortened (response cut at the length cap).";
+    }
+    return "";
   }
 
   record DiffStats(
@@ -512,6 +525,11 @@ public class VerdictBuilder {
       summaryMarkdown =
           ReviewResult.truncationNotice(diffStats.omittedFiles(), diffStats.truncation())
               + summaryMarkdown;
+    } else if (diffStats.truncation().summaryResponseCut()) {
+      // Summary-only cut: the findings are complete, so the partial-review banner (and the
+      // approval hold that goes with file gaps) would overstate it — a dedicated banner names
+      // the cut without holding the verdict.
+      summaryMarkdown = ReviewResult.SUMMARY_CUT_NOTICE + summaryMarkdown;
     }
 
     return new ReviewResult(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -17,6 +17,7 @@ package dev.thiagogonzaga.thrillhousebot.review;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
@@ -386,6 +387,37 @@ class DiffBudgetPlannerTest {
     plan.recordResponseCutFiles(List.of("src/Cut.java"));
 
     assertEquals(List.of("src/Cut.java"), plan.responseCutFiles());
+  }
+
+  @Test
+  void summaryCutFlagIsRecordedLiveButItsAccessorReturnsASnapshot() {
+    // #500 scope A: the flag rides the shared plan like the runtime-gap lists — written after the
+    // plan is built, read by the verdict — and, like them, its record accessor must not leak the
+    // mutable backing.
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    assertFalse(plan.summaryWasCut());
+
+    plan.recordSummaryResponseCut();
+
+    assertTrue(plan.summaryWasCut());
+    assertFalse(plan.truncated(), "a summary cut is not a coverage gap and must not hold approval");
+    var snapshot = plan.summaryResponseCut();
+    snapshot.set(false);
+    assertTrue(plan.summaryWasCut(), "mutating the snapshot must not touch the live flag");
+  }
+
+  @Test
+  void aPlanBuiltWithItsOwnSummaryCutFlagKeepsThatInstanceLive() {
+    var live = new java.util.concurrent.atomic.AtomicBoolean(true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, live);
+
+    assertTrue(plan.summaryWasCut());
+    assertNotSame(live, plan.summaryResponseCut(), "the accessor returns a defensive snapshot");
+
+    live.set(false);
+    assertFalse(plan.summaryWasCut(), "the passed-in flag stays the live backing");
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -298,6 +298,8 @@ class FindingPipelineTest {
     assertEquals(List.of("a.java"), plan.responseCutFiles());
     assertTrue(plan.runtimeUncoveredFiles().isEmpty());
     assertTrue(plan.truncated());
+    assertFalse(
+        plan.summaryWasCut(), "a batch cut is not a summary cut — the classes are disjoint");
     var changedFiles = captor.getValue().changedFiles();
     assertTrue(changedFiles.contains("a.java (modified"), changedFiles);
     assertTrue(
@@ -377,13 +379,16 @@ class FindingPipelineTest {
     when(aiReviewService.summarize(eq(session), any()))
         .thenThrow(new AiResponseTruncatedException("finish_reason=length", "{\"summ", true));
 
-    var result =
-        pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+    var plan = multiBatchPlan();
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
 
     verify(aiReviewService, times(1)).summarize(eq(session), any());
     assertEquals(2, result.findings().size());
     assertNull(result.summary());
     assertNotNull(session.getAiResponseJson(), "the paid findings must still be persisted");
+    assertTrue(
+        plan.summaryWasCut(),
+        "the summary cut must be recorded on the plan so the posted review discloses it");
   }
 
   @Test
@@ -402,13 +407,16 @@ class FindingPipelineTest {
     when(aiReviewService.summarize(eq(session), any()))
         .thenThrow(new AiResponseTruncatedException("finish_reason=length", partial, true));
 
-    var result =
-        pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+    var plan = multiBatchPlan();
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
 
     assertEquals(2, result.findings().size());
     assertNotNull(result.summary());
     assertEquals("solid", result.summary().overallAssessment());
     assertNotNull(session.getAiResponseJson());
+    assertTrue(
+        plan.summaryWasCut(),
+        "a salvaged summary is still a shortened one — the cut must be recorded for disclosure");
   }
 
   @Test
@@ -429,6 +437,7 @@ class FindingPipelineTest {
     assertTrue(result.findings().isEmpty());
     assertNull(result.summary());
     assertNotNull(session.getAiResponseJson());
+    assertTrue(plan.summaryWasCut(), "the degenerate path records the summary cut on the plan too");
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -327,6 +327,64 @@ class ReviewResultTest {
   }
 
   @Test
+  void coverageGapClauseNamesTheSummaryCutAlongsideFileGaps() {
+    // #500 scope A: when the summary call's response was cut too, the clause must say so in the
+    // posted review — naming both knobs (the summary runs on the concise model) and making clear
+    // the findings themselves are complete — instead of leaving the cut log-only while the
+    // sibling ceiling degradation of the same lane discloses itself.
+    var detail =
+        new ReviewResult.TruncationDetail(List.of("a.java"), List.of(), List.of(), List.of(), true);
+
+    var clause = ReviewResult.coverageGapClause(1, detail);
+
+    assertTrue(clause.contains("1 file(s) were omitted entirely (a.java)"), clause);
+    assertTrue(
+        clause.contains(
+            "the summary was shortened because the model's response was cut at its length cap"
+                + " (max-output-tokens / REVIEW_CONCISE_MAX_OUTPUT_TOKENS) — the findings"
+                + " themselves are complete"),
+        clause);
+  }
+
+  @Test
+  void coverageGapBriefMarksTheSummaryCut() {
+    var result =
+        new ReviewResult(
+            List.of(),
+            0,
+            0,
+            0,
+            0,
+            null,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            1,
+            false,
+            true,
+            new ReviewResult.TruncationDetail(
+                List.of("a.java"), List.of(), List.of(), List.of(), true));
+
+    var brief = result.coverageGapBrief();
+
+    assertTrue(brief.contains("1 file(s) omitted"), brief);
+    assertTrue(brief.contains("summary shortened (response cut at the length cap)"), brief);
+  }
+
+  @Test
+  void truncationDetailWithOnlyTheSummaryCutIsNotEmpty() {
+    var detail =
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true);
+    assertFalse(detail.isEmpty());
+    // The four-list convenience constructor keeps the pre-summary-cut shape: flag unset.
+    assertFalse(
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of())
+            .summaryResponseCut());
+  }
+
+  @Test
   void truncationDetailWithOnlySpendCeilingSkipsIsNotEmpty() {
     var detail = new ReviewResult.TruncationDetail(List.of(), List.of(), List.of("c.java"));
     assertFalse(detail.isEmpty());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -264,6 +264,89 @@ class VerdictBuilderTest {
   }
 
   @Test
+  void aSummaryOnlyCutIsDisclosedWithoutHoldingApproval() {
+    // #500 scope A: the summary call's response was cut but every batch succeeded — the findings
+    // are complete, so approval must not be held, but the posted review must say the summary was
+    // shortened (naming both knobs) instead of leaving the cut log-only.
+    var ctx = contextWithLineCapOmissions(0);
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    plan.recordSummaryResponseCut();
+
+    var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    assertEquals(0, result.omittedFiles());
+    assertFalse(result.truncated());
+    assertEquals(ReviewState.APPROVE, result.reviewState());
+    assertTrue(result.truncation().summaryResponseCut());
+    assertTrue(
+        result.summaryMarkdown().contains("**Summary shortened.**"), result.summaryMarkdown());
+    assertTrue(
+        result.summaryMarkdown().contains("REVIEW_CONCISE_MAX_OUTPUT_TOKENS"),
+        result.summaryMarkdown());
+    // The partial-review banner's framing (findings cover only part of the diff) would overstate
+    // a summary-only cut.
+    assertFalse(result.summaryMarkdown().contains("partial review"), result.summaryMarkdown());
+    var checkSummary = VerdictBuilder.checkSummaryForResult(result);
+    assertTrue(
+        checkSummary.contains("The summary was shortened (response cut at the length cap)."),
+        checkSummary);
+  }
+
+  @Test
+  void aSummaryCutAlongsideFileGapsFoldsIntoTheCoverageClause() {
+    // With a real file gap present the partial-review banner renders anyway, so the summary cut
+    // becomes one more clause there — the dedicated summary-only banner must not stack on top.
+    var ctx = contextWithLineCapOmissions(0);
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of("big.java"), List.of(), true);
+    plan.recordSummaryResponseCut();
+
+    var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    assertTrue(result.truncated());
+    assertEquals(ReviewState.COMMENT, result.reviewState());
+    assertTrue(
+        result
+            .summaryMarkdown()
+            .contains("the summary was shortened because the model's response was cut"),
+        result.summaryMarkdown());
+    assertFalse(
+        result.summaryMarkdown().contains("**Summary shortened.**"), result.summaryMarkdown());
+    var checkSummary = VerdictBuilder.checkSummaryForResult(result);
+    assertTrue(
+        checkSummary.contains("summary shortened (response cut at the length cap)"), checkSummary);
+  }
+
+  @Test
+  void checkSummaryKeepsTheSummaryCutMarkerWhenFindingsArePresent() {
+    // The findings-present branch shares the same suffix as the no-issues branches: a review with
+    // findings whose summary response was cut must still carry the marker in the check run.
+    var result =
+        new ReviewResult(
+            List.of(new Finding(RiskLevel.LOW, "f.java", 1, "T", "d", null, null)),
+            0,
+            0,
+            0,
+            1,
+            RiskLevel.LOW,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0,
+            false,
+            true,
+            new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true));
+
+    var checkSummary = VerdictBuilder.checkSummaryForResult(result);
+
+    assertTrue(checkSummary.contains("1 findings"), checkSummary);
+    assertTrue(
+        checkSummary.contains("The summary was shortened (response cut at the length cap)."),
+        checkSummary);
+  }
+
+  @Test
   void clippedOnlyReviewIsDisclosedAsPartialAndHoldsApproval() {
     var ctx = contextWithLineCapOmissions(0);
     var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of("huge.java"), true);


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Follow-up to #511. The spend-ceiling degradation of the summary lane discloses itself in the posted review, but the length-cap truncation of the same lane was log-only — two sibling degradations of one lane, one visible, one mute.

- `BudgetPlan` gains a live `summaryResponseCut` flag (same shared-accumulator pattern as the runtime-gap lists, with a defensive-snapshot accessor); `FindingPipeline` records it in both branches of `salvagedOrCountsOnlySummary`, including the degenerate `summarizeWithoutReview` path.
- `ReviewResult.TruncationDetail` gains a matching fifth component (back-compat constructors keep the old shapes). With file-coverage gaps present the cut folds into the partial-review clause, naming both knobs (`max-output-tokens` / `REVIEW_CONCISE_MAX_OUTPUT_TOKENS`); with no file gap a dedicated "Summary shortened" banner renders instead and does **not** hold approval, since the findings themselves are complete. The check-run summary carries the matching brief marker on every return path, including reviews with findings.
- The check-run suffix derivation is extracted into `truncationSuffixFor` and the banner constant becomes a text block, keeping `checkSummaryForResult` under Sonar's complexity gate with no nested ternary.

## Related Issues

Refs #500 (follow-up; the issue itself was closed by #511)

## How Has This Been Tested?

- [x] Unit tests

Red/green proven: with the wiring stashed out, all five new behavioral tests fail on exactly the new assertions (flag not recorded, banner absent, clause absent); with the wiring in place the full suite passes (2566 tests, 0 failures). Jacoco ∩ diff shows every changed line and branch covered. SpotBugs and Spotless are clean. The text-block conversion was verified character-identical to the previous concatenation.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Summary-only cut, posted review banner:

> ⚠️ **Summary shortened.** The model's summary response was cut at its length cap (max-output-tokens / REVIEW_CONCISE_MAX_OUTPUT_TOKENS) — the findings themselves are complete.

Combined with file gaps, one clause of the partial-review banner:

> …, and the summary was shortened because the model's response was cut at its length cap (max-output-tokens / REVIEW_CONCISE_MAX_OUTPUT_TOKENS) — the findings themselves are complete

## Additional Notes

A summary-only cut deliberately does not hold approval: the findings are complete, so downgrading APPROVE would punish a prose-only degradation. File-gap classes keep holding approval exactly as before.

An earlier revision of this description claimed the #511-round Sonar cleanups (`retryBatch` extraction, unnamed catch variable, `assertThrows` hoists) were part of this diff — they were not; they landed with #511's squash. Credit to the bot review for catching the drift.