### PR TITLE
fix(config): hold the concise response cap to the shared-window reservation

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -342,6 +342,14 @@ public class StartupConfigValidator {
    * and reply calls — #498) at boot, the same fail-fast contract as the other budget keys. Empty is
    * allowed: an operator who clears {@code REVIEW_CONCISE_MAX_OUTPUT_TOKENS} drops the cap and the
    * provider default applies.
+   *
+   * <p>On a shared-window active model the concise cap is also held to the same reservation rule as
+   * the active model's own response cap ({@link #validateEffectiveBudget}): the concise calls spend
+   * their {@code max_tokens} out of the same window the budgeter packed the prompt into with only
+   * {@code reservedOutputTokens} held back, so licensing more output than was reserved overruns the
+   * window just as surely from this knob (#517). Not applied when token budgeting is off (no packed
+   * prompt to overrun) or when the active model declares {@code separate-output-budget} (nothing is
+   * reserved, and the response never draws on the window).
    */
   private void validateConciseResponseCap(List<String> problems) {
     conciseMaxOutputTokens
@@ -352,6 +360,29 @@ public class StartupConfigValidator {
                     "REVIEW_CONCISE_MAX_OUTPUT_TOKENS must be >= 1"
                         + " (quarkus.langchain4j.openai.concise.chat-model.max-tokens): "
                         + v));
+    if (activeModel.maxInputTokens() > 0 && !activeModel.separateOutputBudget()) {
+      var outputBuffer = activeModel.reservedOutputTokens();
+      conciseMaxOutputTokens
+          .filter(v -> v > outputBuffer)
+          .ifPresent(
+              v ->
+                  problems.add(
+                      "the effective output buffer ("
+                          + outputBuffer
+                          + ") must be >= REVIEW_CONCISE_MAX_OUTPUT_TOKENS ("
+                          + v
+                          + ", quarkus.langchain4j.openai.concise.chat-model.max-tokens) for model"
+                          + " '"
+                          + activeModel.modelName()
+                          + "' so the token budget reserves the response cap the"
+                          + " summary/verifier/reply calls send. Lower"
+                          + " REVIEW_CONCISE_MAX_OUTPUT_TOKENS, raise"
+                          + " REVIEW_OUTPUT_BUFFER_TOKENS to cover it, or set"
+                          + " thrillhousebot.ai.models.\""
+                          + activeModel.modelName()
+                          + "\".separate-output-budget=true if this model's response allowance is"
+                          + " independent of its input window."));
+    }
   }
 
   /**

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -15,12 +15,19 @@
  */
 package dev.thiagogonzaga.thrillhousebot.config;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.WithName;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -160,6 +167,11 @@ class StartupConfigValidatorTest {
 
     ConfigBuilder conciseMaxOutputTokens(Optional<Integer> v) {
       this.conciseMaxOutputTokens = v;
+      return this;
+    }
+
+    ConfigBuilder modelName(String v) {
+      this.modelName = v;
       return this;
     }
 
@@ -332,6 +344,70 @@ class StartupConfigValidatorTest {
     // An operator may clear REVIEW_CONCISE_MAX_OUTPUT_TOKENS (empty value) so the concise calls
     // fall back to the provider default; absence is not a misconfiguration.
     new ConfigBuilder().conciseMaxOutputTokens(Optional.empty()).build().validate();
+  }
+
+  @Test
+  void failsFastWhenTheConciseCapExceedsTheBufferOnASharedWindow() {
+    // #517: post-#507 the summary/verifier/reply calls send REVIEW_CONCISE_MAX_OUTPUT_TOKENS as
+    // max_tokens against the same shared window the budgeter packed to budget - buffer, so the
+    // concise cap is held to the same reservation rule as the active model's own response cap:
+    // 384000 on the active cap refuses boot, and the identical value on the concise cap must too.
+    var ex =
+        assertFailsValidation(
+            new ConfigBuilder().conciseMaxOutputTokens(Optional.of(384_000)).build());
+    assertTrue(
+        ex.getMessage()
+            .contains(
+                "effective output buffer (8192) must be >= REVIEW_CONCISE_MAX_OUTPUT_TOKENS"
+                    + " (384000"),
+        ex.getMessage());
+    // The message has to hand the operator every way out, in the active-model rule's style.
+    assertTrue(ex.getMessage().contains("REVIEW_OUTPUT_BUFFER_TOKENS"), ex.getMessage());
+    assertTrue(
+        ex.getMessage()
+            .contains("thrillhousebot.ai.models.\"deepseek-chat\".separate-output-budget=true"),
+        "the failure must point at the escape hatch: " + ex.getMessage());
+  }
+
+  @Test
+  void allowsAConciseCapAboveTheBufferWhenTheOutputBudgetIsSeparate() {
+    // On a separate-output-budget model nothing is reserved out of the window for responses, so
+    // the shared-window rule does not apply to the concise cap either — the deepseek-v4-flash
+    // shape (384000 out against an 8192 buffer) must keep booting.
+    var settings = emptyModelSettings();
+    lenient().when(settings.maxInputTokens()).thenReturn(Optional.of(1_000_000));
+    lenient().when(settings.separateOutputBudget()).thenReturn(Optional.of(true));
+
+    new ConfigBuilder()
+        .model("deepseek-chat", settings)
+        .conciseMaxOutputTokens(Optional.of(384_000))
+        .build()
+        .validate();
+  }
+
+  @Test
+  void allowsAConciseCapAboveTheBufferWhenTokenBudgetingIsDisabled() {
+    // With budgeting off there is no packed prompt to overrun, so — exactly like the active-model
+    // rule — the concise reservation check does not apply.
+    new ConfigBuilder()
+        .maxInputTokens(0)
+        .conciseMaxOutputTokens(Optional.of(384_000))
+        .build()
+        .validate();
+  }
+
+  @Test
+  void holdsTheConciseCapToTheActiveModelsEffectiveBuffer() {
+    // The reservation the rule compares against is the active model's resolved buffer — a
+    // per-model output-buffer override that covers the concise cap must boot.
+    var settings = emptyModelSettings();
+    lenient().when(settings.outputBufferTokens()).thenReturn(Optional.of(16_384));
+
+    new ConfigBuilder()
+        .model("deepseek-chat", settings)
+        .conciseMaxOutputTokens(Optional.of(16_384))
+        .build()
+        .validate();
   }
 
   @Test
@@ -515,7 +591,13 @@ class StartupConfigValidatorTest {
     lenient().when(settings.frequencyPenalty()).thenReturn(Optional.of(-2.0));
     lenient().when(settings.presencePenalty()).thenReturn(Optional.of(2.0));
     lenient().when(settings.seed()).thenReturn(Optional.of(42));
-    new ConfigBuilder().model("deepseek-chat", settings).build().validate();
+    // The 4096 buffer override shrinks the shared-window reservation, so the concise cap must fit
+    // inside it too (#517) — this test's subject is the per-model entry, not that rule.
+    new ConfigBuilder()
+        .conciseMaxOutputTokens(Optional.of(4_096))
+        .model("deepseek-chat", settings)
+        .build()
+        .validate();
   }
 
   @Test
@@ -534,8 +616,11 @@ class StartupConfigValidatorTest {
     // override restores headroom, so the boot must succeed.
     var settings = emptyModelSettings();
     lenient().when(settings.outputBufferTokens()).thenReturn(Optional.of(1_000));
+    // The 1000 buffer override also shrinks the shared-window reservation below the default
+    // concise cap, so the cap is lowered with it (#517) — this test pins the repair, not that rule.
     new ConfigBuilder()
         .outputBufferTokens(45_000)
+        .conciseMaxOutputTokens(Optional.of(1_000))
         .model("deepseek-chat", settings)
         .build()
         .validate();
@@ -671,6 +756,83 @@ class StartupConfigValidatorTest {
     assertEquals(
         StartupConfigValidator.DashboardOauthStatus.PARTIAL,
         StartupConfigValidator.dashboardOauthStatus(false, true));
+  }
+
+  @Nested
+  class ShippedDefaults {
+
+    /**
+     * Budget-relevant subset of the shipped per-model table, bound straight from {@code
+     * src/main/resources/application.properties} (no env source, so every {@code ${VAR:default}}
+     * resolves to its shipped default).
+     */
+    @ConfigMapping(prefix = "thrillhousebot.ai")
+    interface ShippedModelsProbe {
+      Map<String, ModelProbe> models();
+
+      interface ModelProbe {
+        @WithName("max-input-tokens")
+        Optional<Integer> maxInputTokens();
+
+        @WithName("max-output-tokens")
+        Optional<Integer> maxOutputTokens();
+
+        @WithName("output-buffer-tokens")
+        Optional<Integer> outputBufferTokens();
+
+        @WithName("separate-output-budget")
+        Optional<Boolean> separateOutputBudget();
+      }
+    }
+
+    @Test
+    void everyShippedModelBootsUnderTheShippedConciseCap() throws Exception {
+      // The #502 lesson: the concise reservation rule only fires for the ACTIVE model, so a bad
+      // shipped combination (a concise default above some model's effective buffer) would pass
+      // every fixed-model test and refuse boot only for deployments naming that model. Walk the
+      // whole shipped table with each entry active instead of trusting the defaults.
+      var shipped =
+          new SmallRyeConfigBuilder()
+              .addDefaultInterceptors() // ${VAR:default} expansion, as at runtime
+              .withValidateUnknown(false)
+              .withMapping(ShippedModelsProbe.class)
+              .withSources(
+                  new PropertiesConfigSource(
+                      Paths.get("src/main/resources/application.properties").toUri().toURL()))
+              .build();
+      var conciseCap =
+          shipped.getValue(
+              "quarkus.langchain4j.openai.concise.chat-model.max-tokens", Integer.class);
+      var reviewBuffer = shipped.getValue("thrillhousebot.review.output-buffer-tokens", int.class);
+      var reviewBudget = shipped.getValue("thrillhousebot.review.max-input-tokens", int.class);
+      var models = shipped.getConfigMapping(ShippedModelsProbe.class).models();
+      assertFalse(models.isEmpty(), "the shipped model table must resolve");
+
+      models.forEach(
+          (name, probe) -> {
+            var settings = emptyModelSettings();
+            lenient().when(settings.maxInputTokens()).thenReturn(probe.maxInputTokens());
+            lenient().when(settings.maxOutputTokens()).thenReturn(probe.maxOutputTokens());
+            lenient().when(settings.outputBufferTokens()).thenReturn(probe.outputBufferTokens());
+            lenient()
+                .when(settings.separateOutputBudget())
+                .thenReturn(probe.separateOutputBudget());
+            var validator =
+                new ConfigBuilder()
+                    .modelName(name)
+                    .maxInputTokens(reviewBudget)
+                    .outputBufferTokens(reviewBuffer)
+                    .conciseMaxOutputTokens(Optional.of(conciseCap))
+                    .model(name, settings)
+                    .build();
+            assertDoesNotThrow(
+                validator::validate,
+                "shipped defaults must boot with model '"
+                    + name
+                    + "' active under the shipped concise cap "
+                    + conciseCap);
+          });
+    }
   }
 
   @Nested


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Post-#507, the summary/verifier/reply calls send `REVIEW_CONCISE_MAX_OUTPUT_TOKENS` as `max_tokens`, but the only boot check on that value was `>= 1` — while the summary prompt is still packed against the same shared window with only the output buffer reserved. A concise cap above the effective buffer on a shared-window model booted cleanly into exactly the state the active-model rule exists to refuse: on providers that validate `prompt + max_tokens <= context`, the summary call 400s deterministically, retries `maxAiRetries` times, and the fully paid multi-batch review is discarded (audit report AUDIT3-B, finding 1).

`validateConciseResponseCap` now applies the same shared-window reservation rule as the active model's own response cap (`validateEffectiveBudget`): when token budgeting is on and the active model does not declare `separate-output-budget`, a concise cap above `reservedOutputTokens` is refused at boot. The refusal message names `REVIEW_CONCISE_MAX_OUTPUT_TOKENS` and every fix option in the existing rule's style: lower the cap, raise `REVIEW_OUTPUT_BUFFER_TOKENS` to cover it, or set `thrillhousebot.ai.models."<model>".separate-output-budget=true` when the model's response allowance is independent of its input window. The rule is skipped when budgeting is off (no packed prompt to overrun) or on a separate-output-budget model (nothing is reserved) — so the shipped deepseek-v4-flash shape keeps booting, and an empty cap (provider default) stays allowed, consistent with the uncapped-active-model policy.

Shipped defaults are unaffected: concise 8192 == buffer 8192 and the rule is strict-greater. A guard test walks the entire shipped model table from `application.properties` with each entry active (the #502 lesson: the rule only fires for the active model, so a bad shipped combination would pass every fixed-model test and refuse boot only for deployments naming that model).

Scope: `StartupConfigValidator.validateConciseResponseCap` and `StartupConfigValidatorTest` only. Two existing tests that override the active model's output buffer below the default concise cap (`bootsWhenAModelSettingsEntryIsValid`, `bootsWhenAPerModelOverrideRepairsABrokenGlobalCombination`) now align their concise cap with the shrunken reservation — that combination is precisely the overrun state the audit calls out ("or lowers the buffer below the concise default 8192"), and those tests pin per-model resolution, not the concise rule.

## Related Issues

Fixes #517

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Red/green proof — `failsFastWhenTheConciseCapExceedsTheBufferOnASharedWindow` (derived from the audit probe `Audit3BConciseCapGuardProbeTest.theSameValueOnTheConciseCapBootsWithoutObjection`: the identical 384000 that is refused on the active cap boots without objection on the concise cap) fails on unfixed `5c04600` in exactly the claimed way:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest.failsFastWhenTheConciseCapExceedsTheBufferOnASharedWindow -- Time elapsed: 0.030 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Expected dev.thiagogonzaga.thrillhousebot.config.ConfigValidationException to be thrown, but nothing was thrown.
	at org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3234)
	at dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest.assertFailsValidation(StartupConfigValidatorTest.java:232)
	at dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest.failsFastWhenTheConciseCapExceedsTheBufferOnASharedWindow(StartupConfigValidatorTest.java:356)
```

With the fix it passes, refusing boot with:

```
- the effective output buffer (8192) must be >= REVIEW_CONCISE_MAX_OUTPUT_TOKENS (384000, quarkus.langchain4j.openai.concise.chat-model.max-tokens) for model 'deepseek-chat' so the token budget reserves the response cap the summary/verifier/reply calls send. Lower REVIEW_CONCISE_MAX_OUTPUT_TOKENS, raise REVIEW_OUTPUT_BUFFER_TOKENS to cover it, or set thrillhousebot.ai.models."deepseek-chat".separate-output-budget=true if this model's response allowance is independent of its input window.
```

New coverage, mirroring the active rule's pinning tests:

- `failsFastWhenTheConciseCapExceedsTheBufferOnASharedWindow` — refusal, message names the env var, the buffer key, and the separate-output-budget escape hatch.
- `allowsAConciseCapAboveTheBufferWhenTheOutputBudgetIsSeparate` — the deepseek-v4-flash shape (384000 out, 8192 buffer, separate budget) keeps booting.
- `allowsAConciseCapAboveTheBufferWhenTokenBudgetingIsDisabled` — budgeting off skips the rule, same as the active rule.
- `holdsTheConciseCapToTheActiveModelsEffectiveBuffer` — the reservation compared against is the active model's resolved buffer (per-model override respected).
- `ShippedDefaults.everyShippedModelBootsUnderTheShippedConciseCap` — walks all 18 shipped model entries from `application.properties` (no env source, shipped `${VAR:default}` values) with each one active; every one must boot under the shipped concise cap.

Gates: `spotless:apply` clean, `clean compile spotbugs:check spotless:check` green (BugInstance size 0), full `clean test` suite green (`Tests run: 2571, Failures: 0, Errors: 0, Skipped: 0`). JaCoCo ∩ diff: zero missed lines and zero missed branches in the changed main code.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

See the red/green proof above.

## Additional Notes

Latent (misconfiguration-triggered) per the audit: no correct configuration behaves worse than before #507, and default deployments were never exposed. No behavior change for separate-output-budget models, disabled budgeting, or an unset cap.