### PR TITLE
fix(review): disclose a ceiling-skipped summary in the posted review

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -94,7 +94,8 @@ public class DiffBudgetPlanner {
       List<String> runtimeUncoveredFiles,
       List<String> spendCeilingSkippedFiles,
       List<String> responseCutFiles,
-      java.util.concurrent.atomic.AtomicBoolean summaryResponseCut) {
+      java.util.concurrent.atomic.AtomicBoolean summaryResponseCut,
+      java.util.concurrent.atomic.AtomicBoolean summarySkippedAtCeiling) {
     public BudgetPlan {
       batches = List.copyOf(batches);
       omittedFiles = List.copyOf(omittedFiles);
@@ -112,6 +113,10 @@ public class DiffBudgetPlanner {
           summaryResponseCut == null
               ? new java.util.concurrent.atomic.AtomicBoolean(false)
               : summaryResponseCut;
+      summarySkippedAtCeiling =
+          summarySkippedAtCeiling == null
+              ? new java.util.concurrent.atomic.AtomicBoolean(false)
+              : summarySkippedAtCeiling;
     }
 
     /** Marks the review's summary response as cut at the model's length cap (#500 scope A). */
@@ -122,6 +127,21 @@ public class DiffBudgetPlanner {
     /** Whether the summary response was cut — salvaged or degraded, the disclosure names it. */
     public boolean summaryWasCut() {
       return summaryResponseCut.get();
+    }
+
+    /**
+     * Marks the review's summary call as skipped (or refused mid-call) because the review's token
+     * spend ceiling ({@code REVIEW_MAX_TOKENS_PER_REVIEW}) was reached (#518) — the ceiling sibling
+     * of {@link #recordSummaryResponseCut()}, so the counts-only degradation is disclosed in the
+     * posted review instead of only in the log.
+     */
+    void recordSummarySkippedAtCeiling() {
+      summarySkippedAtCeiling.set(true);
+    }
+
+    /** Whether the summary call was skipped at the spend ceiling — the disclosure names it. */
+    public boolean summaryWasSkippedAtCeiling() {
+      return summarySkippedAtCeiling.get();
     }
 
     /**
@@ -190,6 +210,28 @@ public class DiffBudgetPlanner {
           null);
     }
 
+    /** Back-compat convenience predating {@code summarySkippedAtCeiling}; starts it unset. */
+    public BudgetPlan(
+        List<DiffBatch> batches,
+        List<String> omittedFiles,
+        List<String> clippedFiles,
+        boolean budgeted,
+        List<String> runtimeUncoveredFiles,
+        List<String> spendCeilingSkippedFiles,
+        List<String> responseCutFiles,
+        java.util.concurrent.atomic.AtomicBoolean summaryResponseCut) {
+      this(
+          batches,
+          omittedFiles,
+          clippedFiles,
+          budgeted,
+          runtimeUncoveredFiles,
+          spendCeilingSkippedFiles,
+          responseCutFiles,
+          summaryResponseCut,
+          null);
+    }
+
     /** Defensive copy: the mutable runtime-gap backing must never escape the plan. */
     @Override
     public List<String> runtimeUncoveredFiles() {
@@ -215,6 +257,16 @@ public class DiffBudgetPlanner {
     @Override
     public java.util.concurrent.atomic.AtomicBoolean summaryResponseCut() {
       return new java.util.concurrent.atomic.AtomicBoolean(summaryResponseCut.get());
+    }
+
+    /**
+     * Defensive snapshot, like {@link #summaryResponseCut()}: the live flag is only written through
+     * {@link #recordSummarySkippedAtCeiling()} and read through {@link
+     * #summaryWasSkippedAtCeiling()}.
+     */
+    @Override
+    public java.util.concurrent.atomic.AtomicBoolean summarySkippedAtCeiling() {
+      return new java.util.concurrent.atomic.AtomicBoolean(summarySkippedAtCeiling.get());
     }
 
     /** Records files a batch left unreviewed at runtime, ignoring nulls and duplicates. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -270,7 +270,7 @@ public class FindingPipeline {
     refined = populateMissingAnchors(refined, lineResolver);
 
     if (tokenLedger.ceilingReached(ledgerSessionId(session))) {
-      return countsOnlySummary(session, refined, "skipping the summary call");
+      return countsOnlySummary(session, refined, plan, "skipping the summary call");
     }
     var overview = clampOverview(changedFilesOverview(ctx, plan), promptInputs);
     var summaryInputs =
@@ -287,7 +287,7 @@ public class FindingPipeline {
     } catch (TokenSpendCeilingExceededException _) {
       // The gate above passed but a late usage callback (e.g. a timed-out batch attempt's
       // response) crossed the ceiling first, or a summary retry was refused mid-loop.
-      return countsOnlySummary(session, refined, "summary call refused");
+      return countsOnlySummary(session, refined, plan, "summary call refused");
     } catch (AiResponseTruncatedException e) {
       // #500 scope A: every batch call succeeded and was billed. Losing the whole review to a
       // truncated summary would discard exactly the paid work #495 preserved on the batch lane —
@@ -307,10 +307,17 @@ public class FindingPipeline {
    * The summary degradation for a review whose token spend ceiling tripped after the batch calls:
    * the findings are already paid for, so they are kept and persisted with a {@code null} model
    * summary — the renderer's counts-only shape, the same one a summary call that returns no summary
-   * object produces — rather than spending past the ceiling or discarding the review.
+   * object produces — rather than spending past the ceiling or discarding the review. Recorded on
+   * the plan so the posted review names the ceiling (#518), like the truncation flavor of the same
+   * lane ({@link #salvagedOrCountsOnlySummary}) — a log-only warning would let a bare counts-only
+   * review post with no stated reason when no batch was also skipped.
    */
   private ReviewResponse countsOnlySummary(
-      ReviewSession session, ReviewResponse refined, String what) {
+      ReviewSession session,
+      ReviewResponse refined,
+      DiffBudgetPlanner.BudgetPlan plan,
+      String what) {
+    plan.recordSummarySkippedAtCeiling();
     Log.warnf(
         "Review session %d reached its token spend ceiling before the summary call (%d tokens"
             + " spent, ceiling %d — REVIEW_MAX_TOKENS_PER_REVIEW); %s and keeping the %d paid"
@@ -329,9 +336,10 @@ public class FindingPipeline {
    * keeps its paid findings with the {@link #countsOnlySummary counts-only} shape. Either way the
    * truncation is disclosed in the log with the caps that apply — the summary call runs on the
    * concise model, so both knobs are named — and recorded on the plan so the posted review carries
-   * the same disclosure instead of leaving it log-only (the sibling spend-ceiling degradation of
-   * this lane already discloses itself). Statuses are never taken from the salvage: the code-blind
-   * summary call must not decide what was resolved (same rule as the parsed path).
+   * the same disclosure instead of leaving it log-only, exactly like the sibling spend-ceiling
+   * degradation of this lane records {@code summarySkippedAtCeiling} in {@link #countsOnlySummary}
+   * (#518). Statuses are never taken from the salvage: the code-blind summary call must not decide
+   * what was resolved (same rule as the parsed path).
    */
   private ReviewResponse salvagedOrCountsOnlySummary(
       ReviewSession session,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -128,8 +128,11 @@ public record ReviewResult(
    * was cut at its length cap and the findings up to the cut were kept (#500). {@code
    * summaryResponseCut} marks the same length-cap cut on the summary call: the findings are
    * complete, but the prose summary was salvaged from a cut response or replaced by the counts-only
-   * fallback. All empty on the legacy line-cap path, where only a count is known — the rendered
-   * copy then falls back to the numeric clause.
+   * fallback. {@code summarySkippedAtCeiling} marks the ceiling flavor of that same degradation:
+   * the summary call was skipped (or refused mid-call) because the review's token spend ceiling
+   * ({@code REVIEW_MAX_TOKENS_PER_REVIEW}) was reached — here too the findings are complete (#518).
+   * All empty on the legacy line-cap path, where only a count is known — the rendered copy then
+   * falls back to the numeric clause.
    */
   @RegisterForReflection
   public record TruncationDetail(
@@ -137,9 +140,10 @@ public record ReviewResult(
       List<String> clippedFileNames,
       List<String> spendCeilingSkippedFileNames,
       List<String> responseCutFileNames,
-      boolean summaryResponseCut) {
+      boolean summaryResponseCut,
+      boolean summarySkippedAtCeiling) {
     public static final TruncationDetail EMPTY =
-        new TruncationDetail(List.of(), List.of(), List.of(), List.of(), false);
+        new TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, false);
 
     public TruncationDetail {
       omittedFileNames = omittedFileNames == null ? List.of() : List.copyOf(omittedFileNames);
@@ -154,7 +158,7 @@ public record ReviewResult(
 
     /** Convenience for the token-budget-only surfaces, which have no spend-ceiling skips. */
     public TruncationDetail(List<String> omittedFileNames, List<String> clippedFileNames) {
-      this(omittedFileNames, clippedFileNames, List.of(), List.of(), false);
+      this(omittedFileNames, clippedFileNames, List.of(), List.of(), false, false);
     }
 
     /** Back-compat convenience predating {@code responseCutFileNames}; starts it empty. */
@@ -162,7 +166,13 @@ public record ReviewResult(
         List<String> omittedFileNames,
         List<String> clippedFileNames,
         List<String> spendCeilingSkippedFileNames) {
-      this(omittedFileNames, clippedFileNames, spendCeilingSkippedFileNames, List.of(), false);
+      this(
+          omittedFileNames,
+          clippedFileNames,
+          spendCeilingSkippedFileNames,
+          List.of(),
+          false,
+          false);
     }
 
     /** Back-compat convenience predating {@code summaryResponseCut}; starts it unset. */
@@ -176,11 +186,28 @@ public record ReviewResult(
           clippedFileNames,
           spendCeilingSkippedFileNames,
           responseCutFileNames,
+          false,
+          false);
+    }
+
+    /** Back-compat convenience predating {@code summarySkippedAtCeiling}; starts it unset. */
+    public TruncationDetail(
+        List<String> omittedFileNames,
+        List<String> clippedFileNames,
+        List<String> spendCeilingSkippedFileNames,
+        List<String> responseCutFileNames,
+        boolean summaryResponseCut) {
+      this(
+          omittedFileNames,
+          clippedFileNames,
+          spendCeilingSkippedFileNames,
+          responseCutFileNames,
+          summaryResponseCut,
           false);
     }
 
     public boolean isEmpty() {
-      return !hasFileGaps() && !summaryResponseCut;
+      return !hasFileGaps() && !summaryResponseCut && !summarySkippedAtCeiling;
     }
 
     /**
@@ -326,6 +353,21 @@ public record ReviewResult(
       """;
 
   /**
+   * The ceiling sibling of {@link #SUMMARY_CUT_NOTICE} (#518): the summary call was skipped because
+   * the review's token spend ceiling was reached, with every batch already reviewed — the findings
+   * are complete, so the partial-review banner would overstate the damage here too, and the knob to
+   * raise is named instead. When a file-coverage gap exists as well, {@link #coverageGapClause(int,
+   * TruncationDetail)} folds the skip in as one more clause and this banner is not used.
+   */
+  static final String SUMMARY_SKIPPED_NOTICE =
+      """
+      > ⚠️ **Summary skipped.** The review's token spend ceiling\
+       (REVIEW_MAX_TOKENS_PER_REVIEW) was reached before the summary could be generated — the\
+       findings themselves are complete.
+
+      """;
+
+  /**
    * The shared "N file(s) were omitted …" clause, so the review banner and the on-demand-command
    * disclosure never drift on the omitted count and the reason — only the surrounding framing
    * differs between the two surfaces.
@@ -407,15 +449,22 @@ public record ReviewResult(
                   + " its length cap (max-output-tokens) — findings up to the cut were kept (%s)",
               detail.responseCutFileNames().size(), nameList(detail.responseCutFileNames())));
     }
-    // The summary-cut class affects prose, not findings: the findings are complete, but the
-    // summary call's response hit the same length cap and was salvaged (or replaced by the
-    // counts-only fallback) — the sibling spend-ceiling degradation of the same lane already
-    // discloses itself, so staying silent here would make the two lanes inconsistent.
+    // The summary flags affect prose, not findings: the findings are complete, but the summary
+    // call either had its response cut at the length cap and was salvaged (or replaced by the
+    // counts-only fallback), or was skipped outright at the token spend ceiling (#518) — the two
+    // flavors of the same degradation, disclosed with the same shape so neither lane stays
+    // log-only.
     if (detail.summaryResponseCut()) {
       clauses.add(
           "the summary was shortened because the model's response was cut at its length cap"
               + " (max-output-tokens / REVIEW_CONCISE_MAX_OUTPUT_TOKENS) — the findings themselves"
               + " are complete");
+    }
+    if (detail.summarySkippedAtCeiling()) {
+      clauses.add(
+          "the summary was skipped because the review's token spend ceiling"
+              + " (REVIEW_MAX_TOKENS_PER_REVIEW) was reached — the findings themselves are"
+              + " complete");
     }
     return String.join(", and ", clauses);
   }
@@ -456,6 +505,9 @@ public record ReviewResult(
     }
     if (truncation.summaryResponseCut()) {
       parts.add("summary shortened (response cut at the length cap)");
+    }
+    if (truncation.summarySkippedAtCeiling()) {
+      parts.add("summary skipped (token spend ceiling reached)");
     }
     return String.join(", ", parts);
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -134,7 +134,8 @@ public class VerdictBuilder {
                 clipped,
                 ceilingSkipped,
                 responseCut,
-                plan.summaryWasCut())
+                plan.summaryWasCut(),
+                plan.summaryWasSkippedAtCeiling())
             : ReviewResult.TruncationDetail.EMPTY;
     var omitted =
         plan.budgeted()
@@ -290,8 +291,9 @@ public class VerdictBuilder {
 
   /**
    * The coverage suffix of the check-run summary: the partial-review brief when file coverage was
-   * truncated (that brief already folds a summary cut in as one of its counts), the summary-only
-   * marker when just the summary response was cut, empty otherwise.
+   * truncated (that brief already folds a summary cut or skip in as one of its counts), the
+   * summary-only marker when just the summary response was cut — or skipped at the token spend
+   * ceiling (#518) — and empty otherwise.
    */
   private static String truncationSuffixFor(ReviewResult result) {
     if (result.truncated()) {
@@ -301,6 +303,9 @@ public class VerdictBuilder {
     }
     if (result.truncation().summaryResponseCut()) {
       return " The summary was shortened (response cut at the length cap).";
+    }
+    if (result.truncation().summarySkippedAtCeiling()) {
+      return " The summary was skipped (token spend ceiling reached).";
     }
     return "";
   }
@@ -535,6 +540,11 @@ public class VerdictBuilder {
       // approval hold that goes with file gaps) would overstate it — a dedicated banner names
       // the cut without holding the verdict.
       summaryMarkdown = ReviewResult.SUMMARY_CUT_NOTICE + summaryMarkdown;
+    } else if (diffStats.truncation().summarySkippedAtCeiling()) {
+      // Summary skipped at the token spend ceiling with no file gap (#518): same rationale as the
+      // summary-only cut — the findings are complete, so a dedicated banner names the ceiling
+      // without holding the verdict.
+      summaryMarkdown = ReviewResult.SUMMARY_SKIPPED_NOTICE + summaryMarkdown;
     }
 
     return new ReviewResult(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -421,6 +421,40 @@ class DiffBudgetPlannerTest {
   }
 
   @Test
+  void summarySkippedAtCeilingFlagIsRecordedLiveButItsAccessorReturnsASnapshot() {
+    // #518: the ceiling sibling of the summary-cut flag rides the shared plan the same way —
+    // written after the plan is built, read by the verdict — and, like it, its record accessor
+    // must not leak the mutable backing.
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    assertFalse(plan.summaryWasSkippedAtCeiling());
+
+    plan.recordSummarySkippedAtCeiling();
+
+    assertTrue(plan.summaryWasSkippedAtCeiling());
+    assertFalse(
+        plan.truncated(), "a skipped summary is not a coverage gap and must not hold approval");
+    assertFalse(plan.summaryWasCut(), "the ceiling skip is not a response cut — disjoint classes");
+    var snapshot = plan.summarySkippedAtCeiling();
+    snapshot.set(false);
+    assertTrue(plan.summaryWasSkippedAtCeiling(), "mutating the snapshot must not touch the flag");
+  }
+
+  @Test
+  void aPlanBuiltWithItsOwnSummarySkipFlagKeepsThatInstanceLive() {
+    var live = new java.util.concurrent.atomic.AtomicBoolean(true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, live);
+
+    assertTrue(plan.summaryWasSkippedAtCeiling());
+    assertNotSame(
+        live, plan.summarySkippedAtCeiling(), "the accessor returns a defensive snapshot");
+
+    live.set(false);
+    assertFalse(plan.summaryWasSkippedAtCeiling(), "the passed-in flag stays the live backing");
+  }
+
+  @Test
   void clippedFilesAreReportedUnchangedWhenNoBatchFailed() {
     // No runtime gap: the clipped list passes through, so a partially analyzed file keeps its
     // "clipped" meaning rather than being reported as wholly uncovered.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -391,6 +391,9 @@ class FindingPipelineTest {
     assertTrue(
         plan.summaryWasCut(),
         "the summary cut must be recorded on the plan so the posted review discloses it");
+    assertFalse(
+        plan.summaryWasSkippedAtCeiling(),
+        "a response cut is not a ceiling skip — disjoint classes");
   }
 
   @Test
@@ -1200,12 +1203,16 @@ class FindingPipelineTest {
     when(aiReviewService.summarize(eq(session), any()))
         .thenThrow(new TokenSpendCeilingExceededException(120_000, 100_000));
 
-    var result =
-        pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+    var plan = multiBatchPlan();
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
 
     assertEquals(2, result.findings().size());
     assertNull(result.summary());
     assertNotNull(session.getAiResponseJson());
+    assertTrue(
+        plan.summaryWasSkippedAtCeiling(),
+        "the refused summary must be recorded on the plan so the posted review discloses it");
+    assertFalse(plan.summaryWasCut(), "a ceiling refusal is not a response cut — disjoint classes");
   }
 
   @Test
@@ -1225,13 +1232,87 @@ class FindingPipelineTest {
         .when(aiReviewService.summarize(eq(session), any()))
         .thenReturn(new ReviewResponse(List.of(), List.of(), null));
 
-    var result =
-        pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+    var plan = multiBatchPlan();
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
 
     verify(aiReviewService, never()).summarize(any(), any());
     assertEquals(2, result.findings().size());
     assertNull(result.summary());
     assertNotNull(session.getAiResponseJson(), "the paid findings must still be persisted");
+    assertTrue(
+        plan.summaryWasSkippedAtCeiling(),
+        "the skipped summary must be recorded on the plan so the posted review discloses it");
+  }
+
+  @Test
+  void aCeilingSkippedSummaryIsDisclosedInThePostedReviewNotJustTheLog() {
+    // #518 — the ceiling flavor of the summary degradation must reach the posted review through
+    // the plan, exactly like #513's summary-response-cut: with zero skipped batches a log-only
+    // warning lets a bare counts-only review post with no stated reason.
+    var session = persistedSession();
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("a.java", "A")), List.of(), null));
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(2), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("b.java", "B")), List.of(), null));
+    when(tokenLedger.ceilingReached(42L)).thenReturn(true);
+
+    var plan = multiBatchPlan();
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    assertNull(result.summary());
+    var verdict = verdictSeam().build(ctx, result, CI_CLEAR, plan);
+    assertTrue(
+        verdict.summaryMarkdown().contains("REVIEW_MAX_TOKENS_PER_REVIEW"),
+        "the posted review must name the ceiling that degraded the summary, got: "
+            + verdict.summaryMarkdown());
+    assertFalse(verdict.truncated(), "a skipped summary is not a file-coverage gap");
+  }
+
+  @Test
+  void aSummaryCallRefusedAtTheCeilingIsDisclosedInThePostedReviewNotJustTheLog() {
+    // #518, second degradation site: the pre-summary gate passed but the summary call itself was
+    // refused at the ceiling — the same counts-only shape must carry the same disclosure.
+    var session = persistedSession();
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("a.java", "A")), List.of(), null));
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(2), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("b.java", "B")), List.of(), null));
+    when(tokenLedger.ceilingReached(42L)).thenReturn(false);
+    when(aiReviewService.summarize(eq(session), any()))
+        .thenThrow(new TokenSpendCeilingExceededException(120_000, 100_000));
+
+    var plan = multiBatchPlan();
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    assertNull(result.summary());
+    var verdict = verdictSeam().build(ctx, result, CI_CLEAR, plan);
+    assertTrue(
+        verdict.summaryMarkdown().contains("REVIEW_MAX_TOKENS_PER_REVIEW"),
+        "the posted review must name the ceiling that refused the summary call, got: "
+            + verdict.summaryMarkdown());
+    assertFalse(verdict.truncated(), "a skipped summary is not a file-coverage gap");
+  }
+
+  private static final CiStatusEvaluator.CiEvaluation CI_CLEAR =
+      new CiStatusEvaluator.CiEvaluation(List.of(), false);
+
+  /**
+   * The verdict seam the orchestrator hands the pipeline's plan to — the disclosure contract under
+   * test is that a summary degradation recorded on the plan reaches the rendered review.
+   */
+  private VerdictBuilder verdictSeam() {
+    var summaryGenerator = mock(PrSummaryGenerator.class);
+    when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any(), any()))
+        .thenReturn("");
+    return new VerdictBuilder(
+        summaryGenerator,
+        followUpAnalyzer,
+        BotIdentity.from(List.of("thrillhousebot[bot]")),
+        BlockingStrictness.BALANCED);
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummaryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummaryTest.java
@@ -179,6 +179,37 @@ class FollowUpDeltaSummaryTest {
   }
 
   @Test
+  void ceilingSkippedSummaryOnlyMustNotClaimPartialDiffCoverageInTheDeltaComment() {
+    // #518's flag gets the same treatment as the summary cut (#516): a summary skipped at the
+    // token spend ceiling leaves the findings — and this comment's counts — covering the whole
+    // diff, so the per-file partial-coverage framing must not render.
+    var truncation =
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, true);
+    var result =
+        new ReviewResult(
+            List.of(finding("a.java")),
+            0,
+            0,
+            1,
+            0,
+            RiskLevel.MEDIUM,
+            ReviewState.COMMENT,
+            false,
+            "summary",
+            List.of(),
+            List.of(),
+            0,
+            false,
+            true,
+            truncation);
+
+    var body = FollowUpDeltaSummary.render(result).orElseThrow();
+
+    assertFalse(body.contains("Large PR — partial coverage"), body);
+    assertFalse(body.contains("covers only part of the diff"), body);
+  }
+
+  @Test
   void untruncatedReviewCarriesNoDisclosure() {
     var body = FollowUpDeltaSummary.render(followUp(List.of(finding("a.java")), List.of(), 0));
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -418,6 +418,78 @@ class ReviewResultTest {
   }
 
   @Test
+  void truncationDetailWithOnlyTheCeilingSkippedSummaryIsNotEmpty() {
+    // #518: like the summary cut, the ceiling-skipped summary must defeat the EMPTY guards so
+    // the summary-aware surfaces render it...
+    var detail =
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, true);
+    assertFalse(detail.isEmpty());
+    // ...while the per-file surfaces treat it as gap-free, exactly like the cut flag (#516).
+    assertFalse(detail.hasFileGaps());
+    // The five-arg convenience constructor keeps the pre-#518 shape: flag unset.
+    assertFalse(
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true)
+            .summarySkippedAtCeiling());
+  }
+
+  @Test
+  void coverageGapClauseNamesTheCeilingSkippedSummaryAlongsideFileGaps() {
+    // #518: when the summary call was skipped at the token spend ceiling, the clause must say so
+    // in the posted review — naming the ceiling knob and making clear the findings themselves are
+    // complete — instead of leaving the degradation log-only.
+    var detail =
+        new ReviewResult.TruncationDetail(
+            List.of("a.java"), List.of(), List.of(), List.of(), false, true);
+
+    var clause = ReviewResult.coverageGapClause(1, detail);
+
+    assertTrue(clause.contains("1 file(s) were omitted entirely (a.java)"), clause);
+    assertTrue(
+        clause.contains(
+            "the summary was skipped because the review's token spend ceiling"
+                + " (REVIEW_MAX_TOKENS_PER_REVIEW) was reached — the findings themselves are"
+                + " complete"),
+        clause);
+  }
+
+  @Test
+  void coverageGapBriefMarksTheCeilingSkippedSummary() {
+    var result =
+        new ReviewResult(
+            List.of(),
+            0,
+            0,
+            0,
+            0,
+            null,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            1,
+            false,
+            true,
+            new ReviewResult.TruncationDetail(
+                List.of("a.java"), List.of(), List.of(), List.of(), false, true));
+
+    var brief = result.coverageGapBrief();
+
+    assertTrue(brief.contains("1 file(s) omitted"), brief);
+    assertTrue(brief.contains("summary skipped (token spend ceiling reached)"), brief);
+  }
+
+  @Test
+  void truncationDisclosureTreatsACeilingSkipFlagOnlyDetailAsEmpty() {
+    // #516's guard must hold for the ceiling flavor too: no file gap means no partial-coverage
+    // framing, whichever summary flag is set.
+    var detail =
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, true);
+
+    assertEquals("", ReviewResult.truncationDisclosure(0, detail));
+  }
+
+  @Test
   void truncationDetailWithOnlySpendCeilingSkipsIsNotEmpty() {
     var detail = new ReviewResult.TruncationDetail(List.of(), List.of(), List.of("c.java"));
     assertFalse(detail.isEmpty());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -293,6 +293,59 @@ class VerdictBuilderTest {
   }
 
   @Test
+  void aCeilingSkippedSummaryIsDisclosedWithoutHoldingApproval() {
+    // #518: the ceiling flavor of the summary degradation — every batch succeeded, the summary
+    // call was skipped at the token spend ceiling. Like the summary-only cut, the findings are
+    // complete: approval must not be held, but the posted review must name the ceiling instead of
+    // leaving the degradation log-only.
+    var ctx = contextWithLineCapOmissions(0);
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    plan.recordSummarySkippedAtCeiling();
+
+    var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    assertEquals(0, result.omittedFiles());
+    assertFalse(result.truncated());
+    assertEquals(ReviewState.APPROVE, result.reviewState());
+    assertTrue(result.truncation().summarySkippedAtCeiling());
+    assertTrue(result.summaryMarkdown().contains("**Summary skipped.**"), result.summaryMarkdown());
+    assertTrue(
+        result.summaryMarkdown().contains("REVIEW_MAX_TOKENS_PER_REVIEW"),
+        result.summaryMarkdown());
+    // The partial-review banner's framing (findings cover only part of the diff) would overstate
+    // a summary-only degradation.
+    assertFalse(result.summaryMarkdown().contains("partial review"), result.summaryMarkdown());
+    var checkSummary = VerdictBuilder.checkSummaryForResult(result);
+    assertTrue(
+        checkSummary.contains("The summary was skipped (token spend ceiling reached)."),
+        checkSummary);
+  }
+
+  @Test
+  void aCeilingSkippedSummaryAlongsideFileGapsFoldsIntoTheCoverageClause() {
+    // With a real file gap the partial-review banner renders anyway, so the ceiling skip becomes
+    // one more clause there — the dedicated summary-only banner must not stack on top.
+    var ctx = contextWithLineCapOmissions(0);
+    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of("big.java"), List.of(), true);
+    plan.recordSummarySkippedAtCeiling();
+
+    var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    assertTrue(result.truncated());
+    assertEquals(ReviewState.COMMENT, result.reviewState());
+    assertTrue(
+        result
+            .summaryMarkdown()
+            .contains("the summary was skipped because the review's token spend ceiling"),
+        result.summaryMarkdown());
+    assertFalse(
+        result.summaryMarkdown().contains("**Summary skipped.**"), result.summaryMarkdown());
+    var checkSummary = VerdictBuilder.checkSummaryForResult(result);
+    assertTrue(
+        checkSummary.contains("summary skipped (token spend ceiling reached)"), checkSummary);
+  }
+
+  @Test
   void aSummaryCutAlongsideFileGapsFoldsIntoTheCoverageClause() {
     // With a real file gap present the partial-review banner renders anyway, so the summary cut
     // becomes one more clause there — the dedicated summary-only banner must not stack on top.


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

When the token spend ceiling trips after every batch succeeded — before the summary call, or refusing the summary call itself — the review degrades to the counts-only summary with a **log-only** warning: `TruncationDetail` stayed empty, so the posted review carried a bare counts-only summary with no stated reason (and could even APPROVE). #513 fixed exactly this asymmetry for the *truncation* flavor of the same summary lane; this PR gives the ceiling flavor the same seams:

- `BudgetPlan` gains a `summarySkippedAtCeiling` flag (recorder + snapshot accessor, mirroring `summaryResponseCut`), recorded in `FindingPipeline.countsOnlySummary` — covering **both** of its call sites (pre-summary gate skip, and the mid-call `TokenSpendCeilingExceededException` refusal).
- `VerdictBuilder.build` threads it into a matching `TruncationDetail.summarySkippedAtCeiling` component.
- Rendering: a dedicated `SUMMARY_SKIPPED_NOTICE` banner ("**Summary skipped.** The review's token spend ceiling (REVIEW_MAX_TOKENS_PER_REVIEW) was reached … the findings themselves are complete."), a `coverageGapClause` clause and `coverageGapBrief` part naming the ceiling, and a check-run suffix — each folding into the partial-review clause instead of stacking when real file gaps exist.
- **No approval hold**: the findings are complete; `truncated()` is untouched by the flag.
- #516's empty-guard treats the new flag exactly like `summaryResponseCut`: `hasFileGaps()` ignores it, so the delta comment / on-demand disclosure never wrap it in partial-coverage framing.
- Fixes the two over-claiming comments ("the sibling spend-ceiling degradation of the same lane already discloses itself" — previously true only when batches were also skipped): `FindingPipeline.salvagedOrCountsOnlySummary` javadoc and the `ReviewResult.coverageGapClause` comment now describe both flavors accurately.

## Related Issues

Fixes #518

## How Has This Been Tested?

- [x] Unit tests

Red/green proven via two integration tests through the real pipeline→plan→verdict seam (see Logs): `FindingPipelineTest.aCeilingSkippedSummaryIsDisclosedInThePostedReviewNotJustTheLog` and `…aSummaryCallRefusedAtTheCeilingIsDisclosedInThePostedReviewNotJustTheLog` — one per `countsOnlySummary` call site. Plus mirrors of #513's unit tests for the new flag: plan recorder/snapshot (`DiffBudgetPlannerTest`), verdict banner/no-approval-hold and fold-into-clause (`VerdictBuilderTest`), clause/brief/isEmpty/hasFileGaps and the #516 guard (`ReviewResultTest`), delta-comment guard (`FollowUpDeltaSummaryTest`), and disjointness assertions on the pipeline paths. Full suite: 2581 tests, 0 failures.

Gates: `spotless:apply` → `clean compile spotbugs:check spotless:check` (BugInstance size 0) → `clean test` green. JaCoCo ∩ `git diff -U0` against the stack parent: zero uncovered lines/branches in changed main code.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Red run of both integration tests on unfixed code (stack parent, before this commit):

```
[ERROR] FindingPipelineTest.aCeilingSkippedSummaryIsDisclosedInThePostedReviewNotJustTheLog:1254
the posted review must name the ceiling that degraded the summary, got:  ==> expected: <true> but was: <false>
[ERROR] FindingPipelineTest.aSummaryCallRefusedAtTheCeilingIsDisclosedInThePostedReviewNotJustTheLog:1281
the posted review must name the ceiling that refused the summary call, got:  ==> expected: <true> but was: <false>
```

Both green with the fix applied.

## Additional Notes

Third PR of the #515 → #516 → #518 stack: based on `fix/516-delta-disclosure`; **re-target to `release/v0.6.0` after #523 (#516) merges** — the diff scoped to this issue is the last commit. Design per audit finding AUDIT3-A F2, following #513's implementation as the pattern.