### PR TITLE
fix(config): name the real buffer knob in the concise-cap refusal

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -350,6 +350,12 @@ public class StartupConfigValidator {
    * window just as surely from this knob (#517). Not applied when token budgeting is off (no packed
    * prompt to overrun) or when the active model declares {@code separate-output-budget} (nothing is
    * reserved, and the response never draws on the window).
+   *
+   * <p>The buffer remedy names the knob that actually sources the effective buffer: when the active
+   * model carries an {@code output-buffer-tokens} override, {@link
+   * ActiveModelSettings#outputBufferTokens} never reads the global value, so advising {@code
+   * REVIEW_OUTPUT_BUFFER_TOKENS} there would send the operator to an inert knob and re-boot into
+   * the identical refusal (#528).
    */
   private void validateConciseResponseCap(List<String> problems) {
     conciseMaxOutputTokens
@@ -362,6 +368,14 @@ public class StartupConfigValidator {
                         + v));
     if (activeModel.maxInputTokens() > 0 && !activeModel.separateOutputBudget()) {
       var outputBuffer = activeModel.reservedOutputTokens();
+      // A per-model output-buffer-tokens override shadows the global env var entirely, so the
+      // remedy must name whichever knob the effective buffer actually came from (#528).
+      var bufferKnob =
+          Optional.ofNullable(config.ai().models().get(activeModel.modelName()))
+                  .flatMap(ThrillhouseConfig.AiPricingConfig.ModelSettings::outputBufferTokens)
+                  .isPresent()
+              ? "thrillhousebot.ai.models.\"" + activeModel.modelName() + "\".output-buffer-tokens"
+              : "REVIEW_OUTPUT_BUFFER_TOKENS";
       conciseMaxOutputTokens
           .filter(v -> v > outputBuffer)
           .ifPresent(
@@ -376,8 +390,9 @@ public class StartupConfigValidator {
                           + activeModel.modelName()
                           + "' so the token budget reserves the response cap the"
                           + " summary/verifier/reply calls send. Lower"
-                          + " REVIEW_CONCISE_MAX_OUTPUT_TOKENS, raise"
-                          + " REVIEW_OUTPUT_BUFFER_TOKENS to cover it, or set"
+                          + " REVIEW_CONCISE_MAX_OUTPUT_TOKENS, raise "
+                          + bufferKnob
+                          + " to cover it, or set"
                           + " thrillhousebot.ai.models.\""
                           + activeModel.modelName()
                           + "\".separate-output-budget=true if this model's response allowance is"

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -411,6 +411,39 @@ class StartupConfigValidatorTest {
   }
 
   @Test
+  void namesThePerModelBufferKnobWhenAnOverrideSourcesTheEffectiveBuffer() {
+    // #528: when a per-model output-buffer-tokens override is present, the global env var is never
+    // read (ActiveModelSettings resolves the override first), so advising "raise
+    // REVIEW_OUTPUT_BUFFER_TOKENS" sends the operator to a knob that changes nothing — following
+    // it re-boots into the identical refusal. The remedy must name the override property instead.
+    var settings = emptyModelSettings();
+    lenient().when(settings.outputBufferTokens()).thenReturn(Optional.of(4_096));
+
+    var ex =
+        assertFailsValidation(
+            new ConfigBuilder()
+                .model("deepseek-chat", settings)
+                .conciseMaxOutputTokens(Optional.of(8_192))
+                .build());
+    assertTrue(
+        ex.getMessage()
+            .contains(
+                "effective output buffer (4096) must be >= REVIEW_CONCISE_MAX_OUTPUT_TOKENS"
+                    + " (8192"),
+        ex.getMessage());
+    assertTrue(
+        ex.getMessage()
+            .contains(
+                "raise thrillhousebot.ai.models.\"deepseek-chat\".output-buffer-tokens to cover"
+                    + " it"),
+        "the remedy must name the override that sources the effective buffer: " + ex.getMessage());
+    assertFalse(
+        ex.getMessage().contains("REVIEW_OUTPUT_BUFFER_TOKENS"),
+        "the global env var is inert under the override and must not be advised: "
+            + ex.getMessage());
+  }
+
+  @Test
   void failsFastWhenSafetyMarginOutOfRange() {
     assertTrue(
         assertFailsValidation(new ConfigBuilder().tokenSafetyMargin(0).build())


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The concise-cap boot refusal (#517/#520) lists three ways out, one of which is "raise REVIEW_OUTPUT_BUFFER_TOKENS to cover it". When the effective output buffer comes from a per-model `output-buffer-tokens` override, `ActiveModelSettings.outputBufferTokens()` never reads that env var — an operator who follows the advice re-boots into the identical refusal with the buffer still pinned by the override.

`validateConciseResponseCap` now names the knob that actually sources the effective buffer:

- override present → the remedy names `thrillhousebot.ai.models."<model>".output-buffer-tokens`
- global value is the source → the existing `REVIEW_OUTPUT_BUFFER_TOKENS` wording is kept byte-for-byte

The other two remedies (lower `REVIEW_CONCISE_MAX_OUTPUT_TOKENS`; set `separate-output-budget=true`) are valid in every configuration and are unchanged.

## Related Issues

Fixes #528

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

New test `namesThePerModelBufferKnobWhenAnOverrideSourcesTheEffectiveBuffer` reproduces the audit probe (global buffer 8192, per-model override 4096, concise cap 8192): the refusal must name the override property and must not advise the inert env var. On unfixed code it fails exactly as the audit described:

```
[ERROR]   StartupConfigValidatorTest.namesThePerModelBufferKnobWhenAnOverrideSourcesTheEffectiveBuffer:434 the remedy must name the override that sources the effective buffer: ThrillhouseBot cannot start ? required configuration is missing or invalid:
  - the effective output buffer (4096) must be >= REVIEW_CONCISE_MAX_OUTPUT_TOKENS (8192, quarkus.langchain4j.openai.concise.chat-model.max-tokens) for model 'deepseek-chat' so the token budget reserves the response cap the summary/verifier/reply calls send. Lower REVIEW_CONCISE_MAX_OUTPUT_TOKENS, raise REVIEW_OUTPUT_BUFFER_TOKENS to cover it, or set thrillhousebot.ai.models."deepseek-chat".separate-output-budget=true if this model's response allowance is independent of its input window.
Set the values above (see .env.example) and restart. Dashboard OAuth (GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET) is optional. ==> expected: <true> but was: <false>
```

With the fix it passes, and the pre-existing `failsFastWhenTheConciseCapExceedsTheBufferOnASharedWindow` pins that the global-sourced message still names `REVIEW_OUTPUT_BUFFER_TOKENS`.

Gates: `spotless:apply` clean; `clean compile spotbugs:check spotless:check` — BugInstance size is 0, BUILD SUCCESS; full `clean test` — 2594 tests, 0 failures, 0 errors; jacoco ∩ diff — zero uncovered lines and zero uncovered branches in the changed main code.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Refusal message with the fix, override-sourced configuration:

```
the effective output buffer (4096) must be >= REVIEW_CONCISE_MAX_OUTPUT_TOKENS (8192, quarkus.langchain4j.openai.concise.chat-model.max-tokens) for model 'deepseek-chat' so the token budget reserves the response cap the summary/verifier/reply calls send. Lower REVIEW_CONCISE_MAX_OUTPUT_TOKENS, raise thrillhousebot.ai.models."deepseek-chat".output-buffer-tokens to cover it, or set thrillhousebot.ai.models."deepseek-chat".separate-output-budget=true if this model's response allowance is independent of its input window.
```

## Additional Notes

Message polish only (audit finding severity: cleanup) — no behavior change to which configurations boot or refuse. Scope is `StartupConfigValidator` and its test class, per the audit's suggested fix.