### PR TITLE
refactor(review): consolidate cause walk, retire back-compat ctors, share customizer tuning

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
@@ -266,7 +266,8 @@ public abstract class AbstractPrSuggestionGenerator {
     }
     return ReviewResult.truncationDisclosure(
         plan.omittedFiles().size() + plan.clippedFiles().size(),
-        new ReviewResult.TruncationDetail(plan.omittedFiles(), plan.clippedFiles()));
+        new ReviewResult.TruncationDetail(
+            plan.omittedFiles(), plan.clippedFiles(), List.of(), List.of(), false, false));
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -144,94 +144,6 @@ public class DiffBudgetPlanner {
       return summarySkippedAtCeiling.get();
     }
 
-    /**
-     * A fresh plan with no runtime coverage gaps yet; failures are recorded on it as they occur.
-     */
-    public BudgetPlan(
-        List<DiffBatch> batches,
-        List<String> omittedFiles,
-        List<String> clippedFiles,
-        boolean budgeted) {
-      this(batches, omittedFiles, clippedFiles, budgeted, new CopyOnWriteArrayList<>());
-    }
-
-    /** Back-compat convenience predating {@code spendCeilingSkippedFiles}; starts it empty. */
-    public BudgetPlan(
-        List<DiffBatch> batches,
-        List<String> omittedFiles,
-        List<String> clippedFiles,
-        boolean budgeted,
-        List<String> runtimeUncoveredFiles) {
-      this(
-          batches,
-          omittedFiles,
-          clippedFiles,
-          budgeted,
-          runtimeUncoveredFiles,
-          new CopyOnWriteArrayList<>());
-    }
-
-    /** Back-compat convenience predating {@code responseCutFiles}; starts it empty. */
-    public BudgetPlan(
-        List<DiffBatch> batches,
-        List<String> omittedFiles,
-        List<String> clippedFiles,
-        boolean budgeted,
-        List<String> runtimeUncoveredFiles,
-        List<String> spendCeilingSkippedFiles) {
-      this(
-          batches,
-          omittedFiles,
-          clippedFiles,
-          budgeted,
-          runtimeUncoveredFiles,
-          spendCeilingSkippedFiles,
-          new CopyOnWriteArrayList<>(),
-          null);
-    }
-
-    /** Back-compat convenience predating {@code summaryResponseCut}; starts it unset. */
-    public BudgetPlan(
-        List<DiffBatch> batches,
-        List<String> omittedFiles,
-        List<String> clippedFiles,
-        boolean budgeted,
-        List<String> runtimeUncoveredFiles,
-        List<String> spendCeilingSkippedFiles,
-        List<String> responseCutFiles) {
-      this(
-          batches,
-          omittedFiles,
-          clippedFiles,
-          budgeted,
-          runtimeUncoveredFiles,
-          spendCeilingSkippedFiles,
-          responseCutFiles,
-          null);
-    }
-
-    /** Back-compat convenience predating {@code summarySkippedAtCeiling}; starts it unset. */
-    public BudgetPlan(
-        List<DiffBatch> batches,
-        List<String> omittedFiles,
-        List<String> clippedFiles,
-        boolean budgeted,
-        List<String> runtimeUncoveredFiles,
-        List<String> spendCeilingSkippedFiles,
-        List<String> responseCutFiles,
-        java.util.concurrent.atomic.AtomicBoolean summaryResponseCut) {
-      this(
-          batches,
-          omittedFiles,
-          clippedFiles,
-          budgeted,
-          runtimeUncoveredFiles,
-          spendCeilingSkippedFiles,
-          responseCutFiles,
-          summaryResponseCut,
-          null);
-    }
-
     /** Defensive copy: the mutable runtime-gap backing must never escape the plan. */
     @Override
     public List<String> runtimeUncoveredFiles() {
@@ -438,13 +350,23 @@ public class DiffBudgetPlanner {
       List<GitHubPullRequestClient.FileDiff> reviewable, int diffBudgetTokens, int maxBatches) {
     var budgeted = diffBudgetTokens > 0;
     if (reviewable.isEmpty()) {
-      return new BudgetPlan(List.of(), List.of(), List.of(), budgeted);
+      return new BudgetPlan(
+          List.of(), List.of(), List.of(), budgeted, null, null, null, null, null);
     }
 
     var rendered = renderAndSize(reviewable, diffBudgetTokens);
 
     if (!budgeted) {
-      return new BudgetPlan(List.of(toBatch(rendered.sized())), List.of(), List.of(), false);
+      return new BudgetPlan(
+          List.of(toBatch(rendered.sized())),
+          List.of(),
+          List.of(),
+          false,
+          null,
+          null,
+          null,
+          null,
+          null);
     }
     return pack(rendered, diffBudgetTokens, Math.max(1, maxBatches));
   }
@@ -565,7 +487,7 @@ public class DiffBudgetPlanner {
     // exactly one class or the disclosure would list it twice and the verdict double-count it.
     var omittedSet = new HashSet<>(omitted);
     var clipped = rendered.clipped().stream().filter(n -> !omittedSet.contains(n)).toList();
-    return new BudgetPlan(batches, omitted, clipped, true);
+    return new BudgetPlan(batches, omitted, clipped, true, null, null, null, null, null);
   }
 
   /** Index of the first open bin with room for {@code tokens}, or -1 if none. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -27,6 +27,7 @@ import dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService;
 import dev.thiagogonzaga.thrillhousebot.review.ai.PrReviewPrompts;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewTokenLedger;
+import dev.thiagogonzaga.thrillhousebot.review.ai.Throwables;
 import dev.thiagogonzaga.thrillhousebot.review.ai.TokenCounter;
 import dev.thiagogonzaga.thrillhousebot.review.ai.TokenSpendCeilingExceededException;
 import dev.thiagogonzaga.thrillhousebot.review.ai.TruncatedResponseSalvager;
@@ -58,9 +59,6 @@ public class FindingPipeline {
 
   /** Directory rows listed in the scope header before the remainder is rolled up by count. */
   private static final int MAX_SCOPE_DIRECTORIES = 10;
-
-  /** Cause-chain links inspected before giving up, so a cyclic chain cannot spin. */
-  private static final int MAX_CAUSE_DEPTH = 16;
 
   private record BatchOutcome(
       int index,
@@ -580,22 +578,12 @@ public class FindingPipeline {
   }
 
   /**
-   * Whether a batch failure was the spend ceiling refusing the call before it was made. Bounded
-   * cause walk like {@link AiResponseTruncatedException#findIn} (where the truncation flavour of
-   * this check was hoisted, so the pipeline and the orchestrator share one walk) and for the same
-   * reason: the refusal arrives wrapped in the parallel pass's {@link CompletionException}, and an
-   * unbounded walk over a cyclic chain would spin forever on the review thread.
+   * Whether a batch failure was the spend ceiling refusing the call before it was made. The refusal
+   * arrives wrapped in the parallel pass's {@link CompletionException}, so this shares the bounded
+   * cause walk in {@link Throwables#findCause} with {@link AiResponseTruncatedException#findIn}.
    */
   private static boolean isSpendCeilingBlocked(Throwable failure) {
-    var cause = failure;
-    for (var depth = 0;
-        cause != null && depth < MAX_CAUSE_DEPTH;
-        depth++, cause = cause.getCause()) {
-      if (cause instanceof TokenSpendCeilingExceededException) {
-        return true;
-      }
-    }
-    return false;
+    return Throwables.findCause(failure, TokenSpendCeilingExceededException.class).isPresent();
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -156,56 +156,6 @@ public record ReviewResult(
           responseCutFileNames == null ? List.of() : List.copyOf(responseCutFileNames);
     }
 
-    /** Convenience for the token-budget-only surfaces, which have no spend-ceiling skips. */
-    public TruncationDetail(List<String> omittedFileNames, List<String> clippedFileNames) {
-      this(omittedFileNames, clippedFileNames, List.of(), List.of(), false, false);
-    }
-
-    /** Back-compat convenience predating {@code responseCutFileNames}; starts it empty. */
-    public TruncationDetail(
-        List<String> omittedFileNames,
-        List<String> clippedFileNames,
-        List<String> spendCeilingSkippedFileNames) {
-      this(
-          omittedFileNames,
-          clippedFileNames,
-          spendCeilingSkippedFileNames,
-          List.of(),
-          false,
-          false);
-    }
-
-    /** Back-compat convenience predating {@code summaryResponseCut}; starts it unset. */
-    public TruncationDetail(
-        List<String> omittedFileNames,
-        List<String> clippedFileNames,
-        List<String> spendCeilingSkippedFileNames,
-        List<String> responseCutFileNames) {
-      this(
-          omittedFileNames,
-          clippedFileNames,
-          spendCeilingSkippedFileNames,
-          responseCutFileNames,
-          false,
-          false);
-    }
-
-    /** Back-compat convenience predating {@code summarySkippedAtCeiling}; starts it unset. */
-    public TruncationDetail(
-        List<String> omittedFileNames,
-        List<String> clippedFileNames,
-        List<String> spendCeilingSkippedFileNames,
-        List<String> responseCutFileNames,
-        boolean summaryResponseCut) {
-      this(
-          omittedFileNames,
-          clippedFileNames,
-          spendCeilingSkippedFileNames,
-          responseCutFileNames,
-          summaryResponseCut,
-          false);
-    }
-
     public boolean isEmpty() {
       return !hasFileGaps() && !summaryResponseCut && !summarySkippedAtCeiling;
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponseTruncatedException.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponseTruncatedException.java
@@ -42,9 +42,6 @@ import java.util.Optional;
  */
 public class AiResponseTruncatedException extends AiReviewException {
 
-  /** Cause-chain links inspected before giving up, so a cyclic chain cannot spin. */
-  private static final int MAX_CAUSE_DEPTH = 16;
-
   private final String partialBody;
   private final boolean conciseModelImplicated;
 
@@ -90,22 +87,10 @@ public class AiResponseTruncatedException extends AiReviewException {
   /**
    * The truncation inside a failure's cause chain, if any. Hoisted from {@code FindingPipeline} so
    * every layer that reacts to a truncation — the pipeline's disclose step, the orchestrator's
-   * failure notice — shares one walk instead of each growing its own.
-   *
-   * <p>Bounded rather than walked to {@code null}: a cause chain can cycle — a {@link Throwable}
-   * overriding {@code getCause()}, or plain {@code A caused-by B caused-by A} — and an unbounded
-   * walk would spin forever on the review thread. The bound is far above any real chain (the
-   * failure arrives wrapped at depth 2 in practice), so a truncation is never missed for depth.
+   * failure notice — shares one walk instead of each growing its own; the walk itself is the
+   * generic bounded one in {@link Throwables#findCause}.
    */
   public static Optional<AiResponseTruncatedException> findIn(Throwable failure) {
-    var cause = failure;
-    for (var depth = 0;
-        cause != null && depth < MAX_CAUSE_DEPTH;
-        depth++, cause = cause.getCause()) {
-      if (cause instanceof AiResponseTruncatedException truncation) {
-        return Optional.of(truncation);
-      }
-    }
-    return Optional.empty();
+    return Throwables.findCause(failure, AiResponseTruncatedException.class);
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelCustomizers.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelCustomizers.java
@@ -23,6 +23,7 @@ import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.ModelName;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 /**
  * Applies the operator's model tuning to the OpenAI-compatible chat models: the reasoning-effort
@@ -65,6 +66,61 @@ public final class ChatModelCustomizers {
         : Optional.empty();
   }
 
+  /**
+   * The shared customizer body, applied through one builder flavour's setter references — the
+   * blocking and streaming builders share no supertype, so the four customizers adapt via {@link
+   * #BLOCKING_TUNING}/{@link #STREAMING_TUNING} instead of each repeating the knob list. {@code
+   * applyResponseCap} is false for the concise pair, which must never see the active model's {@code
+   * max-output-tokens} (it would stomp the named config block's cap).
+   */
+  private record SharedTuning<B>(
+      BiConsumer<B, String> reasoningEffort,
+      BiConsumer<B, Double> temperature,
+      BiConsumer<B, Double> topP,
+      BiConsumer<B, Integer> maxTokens,
+      BiConsumer<B, Double> frequencyPenalty,
+      BiConsumer<B, Double> presencePenalty,
+      BiConsumer<B, Integer> seed) {
+
+    void apply(
+        ThrillhouseConfig config,
+        ActiveModelSettings activeModel,
+        B builder,
+        boolean applyResponseCap) {
+      ChatModelCustomizers.reasoningEffort(config)
+          .ifPresent(v -> reasoningEffort.accept(builder, v));
+      activeModel.temperature().ifPresent(v -> temperature.accept(builder, v));
+      activeModel.topP().ifPresent(v -> topP.accept(builder, v));
+      if (applyResponseCap) {
+        activeModel.maxOutputTokens().ifPresent(v -> maxTokens.accept(builder, v));
+      }
+      activeModel.frequencyPenalty().ifPresent(v -> frequencyPenalty.accept(builder, v));
+      activeModel.presencePenalty().ifPresent(v -> presencePenalty.accept(builder, v));
+      activeModel.seed().ifPresent(v -> seed.accept(builder, v));
+    }
+  }
+
+  private static final SharedTuning<OpenAiChatModel.OpenAiChatModelBuilder> BLOCKING_TUNING =
+      new SharedTuning<>(
+          OpenAiChatModel.OpenAiChatModelBuilder::reasoningEffort,
+          OpenAiChatModel.OpenAiChatModelBuilder::temperature,
+          OpenAiChatModel.OpenAiChatModelBuilder::topP,
+          OpenAiChatModel.OpenAiChatModelBuilder::maxTokens,
+          OpenAiChatModel.OpenAiChatModelBuilder::frequencyPenalty,
+          OpenAiChatModel.OpenAiChatModelBuilder::presencePenalty,
+          OpenAiChatModel.OpenAiChatModelBuilder::seed);
+
+  private static final SharedTuning<OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder>
+      STREAMING_TUNING =
+          new SharedTuning<>(
+              OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder::reasoningEffort,
+              OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder::temperature,
+              OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder::topP,
+              OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder::maxTokens,
+              OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder::frequencyPenalty,
+              OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder::presencePenalty,
+              OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder::seed);
+
   /** Tuning for the blocking model (verifier, describe, changelog, docs, replies). */
   @ApplicationScoped
   static class ChatModelCustomizer
@@ -80,13 +136,7 @@ public final class ChatModelCustomizers {
 
     @Override
     public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
-      reasoningEffort(config).ifPresent(builder::reasoningEffort);
-      activeModel.temperature().ifPresent(builder::temperature);
-      activeModel.topP().ifPresent(builder::topP);
-      activeModel.maxOutputTokens().ifPresent(builder::maxTokens);
-      activeModel.frequencyPenalty().ifPresent(builder::frequencyPenalty);
-      activeModel.presencePenalty().ifPresent(builder::presencePenalty);
-      activeModel.seed().ifPresent(builder::seed);
+      BLOCKING_TUNING.apply(config, activeModel, builder, true);
     }
   }
 
@@ -105,13 +155,7 @@ public final class ChatModelCustomizers {
 
     @Override
     public void customize(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder builder) {
-      reasoningEffort(config).ifPresent(builder::reasoningEffort);
-      activeModel.temperature().ifPresent(builder::temperature);
-      activeModel.topP().ifPresent(builder::topP);
-      activeModel.maxOutputTokens().ifPresent(builder::maxTokens);
-      activeModel.frequencyPenalty().ifPresent(builder::frequencyPenalty);
-      activeModel.presencePenalty().ifPresent(builder::presencePenalty);
-      activeModel.seed().ifPresent(builder::seed);
+      STREAMING_TUNING.apply(config, activeModel, builder, true);
     }
   }
 
@@ -137,12 +181,7 @@ public final class ChatModelCustomizers {
 
     @Override
     public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
-      reasoningEffort(config).ifPresent(builder::reasoningEffort);
-      activeModel.temperature().ifPresent(builder::temperature);
-      activeModel.topP().ifPresent(builder::topP);
-      activeModel.frequencyPenalty().ifPresent(builder::frequencyPenalty);
-      activeModel.presencePenalty().ifPresent(builder::presencePenalty);
-      activeModel.seed().ifPresent(builder::seed);
+      BLOCKING_TUNING.apply(config, activeModel, builder, false);
     }
   }
 
@@ -165,12 +204,7 @@ public final class ChatModelCustomizers {
 
     @Override
     public void customize(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder builder) {
-      reasoningEffort(config).ifPresent(builder::reasoningEffort);
-      activeModel.temperature().ifPresent(builder::temperature);
-      activeModel.topP().ifPresent(builder::topP);
-      activeModel.frequencyPenalty().ifPresent(builder::frequencyPenalty);
-      activeModel.presencePenalty().ifPresent(builder::presencePenalty);
-      activeModel.seed().ifPresent(builder::seed);
+      STREAMING_TUNING.apply(config, activeModel, builder, false);
     }
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
@@ -203,7 +203,8 @@ public class ReviewResponseParser {
    * ": "}-separated in a stable order — {@code "claim"} first when present (the field the
    * production shape led with), then the rest in emission order; non-string scalars flatten via
    * {@code asText()}; arrays, and objects without any string-valued field, degrade to their JSON
-   * text so no content is silently lost.
+   * text. Non-string members of an object that does have string-valued fields (e.g. {@code line:
+   * 42}) are dropped by design — the gap list renders prose, and the string fields carry it.
    */
   private static String flattenGap(JsonNode gap) {
     if (!gap.isObject()) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/Throwables.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/Throwables.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import java.util.Optional;
+
+/** The one bounded cause-chain walk shared by every layer that reacts to a wrapped failure. */
+public final class Throwables {
+
+  /** Cause-chain links inspected before giving up, so a cyclic chain cannot spin. */
+  private static final int MAX_CAUSE_DEPTH = 16;
+
+  private Throwables() {}
+
+  /**
+   * The first throwable of the given type in a failure's cause chain — the failure itself included
+   * — or empty when none is found within the bound.
+   *
+   * <p>Bounded rather than walked to {@code null}: a cause chain can cycle — a {@link Throwable}
+   * overriding {@code getCause()}, or plain {@code A caused-by B caused-by A} — and an unbounded
+   * walk would spin forever on the review thread. The bound is far above any real chain (the
+   * failure arrives wrapped at depth 2 in practice), so a match is never missed for depth.
+   */
+  public static <T extends Throwable> Optional<T> findCause(Throwable failure, Class<T> type) {
+    var cause = failure;
+    for (var depth = 0;
+        cause != null && depth < MAX_CAUSE_DEPTH;
+        depth++, cause = cause.getCause()) {
+      if (type.isInstance(cause)) {
+        return Optional.of(type.cast(cause));
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -320,7 +320,9 @@ class DiffBudgetPlannerTest {
     // The canonical constructor normalizes a null accumulator rather than storing it: a null here
     // would NPE the moment a failed batch recorded a gap, on the async review thread, taking the
     // whole review down with it.
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true, null);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
 
     assertTrue(plan.runtimeUncoveredFiles().isEmpty(), "a null accumulator normalizes to empty");
 
@@ -335,7 +337,9 @@ class DiffBudgetPlannerTest {
     // (verdict holds, summary discloses) while staying separately attributable so the disclosure
     // can name the spend ceiling rather than the diff budget. Nulls and duplicates are dropped
     // like recordUncoveredFiles does, and the accessor is a defensive copy.
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
 
     plan.recordSpendCeilingSkippedFiles(Arrays.asList("a.java", null, "a.java", "b.java"));
 
@@ -351,7 +355,9 @@ class DiffBudgetPlannerTest {
   void aPlanBuiltWithANullSpendCeilingListStillAcceptsSkips() {
     // Same normalization contract as the runtime-gap list: a null accumulator must not NPE the
     // moment a ceiling-blocked batch records a skip on the review thread.
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true, null, null);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
 
     assertTrue(plan.spendCeilingSkippedFiles().isEmpty());
 
@@ -365,7 +371,9 @@ class DiffBudgetPlannerTest {
     // #500: a salvaged batch's files are partially reviewed — they must trip the truncation gate
     // (approval held, disclosure rendered) without joining the not-reviewed sets, keep dedupe/null
     // hygiene like the other recorders, and stay behind a defensive copy.
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
 
     plan.recordResponseCutFiles(Arrays.asList("a.java", null, "a.java", "b.java"));
 
@@ -380,7 +388,8 @@ class DiffBudgetPlannerTest {
   @Test
   void aPlanBuiltWithANullResponseCutListStillAcceptsRecords() {
     var plan =
-        new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true, null, null, null);
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
 
     assertTrue(plan.responseCutFiles().isEmpty());
 
@@ -394,7 +403,9 @@ class DiffBudgetPlannerTest {
     // #500 scope A: the flag rides the shared plan like the runtime-gap lists — written after the
     // plan is built, read by the verdict — and, like them, its record accessor must not leak the
     // mutable backing.
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
     assertFalse(plan.summaryWasCut());
 
     plan.recordSummaryResponseCut();
@@ -411,7 +422,7 @@ class DiffBudgetPlannerTest {
     var live = new java.util.concurrent.atomic.AtomicBoolean(true);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, live);
+            List.of(), List.of(), List.of(), true, null, null, null, live, null);
 
     assertTrue(plan.summaryWasCut());
     assertNotSame(live, plan.summaryResponseCut(), "the accessor returns a defensive snapshot");
@@ -425,7 +436,9 @@ class DiffBudgetPlannerTest {
     // #518: the ceiling sibling of the summary-cut flag rides the shared plan the same way —
     // written after the plan is built, read by the verdict — and, like it, its record accessor
     // must not leak the mutable backing.
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
     assertFalse(plan.summaryWasSkippedAtCeiling());
 
     plan.recordSummarySkippedAtCeiling();
@@ -459,7 +472,8 @@ class DiffBudgetPlannerTest {
     // No runtime gap: the clipped list passes through, so a partially analyzed file keeps its
     // "clipped" meaning rather than being reported as wholly uncovered.
     var plan =
-        new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of("src/Clipped.java"), true);
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of("src/Clipped.java"), true, null, null, null, null, null);
 
     assertEquals(List.of("src/Clipped.java"), plan.effectiveClippedFiles());
   }
@@ -470,7 +484,15 @@ class DiffBudgetPlannerTest {
     // out of the clipped list and is reported as omitted, so coverage is never overstated.
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of("src/Clipped.java", "src/Other.java"), true);
+            List.of(),
+            List.of(),
+            List.of("src/Clipped.java", "src/Other.java"),
+            true,
+            null,
+            null,
+            null,
+            null,
+            null);
 
     plan.recordUncoveredFiles(List.of("src/Clipped.java"));
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -168,7 +168,15 @@ class FindingPipelineTest {
 
   private static DiffBudgetPlanner.BudgetPlan multiBatchPlan(List<String> omittedByName) {
     return new DiffBudgetPlanner.BudgetPlan(
-        List.of(batch("a.java"), batch("b.java")), omittedByName, List.of(), true);
+        List.of(batch("a.java"), batch("b.java")),
+        omittedByName,
+        List.of(),
+        true,
+        null,
+        null,
+        null,
+        null,
+        null);
   }
 
   @Test
@@ -432,7 +440,8 @@ class FindingPipelineTest {
     var template =
         new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
     var plan =
-        new DiffBudgetPlanner.BudgetPlan(List.of(), List.of("a.java", "b.java"), List.of(), true);
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of("a.java", "b.java"), List.of(), true, null, null, null, null, null);
     when(aiReviewService.summarize(eq(session), any()))
         .thenThrow(new AiResponseTruncatedException("finish_reason=length", null, true));
 
@@ -758,7 +767,15 @@ class FindingPipelineTest {
         new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(batch("clipped.java")), List.of(), List.of(), true);
+            List.of(batch("clipped.java")),
+            List.of(),
+            List.of(),
+            true,
+            null,
+            null,
+            null,
+            null,
+            null);
     var captor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
     when(aiReviewService.review(eq(session), captor.capture()))
         .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -777,7 +794,8 @@ class FindingPipelineTest {
     var template =
         new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
     var plan =
-        new DiffBudgetPlanner.BudgetPlan(List.of(batch("a.java")), List.of(), List.of(), false);
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(batch("a.java")), List.of(), List.of(), false, null, null, null, null, null);
     var captor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
     when(aiReviewService.review(eq(session), captor.capture()))
         .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -799,7 +817,8 @@ class FindingPipelineTest {
     var ctx = reviewContext();
     var template = new AiReviewService.PromptInputs("d", "ctx", "base", "s", "t", "", "");
     var plan =
-        new DiffBudgetPlanner.BudgetPlan(List.of(batch("a.java")), List.of(), List.of(), false);
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(batch("a.java")), List.of(), List.of(), false, null, null, null, null, null);
     when(aiReviewService.review(eq(session), any()))
         .thenThrow(new TokenSpendCeilingExceededException(120_000, 100_000));
 
@@ -866,7 +885,9 @@ class FindingPipelineTest {
             new FileDiff("a.java", "modified", 3, 0, 3, "@@ -1 +1 @@\n+x\n"),
             new FileDiff("b.java", "modified", 2, 0, 2, "@@ -1 +1 @@\n+y\n"));
     var batch = new DiffBudgetPlanner.DiffBatch("### a.java\n### b.java\n", batchFiles, 10);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(batch), List.of(), List.of("a.java"), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(batch), List.of(), List.of("a.java"), true, null, null, null, null, null);
     when(aiReviewService.review(eq(session), any()))
         .thenReturn(
             new ReviewResponse(
@@ -894,7 +915,15 @@ class FindingPipelineTest {
         .thenReturn(Map.of(1, "a.java"));
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(batch("a.java"), batch("b.java")), List.of(), List.of("a.java"), true);
+            List.of(batch("a.java"), batch("b.java")),
+            List.of(),
+            List.of("a.java"),
+            true,
+            null,
+            null,
+            null,
+            null,
+            null);
     when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt()))
         .thenReturn(
             new ReviewResponse(
@@ -980,7 +1009,15 @@ class FindingPipelineTest {
     var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(batch("a.java"), batch("b.java")), List.of(), List.of("a.java"), true);
+            List.of(batch("a.java"), batch("b.java")),
+            List.of(),
+            List.of("a.java"),
+            true,
+            null,
+            null,
+            null,
+            null,
+            null);
     when(budgetPlanner.perCallInputBudget()).thenReturn(1_000_000);
     when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
         .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -1014,7 +1051,15 @@ class FindingPipelineTest {
     var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(batch("a.java"), batch("b.java")), List.of("z.java"), List.of("a.java"), true);
+            List.of(batch("a.java"), batch("b.java")),
+            List.of("z.java"),
+            List.of("a.java"),
+            true,
+            null,
+            null,
+            null,
+            null,
+            null);
     when(budgetPlanner.perCallInputBudget()).thenReturn(1_000_000);
     when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
         .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -1459,7 +1504,8 @@ class FindingPipelineTest {
     var template =
         new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
     var plan =
-        new DiffBudgetPlanner.BudgetPlan(List.of(), List.of("a.java", "b.java"), List.of(), true);
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of("a.java", "b.java"), List.of(), true, null, null, null, null, null);
     var summary = new ReviewResponse.Summary(0, 0, 0, 0, 0, "too large", "unknown", List.of());
     var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
     when(aiReviewService.summarize(eq(session), captor.capture()))
@@ -1481,7 +1527,9 @@ class FindingPipelineTest {
     var session = ReviewSession.create("owner/repo", 1, "PR", "sha");
     var template =
         new AiReviewService.PromptInputs("(no changes detected)", "ctx", "base", "s", "t", "", "");
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
     var captor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
     when(aiReviewService.review(eq(session), captor.capture()))
         .thenReturn(new ReviewResponse(List.of(), List.of(), null));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummaryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummaryTest.java
@@ -121,7 +121,8 @@ class FollowUpDeltaSummaryTest {
     // describe a clipped (partially analyzed) file as omitted; the detail must distinguish them
     // (F8).
     var truncation =
-        new ReviewResult.TruncationDetail(List.of("omitted.java"), List.of("clipped.java"));
+        new ReviewResult.TruncationDetail(
+            List.of("omitted.java"), List.of("clipped.java"), List.of(), List.of(), false, false);
     var result =
         new ReviewResult(
             List.of(finding("a.java")),
@@ -153,7 +154,7 @@ class FollowUpDeltaSummaryTest {
     // summary-cut clause in it renders the self-contradictory "the findings themselves are
     // complete, so this covers only part of the diff".
     var truncation =
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true);
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true, false);
     var result =
         new ReviewResult(
             List.of(finding("a.java")),

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -192,13 +192,15 @@ class ReviewResultTest {
     // diff") is about per-file gaps. A detail whose only content is a summary flag means the
     // findings cover the whole diff, so this surface must render nothing.
     var detail =
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true);
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true, false);
 
     assertEquals("", ReviewResult.truncationDisclosure(0, detail));
     // The guard's null arm behaves like an empty detail, and a detail with file gaps still
     // discloses even when the caller's count is zero — the names are the coverage truth.
     assertEquals("", ReviewResult.truncationDisclosure(0, null));
-    var clippedOnly = new ReviewResult.TruncationDetail(List.of(), List.of("clipped.java"));
+    var clippedOnly =
+        new ReviewResult.TruncationDetail(
+            List.of(), List.of("clipped.java"), List.of(), List.of(), false, false);
     assertTrue(
         ReviewResult.truncationDisclosure(0, clippedOnly).contains("partially analyzed"),
         ReviewResult.truncationDisclosure(0, clippedOnly));
@@ -210,7 +212,7 @@ class ReviewResultTest {
     // as one more clause — the flag-only guard must not suppress this shape.
     var detail =
         new ReviewResult.TruncationDetail(
-            List.of("omitted.java"), List.of(), List.of(), List.of(), true);
+            List.of("omitted.java"), List.of(), List.of(), List.of(), true, false);
 
     var disclosure = ReviewResult.truncationDisclosure(1, detail);
 
@@ -246,7 +248,12 @@ class ReviewResultTest {
     // wording.
     var detail =
         new ReviewResult.TruncationDetail(
-            List.of("a.java"), List.of("b.java"), List.of("c.java", "d.java"));
+            List.of("a.java"),
+            List.of("b.java"),
+            List.of("c.java", "d.java"),
+            List.of(),
+            false,
+            false);
 
     var clause = ReviewResult.coverageGapClause(4, detail);
 
@@ -261,7 +268,9 @@ class ReviewResultTest {
 
   @Test
   void coverageGapClauseWithOnlySpendCeilingSkipsDropsTheBudgetWording() {
-    var detail = new ReviewResult.TruncationDetail(List.of(), List.of(), List.of("c.java"));
+    var detail =
+        new ReviewResult.TruncationDetail(
+            List.of(), List.of(), List.of("c.java"), List.of(), false, false);
 
     var clause = ReviewResult.coverageGapClause(1, detail);
 
@@ -288,7 +297,8 @@ class ReviewResultTest {
             2,
             false,
             true,
-            new ReviewResult.TruncationDetail(List.of("a.java"), List.of(), List.of("c.java")));
+            new ReviewResult.TruncationDetail(
+                List.of("a.java"), List.of(), List.of("c.java"), List.of(), false, false));
 
     var brief = result.coverageGapBrief();
 
@@ -298,7 +308,7 @@ class ReviewResultTest {
 
   @Test
   void truncationDetailNormalizesNullListsToEmpty() {
-    var detail = new ReviewResult.TruncationDetail(null, null, null, null);
+    var detail = new ReviewResult.TruncationDetail(null, null, null, null, false, false);
     assertTrue(detail.isEmpty());
     assertEquals(List.of(), detail.spendCeilingSkippedFileNames());
     assertEquals(List.of(), detail.responseCutFileNames());
@@ -311,7 +321,7 @@ class ReviewResultTest {
     // them into the budget or ceiling wording.
     var detail =
         new ReviewResult.TruncationDetail(
-            List.of("a.java"), List.of(), List.of(), List.of("cut.java"));
+            List.of("a.java"), List.of(), List.of(), List.of("cut.java"), false, false);
 
     var clause = ReviewResult.coverageGapClause(2, detail);
 
@@ -342,7 +352,7 @@ class ReviewResultTest {
             false,
             true,
             new ReviewResult.TruncationDetail(
-                List.of(), List.of(), List.of(), List.of("cut.java")));
+                List.of(), List.of(), List.of(), List.of("cut.java"), false, false));
 
     var brief = result.coverageGapBrief();
 
@@ -353,10 +363,13 @@ class ReviewResultTest {
   @Test
   void truncationDetailWithOnlyResponseCutFilesIsNotEmpty() {
     var detail =
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of("cut.java"));
+        new ReviewResult.TruncationDetail(
+            List.of(), List.of(), List.of(), List.of("cut.java"), false, false);
     assertFalse(detail.isEmpty());
     // The three-list convenience constructor keeps the pre-#500 shape: no response-cut files.
-    assertTrue(new ReviewResult.TruncationDetail(List.of(), List.of(), List.of()).isEmpty());
+    assertTrue(
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, false)
+            .isEmpty());
   }
 
   @Test
@@ -366,7 +379,8 @@ class ReviewResultTest {
     // the findings themselves are complete — instead of leaving the cut log-only while the
     // sibling ceiling degradation of the same lane discloses itself.
     var detail =
-        new ReviewResult.TruncationDetail(List.of("a.java"), List.of(), List.of(), List.of(), true);
+        new ReviewResult.TruncationDetail(
+            List.of("a.java"), List.of(), List.of(), List.of(), true, false);
 
     var clause = ReviewResult.coverageGapClause(1, detail);
 
@@ -398,7 +412,7 @@ class ReviewResultTest {
             false,
             true,
             new ReviewResult.TruncationDetail(
-                List.of("a.java"), List.of(), List.of(), List.of(), true));
+                List.of("a.java"), List.of(), List.of(), List.of(), true, false));
 
     var brief = result.coverageGapBrief();
 
@@ -409,11 +423,11 @@ class ReviewResultTest {
   @Test
   void truncationDetailWithOnlyTheSummaryCutIsNotEmpty() {
     var detail =
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true);
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true, false);
     assertFalse(detail.isEmpty());
     // The four-list convenience constructor keeps the pre-summary-cut shape: flag unset.
     assertFalse(
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of())
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, false)
             .summaryResponseCut());
   }
 
@@ -428,7 +442,7 @@ class ReviewResultTest {
     assertFalse(detail.hasFileGaps());
     // The five-arg convenience constructor keeps the pre-#518 shape: flag unset.
     assertFalse(
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true)
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true, false)
             .summarySkippedAtCeiling());
   }
 
@@ -491,10 +505,14 @@ class ReviewResultTest {
 
   @Test
   void truncationDetailWithOnlySpendCeilingSkipsIsNotEmpty() {
-    var detail = new ReviewResult.TruncationDetail(List.of(), List.of(), List.of("c.java"));
+    var detail =
+        new ReviewResult.TruncationDetail(
+            List.of(), List.of(), List.of("c.java"), List.of(), false, false);
     assertFalse(detail.isEmpty());
     // The two-list convenience constructor keeps the pre-#499 shape: no ceiling skips.
-    assertTrue(new ReviewResult.TruncationDetail(List.of(), List.of()).isEmpty());
+    assertTrue(
+        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, false)
+            .isEmpty());
   }
 
   /**

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -366,7 +366,7 @@ class ReviewResultTest {
         new ReviewResult.TruncationDetail(
             List.of(), List.of(), List.of(), List.of("cut.java"), false, false);
     assertFalse(detail.isEmpty());
-    // The three-list convenience constructor keeps the pre-#500 shape: no response-cut files.
+    // The canonical constructor with an empty response-cut list keeps the pre-#500 shape.
     assertTrue(
         new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, false)
             .isEmpty());
@@ -425,7 +425,7 @@ class ReviewResultTest {
     var detail =
         new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true, false);
     assertFalse(detail.isEmpty());
-    // The four-list convenience constructor keeps the pre-summary-cut shape: flag unset.
+    // The canonical constructor with the cut flag unset keeps the pre-summary-cut shape.
     assertFalse(
         new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, false)
             .summaryResponseCut());
@@ -440,7 +440,7 @@ class ReviewResultTest {
     assertFalse(detail.isEmpty());
     // ...while the per-file surfaces treat it as gap-free, exactly like the cut flag (#516).
     assertFalse(detail.hasFileGaps());
-    // The five-arg convenience constructor keeps the pre-#518 shape: flag unset.
+    // The canonical constructor with the ceiling flag unset keeps the pre-#518 shape.
     assertFalse(
         new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true, false)
             .summarySkippedAtCeiling());
@@ -509,7 +509,7 @@ class ReviewResultTest {
         new ReviewResult.TruncationDetail(
             List.of(), List.of(), List.of("c.java"), List.of(), false, false);
     assertFalse(detail.isEmpty());
-    // The two-list convenience constructor keeps the pre-#499 shape: no ceiling skips.
+    // The canonical constructor with an empty ceiling-skip list keeps the pre-#499 shape.
     assertTrue(
         new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, false)
             .isEmpty());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -134,7 +134,9 @@ class VerdictBuilderTest {
   @Test
   void budgetedReviewDisclosesOnlyThePlanOmissions() {
     var ctx = contextWithLineCapOmissions(3);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of("big.java"), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of("big.java"), List.of(), true, null, null, null, null, null);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -145,7 +147,9 @@ class VerdictBuilderTest {
   @Test
   void budgetedReviewWithFullCoverageIsNotTruncated() {
     var ctx = contextWithLineCapOmissions(3);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -160,7 +164,9 @@ class VerdictBuilderTest {
     // reads that same instance and must fold them into the omitted set — holding APPROVE and naming
     // them — exactly like a planned omission, so a partial review never claims full coverage.
     var ctx = contextWithLineCapOmissions(0);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
     plan.recordUncoveredFiles(List.of("failed.java"));
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -178,7 +184,9 @@ class VerdictBuilderTest {
     // No double-count: a clipped file whose batch then failed is reported as omitted, not also as
     // partially analyzed.
     var ctx = contextWithLineCapOmissions(0);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of("f.java"), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of("f.java"), true, null, null, null, null, null);
     plan.recordUncoveredFiles(List.of("f.java"));
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -195,7 +203,9 @@ class VerdictBuilderTest {
     // holds approval, counts as omitted — but the rendered disclosure must name the ceiling (a
     // spend limit with its own knob), not the diff budget, as the reason.
     var ctx = contextWithLineCapOmissions(0);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of("big.java"), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of("big.java"), List.of(), true, null, null, null, null, null);
     plan.recordSpendCeilingSkippedFiles(List.of("skipped.java"));
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -224,7 +234,9 @@ class VerdictBuilderTest {
     // files were reviewed up to the cut and the findings kept, so the disclosure must say the
     // response was cut (naming the cap), hold approval, and NOT list the files as "not reviewed".
     var ctx = contextWithLineCapOmissions(0);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
     plan.recordResponseCutFiles(List.of("cut.java"));
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -252,7 +264,9 @@ class VerdictBuilderTest {
     // A clipped file's batch can also have its response cut. One file, one disclosure: the
     // stronger (output-side) statement wins, and the file is never counted twice.
     var ctx = contextWithLineCapOmissions(0);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of("c.java"), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of("c.java"), true, null, null, null, null, null);
     plan.recordResponseCutFiles(List.of("c.java"));
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -269,7 +283,9 @@ class VerdictBuilderTest {
     // are complete, so approval must not be held, but the posted review must say the summary was
     // shortened (naming both knobs) instead of leaving the cut log-only.
     var ctx = contextWithLineCapOmissions(0);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
     plan.recordSummaryResponseCut();
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -299,7 +315,9 @@ class VerdictBuilderTest {
     // complete: approval must not be held, but the posted review must name the ceiling instead of
     // leaving the degradation log-only.
     var ctx = contextWithLineCapOmissions(0);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
     plan.recordSummarySkippedAtCeiling();
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -326,7 +344,9 @@ class VerdictBuilderTest {
     // With a real file gap the partial-review banner renders anyway, so the ceiling skip becomes
     // one more clause there — the dedicated summary-only banner must not stack on top.
     var ctx = contextWithLineCapOmissions(0);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of("big.java"), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of("big.java"), List.of(), true, null, null, null, null, null);
     plan.recordSummarySkippedAtCeiling();
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -350,7 +370,9 @@ class VerdictBuilderTest {
     // With a real file gap present the partial-review banner renders anyway, so the summary cut
     // becomes one more clause there — the dedicated summary-only banner must not stack on top.
     var ctx = contextWithLineCapOmissions(0);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of("big.java"), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of("big.java"), List.of(), true, null, null, null, null, null);
     plan.recordSummaryResponseCut();
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -389,7 +411,8 @@ class VerdictBuilderTest {
             0,
             false,
             true,
-            new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true));
+            new ReviewResult.TruncationDetail(
+                List.of(), List.of(), List.of(), List.of(), true, false));
 
     var checkSummary = VerdictBuilder.checkSummaryForResult(result);
 
@@ -402,7 +425,9 @@ class VerdictBuilderTest {
   @Test
   void clippedOnlyReviewIsDisclosedAsPartialAndHoldsApproval() {
     var ctx = contextWithLineCapOmissions(0);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of("huge.java"), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of("huge.java"), true, null, null, null, null, null);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -415,7 +440,15 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(0);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of("big.java"), List.of("huge.java"), true);
+            List.of(),
+            List.of("big.java"),
+            List.of("huge.java"),
+            true,
+            null,
+            null,
+            null,
+            null,
+            null);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -432,7 +465,9 @@ class VerdictBuilderTest {
   @Test
   void budgetOmittedFilesAreDroppedFromTheWalkthroughRows() {
     var ctx = contextWithLineCapOmissions(0); // reviewable: a.java
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of("a.java"), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of("a.java"), List.of(), true, null, null, null, null, null);
     var rowsCaptor = ArgumentCaptor.forClass(List.class);
 
     builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -454,7 +489,9 @@ class VerdictBuilderTest {
             List.of(
                 new FileDiff("reviewed.java", "modified", 1, 0, 1, ""),
                 new FileDiff("skipped.java", "modified", 1, 0, 1, "")));
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
     plan.recordSpendCeilingSkippedFiles(List.of("skipped.java"));
     var rowsCaptor = ArgumentCaptor.forClass(List.class);
 
@@ -482,7 +519,9 @@ class VerdictBuilderTest {
             List.of(
                 new FileDiff(null, "modified", 1, 0, 1, ""),
                 new FileDiff("a.java", "modified", 1, 0, 1, "")));
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of("a.java"), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of("a.java"), List.of(), true, null, null, null, null, null);
     var rowsCaptor = ArgumentCaptor.forClass(List.class);
 
     builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -557,7 +596,9 @@ class VerdictBuilderTest {
             new FollowUpAnalyzer(new com.fasterxml.jackson.databind.ObjectMapper()),
             BotIdentity.from(List.of("thrillhousebot[bot]")),
             BlockingStrictness.BALANCED);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
 
     var result =
         realBuilder.build(
@@ -576,7 +617,9 @@ class VerdictBuilderTest {
             new FollowUpAnalyzer(new com.fasterxml.jackson.databind.ObjectMapper()),
             BotIdentity.from(List.of("thrillhousebot[bot]")),
             BlockingStrictness.BALANCED);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
     var ctx =
         new ReviewContextLoader.ReviewContext(
             List.of(),
@@ -719,7 +762,12 @@ class VerdictBuilderTest {
             List.of(new DiffBudgetPlanner.DiffBatch(DISPATCHING_DIFF, List.of(), 10)),
             List.of(),
             List.of(),
-            true);
+            true,
+            null,
+            null,
+            null,
+            null,
+            null);
 
     var result =
         builderWithRealAnalyzer(summaryGenerator)
@@ -737,7 +785,9 @@ class VerdictBuilderTest {
   void declineRecheckReadsTheLegacyDiffWhenBudgetingIsDisabled() {
     // budgeted=false: the planner holds no batches, so the legacy uncapped ctx.diff() is the only
     // record of what the model saw and must still be the material the decline is checked against.
-    var legacyPlan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), false);
+    var legacyPlan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), false, null, null, null, null, null);
 
     var result =
         builderWithRealAnalyzer(summaryGenerator)
@@ -757,7 +807,8 @@ class VerdictBuilderTest {
     // budgeted=true but every file overflowed the budget, so batches is empty and the concatenation
     // would yield nothing; ctx.diff() is the fallback the re-check must use.
     var emptyBudgetedPlan =
-        new DiffBudgetPlanner.BudgetPlan(List.of(), List.of("big.java"), List.of(), true);
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of("big.java"), List.of(), true, null, null, null, null, null);
 
     var result =
         builderWithRealAnalyzer(summaryGenerator)
@@ -773,7 +824,9 @@ class VerdictBuilderTest {
   @Test
   void disabledBudgetingDisclosesTheLegacyLineCapCount() {
     var ctx = contextWithLineCapOmissions(2);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), false);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), false, null, null, null, null, null);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -789,7 +842,8 @@ class VerdictBuilderTest {
       new CiStatusEvaluator.CiEvaluation(List.of(), true);
 
   private static final DiffBudgetPlanner.BudgetPlan FULL_COVERAGE =
-      new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+      new DiffBudgetPlanner.BudgetPlan(
+          List.of(), List.of(), List.of(), true, null, null, null, null, null);
 
   private VerdictBuilder builderWith(CiGatingMode mode) {
     return new VerdictBuilder(
@@ -963,7 +1017,9 @@ class VerdictBuilderTest {
               return new DiffLineResolver(Map.of());
             },
             null);
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), false);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), false, null, null, null, null, null);
 
     builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -993,7 +1049,8 @@ class VerdictBuilderTest {
             contextWithLineCapOmissions(0),
             response,
             CI_CLEAR,
-            new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), false));
+            new DiffBudgetPlanner.BudgetPlan(
+                List.of(), List.of(), List.of(), false, null, null, null, null, null));
 
     assertEquals(ReviewState.REQUEST_CHANGES, result.reviewState());
   }
@@ -1021,7 +1078,8 @@ class VerdictBuilderTest {
             contextWithLineCapOmissions(0),
             response,
             CI_CLEAR,
-            new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), false));
+            new DiffBudgetPlanner.BudgetPlan(
+                List.of(), List.of(), List.of(), false, null, null, null, null, null));
 
     assertEquals(ReviewState.COMMENT, result.reviewState());
   }
@@ -1145,7 +1203,8 @@ class VerdictBuilderTest {
             contextWithLineCapOmissions(0),
             response,
             CI_CLEAR,
-            new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), false));
+            new DiffBudgetPlanner.BudgetPlan(
+                List.of(), List.of(), List.of(), false, null, null, null, null, null));
 
     assertEquals(ReviewState.COMMENT, result.reviewState());
   }
@@ -1217,7 +1276,9 @@ class VerdictBuilderTest {
    */
   @Test
   void unresolvedCountAcrossAZeroFindingRoundStaysAtTheOneRealFinding() {
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
     var stillUnresolved =
         new ReviewResponse(
             List.of(),
@@ -1241,7 +1302,9 @@ class VerdictBuilderTest {
    */
   @Test
   void resolvedPriorFindingNoLongerPhantomHoldsApproveAfterAZeroFindingRound() {
-    var plan = new DiffBudgetPlanner.BudgetPlan(List.of(), List.of(), List.of(), true);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, null, null);
     var resolvedNow =
         new ReviewResponse(
             List.of(),


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [x] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

The four audit-3 structural cleanups, all behavior-preserving (no functional change):

1. **One bounded cause walk.** The structurally identical walks in `FindingPipeline.isSpendCeilingBlocked` and `AiResponseTruncatedException.findIn` — each with its own `MAX_CAUSE_DEPTH` that could silently drift apart — are replaced by a single generic `Throwables.findCause(Throwable, Class<T>)` with the one `MAX_CAUSE_DEPTH = 16`. Both former walkers now delegate; `findIn` keeps its public signature, so its callers (`ReviewOrchestrator`, `FindingPipeline`) are untouched.
2. **Back-compat constructor chains retired.** `BudgetPlan` (five non-canonical constructors, including the 8-arg one added alongside the `summarySkippedAtCeiling` flag) and `TruncationDetail` (four) now have only their canonical constructors. Grep found main-source callers of the short forms (`DiffBudgetPlanner` ×3, `AbstractPrSuggestionGenerator` ×1) — migrated too, along with every test call site (61 mechanical arity migrations across 5 test files). A repo-wide balanced-paren scan confirms every remaining `new BudgetPlan(...)` has 9 args and every `new TruncationDetail(...)` has 6.
3. **Shared customizer applier.** The four near-identical `ChatModelCustomizers` bodies now run one `SharedTuning.apply(...)`; the blocking and streaming builders share no supertype, so the two flavours adapt via setter-reference bundles (`BLOCKING_TUNING`/`STREAMING_TUNING`). The knob list and its order live in exactly one place; the concise pair passes `applyResponseCap=false` and still never sees the active model's `max-output-tokens`. The four CDI bean classes remain, as the qualifier constraints require.
4. **`flattenGap` javadoc fixed.** It no longer claims "no content is silently lost": non-string members of a mixed gap object (e.g. `line: 42`) are dropped by design when string-valued fields exist, and the doc now says so.

Proof of no behavior change: the full suite (2593 tests) is green with only mechanical test edits — constructor-arity migrations, no assertion touched.

## Related Issues

Fixes #519

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Full suite: `./mvnw clean test` — 2593 tests, 0 failures, 0 errors, 0 skipped. `spotbugs:check` BugInstance size 0; `spotless:check` clean. Jacoco intersected with the diff: zero uncovered lines and zero uncovered branches in changed main code (existing tests already exercise every branch of the shared walk — including the cyclic-chain depth bound — and both `applyResponseCap` outcomes of both tuning flavours).

## Screenshots / Logs

N/A

## Additional Notes

Pure refactor pulled into v0.6.0 so no tech debt carries to 0.7. No red/green proof applies (no behavioral test); every test edit is a comment-free mechanical arity migration.