### PR TITLE
fix(review): drop ceiling-skipped files from the walkthrough rows

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -23,6 +23,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -146,7 +147,11 @@ public class VerdictBuilder {
     var diffStats =
         DiffStats.fromFiles(overviewFiles, omitted, truncation)
             .withAuthoritativeTotals(ctx.prTotals());
-    var omittedNames = Set.copyOf(truncation.omittedFileNames());
+    // Rows are dropped for every never-reviewed class — planned/runtime omissions AND ceiling
+    // skips (the detail keeps them separate only so the disclosure names the ceiling) — while
+    // clipped and response-cut files keep theirs: those were partially reviewed.
+    var omittedNames = new HashSet<>(truncation.omittedFileNames());
+    omittedNames.addAll(truncation.spendCeilingSkippedFileNames());
     var changedFiles =
         toChangedFiles(
             overviewFiles.stream()

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -389,6 +389,32 @@ class VerdictBuilderTest {
     assertTrue(rowsCaptor.getValue().isEmpty(), rowsCaptor.getValue().toString());
   }
 
+  @Test
+  void ceilingSkippedFilesAreDroppedFromTheWalkthroughRowsLikeOtherNotReviewedFiles() {
+    // #515 — a file skipped at the token spend ceiling was never reviewed at all: the banner says
+    // so and the model-facing overview lists it as not reviewed, so its walkthrough row must be
+    // dropped like every other not-reviewed class — only partially reviewed files (clipped,
+    // response-cut) keep their rows.
+    var ctx =
+        contextWithLineCapOmissions(
+            0,
+            List.of(
+                new FileDiff("reviewed.java", "modified", 1, 0, 1, ""),
+                new FileDiff("skipped.java", "modified", 1, 0, 1, "")));
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    plan.recordSpendCeilingSkippedFiles(List.of("skipped.java"));
+    var rowsCaptor = ArgumentCaptor.forClass(List.class);
+
+    builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    verify(summaryGenerator)
+        .generate(anyInt(), anyInt(), anyInt(), rowsCaptor.capture(), any(), any());
+    assertEquals(
+        List.of(new PrSummaryGenerator.ChangedFile("reviewed.java", "modified")),
+        rowsCaptor.getValue(),
+        "a ceiling-skipped (never reviewed) file must not keep its walkthrough row");
+  }
+
   /**
    * #471 — the walkthrough filter is the third site that asks an immutable name set whether it
    * holds a {@code FileDiff.filename()} that Jackson never validated. {@code contains(null)} throws


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

A file skipped at the token spend ceiling is never reviewed at all: the banner above the "Changed Files" table says it "was not reviewed because the review's token spend ceiling (REVIEW_MAX_TOKENS_PER_REVIEW) was reached", and the model-facing overview lists it as not reviewed. Yet its row still rendered in the walkthrough table, because the row filter in `VerdictBuilder.build` uses `truncation.omittedFileNames()` — which #509 defined as effective-omitted **minus** ceiling-skips (pulled out only so the disclosure names the ceiling). The one posted comment contradicted itself.

The row filter now drops the union of omitted and ceiling-skipped names, so every never-reviewed class loses its row, while clipped and response-cut files (partially reviewed — deliberate per #511) keep theirs.

## Related Issues

Fixes #515

## How Has This Been Tested?

- [x] Unit tests

New test `VerdictBuilderTest.ceilingSkippedFilesAreDroppedFromTheWalkthroughRowsLikeOtherNotReviewedFiles` (red/green proven — see Logs). Full suite: 2567 tests, 0 failures.

Gates: `spotless:apply` → `clean compile spotbugs:check spotless:check` (BugInstance size 0) → `clean test` green. JaCoCo ∩ `git diff -U0 5c04600...HEAD`: zero uncovered lines/branches in changed main code.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Red run of the new test on unfixed code (`5c04600`):

```
[ERROR] VerdictBuilderTest.ceilingSkippedFilesAreDroppedFromTheWalkthroughRowsLikeOtherNotReviewedFiles:412
a ceiling-skipped (never reviewed) file must not keep its walkthrough row
==> expected: <[ChangedFile[path=reviewed.java, changeType=modified]]>
but was: <[ChangedFile[path=reviewed.java, changeType=modified], ChangedFile[path=skipped.java, changeType=modified]]>
```

Green with the fix applied.

## Additional Notes

First of a three-PR stack (#515 → #516 → #518) on the rendering seams; the follow-ups build on this branch.