### PR TITLE
fix(review): degrade a ceiling-refused summary on the degenerate lane

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -623,6 +623,13 @@ public class FindingPipeline {
     ReviewResponse summaryResponse;
     try {
       summaryResponse = aiReviewService.summarize(session, summaryInputs);
+    } catch (TokenSpendCeilingExceededException _) {
+      // Same degradation as the multi-call summarize seam: a summary retry refused mid-loop at
+      // the spend ceiling must not fail the review — this lane's only AI call is the summary, so
+      // the review must still post with its omission disclosures, and the skip is recorded on the
+      // plan so the posted review names the ceiling.
+      return countsOnlySummary(
+          session, new ReviewResponse(List.of(), List.of(), null), plan, "summary call refused");
     } catch (AiResponseTruncatedException e) {
       // Same degradation as the multi-call summary seam (#500 scope A): this path has no findings
       // by construction, but the review must still post with its omission disclosures rather than

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -455,6 +455,32 @@ class FindingPipelineTest {
   }
 
   @Test
+  void summarizeWithoutReviewDegradesToCountsOnlyWhenTheCeilingRefusesTheSummary() {
+    // The degenerate all-omitted plan makes exactly one AI call — the summary. A mid-retry spend
+    // ceiling refusal there must not fail the review either: same counts-only degradation as the
+    // multi-call lane's summarize seam, with the skip recorded on the plan for disclosure.
+    var session = persistedSession();
+    var template =
+        new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of("a.java", "b.java"), List.of(), true, null, null, null, null, null);
+    when(aiReviewService.summarize(eq(session), any()))
+        .thenThrow(new TokenSpendCeilingExceededException(120_000, 100_000));
+
+    var result =
+        pipeline.run(session, template, reviewContext(), plan, new DiffLineResolver(Map.of()));
+
+    assertTrue(result.findings().isEmpty());
+    assertNull(result.summary(), "counts-only shape: no model summary");
+    assertNotNull(session.getAiResponseJson(), "the degraded review is still persisted and posts");
+    assertTrue(
+        plan.summaryWasSkippedAtCeiling(),
+        "the ceiling skip must be recorded on the plan so the posted review disclosures name it");
+    assertFalse(plan.summaryWasCut(), "a ceiling skip is not a response cut — disjoint classes");
+  }
+
+  @Test
   void multiCallSurvivesACyclicCauseChainOnAFailedBatch() {
     // The truncation check walks the cause chain, and a cycle (here A caused-by B caused-by A)
     // would spin forever on the review thread if the walk were unbounded. The batch must instead


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

On the degenerate budgeted lane (every reviewable file over budget, zero batches), `FindingPipeline.summarizeWithoutReview` makes the review's only AI call — the summary. `AiReviewService.runWithRetries` runs the token-spend gate before every attempt and deliberately lets the typed `TokenSpendCeilingExceededException` propagate; the multi-call lane catches exactly that at its summarize seam and degrades to `countsOnlySummary`, but `summarizeWithoutReview` caught only `AiResponseTruncatedException`. A mid-retry ceiling refusal (attempt 1 bills usage that reaches `REVIEW_MAX_TOKENS_PER_REVIEW` and then fails transiently; attempt 2's gate throws) therefore escaped `run`, landed in `ReviewOrchestrator.handleReviewFailure`, and the whole review was lost instead of posting counts-only with its omission disclosures — defeating this lane's own stated contract. `plan.summarySkippedAtCeiling` was never recorded either, so no disclosure would have been rendered even if the review had survived.

Fix: catch `TokenSpendCeilingExceededException` at the same seam and degrade to `countsOnlySummary(...)` exactly like the multi-call lane — the review still posts with its omission disclosures, and the ceiling skip is recorded on the plan so the posted review names `REVIEW_MAX_TOKENS_PER_REVIEW`.

## Related Issues

Fixes #526

## How Has This Been Tested?

- [x] Unit tests

New test `FindingPipelineTest.summarizeWithoutReviewDegradesToCountsOnlyWhenTheCeilingRefusesTheSummary`: degenerate all-omitted plan, summarize stub throwing the typed refusal; asserts the review no longer throws, returns the counts-only shape (empty findings, null summary), persists the response, records `summaryWasSkippedAtCeiling()` on the plan, and leaves `summaryWasCut()` false (disjoint classes).

Red on unfixed code (the refusal escapes `pipeline.run` and the skip is never recorded):

```
[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.summarizeWithoutReviewDegradesToCountsOnlyWhenTheCeilingRefusesTheSummary -- Time elapsed: 2.596 s <<< ERROR!
dev.thiagogonzaga.thrillhousebot.review.ai.TokenSpendCeilingExceededException: AI call skipped: this review has consumed 120000 tokens, at or above its 100000-token spend ceiling (REVIEW_MAX_TOKENS_PER_REVIEW / thrillhousebot.review.max-tokens-per-review)
	at dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewService.summarize(AiReviewService.java:103)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.summarizeWithoutReview(FindingPipeline.java:625)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.runWithLedger(FindingPipeline.java:144)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipeline.run(FindingPipeline.java:128)
```

Green with the fix. Gates: `spotless:apply` clean; `clean compile spotbugs:check spotless:check` — BugInstance size is 0; full `clean test` — 2595 tests, 0 failures. Jacoco on the changed lines: 0 missed instructions, 0 missed branches.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

The catch mirrors the multi-call lane's `"summary call refused"` degradation verbatim; no rendering changes — the disclosure plumbing shipped in #524 renders the recorded skip.