### PR TITLE
fix(review): keep partial-coverage framing out of a summary-only-cut delta comment

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -180,11 +180,21 @@ public record ReviewResult(
     }
 
     public boolean isEmpty() {
-      return omittedFileNames.isEmpty()
-          && clippedFileNames.isEmpty()
-          && spendCeilingSkippedFileNames.isEmpty()
-          && responseCutFileNames.isEmpty()
-          && !summaryResponseCut;
+      return !hasFileGaps() && !summaryResponseCut;
+    }
+
+    /**
+     * Whether any per-file coverage gap exists — a name in any of the four file classes. False for
+     * a detail whose only content is a summary flag: the findings then cover the whole diff, so
+     * surfaces whose framing is per-file partial coverage (the on-demand disclosure, the delta
+     * comment) treat such a detail as empty (#516) while the summary-aware surfaces (banner,
+     * coverage clause, check-run brief) still disclose the flag.
+     */
+    public boolean hasFileGaps() {
+      return !omittedFileNames.isEmpty()
+          || !clippedFileNames.isEmpty()
+          || !spendCeilingSkippedFileNames.isEmpty()
+          || !responseCutFileNames.isEmpty();
     }
   }
 
@@ -481,9 +491,14 @@ public record ReviewResult(
    * #truncationNotice(int, TruncationDetail)} so an on-demand command that batches under the token
    * budget upholds the same "reported by name, never silently dropped" contract as the review
    * banner; falls back to the numeric clause when only a count is known.
+   *
+   * <p>A detail carrying only a summary flag (no file names) is treated as empty here: this
+   * disclosure's framing — "Large PR — partial coverage … covers only part of the diff" — is about
+   * per-file gaps, and with the findings complete it would be self-contradictory (#516). The
+   * summary-aware surfaces (review banner, check-run suffix) disclose the flag instead.
    */
   public static String truncationDisclosure(int omittedFiles, TruncationDetail detail) {
-    if (omittedFiles <= 0 && (detail == null || detail.isEmpty())) {
+    if (omittedFiles <= 0 && (detail == null || !detail.hasFileGaps())) {
       return "";
     }
     return "\n\n> ⚠️ **Large PR — partial coverage.** "

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -23,6 +23,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -146,7 +147,11 @@ public class VerdictBuilder {
     var diffStats =
         DiffStats.fromFiles(overviewFiles, omitted, truncation)
             .withAuthoritativeTotals(ctx.prTotals());
-    var omittedNames = Set.copyOf(truncation.omittedFileNames());
+    // Rows are dropped for every never-reviewed class — planned/runtime omissions AND ceiling
+    // skips (the detail keeps them separate only so the disclosure names the ceiling) — while
+    // clipped and response-cut files keep theirs: those were partially reviewed.
+    var omittedNames = new HashSet<>(truncation.omittedFileNames());
+    omittedNames.addAll(truncation.spendCeilingSkippedFileNames());
     var changedFiles =
         toChangedFiles(
             overviewFiles.stream()

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummaryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummaryTest.java
@@ -147,6 +147,38 @@ class FollowUpDeltaSummaryTest {
   }
 
   @Test
+  void summaryOnlyCutMustNotClaimPartialDiffCoverageInTheDeltaComment() {
+    // #516 — only the summary response was cut: the findings (and this comment's counts) cover
+    // the whole diff. The partial-coverage framing is about per-file gaps; wrapping the
+    // summary-cut clause in it renders the self-contradictory "the findings themselves are
+    // complete, so this covers only part of the diff".
+    var truncation =
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true);
+    var result =
+        new ReviewResult(
+            List.of(finding("a.java")),
+            0,
+            0,
+            1,
+            0,
+            RiskLevel.MEDIUM,
+            ReviewState.COMMENT,
+            false,
+            "summary",
+            List.of(),
+            List.of(),
+            0,
+            false,
+            true,
+            truncation);
+
+    var body = FollowUpDeltaSummary.render(result).orElseThrow();
+
+    assertFalse(body.contains("Large PR — partial coverage"), body);
+    assertFalse(body.contains("covers only part of the diff"), body);
+  }
+
+  @Test
   void untruncatedReviewCarriesNoDisclosure() {
     var body = FollowUpDeltaSummary.render(followUp(List.of(finding("a.java")), List.of(), 0));
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -186,6 +186,39 @@ class ReviewResultTest {
     assertFalse(disclosure.contains("partial review"), disclosure);
   }
 
+  @Test
+  void truncationDisclosureTreatsASummaryFlagOnlyDetailAsEmpty() {
+    // #516 — the disclosure's framing ("Large PR — partial coverage … covers only part of the
+    // diff") is about per-file gaps. A detail whose only content is a summary flag means the
+    // findings cover the whole diff, so this surface must render nothing.
+    var detail =
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true);
+
+    assertEquals("", ReviewResult.truncationDisclosure(0, detail));
+    // The guard's null arm behaves like an empty detail, and a detail with file gaps still
+    // discloses even when the caller's count is zero — the names are the coverage truth.
+    assertEquals("", ReviewResult.truncationDisclosure(0, null));
+    var clippedOnly = new ReviewResult.TruncationDetail(List.of(), List.of("clipped.java"));
+    assertTrue(
+        ReviewResult.truncationDisclosure(0, clippedOnly).contains("partially analyzed"),
+        ReviewResult.truncationDisclosure(0, clippedOnly));
+  }
+
+  @Test
+  void truncationDisclosureStillRendersWhenFileGapsAccompanyTheSummaryCut() {
+    // With a real file gap the partial-coverage framing is correct, and the summary cut folds in
+    // as one more clause — the flag-only guard must not suppress this shape.
+    var detail =
+        new ReviewResult.TruncationDetail(
+            List.of("omitted.java"), List.of(), List.of(), List.of(), true);
+
+    var disclosure = ReviewResult.truncationDisclosure(1, detail);
+
+    assertTrue(disclosure.contains("partial coverage"), disclosure);
+    assertTrue(disclosure.contains("omitted.java"), disclosure);
+    assertTrue(disclosure.contains("the summary was shortened"), disclosure);
+  }
+
   /**
    * #455 — the recognizer decides whether a prior review body is the bot's own verdict prose (and
    * so must never be fed back to the model as a "previous finding") or someone else's text, which

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -389,6 +389,32 @@ class VerdictBuilderTest {
     assertTrue(rowsCaptor.getValue().isEmpty(), rowsCaptor.getValue().toString());
   }
 
+  @Test
+  void ceilingSkippedFilesAreDroppedFromTheWalkthroughRowsLikeOtherNotReviewedFiles() {
+    // #515 — a file skipped at the token spend ceiling was never reviewed at all: the banner says
+    // so and the model-facing overview lists it as not reviewed, so its walkthrough row must be
+    // dropped like every other not-reviewed class — only partially reviewed files (clipped,
+    // response-cut) keep their rows.
+    var ctx =
+        contextWithLineCapOmissions(
+            0,
+            List.of(
+                new FileDiff("reviewed.java", "modified", 1, 0, 1, ""),
+                new FileDiff("skipped.java", "modified", 1, 0, 1, "")));
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    plan.recordSpendCeilingSkippedFiles(List.of("skipped.java"));
+    var rowsCaptor = ArgumentCaptor.forClass(List.class);
+
+    builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    verify(summaryGenerator)
+        .generate(anyInt(), anyInt(), anyInt(), rowsCaptor.capture(), any(), any());
+    assertEquals(
+        List.of(new PrSummaryGenerator.ChangedFile("reviewed.java", "modified")),
+        rowsCaptor.getValue(),
+        "a ceiling-skipped (never reviewed) file must not keep its walkthrough row");
+  }
+
   /**
    * #471 — the walkthrough filter is the third site that asks an immutable name set whether it
    * holds a {@code FileDiff.filename()} that Jackson never validated. {@code contains(null)} throws


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

When only the summary response was cut at the model's length cap (findings complete, no file-coverage gap), the opt-in follow-up delta comment (`REVIEW_FOLLOW_UP_SUMMARY_ENABLED=true`) rendered:

> ⚠️ **Large PR — partial coverage.** the summary was shortened … — the findings themselves are complete, so this covers only part of the diff.

Self-contradictory and false: the PR need not be large, coverage is not partial, and the delta comment's counts are complete. #513's `summaryResponseCut` flag made `TruncationDetail.isEmpty()` false, which defeated `truncationDisclosure`'s empty-guard — the one consumer #513's dedicated `SUMMARY_CUT_NOTICE` banner (built precisely to avoid this framing) missed.

`TruncationDetail` gains `hasFileGaps()` (any name in the four file classes; `isEmpty()` is now expressed through it), and `truncationDisclosure` guards on that instead of `isEmpty()`: a summary-flag-only detail renders nothing there, since the framing is per-file coverage. The summary-aware surfaces (banner, coverage clause, check-run suffix) are untouched, and a detail with real file gaps still folds the summary cut in as a clause. The other two `truncationDisclosure` consumers cannot carry the flag (2-arg detail with flag unset / count-only overload), so they are unaffected.

## Related Issues

Fixes #516

## How Has This Been Tested?

- [x] Unit tests

New tests (red/green proven — see Logs): `FollowUpDeltaSummaryTest.summaryOnlyCutMustNotClaimPartialDiffCoverageInTheDeltaComment` (the audit's ready-made failing test) and `ReviewResultTest.truncationDisclosureTreatsASummaryFlagOnlyDetailAsEmpty`, plus a green companion `truncationDisclosureStillRendersWhenFileGapsAccompanyTheSummaryCut` pinning no over-suppression. Full suite: 2570 tests, 0 failures.

Gates: `spotless:apply` → `clean compile spotbugs:check spotless:check` (BugInstance size 0) → `clean test` green. JaCoCo ∩ `git diff -U0` against the stack parent: zero uncovered lines/branches in changed main code.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Red runs on unfixed code:

```
[ERROR] FollowUpDeltaSummaryTest.summaryOnlyCutMustNotClaimPartialDiffCoverageInTheDeltaComment:177
## 🤖 ThrillhouseBot — changes since the last review

- **New findings this round:** 1
- **Previous findings resolved:** 0
- **Previous findings still open:** 0


> ⚠️ **Large PR — partial coverage.** the summary was shortened because the model's response was cut at its length cap (max-output-tokens / REVIEW_CONCISE_MAX_OUTPUT_TOKENS) — the findings themselves are complete, so this covers only part of the diff. ==> expected: <false> but was: <true>
```

```
[ERROR] ReviewResultTest.truncationDisclosureTreatsASummaryFlagOnlyDetailAsEmpty:197 expected: <> but was: <

> ⚠️ **Large PR — partial coverage.** the summary was shortened because the model's response was cut at its length cap (max-output-tokens / REVIEW_CONCISE_MAX_OUTPUT_TOKENS) — the findings themselves are complete, so this covers only part of the diff.>
```

Both green with the fix applied.

## Additional Notes

Second PR of the #515 → #516 → #518 stack: based on `fix/515-walkthrough-rows`; **re-target to `release/v0.6.0` after #522 (#515) merges** — the diff scoped to this issue is the last commit.