### PR TITLE
fix(review): meter and ceiling-gate the finding-verifier AI call

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -405,7 +405,7 @@ public class FindingPipeline {
         // salvage-or-disclose step as a parallel-pass truncation, and no further retry (#495).
         outcomesByIndex[index] =
             salvageTruncatedBatch(
-                index, batches, promptInputs, plan, previousFilesById, truncation.get());
+                session, index, batches, promptInputs, plan, previousFilesById, truncation.get());
         return;
       }
       // Soft-fail like the on-request generators (DocGenerationService / PrImprovementService):
@@ -451,7 +451,7 @@ public class FindingPipeline {
           // the complete leading findings out of the buffered partial body first (#500).
           outcomesByIndex[i] =
               salvageTruncatedBatch(
-                  i, batches, promptInputs, plan, previousFilesById, truncation.get());
+                  session, i, batches, promptInputs, plan, previousFilesById, truncation.get());
         } else if (isSpendCeilingBlocked(e)) {
           // Deterministic like a truncation: the ledger is monotonic within a review, so a retry
           // would be refused identically. Degrade like the budgeter — disclose, with the ceiling
@@ -487,16 +487,19 @@ public class FindingPipeline {
     var batchInputs = withDiff(promptInputs, PromptTemplateEscaper.fence(batch.text()), "");
     var batchResponse =
         aiReviewService.reviewBatch(session, batchInputs, index + 1, batches.size());
-    return refineBatchOutcome(index, batch, batchInputs, batchResponse, plan, previousFilesById);
+    return refineBatchOutcome(
+        session, index, batch, batchInputs, batchResponse, plan, previousFilesById);
   }
 
   /**
    * Runs one batch's raw response through the per-batch chain — quote validation and framework
    * filtering against the batch's own in-budget text, verification, and status scoping. Shared by
    * the parsed path and the salvage path, so salvaged findings face exactly the checks a normally
-   * parsed batch's findings do.
+   * parsed batch's findings do. The session keys the spend ledger for the verification call, which
+   * is metered and ceiling-gated inside {@link FindingVerificationService}.
    */
   private BatchOutcome refineBatchOutcome(
+      ReviewSession session,
       int index,
       DiffBudgetPlanner.DiffBatch batch,
       AiReviewService.PromptInputs batchInputs,
@@ -507,6 +510,7 @@ public class FindingPipeline {
     validated = frameworkFilter.filter(validated, batch.text());
     var verified =
         findingVerificationService.verify(
+            ledgerSessionId(session),
             validated,
             batchInputs.diff(),
             batchInputs.projectStack(),
@@ -526,9 +530,11 @@ public class FindingPipeline {
    * When nothing salvages (the cut landed before the first element closed, or the lane carried no
    * body), it falls back to the pre-#500 behaviour: the files are disclosed as not reviewed.
    * Replaces disclosure only — the truncation was already refused a retry (#495), and salvage makes
-   * no AI call of its own, so #509's ceiling accounting is untouched.
+   * no AI call of its own; the verification call it funnels salvaged findings into is metered and
+   * ceiling-gated like any other, so #509's ceiling accounting is untouched.
    */
   private BatchOutcome salvageTruncatedBatch(
+      ReviewSession session,
       int index,
       List<DiffBudgetPlanner.DiffBatch> batches,
       AiReviewService.PromptInputs promptInputs,
@@ -557,7 +563,8 @@ public class FindingPipeline {
     var batchInputs = withDiff(promptInputs, PromptTemplateEscaper.fence(batch.text()), "");
     var partialResponse =
         new ReviewResponse(salvaged.findings(), salvaged.previousFindingsStatus(), null);
-    return refineBatchOutcome(index, batch, batchInputs, partialResponse, plan, previousFilesById);
+    return refineBatchOutcome(
+        session, index, batch, batchInputs, partialResponse, plan, previousFilesById);
   }
 
   private static List<String> filenamesOf(List<GitHubPullRequestClient.FileDiff> files) {
@@ -1028,6 +1035,7 @@ public class FindingPipeline {
     aiResponse = deduplicator.dedupe(aiResponse);
     aiResponse =
         findingVerificationService.verify(
+            ledgerSessionId(session),
             aiResponse,
             promptInputs.diff(),
             promptInputs.projectStack(),

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -17,6 +17,7 @@ package dev.thiagogonzaga.thrillhousebot.review.ai;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.service.Result;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.review.Confidence;
 import dev.thiagogonzaga.thrillhousebot.review.PromptTemplateEscaper;
@@ -38,6 +39,14 @@ import java.util.regex.Pattern;
  *
  * <p>Fails open by design — any verifier error keeps the original findings, so a broken or slow
  * verification call can degrade quality but never lose a review.
+ *
+ * <p>The verifier is a billed review-path call, so it participates in the {@code
+ * REVIEW_MAX_TOKENS_PER_REVIEW} spend ceiling like every other call the review makes: its {@link
+ * Result#tokenUsage() provider-reported usage} is recorded straight into the {@link
+ * ReviewTokenLedger} (the blocking call never passes through the streaming path's {@link
+ * ReviewSessionContext} bind, so the observability listener cannot correlate it), and once the
+ * ceiling is reached the call is skipped fail-open — the unverified findings are kept, which is
+ * exactly this service's error contract.
  */
 @ApplicationScoped
 public class FindingVerificationService {
@@ -45,13 +54,18 @@ public class FindingVerificationService {
   private final FindingVerifier verifier;
   private final ThrillhouseConfig config;
   private final ObjectMapper mapper;
+  private final ReviewTokenLedger tokenLedger;
 
   @Inject
   public FindingVerificationService(
-      FindingVerifier verifier, ThrillhouseConfig config, ObjectMapper mapper) {
+      FindingVerifier verifier,
+      ThrillhouseConfig config,
+      ObjectMapper mapper,
+      ReviewTokenLedger tokenLedger) {
     this.verifier = verifier;
     this.config = config;
     this.mapper = mapper;
+    this.tokenLedger = tokenLedger;
   }
 
   private static final Pattern HEDGING =
@@ -62,23 +76,44 @@ public class FindingVerificationService {
   /**
    * Audits the response's findings; {@code diff}, {@code projectStack} and {@code previousFindings}
    * must already be escaped for prompt templating, the same values handed to the review call.
-   * Previous findings let the verifier reject re-raises of answered findings.
+   * Previous findings let the verifier reject re-raises of answered findings. {@code
+   * ledgerSessionId} is the review's {@link ReviewTokenLedger} key ({@link
+   * ReviewTokenLedger#keyFor}): the call's usage is recorded against it, and once the review's
+   * spend ceiling is reached the call is skipped fail-open, keeping the unverified findings.
    */
   public ReviewResponse verify(
-      ReviewResponse response, String diff, String projectStack, String previousFindings) {
+      long ledgerSessionId,
+      ReviewResponse response,
+      String diff,
+      String projectStack,
+      String previousFindings) {
     ReviewResponse screened = demoteHedgedBlockingFindings(response);
     if (!config.review().verifierEnabled() || screened.findings().isEmpty()) {
       return screened;
     }
+    if (tokenLedger.ceilingReached(ledgerSessionId)) {
+      // The verifier is a fresh billed call; once the ceiling is reached it is not made. Skipping
+      // fail-open keeps the unverified findings — degraded quality, never a lost review.
+      Log.warnf(
+          "Finding verification for review session %d skipped at the review's token spend ceiling"
+              + " (%d tokens spent, ceiling %d — REVIEW_MAX_TOKENS_PER_REVIEW); keeping the %d"
+              + " unverified finding(s)",
+          ledgerSessionId,
+          tokenLedger.tokensSpent(ledgerSessionId),
+          tokenLedger.ceiling(),
+          screened.findings().size());
+      return screened;
+    }
     try {
-      var raw =
-          AiResponses.textOrThrowOnTruncation(
-              verifier.verify(
-                  PromptTemplateEscaper.escape(renderCandidates(screened.findings())),
-                  diff,
-                  projectStack,
-                  previousFindings == null ? "" : previousFindings),
-              "Finding verification");
+      var result =
+          verifier.verify(
+              PromptTemplateEscaper.escape(renderCandidates(screened.findings())),
+              diff,
+              projectStack,
+              previousFindings == null ? "" : previousFindings);
+      // Meter before unwrapping: a truncated response was still billed, so its spend counts.
+      recordVerifierUsage(ledgerSessionId, result);
+      var raw = AiResponses.textOrThrowOnTruncation(result, "Finding verification");
       var verdicts =
           mapper.readValue(ReviewResponseParser.extractJson(raw), VerificationResponse.class);
       return apply(screened, verdicts);
@@ -90,6 +125,21 @@ public class FindingVerificationService {
       Log.warn("Finding verification failed — keeping unverified findings", e);
       return screened;
     }
+  }
+
+  /**
+   * Records the verifier call's provider-reported usage in the review's ledger. The blocking AI
+   * service returns usage on its {@link Result}, so it is recorded here directly — the
+   * observability listener only correlates calls made under the streaming path's session bind,
+   * which this call never is. A missing result or usage (a provider that omits it) records nothing;
+   * the ledger itself tolerates a null side of the count.
+   */
+  private void recordVerifierUsage(long ledgerSessionId, Result<String> result) {
+    var usage = result == null ? null : result.tokenUsage();
+    if (usage == null) {
+      return;
+    }
+    tokenLedger.recordUsage(ledgerSessionId, usage.inputTokenCount(), usage.outputTokenCount());
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewTokenLedger.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewTokenLedger.java
@@ -33,7 +33,9 @@ import java.util.concurrent.atomic.LongAdder;
  * pinned by {@code StreamingChatModelListenerOrderingTest} guarantees the listener's {@code
  * onResponse} runs before the call's own completion handler resolves — so by the time the review
  * path decides whether to make its <em>next</em> call, the previous call's spend is already in the
- * ledger.
+ * ledger. The one review-path call that never runs under that bind — the blocking finding-verifier
+ * call — records its {@code Result}-reported usage directly from {@link
+ * FindingVerificationService}, which also gates it on {@link #ceilingReached}.
  *
  * <p>Entries follow an open/record/clear lifecycle keyed by session id: {@link
  * dev.thiagogonzaga.thrillhousebot.review.FindingPipeline} opens the entry before its first call

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -25,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -93,8 +95,8 @@ class FindingPipelineTest {
     when(quoteValidator.validate(any(), any())).thenAnswer(inv -> inv.getArgument(0));
     when(frameworkFilter.filter(any(), any())).thenAnswer(inv -> inv.getArgument(0));
     when(deduplicator.dedupe(any())).thenAnswer(inv -> inv.getArgument(0));
-    when(findingVerificationService.verify(any(), any(), any(), any()))
-        .thenAnswer(inv -> inv.getArgument(0));
+    when(findingVerificationService.verify(anyLong(), any(), any(), any(), any()))
+        .thenAnswer(inv -> inv.getArgument(1));
     when(followUpAnalyzer.dropRepliedDuplicates(any(), any(), any(), any()))
         .thenAnswer(inv -> inv.getArgument(0));
     lenient()
@@ -200,7 +202,7 @@ class FindingPipelineTest {
     verify(aiReviewService).reviewBatch(eq(session), any(), eq(1), eq(2));
     verify(aiReviewService).reviewBatch(eq(session), any(), eq(2), eq(2));
     verify(aiReviewService).summarize(eq(session), any());
-    verify(findingVerificationService, times(2)).verify(any(), any(), any(), any());
+    verify(findingVerificationService, times(2)).verify(anyLong(), any(), any(), any(), any());
 
     assertEquals(2, result.findings().size());
     assertSame(summary, result.summary());
@@ -283,7 +285,7 @@ class FindingPipelineTest {
     // #495's no-retry stands: salvage replaces the disclose step, never re-enters the retry lane.
     verify(aiReviewService, times(1)).reviewBatch(eq(session), any(), eq(1), anyInt());
     // The salvaged findings run the same validate/verify chain as any batch's.
-    verify(findingVerificationService, times(2)).verify(any(), any(), any(), any());
+    verify(findingVerificationService, times(2)).verify(anyLong(), any(), any(), any(), any());
 
     assertEquals(4, result.findings().size());
     assertEquals("S1", result.findings().get(0).title());
@@ -1252,6 +1254,58 @@ class FindingPipelineTest {
     assertTrue(result.findings().isEmpty());
     assertEquals(List.of("a.java", "b.java"), plan.spendCeilingSkippedFiles());
     verify(aiReviewService, never()).summarize(eq(session), any());
+  }
+
+  @Test
+  void verifierAiCallsAreSkippedOnceTheSpendCeilingIsReached() {
+    // #514: the finding verifier is a billed AI call the review makes once per batch, so the
+    // ceiling's "once reached no further call is made" contract covers it too. Wires a real
+    // FindingVerificationService over a mock FindingVerifier so the assertion sits on the actual
+    // AI seam: past the ceiling the verifier must never fire, while the skip fails open — each
+    // batch keeps its unverified findings and the review completes with the counts-only summary.
+    var thrillhouseConfig = mock(dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig.class);
+    var reviewConfig =
+        mock(dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig.ReviewConfig.class);
+    when(thrillhouseConfig.review()).thenReturn(reviewConfig);
+    when(reviewConfig.verifierEnabled()).thenReturn(true);
+    var findingVerifier = mock(dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerifier.class);
+    var realVerificationService =
+        new FindingVerificationService(
+            findingVerifier, thrillhouseConfig, new ObjectMapper(), tokenLedger);
+    var p =
+        new FindingPipeline(
+            aiReviewService,
+            quoteValidator,
+            frameworkFilter,
+            deduplicator,
+            realVerificationService,
+            followUpAnalyzer,
+            new ObjectMapper(),
+            BotIdentity.from(List.of("thrillhousebot[bot]")),
+            budgetPlanner,
+            new TokenCounter(),
+            tokenLedger,
+            new dev.thiagogonzaga.thrillhousebot.review.ai.TruncatedResponseSalvager(
+                new ObjectMapper()));
+    var session = persistedSession();
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("a.java", "A")), List.of(), null));
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(2), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("b.java", "B")), List.of(), null));
+    when(tokenLedger.ceilingReached(42L)).thenReturn(true);
+    // ceilingReached=true implies spent >= a positive ceiling — stub the state consistently.
+    when(tokenLedger.tokensSpent(42L)).thenReturn(106_000L);
+    when(tokenLedger.ceiling()).thenReturn(100_000L);
+
+    var result = p.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+
+    // No billed verifier call is made past the ceiling (the summary call stays refused too)...
+    verify(findingVerifier, never()).verify(anyString(), anyString(), anyString(), anyString());
+    verify(aiReviewService, never()).summarize(any(), any());
+    // ...and the skip fails open: both batches' unverified findings survive.
+    assertEquals(2, result.findings().size());
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -197,8 +197,8 @@ class ReviewOrchestratorTest {
     when(projectStackResolver.resolve(any(), any(), any(), anyLong())).thenReturn("");
     when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any(), any()))
         .thenReturn("");
-    when(findingVerificationService.verify(any(), any(), any(), any()))
-        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(findingVerificationService.verify(anyLong(), any(), any(), any(), any()))
+        .thenAnswer(invocation -> invocation.getArgument(1));
     when(followUpAnalyzer.dropRepliedDuplicates(any(), any(), any(), any()))
         .thenAnswer(invocation -> invocation.getArgument(0));
     lenient().when(followUpAnalyzer.parsePreviousResponses(any())).thenReturn(List.of());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -22,6 +22,9 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.Result;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,11 +35,16 @@ import org.mockito.MockitoAnnotations;
 
 class FindingVerificationServiceTest {
 
+  /** The review's ledger key, as {@link ReviewTokenLedger#keyFor} would produce it. */
+  private static final long SESSION = 42L;
+
   @Mock private FindingVerifier verifier;
 
   @Mock private ThrillhouseConfig config;
 
   @Mock private ThrillhouseConfig.ReviewConfig reviewConfig;
+
+  @Mock private ReviewTokenLedger tokenLedger;
 
   private FindingVerificationService service;
 
@@ -45,7 +53,33 @@ class FindingVerificationServiceTest {
     MockitoAnnotations.openMocks(this);
     when(config.review()).thenReturn(reviewConfig);
     when(reviewConfig.verifierEnabled()).thenReturn(true);
-    service = new FindingVerificationService(verifier, config, new ObjectMapper());
+    service = new FindingVerificationService(verifier, config, new ObjectMapper(), tokenLedger);
+  }
+
+  /** Swaps in a real, opened ledger so a test can observe the spend the service records. */
+  private ReviewTokenLedger realLedger(long ceiling) {
+    when(reviewConfig.maxTokensPerReview()).thenReturn(ceiling);
+    var ledger = new ReviewTokenLedger(config);
+    ledger.open(SESSION);
+    service = new FindingVerificationService(verifier, config, new ObjectMapper(), ledger);
+    return ledger;
+  }
+
+  private static Result<String> aiOkWithUsage(String text, int inputTokens, int outputTokens) {
+    return Result.<String>builder()
+        .content(text)
+        .finishReason(FinishReason.STOP)
+        .tokenUsage(new TokenUsage(inputTokens, outputTokens))
+        .build();
+  }
+
+  private static Result<String> aiTruncatedWithUsage(
+      String partialText, int inputTokens, int outputTokens) {
+    return Result.<String>builder()
+        .content(partialText)
+        .finishReason(FinishReason.LENGTH)
+        .tokenUsage(new TokenUsage(inputTokens, outputTokens))
+        .build();
   }
 
   private static ReviewResponse.Finding finding(String risk, String confidence, String title) {
@@ -76,7 +110,7 @@ class FindingVerificationServiceTest {
                 null,
                 null));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertEquals("medium", result.findings().get(0).confidence());
     assertEquals("high", result.findings().get(0).risk());
@@ -100,7 +134,7 @@ class FindingVerificationServiceTest {
             new ReviewResponse.Finding("high", "high", "h", 3, "May break", null, null, null),
             new ReviewResponse.Finding("high", "high", "i", 4, "Breaks startup", null, null, null));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertEquals("medium", result.findings().get(0).confidence());
     assertEquals("medium", result.findings().get(1).confidence());
@@ -128,7 +162,7 @@ class FindingVerificationServiceTest {
             new ReviewResponse.Finding(
                 "critical", "medium", "h", 3, "May break", "Possibly wrong.", null, null));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertSame(original, result);
   }
@@ -138,7 +172,7 @@ class FindingVerificationServiceTest {
     when(reviewConfig.verifierEnabled()).thenReturn(false);
     ReviewResponse original = response(finding("critical", "high", "Bug"));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertSame(original, result);
     verifyNoInteractions(verifier);
@@ -148,10 +182,89 @@ class FindingVerificationServiceTest {
   void shouldSkipVerificationWhenNoFindings() {
     var original = new ReviewResponse(List.of(), List.of(), null);
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertSame(original, result);
     verifyNoInteractions(verifier);
+  }
+
+  @Test
+  void skipsTheVerifierAiCallOnceTheSpendCeilingIsReached() {
+    // #514: the verifier is a billed review-path call, so "once reached no further call is made"
+    // applies to it too. The skip fails open — the unverified findings are kept, never lost.
+    when(tokenLedger.ceilingReached(SESSION)).thenReturn(true);
+    ReviewResponse original = response(finding("critical", "high", "Bug"));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    verifyNoInteractions(verifier);
+  }
+
+  @Test
+  void hedgedDemotionStillRunsWhenTheCeilingSkipsTheVerifier() {
+    // The deterministic hedging guard costs no tokens, so the ceiling must not switch it off.
+    when(tokenLedger.ceilingReached(SESSION)).thenReturn(true);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "high", "high", "f", 1, "May break", "This could fail.", null, null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("medium", result.findings().get(0).confidence());
+    verifyNoInteractions(verifier);
+  }
+
+  @Test
+  void recordsTheVerifierCallsUsageInTheReviewsLedger() {
+    // #514: the verifier's spend is real billed usage; the ledger must increase by the
+    // provider-reported input+output of the call.
+    var ledger = realLedger(100_000L);
+    ReviewResponse original = response(finding("critical", "high", "Bug"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(aiOkWithUsage("{\"verdicts\": []}", 1200, 34));
+
+    service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals(1234L, ledger.tokensSpent(SESSION));
+  }
+
+  @Test
+  void recordsUsageEvenWhenTheVerifierResponseIsCutShort() {
+    // A truncated verifier response was still billed: its usage lands in the ledger before the
+    // truncation is turned into the fail-open path.
+    var ledger = realLedger(100_000L);
+    ReviewResponse original = response(finding("critical", "high", "Bug"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(aiTruncatedWithUsage("{\"verdicts\": [{\"id", 900, 100));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result); // fails open, findings kept
+    assertEquals(1000L, ledger.tokensSpent(SESSION));
+  }
+
+  @Test
+  void recordsNothingWhenTheProviderReportsNoUsage() {
+    ReviewResponse original = response(finding("critical", "high", "Bug"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(aiOk("{\"verdicts\": []}"));
+
+    service.verify(SESSION, original, "diff", "stack", "");
+
+    verify(tokenLedger, never()).recordUsage(anyLong(), any(), any());
+  }
+
+  @Test
+  void failsOpenAndRecordsNothingWhenTheVerifierReturnsNoResult() {
+    ReviewResponse original = response(finding("critical", "high", "Bug"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString())).thenReturn(null);
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    verify(tokenLedger, never()).recordUsage(anyLong(), any(), any());
   }
 
   @Test
@@ -165,7 +278,7 @@ class FindingVerificationServiceTest {
             "confidence": "high", "reason": "verified"}]}
             """));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertSame(original, result);
   }
@@ -188,7 +301,7 @@ class FindingVerificationServiceTest {
             ]}
             """));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertEquals(2, result.findings().size());
     assertEquals("Real nit", result.findings().get(0).title());
@@ -213,7 +326,7 @@ class FindingVerificationServiceTest {
             "confidence": "low", "reason": "not verifiable from the diff"}]}
             """));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertEquals(1, result.findings().size());
     var downgraded = result.findings().get(0);
@@ -234,7 +347,7 @@ class FindingVerificationServiceTest {
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(aiTruncated("{\"verdicts\": [{\"id\": 1, \"verdict\": \"downgr"));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     // Fails open: the unverified finding survives at its original risk/confidence.
     assertEquals(1, result.findings().size());
@@ -253,7 +366,7 @@ class FindingVerificationServiceTest {
                 "{\"verdicts\": [{\"id\": 1, \"verdict\": \"downgraded\", \"risk\": \"medium\","
                     + " \"confidence\": \"low\", \"reason\": \"guard\tmissing\nhere\"}]}"));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertEquals("medium", result.findings().get(0).risk());
     assertEquals("low", result.findings().get(0).confidence());
@@ -270,7 +383,7 @@ class FindingVerificationServiceTest {
             "confidence": "high", "reason": "tries to escalate"}]}
             """));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     var kept = result.findings().get(0);
     assertEquals("medium", kept.risk());
@@ -287,7 +400,7 @@ class FindingVerificationServiceTest {
             {"verdicts": [{"id": 1, "verdict": "downgraded", "reason": "no ratings given"}]}
             """));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     var kept = result.findings().get(0);
     assertEquals("high", kept.risk());
@@ -312,7 +425,7 @@ class FindingVerificationServiceTest {
             ]}
             """));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     // Garbled labels must not collapse the rating to the lenient-parse default
     var garbled = result.findings().get(0);
@@ -336,7 +449,7 @@ class FindingVerificationServiceTest {
             {"verdicts": [{"id": 1, "reason": "verdict field omitted"}]}
             """));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertSame(original, result);
   }
@@ -355,7 +468,7 @@ class FindingVerificationServiceTest {
             ]}
             """));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     var blankRisk = result.findings().get(0);
     assertEquals("critical", blankRisk.risk());
@@ -376,7 +489,7 @@ class FindingVerificationServiceTest {
             {"verdicts": [{"id": 2, "verdict": "shrug", "reason": "?"}]}
             """));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertSame(original, result);
   }
@@ -394,7 +507,7 @@ class FindingVerificationServiceTest {
             ]}
             """));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertTrue(result.findings().isEmpty());
   }
@@ -411,7 +524,7 @@ class FindingVerificationServiceTest {
             ```
             """));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertTrue(result.findings().isEmpty());
   }
@@ -422,7 +535,7 @@ class FindingVerificationServiceTest {
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenThrow(new RuntimeException("model unavailable"));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertSame(original, result);
   }
@@ -433,7 +546,7 @@ class FindingVerificationServiceTest {
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(aiOk("not json at all"));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertSame(original, result);
   }
@@ -448,7 +561,7 @@ class FindingVerificationServiceTest {
             {"verdicts": [{"id": 1, "verdict": "rejected", "reason": "fp"}]}
             """));
 
-    var result = service.verify(original, "diff", "stack", "");
+    var result = service.verify(SESSION, original, "diff", "stack", "");
 
     assertTrue(result.findings().isEmpty());
     assertNull(result.summary());
@@ -461,7 +574,7 @@ class FindingVerificationServiceTest {
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(aiOk("{\"verdicts\": []}"));
 
-    service.verify(original, "the-diff", "the-stack", "prior context");
+    service.verify(SESSION, original, "the-diff", "the-stack", "prior context");
 
     var candidates = ArgumentCaptor.forClass(String.class);
     verify(verifier)
@@ -482,7 +595,7 @@ class FindingVerificationServiceTest {
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(aiOk("{\"verdicts\": []}"));
 
-    service.verify(original, "the-diff", "the-stack", null);
+    service.verify(SESSION, original, "the-diff", "the-stack", null);
 
     verify(verifier).verify(anyString(), eq("the-diff"), eq("the-stack"), eq(""));
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/eval/PromptEvalTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/eval/PromptEvalTest.java
@@ -145,9 +145,11 @@ class PromptEvalTest {
             f.suggestionOld(),
             f.suggestionNew());
     var response = new ReviewResponse(List.of(candidate), List.of(), null);
+    // No review session exists here; the unopened sentinel key means no ceiling ever gates the
+    // call and its usage is dropped by the ledger's no-open-entry guard.
     var verified =
         findingVerificationService.verify(
-            response, PromptTemplateEscaper.fence(evalCase.diff()), "", "");
+            Long.MIN_VALUE, response, PromptTemplateEscaper.fence(evalCase.diff()), "", "");
     if (verified.findings().isEmpty()) {
       return "rejected";
     }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`REVIEW_MAX_TOKENS_PER_REVIEW` is documented as a ceiling "on the tokens one review may consume across every AI call it makes", with "Once reached no further call is made". The finding-verifier call — a billed concise-model AI call made once per batch (and once on the single-call path), on by default via `REVIEW_VERIFIER_ENABLED` — escaped both halves of that contract:

- **Not metered**: the verifier is a blocking AI-service call that never passes through `AiReviewService.streamOnce`'s `ReviewSessionContext` bind, so `OtelObservabilityListener.onResponse` saw no session id in the request attributes and dropped its usage. The ceiling undercounted real spend by the whole verification cost — per-call input on the order of the batch review call itself (the prompt repeats the batch diff, findings JSON, project stack and previous findings).
- **Not gated**: `ensureCallAllowed`'s only call site is `AiReviewService.runWithRetries`; nothing on the verifier path consulted the ledger, so a review at its ceiling kept making billed verifier calls (one per batch outcome — parsed and salvaged — plus the single-call path).

**Fix** (in `FindingVerificationService`, the seam both call sites share):

- `verify` now takes the review's ledger key (`ReviewTokenLedger.keyFor`), threaded from `FindingPipeline.refine` / `refineBatchOutcome`.
- **Metering**: the call's `Result#tokenUsage()` is recorded straight into the `ReviewTokenLedger`, before unwrapping — so a truncated-but-billed response still counts. Recording directly (instead of via the listener) is deliberate: the blocking call never runs under the streaming session bind, so there is no double count.
- **Gate**: once `ceilingReached`, the verifier call is skipped **fail-open** — the unverified findings are kept (the service's existing error contract) and the skip is logged at WARN naming `REVIEW_MAX_TOKENS_PER_REVIEW`. The review is never failed and the deterministic hedged-finding demotion (no AI call) still runs.

No doc changes: the fix makes the existing README / `.env.example` / `application.properties` wording ("across every AI call", "once reached no further call is made") true, which is the direction the audit prescribed.

## Related Issues

Fixes #514

## How Has This Been Tested?

- [x] Unit tests

**Red → green proofs** (each new behavioral test fails on unfixed code exactly as claimed, then passes with the fix). Mockito's literal angle-bracket matchers are shown as `⟨any⟩` so they survive markdown sanitization.

**Gate (pipeline level)** — the audit's proof test (`Audit3VerifierGateProofTest`, 2-batch multi-call plan, ledger at its ceiling for the whole run) with the expectation set to the documented behavior (`never()`), run on unfixed `5c04600`:

```
org.mockito.exceptions.verification.NeverWantedButInvoked:
findingVerificationService.verify(⟨any⟩, ⟨any⟩, ⟨any⟩, ⟨any⟩);
Never wanted here:
-⟩ at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService.verify(FindingVerificationService.java:69)
But invoked here:
-⟩ at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.refineBatchOutcome(FindingPipeline.java:509)  (twice, once per batch)
```

That test is adapted into `FindingPipelineTest.verifierAiCallsAreSkippedOnceTheSpendCeilingIsReached`, which wires a **real** `FindingVerificationService` over a mock `FindingVerifier` so the assertion sits on the actual AI seam; against the plumbing without the gate it fails the same way:

```
FindingPipelineTest.verifierAiCallsAreSkippedOnceTheSpendCeilingIsReached:1305
findingVerifier.verify(⟨any string⟩, ⟨any string⟩, ⟨any string⟩, ⟨any string⟩);
Never wanted here: ...
But invoked here:
-⟩ at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService.verify(FindingVerificationService.java:96)  (twice)
```

**Gate + metering (service level)** — new `FindingVerificationServiceTest` tests against the unfixed behavior:

```
skipsTheVerifierAiCallOnceTheSpendCeilingIsReached
org.mockito.exceptions.verification.NoInteractionsWanted:
But found these interactions on mock 'verifier':
-⟩ at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService.verify(FindingVerificationService.java:96)

recordsTheVerifierCallsUsageInTheReviewsLedger
org.opentest4j.AssertionFailedError: expected: ⟨1234⟩ but was: ⟨0⟩

recordsUsageEvenWhenTheVerifierResponseIsCutShort
org.opentest4j.AssertionFailedError: expected: ⟨1000⟩ but was: ⟨0⟩
```

All of the above pass with the fix; the metering tests use a **real** `ReviewTokenLedger` and assert the ledger increases by the provider-reported input+output. Additional tests cover the ceiling skip preserving the hedged-finding demotion, a `Result` with no usage, and a null `Result` (fail-open, nothing recorded).

**Gates**: `spotless:apply` clean; `clean compile spotbugs:check spotless:check` — BugInstance size is 0; `clean test` — **2573 tests, 0 failures, 0 errors, 0 skipped**. Jacoco ∩ `git diff -U0 5c04600...HEAD` over changed main code: zero uncovered lines, zero uncovered branches.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

New WARN on the skip path:

```
Finding verification for review session 42 skipped at the review's token spend ceiling (106000 tokens spent, ceiling 100000 — REVIEW_MAX_TOKENS_PER_REVIEW); keeping the 1 unverified finding(s)
```

## Additional Notes

Scope kept to the verifier seams: `FindingVerificationService` (gate + metering), `FindingPipeline` only in `refineBatchOutcome`/verification call sites (threading the session key through `processBatch`/`salvageTruncatedBatch` callers), and the `ReviewTokenLedger`/`salvageTruncatedBatch` javadocs whose "fed by the listener" / "ceiling accounting untouched" claims the fix completes. `ReviewResult`, `VerdictBuilder`, `DiffBudgetPlanner`, `countsOnlySummary` and the disclosure seams are untouched (owned by #518/#515).