### PR TITLE
refactor(review): model summary degradation as one enum

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
@@ -267,7 +267,11 @@ public abstract class AbstractPrSuggestionGenerator {
     return ReviewResult.truncationDisclosure(
         plan.omittedFiles().size() + plan.clippedFiles().size(),
         new ReviewResult.TruncationDetail(
-            plan.omittedFiles(), plan.clippedFiles(), List.of(), List.of(), false, false));
+            plan.omittedFiles(),
+            plan.clippedFiles(),
+            List.of(),
+            List.of(),
+            SummaryDegradation.NONE));
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -94,8 +94,7 @@ public class DiffBudgetPlanner {
       List<String> runtimeUncoveredFiles,
       List<String> spendCeilingSkippedFiles,
       List<String> responseCutFiles,
-      java.util.concurrent.atomic.AtomicBoolean summaryResponseCut,
-      java.util.concurrent.atomic.AtomicBoolean summarySkippedAtCeiling) {
+      java.util.concurrent.atomic.AtomicReference<SummaryDegradation> summaryDegradationRef) {
     public BudgetPlan {
       batches = List.copyOf(batches);
       omittedFiles = List.copyOf(omittedFiles);
@@ -109,39 +108,26 @@ public class DiffBudgetPlanner {
               ? new CopyOnWriteArrayList<>()
               : spendCeilingSkippedFiles;
       responseCutFiles = responseCutFiles == null ? new CopyOnWriteArrayList<>() : responseCutFiles;
-      summaryResponseCut =
-          summaryResponseCut == null
-              ? new java.util.concurrent.atomic.AtomicBoolean(false)
-              : summaryResponseCut;
-      summarySkippedAtCeiling =
-          summarySkippedAtCeiling == null
-              ? new java.util.concurrent.atomic.AtomicBoolean(false)
-              : summarySkippedAtCeiling;
-    }
-
-    /** Marks the review's summary response as cut at the model's length cap (#500 scope A). */
-    void recordSummaryResponseCut() {
-      summaryResponseCut.set(true);
-    }
-
-    /** Whether the summary response was cut — salvaged or degraded, the disclosure names it. */
-    public boolean summaryWasCut() {
-      return summaryResponseCut.get();
+      summaryDegradationRef =
+          summaryDegradationRef == null
+              ? new java.util.concurrent.atomic.AtomicReference<>(SummaryDegradation.NONE)
+              : summaryDegradationRef;
     }
 
     /**
-     * Marks the review's summary call as skipped (or refused mid-call) because the review's token
-     * spend ceiling ({@code REVIEW_MAX_TOKENS_PER_REVIEW}) was reached (#518) — the ceiling sibling
-     * of {@link #recordSummaryResponseCut()}, so the counts-only degradation is disclosed in the
-     * posted review instead of only in the log.
+     * Records how the review's summary prose degraded — response cut at the model's length cap
+     * (#500 scope A) or call skipped (or refused mid-call) at the token spend ceiling (#518) — so
+     * the posted review discloses the degradation instead of leaving it log-only. The two flavors
+     * arise on disjoint control paths, so a single slot suffices and the meaningless both-at-once
+     * state stays unrepresentable.
      */
-    void recordSummarySkippedAtCeiling() {
-      summarySkippedAtCeiling.set(true);
+    void recordSummaryDegradation(SummaryDegradation degradation) {
+      summaryDegradationRef.set(degradation);
     }
 
-    /** Whether the summary call was skipped at the spend ceiling — the disclosure names it. */
-    public boolean summaryWasSkippedAtCeiling() {
-      return summarySkippedAtCeiling.get();
+    /** How the summary prose degraded, if at all — the disclosure names the flavor. */
+    public SummaryDegradation summaryDegradation() {
+      return summaryDegradationRef.get();
     }
 
     /** Defensive copy: the mutable runtime-gap backing must never escape the plan. */
@@ -163,22 +149,12 @@ public class DiffBudgetPlanner {
     }
 
     /**
-     * Defensive snapshot, like {@link #runtimeUncoveredFiles()}: the live flag is only written
-     * through {@link #recordSummaryResponseCut()} and read through {@link #summaryWasCut()}.
+     * Defensive snapshot, like {@link #runtimeUncoveredFiles()}: the live slot is only written
+     * through {@link #recordSummaryDegradation} and read through {@link #summaryDegradation()}.
      */
     @Override
-    public java.util.concurrent.atomic.AtomicBoolean summaryResponseCut() {
-      return new java.util.concurrent.atomic.AtomicBoolean(summaryResponseCut.get());
-    }
-
-    /**
-     * Defensive snapshot, like {@link #summaryResponseCut()}: the live flag is only written through
-     * {@link #recordSummarySkippedAtCeiling()} and read through {@link
-     * #summaryWasSkippedAtCeiling()}.
-     */
-    @Override
-    public java.util.concurrent.atomic.AtomicBoolean summarySkippedAtCeiling() {
-      return new java.util.concurrent.atomic.AtomicBoolean(summarySkippedAtCeiling.get());
+    public java.util.concurrent.atomic.AtomicReference<SummaryDegradation> summaryDegradationRef() {
+      return new java.util.concurrent.atomic.AtomicReference<>(summaryDegradationRef.get());
     }
 
     /** Records files a batch left unreviewed at runtime, ignoring nulls and duplicates. */
@@ -350,23 +326,14 @@ public class DiffBudgetPlanner {
       List<GitHubPullRequestClient.FileDiff> reviewable, int diffBudgetTokens, int maxBatches) {
     var budgeted = diffBudgetTokens > 0;
     if (reviewable.isEmpty()) {
-      return new BudgetPlan(
-          List.of(), List.of(), List.of(), budgeted, null, null, null, null, null);
+      return new BudgetPlan(List.of(), List.of(), List.of(), budgeted, null, null, null, null);
     }
 
     var rendered = renderAndSize(reviewable, diffBudgetTokens);
 
     if (!budgeted) {
       return new BudgetPlan(
-          List.of(toBatch(rendered.sized())),
-          List.of(),
-          List.of(),
-          false,
-          null,
-          null,
-          null,
-          null,
-          null);
+          List.of(toBatch(rendered.sized())), List.of(), List.of(), false, null, null, null, null);
     }
     return pack(rendered, diffBudgetTokens, Math.max(1, maxBatches));
   }
@@ -487,7 +454,7 @@ public class DiffBudgetPlanner {
     // exactly one class or the disclosure would list it twice and the verdict double-count it.
     var omittedSet = new HashSet<>(omitted);
     var clipped = rendered.clipped().stream().filter(n -> !omittedSet.contains(n)).toList();
-    return new BudgetPlan(batches, omitted, clipped, true, null, null, null, null, null);
+    return new BudgetPlan(batches, omitted, clipped, true, null, null, null, null);
   }
 
   /** Index of the first open bin with room for {@code tokens}, or -1 if none. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -315,7 +315,7 @@ public class FindingPipeline {
       ReviewResponse refined,
       DiffBudgetPlanner.BudgetPlan plan,
       String what) {
-    plan.recordSummarySkippedAtCeiling();
+    plan.recordSummaryDegradation(SummaryDegradation.SKIPPED_AT_CEILING);
     Log.warnf(
         "Review session %d reached its token spend ceiling before the summary call (%d tokens"
             + " spent, ceiling %d — REVIEW_MAX_TOKENS_PER_REVIEW); %s and keeping the %d paid"
@@ -335,16 +335,16 @@ public class FindingPipeline {
    * truncation is disclosed in the log with the caps that apply — the summary call runs on the
    * concise model, so both knobs are named — and recorded on the plan so the posted review carries
    * the same disclosure instead of leaving it log-only, exactly like the sibling spend-ceiling
-   * degradation of this lane records {@code summarySkippedAtCeiling} in {@link #countsOnlySummary}
-   * (#518). Statuses are never taken from the salvage: the code-blind summary call must not decide
-   * what was resolved (same rule as the parsed path).
+   * degradation of this lane records its own flavor in {@link #countsOnlySummary} (#518). Statuses
+   * are never taken from the salvage: the code-blind summary call must not decide what was resolved
+   * (same rule as the parsed path).
    */
   private ReviewResponse salvagedOrCountsOnlySummary(
       ReviewSession session,
       ReviewResponse refined,
       DiffBudgetPlanner.BudgetPlan plan,
       AiResponseTruncatedException truncation) {
-    plan.recordSummaryResponseCut();
+    plan.recordSummaryDegradation(SummaryDegradation.RESPONSE_CUT);
     var salvagedSummary = salvager.salvage(truncation.partialBody()).summary();
     if (salvagedSummary != null) {
       Log.warnf(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -126,13 +126,13 @@ public record ReviewResult(
    * was reached — a different reason with a different fix, so the rendered copy names it separately
    * — and {@code responseCutFileNames} were only partially reviewed because the model's response
    * was cut at its length cap and the findings up to the cut were kept (#500). {@code
-   * summaryResponseCut} marks the same length-cap cut on the summary call: the findings are
-   * complete, but the prose summary was salvaged from a cut response or replaced by the counts-only
-   * fallback. {@code summarySkippedAtCeiling} marks the ceiling flavor of that same degradation:
-   * the summary call was skipped (or refused mid-call) because the review's token spend ceiling
-   * ({@code REVIEW_MAX_TOKENS_PER_REVIEW}) was reached — here too the findings are complete (#518).
-   * All empty on the legacy line-cap path, where only a count is known — the rendered copy then
-   * falls back to the numeric clause.
+   * summaryDegradation} marks the same degradations on the summary call: the findings are complete,
+   * but the prose summary either was salvaged from a length-cap-cut response or replaced by the
+   * counts-only fallback ({@link SummaryDegradation#RESPONSE_CUT}), or the call was skipped (or
+   * refused mid-call) because the review's token spend ceiling ({@code
+   * REVIEW_MAX_TOKENS_PER_REVIEW}) was reached ({@link SummaryDegradation#SKIPPED_AT_CEILING},
+   * #518). All empty on the legacy line-cap path, where only a count is known — the rendered copy
+   * then falls back to the numeric clause.
    */
   @RegisterForReflection
   public record TruncationDetail(
@@ -140,10 +140,9 @@ public record ReviewResult(
       List<String> clippedFileNames,
       List<String> spendCeilingSkippedFileNames,
       List<String> responseCutFileNames,
-      boolean summaryResponseCut,
-      boolean summarySkippedAtCeiling) {
+      SummaryDegradation summaryDegradation) {
     public static final TruncationDetail EMPTY =
-        new TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, false);
+        new TruncationDetail(List.of(), List.of(), List.of(), List.of(), SummaryDegradation.NONE);
 
     public TruncationDetail {
       omittedFileNames = omittedFileNames == null ? List.of() : List.copyOf(omittedFileNames);
@@ -154,18 +153,20 @@ public record ReviewResult(
               : List.copyOf(spendCeilingSkippedFileNames);
       responseCutFileNames =
           responseCutFileNames == null ? List.of() : List.copyOf(responseCutFileNames);
+      summaryDegradation =
+          summaryDegradation == null ? SummaryDegradation.NONE : summaryDegradation;
     }
 
     public boolean isEmpty() {
-      return !hasFileGaps() && !summaryResponseCut && !summarySkippedAtCeiling;
+      return !hasFileGaps() && summaryDegradation == SummaryDegradation.NONE;
     }
 
     /**
      * Whether any per-file coverage gap exists — a name in any of the four file classes. False for
-     * a detail whose only content is a summary flag: the findings then cover the whole diff, so
-     * surfaces whose framing is per-file partial coverage (the on-demand disclosure, the delta
+     * a detail whose only content is a summary degradation: the findings then cover the whole diff,
+     * so surfaces whose framing is per-file partial coverage (the on-demand disclosure, the delta
      * comment) treat such a detail as empty (#516) while the summary-aware surfaces (banner,
-     * coverage clause, check-run brief) still disclose the flag.
+     * coverage clause, check-run brief) still disclose the degradation.
      */
     public boolean hasFileGaps() {
       return !omittedFileNames.isEmpty()
@@ -399,22 +400,25 @@ public record ReviewResult(
                   + " its length cap (max-output-tokens) — findings up to the cut were kept (%s)",
               detail.responseCutFileNames().size(), nameList(detail.responseCutFileNames())));
     }
-    // The summary flags affect prose, not findings: the findings are complete, but the summary
-    // call either had its response cut at the length cap and was salvaged (or replaced by the
-    // counts-only fallback), or was skipped outright at the token spend ceiling (#518) — the two
-    // flavors of the same degradation, disclosed with the same shape so neither lane stays
+    // A summary degradation affects prose, not findings: the findings are complete, but the
+    // summary call either had its response cut at the length cap and was salvaged (or replaced by
+    // the counts-only fallback), or was skipped outright at the token spend ceiling (#518) — the
+    // two flavors of the same degradation, disclosed with the same shape so neither lane stays
     // log-only.
-    if (detail.summaryResponseCut()) {
-      clauses.add(
-          "the summary was shortened because the model's response was cut at its length cap"
-              + " (max-output-tokens / REVIEW_CONCISE_MAX_OUTPUT_TOKENS) — the findings themselves"
-              + " are complete");
-    }
-    if (detail.summarySkippedAtCeiling()) {
-      clauses.add(
-          "the summary was skipped because the review's token spend ceiling"
-              + " (REVIEW_MAX_TOKENS_PER_REVIEW) was reached — the findings themselves are"
-              + " complete");
+    switch (detail.summaryDegradation()) {
+      case RESPONSE_CUT ->
+          clauses.add(
+              "the summary was shortened because the model's response was cut at its length cap"
+                  + " (max-output-tokens / REVIEW_CONCISE_MAX_OUTPUT_TOKENS) — the findings"
+                  + " themselves are complete");
+      case SKIPPED_AT_CEILING ->
+          clauses.add(
+              "the summary was skipped because the review's token spend ceiling"
+                  + " (REVIEW_MAX_TOKENS_PER_REVIEW) was reached — the findings themselves are"
+                  + " complete");
+      case NONE -> {
+        // Nothing to disclose.
+      }
     }
     return String.join(", and ", clauses);
   }
@@ -453,11 +457,12 @@ public record ReviewResult(
               "%d file(s) partially reviewed (response cut at the length cap)",
               truncation.responseCutFileNames().size()));
     }
-    if (truncation.summaryResponseCut()) {
-      parts.add("summary shortened (response cut at the length cap)");
-    }
-    if (truncation.summarySkippedAtCeiling()) {
-      parts.add("summary skipped (token spend ceiling reached)");
+    switch (truncation.summaryDegradation()) {
+      case RESPONSE_CUT -> parts.add("summary shortened (response cut at the length cap)");
+      case SKIPPED_AT_CEILING -> parts.add("summary skipped (token spend ceiling reached)");
+      case NONE -> {
+        // Nothing to disclose.
+      }
     }
     return String.join(", ", parts);
   }
@@ -494,7 +499,7 @@ public record ReviewResult(
    * budget upholds the same "reported by name, never silently dropped" contract as the review
    * banner; falls back to the numeric clause when only a count is known.
    *
-   * <p>A detail carrying only a summary flag (no file names) is treated as empty here: this
+   * <p>A detail carrying only a summary degradation (no file names) is treated as empty here: this
    * disclosure's framing — "Large PR — partial coverage … covers only part of the diff" — is about
    * per-file gaps, and with the findings complete it would be self-contradictory (#516). The
    * summary-aware surfaces (review banner, check-run suffix) disclose the flag instead.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummaryDegradation.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummaryDegradation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * How (if at all) the review's summary prose was degraded. The findings themselves are complete in
+ * every state — only the summary is affected — so none of these holds approval; they exist so the
+ * posted review can disclose the degradation and name the knob to raise instead of staying
+ * log-only. At most one degradation can occur per review: the summary call either had its response
+ * cut at the model's length cap ({@link #RESPONSE_CUT}, #500 scope A) or was skipped (or refused
+ * mid-call) at the review's token spend ceiling ({@link #SKIPPED_AT_CEILING}, #518) — the two are
+ * reached on disjoint control paths, and a single enum keeps the impossible both-at-once state
+ * unrepresentable where a pair of booleans would allow it.
+ */
+@RegisterForReflection
+public enum SummaryDegradation {
+  /** The summary call completed normally (or the review has no summary degradation to disclose). */
+  NONE,
+
+  /**
+   * The summary response was cut at the model's length cap (max-output-tokens /
+   * REVIEW_CONCISE_MAX_OUTPUT_TOKENS): the prose was salvaged from the cut response or replaced by
+   * the counts-only fallback.
+   */
+  RESPONSE_CUT,
+
+  /**
+   * The summary call was skipped (or refused mid-call) because the review's token spend ceiling
+   * (REVIEW_MAX_TOKENS_PER_REVIEW) was reached; the counts-only fallback stands in for the prose.
+   */
+  SKIPPED_AT_CEILING
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -134,8 +134,7 @@ public class VerdictBuilder {
                 clipped,
                 ceilingSkipped,
                 responseCut,
-                plan.summaryWasCut(),
-                plan.summaryWasSkippedAtCeiling())
+                plan.summaryDegradation())
             : ReviewResult.TruncationDetail.EMPTY;
     var omitted =
         plan.budgeted()
@@ -301,13 +300,11 @@ public class VerdictBuilder {
           + result.coverageGapBrief()
           + ") — partial review.";
     }
-    if (result.truncation().summaryResponseCut()) {
-      return " The summary was shortened (response cut at the length cap).";
-    }
-    if (result.truncation().summarySkippedAtCeiling()) {
-      return " The summary was skipped (token spend ceiling reached).";
-    }
-    return "";
+    return switch (result.truncation().summaryDegradation()) {
+      case RESPONSE_CUT -> " The summary was shortened (response cut at the length cap).";
+      case SKIPPED_AT_CEILING -> " The summary was skipped (token spend ceiling reached).";
+      case NONE -> "";
+    };
   }
 
   record DiffStats(
@@ -535,16 +532,16 @@ public class VerdictBuilder {
       summaryMarkdown =
           ReviewResult.truncationNotice(diffStats.omittedFiles(), diffStats.truncation())
               + summaryMarkdown;
-    } else if (diffStats.truncation().summaryResponseCut()) {
-      // Summary-only cut: the findings are complete, so the partial-review banner (and the
-      // approval hold that goes with file gaps) would overstate it — a dedicated banner names
-      // the cut without holding the verdict.
-      summaryMarkdown = ReviewResult.SUMMARY_CUT_NOTICE + summaryMarkdown;
-    } else if (diffStats.truncation().summarySkippedAtCeiling()) {
-      // Summary skipped at the token spend ceiling with no file gap (#518): same rationale as the
-      // summary-only cut — the findings are complete, so a dedicated banner names the ceiling
-      // without holding the verdict.
-      summaryMarkdown = ReviewResult.SUMMARY_SKIPPED_NOTICE + summaryMarkdown;
+    } else {
+      // Summary-only degradation (no file gap): the findings are complete, so the partial-review
+      // banner (and the approval hold that goes with file gaps) would overstate it — a dedicated
+      // banner names the cut, or the token spend ceiling (#518), without holding the verdict.
+      summaryMarkdown =
+          switch (diffStats.truncation().summaryDegradation()) {
+            case RESPONSE_CUT -> ReviewResult.SUMMARY_CUT_NOTICE + summaryMarkdown;
+            case SKIPPED_AT_CEILING -> ReviewResult.SUMMARY_SKIPPED_NOTICE + summaryMarkdown;
+            case NONE -> summaryMarkdown;
+          };
     }
 
     return new ReviewResult(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -322,7 +322,7 @@ class DiffBudgetPlannerTest {
     // whole review down with it.
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
 
     assertTrue(plan.runtimeUncoveredFiles().isEmpty(), "a null accumulator normalizes to empty");
 
@@ -339,7 +339,7 @@ class DiffBudgetPlannerTest {
     // like recordUncoveredFiles does, and the accessor is a defensive copy.
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
 
     plan.recordSpendCeilingSkippedFiles(Arrays.asList("a.java", null, "a.java", "b.java"));
 
@@ -357,7 +357,7 @@ class DiffBudgetPlannerTest {
     // moment a ceiling-blocked batch records a skip on the review thread.
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
 
     assertTrue(plan.spendCeilingSkippedFiles().isEmpty());
 
@@ -373,7 +373,7 @@ class DiffBudgetPlannerTest {
     // hygiene like the other recorders, and stay behind a defensive copy.
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
 
     plan.recordResponseCutFiles(Arrays.asList("a.java", null, "a.java", "b.java"));
 
@@ -389,7 +389,7 @@ class DiffBudgetPlannerTest {
   void aPlanBuiltWithANullResponseCutListStillAcceptsRecords() {
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
 
     assertTrue(plan.responseCutFiles().isEmpty());
 
@@ -399,72 +399,64 @@ class DiffBudgetPlannerTest {
   }
 
   @Test
-  void summaryCutFlagIsRecordedLiveButItsAccessorReturnsASnapshot() {
-    // #500 scope A: the flag rides the shared plan like the runtime-gap lists — written after the
-    // plan is built, read by the verdict — and, like them, its record accessor must not leak the
-    // mutable backing.
-    var plan =
-        new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
-    assertFalse(plan.summaryWasCut());
-
-    plan.recordSummaryResponseCut();
-
-    assertTrue(plan.summaryWasCut());
-    assertFalse(plan.truncated(), "a summary cut is not a coverage gap and must not hold approval");
-    var snapshot = plan.summaryResponseCut();
-    snapshot.set(false);
-    assertTrue(plan.summaryWasCut(), "mutating the snapshot must not touch the live flag");
-  }
-
-  @Test
-  void aPlanBuiltWithItsOwnSummaryCutFlagKeepsThatInstanceLive() {
-    var live = new java.util.concurrent.atomic.AtomicBoolean(true);
-    var plan =
-        new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, live, null);
-
-    assertTrue(plan.summaryWasCut());
-    assertNotSame(live, plan.summaryResponseCut(), "the accessor returns a defensive snapshot");
-
-    live.set(false);
-    assertFalse(plan.summaryWasCut(), "the passed-in flag stays the live backing");
-  }
-
-  @Test
-  void summarySkippedAtCeilingFlagIsRecordedLiveButItsAccessorReturnsASnapshot() {
-    // #518: the ceiling sibling of the summary-cut flag rides the shared plan the same way —
-    // written after the plan is built, read by the verdict — and, like it, its record accessor
+  void summaryResponseCutIsRecordedLiveButItsAccessorReturnsASnapshot() {
+    // #500 scope A: the degradation slot rides the shared plan like the runtime-gap lists —
+    // written after the plan is built, read by the verdict — and, like them, its record accessor
     // must not leak the mutable backing.
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
-    assertFalse(plan.summaryWasSkippedAtCeiling());
+            List.of(), List.of(), List.of(), true, null, null, null, null);
+    assertEquals(SummaryDegradation.NONE, plan.summaryDegradation());
 
-    plan.recordSummarySkippedAtCeiling();
+    plan.recordSummaryDegradation(SummaryDegradation.RESPONSE_CUT);
 
-    assertTrue(plan.summaryWasSkippedAtCeiling());
-    assertFalse(
-        plan.truncated(), "a skipped summary is not a coverage gap and must not hold approval");
-    assertFalse(plan.summaryWasCut(), "the ceiling skip is not a response cut — disjoint classes");
-    var snapshot = plan.summarySkippedAtCeiling();
-    snapshot.set(false);
-    assertTrue(plan.summaryWasSkippedAtCeiling(), "mutating the snapshot must not touch the flag");
+    assertEquals(SummaryDegradation.RESPONSE_CUT, plan.summaryDegradation());
+    assertFalse(plan.truncated(), "a summary cut is not a coverage gap and must not hold approval");
+    var snapshot = plan.summaryDegradationRef();
+    snapshot.set(SummaryDegradation.NONE);
+    assertEquals(
+        SummaryDegradation.RESPONSE_CUT,
+        plan.summaryDegradation(),
+        "mutating the snapshot must not touch the live slot");
   }
 
   @Test
-  void aPlanBuiltWithItsOwnSummarySkipFlagKeepsThatInstanceLive() {
-    var live = new java.util.concurrent.atomic.AtomicBoolean(true);
+  void summarySkippedAtCeilingIsRecordedLiveOverwritingTheSingleSlot() {
+    // #518: the ceiling flavor rides the same single slot — one enum makes the meaningless
+    // cut-and-skipped-at-once state unrepresentable where the old boolean pair allowed it.
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, live);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
+    assertEquals(SummaryDegradation.NONE, plan.summaryDegradation());
 
-    assertTrue(plan.summaryWasSkippedAtCeiling());
-    assertNotSame(
-        live, plan.summarySkippedAtCeiling(), "the accessor returns a defensive snapshot");
+    plan.recordSummaryDegradation(SummaryDegradation.SKIPPED_AT_CEILING);
 
-    live.set(false);
-    assertFalse(plan.summaryWasSkippedAtCeiling(), "the passed-in flag stays the live backing");
+    assertEquals(SummaryDegradation.SKIPPED_AT_CEILING, plan.summaryDegradation());
+    assertFalse(
+        plan.truncated(), "a skipped summary is not a coverage gap and must not hold approval");
+    var snapshot = plan.summaryDegradationRef();
+    snapshot.set(SummaryDegradation.NONE);
+    assertEquals(
+        SummaryDegradation.SKIPPED_AT_CEILING,
+        plan.summaryDegradation(),
+        "mutating the snapshot must not touch the live slot");
+  }
+
+  @Test
+  void aPlanBuiltWithItsOwnDegradationSlotKeepsThatInstanceLive() {
+    var live = new java.util.concurrent.atomic.AtomicReference<>(SummaryDegradation.RESPONSE_CUT);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), true, null, null, null, live);
+
+    assertEquals(SummaryDegradation.RESPONSE_CUT, plan.summaryDegradation());
+    assertNotSame(live, plan.summaryDegradationRef(), "the accessor returns a defensive snapshot");
+
+    live.set(SummaryDegradation.NONE);
+    assertEquals(
+        SummaryDegradation.NONE,
+        plan.summaryDegradation(),
+        "the passed-in slot stays the live backing");
   }
 
   @Test
@@ -473,7 +465,7 @@ class DiffBudgetPlannerTest {
     // "clipped" meaning rather than being reported as wholly uncovered.
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of("src/Clipped.java"), true, null, null, null, null, null);
+            List.of(), List.of(), List.of("src/Clipped.java"), true, null, null, null, null);
 
     assertEquals(List.of("src/Clipped.java"), plan.effectiveClippedFiles());
   }
@@ -488,7 +480,6 @@ class DiffBudgetPlannerTest {
             List.of(),
             List.of("src/Clipped.java", "src/Other.java"),
             true,
-            null,
             null,
             null,
             null,

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -175,7 +175,6 @@ class FindingPipelineTest {
         null,
         null,
         null,
-        null,
         null);
   }
 
@@ -308,8 +307,10 @@ class FindingPipelineTest {
     assertEquals(List.of("a.java"), plan.responseCutFiles());
     assertTrue(plan.runtimeUncoveredFiles().isEmpty());
     assertTrue(plan.truncated());
-    assertFalse(
-        plan.summaryWasCut(), "a batch cut is not a summary cut — the classes are disjoint");
+    assertEquals(
+        SummaryDegradation.NONE,
+        plan.summaryDegradation(),
+        "a batch cut is not a summary degradation — the classes are disjoint");
     var changedFiles = captor.getValue().changedFiles();
     assertTrue(changedFiles.contains("a.java (modified"), changedFiles);
     assertTrue(
@@ -396,12 +397,10 @@ class FindingPipelineTest {
     assertEquals(2, result.findings().size());
     assertNull(result.summary());
     assertNotNull(session.getAiResponseJson(), "the paid findings must still be persisted");
-    assertTrue(
-        plan.summaryWasCut(),
+    assertEquals(
+        SummaryDegradation.RESPONSE_CUT,
+        plan.summaryDegradation(),
         "the summary cut must be recorded on the plan so the posted review discloses it");
-    assertFalse(
-        plan.summaryWasSkippedAtCeiling(),
-        "a response cut is not a ceiling skip — disjoint classes");
   }
 
   @Test
@@ -427,8 +426,9 @@ class FindingPipelineTest {
     assertNotNull(result.summary());
     assertEquals("solid", result.summary().overallAssessment());
     assertNotNull(session.getAiResponseJson());
-    assertTrue(
-        plan.summaryWasCut(),
+    assertEquals(
+        SummaryDegradation.RESPONSE_CUT,
+        plan.summaryDegradation(),
         "a salvaged summary is still a shortened one — the cut must be recorded for disclosure");
   }
 
@@ -441,7 +441,7 @@ class FindingPipelineTest {
         new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of("a.java", "b.java"), List.of(), true, null, null, null, null, null);
+            List.of(), List.of("a.java", "b.java"), List.of(), true, null, null, null, null);
     when(aiReviewService.summarize(eq(session), any()))
         .thenThrow(new AiResponseTruncatedException("finish_reason=length", null, true));
 
@@ -451,7 +451,10 @@ class FindingPipelineTest {
     assertTrue(result.findings().isEmpty());
     assertNull(result.summary());
     assertNotNull(session.getAiResponseJson());
-    assertTrue(plan.summaryWasCut(), "the degenerate path records the summary cut on the plan too");
+    assertEquals(
+        SummaryDegradation.RESPONSE_CUT,
+        plan.summaryDegradation(),
+        "the degenerate path records the summary cut on the plan too");
   }
 
   @Test
@@ -464,7 +467,7 @@ class FindingPipelineTest {
         new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of("a.java", "b.java"), List.of(), true, null, null, null, null, null);
+            List.of(), List.of("a.java", "b.java"), List.of(), true, null, null, null, null);
     when(aiReviewService.summarize(eq(session), any()))
         .thenThrow(new TokenSpendCeilingExceededException(120_000, 100_000));
 
@@ -474,10 +477,10 @@ class FindingPipelineTest {
     assertTrue(result.findings().isEmpty());
     assertNull(result.summary(), "counts-only shape: no model summary");
     assertNotNull(session.getAiResponseJson(), "the degraded review is still persisted and posts");
-    assertTrue(
-        plan.summaryWasSkippedAtCeiling(),
+    assertEquals(
+        SummaryDegradation.SKIPPED_AT_CEILING,
+        plan.summaryDegradation(),
         "the ceiling skip must be recorded on the plan so the posted review disclosures name it");
-    assertFalse(plan.summaryWasCut(), "a ceiling skip is not a response cut — disjoint classes");
   }
 
   @Test
@@ -793,15 +796,7 @@ class FindingPipelineTest {
         new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(batch("clipped.java")),
-            List.of(),
-            List.of(),
-            true,
-            null,
-            null,
-            null,
-            null,
-            null);
+            List.of(batch("clipped.java")), List.of(), List.of(), true, null, null, null, null);
     var captor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
     when(aiReviewService.review(eq(session), captor.capture()))
         .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -821,7 +816,7 @@ class FindingPipelineTest {
         new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(batch("a.java")), List.of(), List.of(), false, null, null, null, null, null);
+            List.of(batch("a.java")), List.of(), List.of(), false, null, null, null, null);
     var captor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
     when(aiReviewService.review(eq(session), captor.capture()))
         .thenReturn(new ReviewResponse(List.of(), List.of(), null));
@@ -844,7 +839,7 @@ class FindingPipelineTest {
     var template = new AiReviewService.PromptInputs("d", "ctx", "base", "s", "t", "", "");
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(batch("a.java")), List.of(), List.of(), false, null, null, null, null, null);
+            List.of(batch("a.java")), List.of(), List.of(), false, null, null, null, null);
     when(aiReviewService.review(eq(session), any()))
         .thenThrow(new TokenSpendCeilingExceededException(120_000, 100_000));
 
@@ -913,7 +908,7 @@ class FindingPipelineTest {
     var batch = new DiffBudgetPlanner.DiffBatch("### a.java\n### b.java\n", batchFiles, 10);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(batch), List.of(), List.of("a.java"), true, null, null, null, null, null);
+            List.of(batch), List.of(), List.of("a.java"), true, null, null, null, null);
     when(aiReviewService.review(eq(session), any()))
         .thenReturn(
             new ReviewResponse(
@@ -945,7 +940,6 @@ class FindingPipelineTest {
             List.of(),
             List.of("a.java"),
             true,
-            null,
             null,
             null,
             null,
@@ -1042,7 +1036,6 @@ class FindingPipelineTest {
             null,
             null,
             null,
-            null,
             null);
     when(budgetPlanner.perCallInputBudget()).thenReturn(1_000_000);
     when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
@@ -1081,7 +1074,6 @@ class FindingPipelineTest {
             List.of("z.java"),
             List.of("a.java"),
             true,
-            null,
             null,
             null,
             null,
@@ -1280,10 +1272,10 @@ class FindingPipelineTest {
     assertEquals(2, result.findings().size());
     assertNull(result.summary());
     assertNotNull(session.getAiResponseJson());
-    assertTrue(
-        plan.summaryWasSkippedAtCeiling(),
+    assertEquals(
+        SummaryDegradation.SKIPPED_AT_CEILING,
+        plan.summaryDegradation(),
         "the refused summary must be recorded on the plan so the posted review discloses it");
-    assertFalse(plan.summaryWasCut(), "a ceiling refusal is not a response cut — disjoint classes");
   }
 
   @Test
@@ -1310,8 +1302,9 @@ class FindingPipelineTest {
     assertEquals(2, result.findings().size());
     assertNull(result.summary());
     assertNotNull(session.getAiResponseJson(), "the paid findings must still be persisted");
-    assertTrue(
-        plan.summaryWasSkippedAtCeiling(),
+    assertEquals(
+        SummaryDegradation.SKIPPED_AT_CEILING,
+        plan.summaryDegradation(),
         "the skipped summary must be recorded on the plan so the posted review discloses it");
   }
 
@@ -1531,7 +1524,7 @@ class FindingPipelineTest {
         new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of("a.java", "b.java"), List.of(), true, null, null, null, null, null);
+            List.of(), List.of("a.java", "b.java"), List.of(), true, null, null, null, null);
     var summary = new ReviewResponse.Summary(0, 0, 0, 0, 0, "too large", "unknown", List.of());
     var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
     when(aiReviewService.summarize(eq(session), captor.capture()))
@@ -1555,7 +1548,7 @@ class FindingPipelineTest {
         new AiReviewService.PromptInputs("(no changes detected)", "ctx", "base", "s", "t", "", "");
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
     var captor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
     when(aiReviewService.review(eq(session), captor.capture()))
         .thenReturn(new ReviewResponse(List.of(), List.of(), null));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummaryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummaryTest.java
@@ -122,7 +122,11 @@ class FollowUpDeltaSummaryTest {
     // (F8).
     var truncation =
         new ReviewResult.TruncationDetail(
-            List.of("omitted.java"), List.of("clipped.java"), List.of(), List.of(), false, false);
+            List.of("omitted.java"),
+            List.of("clipped.java"),
+            List.of(),
+            List.of(),
+            SummaryDegradation.NONE);
     var result =
         new ReviewResult(
             List.of(finding("a.java")),
@@ -154,7 +158,8 @@ class FollowUpDeltaSummaryTest {
     // summary-cut clause in it renders the self-contradictory "the findings themselves are
     // complete, so this covers only part of the diff".
     var truncation =
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true, false);
+        new ReviewResult.TruncationDetail(
+            List.of(), List.of(), List.of(), List.of(), SummaryDegradation.RESPONSE_CUT);
     var result =
         new ReviewResult(
             List.of(finding("a.java")),
@@ -185,7 +190,8 @@ class FollowUpDeltaSummaryTest {
     // token spend ceiling leaves the findings — and this comment's counts — covering the whole
     // diff, so the per-file partial-coverage framing must not render.
     var truncation =
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, true);
+        new ReviewResult.TruncationDetail(
+            List.of(), List.of(), List.of(), List.of(), SummaryDegradation.SKIPPED_AT_CEILING);
     var result =
         new ReviewResult(
             List.of(finding("a.java")),

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -192,7 +192,8 @@ class ReviewResultTest {
     // diff") is about per-file gaps. A detail whose only content is a summary flag means the
     // findings cover the whole diff, so this surface must render nothing.
     var detail =
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true, false);
+        new ReviewResult.TruncationDetail(
+            List.of(), List.of(), List.of(), List.of(), SummaryDegradation.RESPONSE_CUT);
 
     assertEquals("", ReviewResult.truncationDisclosure(0, detail));
     // The guard's null arm behaves like an empty detail, and a detail with file gaps still
@@ -200,7 +201,7 @@ class ReviewResultTest {
     assertEquals("", ReviewResult.truncationDisclosure(0, null));
     var clippedOnly =
         new ReviewResult.TruncationDetail(
-            List.of(), List.of("clipped.java"), List.of(), List.of(), false, false);
+            List.of(), List.of("clipped.java"), List.of(), List.of(), SummaryDegradation.NONE);
     assertTrue(
         ReviewResult.truncationDisclosure(0, clippedOnly).contains("partially analyzed"),
         ReviewResult.truncationDisclosure(0, clippedOnly));
@@ -212,7 +213,11 @@ class ReviewResultTest {
     // as one more clause — the flag-only guard must not suppress this shape.
     var detail =
         new ReviewResult.TruncationDetail(
-            List.of("omitted.java"), List.of(), List.of(), List.of(), true, false);
+            List.of("omitted.java"),
+            List.of(),
+            List.of(),
+            List.of(),
+            SummaryDegradation.RESPONSE_CUT);
 
     var disclosure = ReviewResult.truncationDisclosure(1, detail);
 
@@ -252,8 +257,7 @@ class ReviewResultTest {
             List.of("b.java"),
             List.of("c.java", "d.java"),
             List.of(),
-            false,
-            false);
+            SummaryDegradation.NONE);
 
     var clause = ReviewResult.coverageGapClause(4, detail);
 
@@ -270,7 +274,7 @@ class ReviewResultTest {
   void coverageGapClauseWithOnlySpendCeilingSkipsDropsTheBudgetWording() {
     var detail =
         new ReviewResult.TruncationDetail(
-            List.of(), List.of(), List.of("c.java"), List.of(), false, false);
+            List.of(), List.of(), List.of("c.java"), List.of(), SummaryDegradation.NONE);
 
     var clause = ReviewResult.coverageGapClause(1, detail);
 
@@ -298,7 +302,11 @@ class ReviewResultTest {
             false,
             true,
             new ReviewResult.TruncationDetail(
-                List.of("a.java"), List.of(), List.of("c.java"), List.of(), false, false));
+                List.of("a.java"),
+                List.of(),
+                List.of("c.java"),
+                List.of(),
+                SummaryDegradation.NONE));
 
     var brief = result.coverageGapBrief();
 
@@ -308,10 +316,14 @@ class ReviewResultTest {
 
   @Test
   void truncationDetailNormalizesNullListsToEmpty() {
-    var detail = new ReviewResult.TruncationDetail(null, null, null, null, false, false);
+    var detail = new ReviewResult.TruncationDetail(null, null, null, null, null);
     assertTrue(detail.isEmpty());
     assertEquals(List.of(), detail.spendCeilingSkippedFileNames());
     assertEquals(List.of(), detail.responseCutFileNames());
+    assertEquals(
+        SummaryDegradation.NONE,
+        detail.summaryDegradation(),
+        "a null degradation normalizes to NONE");
   }
 
   @Test
@@ -321,7 +333,7 @@ class ReviewResultTest {
     // them into the budget or ceiling wording.
     var detail =
         new ReviewResult.TruncationDetail(
-            List.of("a.java"), List.of(), List.of(), List.of("cut.java"), false, false);
+            List.of("a.java"), List.of(), List.of(), List.of("cut.java"), SummaryDegradation.NONE);
 
     var clause = ReviewResult.coverageGapClause(2, detail);
 
@@ -352,7 +364,7 @@ class ReviewResultTest {
             false,
             true,
             new ReviewResult.TruncationDetail(
-                List.of(), List.of(), List.of(), List.of("cut.java"), false, false));
+                List.of(), List.of(), List.of(), List.of("cut.java"), SummaryDegradation.NONE));
 
     var brief = result.coverageGapBrief();
 
@@ -364,11 +376,12 @@ class ReviewResultTest {
   void truncationDetailWithOnlyResponseCutFilesIsNotEmpty() {
     var detail =
         new ReviewResult.TruncationDetail(
-            List.of(), List.of(), List.of(), List.of("cut.java"), false, false);
+            List.of(), List.of(), List.of(), List.of("cut.java"), SummaryDegradation.NONE);
     assertFalse(detail.isEmpty());
     // The canonical constructor with an empty response-cut list keeps the pre-#500 shape.
     assertTrue(
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, false)
+        new ReviewResult.TruncationDetail(
+                List.of(), List.of(), List.of(), List.of(), SummaryDegradation.NONE)
             .isEmpty());
   }
 
@@ -380,7 +393,7 @@ class ReviewResultTest {
     // sibling ceiling degradation of the same lane discloses itself.
     var detail =
         new ReviewResult.TruncationDetail(
-            List.of("a.java"), List.of(), List.of(), List.of(), true, false);
+            List.of("a.java"), List.of(), List.of(), List.of(), SummaryDegradation.RESPONSE_CUT);
 
     var clause = ReviewResult.coverageGapClause(1, detail);
 
@@ -412,7 +425,11 @@ class ReviewResultTest {
             false,
             true,
             new ReviewResult.TruncationDetail(
-                List.of("a.java"), List.of(), List.of(), List.of(), true, false));
+                List.of("a.java"),
+                List.of(),
+                List.of(),
+                List.of(),
+                SummaryDegradation.RESPONSE_CUT));
 
     var brief = result.coverageGapBrief();
 
@@ -423,12 +440,15 @@ class ReviewResultTest {
   @Test
   void truncationDetailWithOnlyTheSummaryCutIsNotEmpty() {
     var detail =
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true, false);
+        new ReviewResult.TruncationDetail(
+            List.of(), List.of(), List.of(), List.of(), SummaryDegradation.RESPONSE_CUT);
     assertFalse(detail.isEmpty());
-    // The canonical constructor with the cut flag unset keeps the pre-summary-cut shape.
-    assertFalse(
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, false)
-            .summaryResponseCut());
+    // The canonical constructor with no degradation keeps the pre-summary-cut shape.
+    assertEquals(
+        SummaryDegradation.NONE,
+        new ReviewResult.TruncationDetail(
+                List.of(), List.of(), List.of(), List.of(), SummaryDegradation.NONE)
+            .summaryDegradation());
   }
 
   @Test
@@ -436,14 +456,17 @@ class ReviewResultTest {
     // #518: like the summary cut, the ceiling-skipped summary must defeat the EMPTY guards so
     // the summary-aware surfaces render it...
     var detail =
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, true);
+        new ReviewResult.TruncationDetail(
+            List.of(), List.of(), List.of(), List.of(), SummaryDegradation.SKIPPED_AT_CEILING);
     assertFalse(detail.isEmpty());
-    // ...while the per-file surfaces treat it as gap-free, exactly like the cut flag (#516).
+    // ...while the per-file surfaces treat it as gap-free, exactly like the cut flavor (#516).
     assertFalse(detail.hasFileGaps());
-    // The canonical constructor with the ceiling flag unset keeps the pre-#518 shape.
-    assertFalse(
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), true, false)
-            .summarySkippedAtCeiling());
+    // The single slot keeps the two flavors mutually exclusive by construction.
+    assertEquals(
+        SummaryDegradation.RESPONSE_CUT,
+        new ReviewResult.TruncationDetail(
+                List.of(), List.of(), List.of(), List.of(), SummaryDegradation.RESPONSE_CUT)
+            .summaryDegradation());
   }
 
   @Test
@@ -453,7 +476,11 @@ class ReviewResultTest {
     // complete — instead of leaving the degradation log-only.
     var detail =
         new ReviewResult.TruncationDetail(
-            List.of("a.java"), List.of(), List.of(), List.of(), false, true);
+            List.of("a.java"),
+            List.of(),
+            List.of(),
+            List.of(),
+            SummaryDegradation.SKIPPED_AT_CEILING);
 
     var clause = ReviewResult.coverageGapClause(1, detail);
 
@@ -485,7 +512,11 @@ class ReviewResultTest {
             false,
             true,
             new ReviewResult.TruncationDetail(
-                List.of("a.java"), List.of(), List.of(), List.of(), false, true));
+                List.of("a.java"),
+                List.of(),
+                List.of(),
+                List.of(),
+                SummaryDegradation.SKIPPED_AT_CEILING));
 
     var brief = result.coverageGapBrief();
 
@@ -498,7 +529,8 @@ class ReviewResultTest {
     // #516's guard must hold for the ceiling flavor too: no file gap means no partial-coverage
     // framing, whichever summary flag is set.
     var detail =
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, true);
+        new ReviewResult.TruncationDetail(
+            List.of(), List.of(), List.of(), List.of(), SummaryDegradation.SKIPPED_AT_CEILING);
 
     assertEquals("", ReviewResult.truncationDisclosure(0, detail));
   }
@@ -507,11 +539,12 @@ class ReviewResultTest {
   void truncationDetailWithOnlySpendCeilingSkipsIsNotEmpty() {
     var detail =
         new ReviewResult.TruncationDetail(
-            List.of(), List.of(), List.of("c.java"), List.of(), false, false);
+            List.of(), List.of(), List.of("c.java"), List.of(), SummaryDegradation.NONE);
     assertFalse(detail.isEmpty());
     // The canonical constructor with an empty ceiling-skip list keeps the pre-#499 shape.
     assertTrue(
-        new ReviewResult.TruncationDetail(List.of(), List.of(), List.of(), List.of(), false, false)
+        new ReviewResult.TruncationDetail(
+                List.of(), List.of(), List.of(), List.of(), SummaryDegradation.NONE)
             .isEmpty());
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -136,7 +136,7 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(3);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of("big.java"), List.of(), true, null, null, null, null, null);
+            List.of(), List.of("big.java"), List.of(), true, null, null, null, null);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -149,7 +149,7 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(3);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -166,7 +166,7 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(0);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
     plan.recordUncoveredFiles(List.of("failed.java"));
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -186,7 +186,7 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(0);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of("f.java"), true, null, null, null, null, null);
+            List.of(), List.of(), List.of("f.java"), true, null, null, null, null);
     plan.recordUncoveredFiles(List.of("f.java"));
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -205,7 +205,7 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(0);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of("big.java"), List.of(), true, null, null, null, null, null);
+            List.of(), List.of("big.java"), List.of(), true, null, null, null, null);
     plan.recordSpendCeilingSkippedFiles(List.of("skipped.java"));
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -236,7 +236,7 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(0);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
     plan.recordResponseCutFiles(List.of("cut.java"));
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -266,7 +266,7 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(0);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of("c.java"), true, null, null, null, null, null);
+            List.of(), List.of(), List.of("c.java"), true, null, null, null, null);
     plan.recordResponseCutFiles(List.of("c.java"));
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -285,15 +285,15 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(0);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
-    plan.recordSummaryResponseCut();
+            List.of(), List.of(), List.of(), true, null, null, null, null);
+    plan.recordSummaryDegradation(SummaryDegradation.RESPONSE_CUT);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
     assertEquals(0, result.omittedFiles());
     assertFalse(result.truncated());
     assertEquals(ReviewState.APPROVE, result.reviewState());
-    assertTrue(result.truncation().summaryResponseCut());
+    assertEquals(SummaryDegradation.RESPONSE_CUT, result.truncation().summaryDegradation());
     assertTrue(
         result.summaryMarkdown().contains("**Summary shortened.**"), result.summaryMarkdown());
     assertTrue(
@@ -317,15 +317,15 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(0);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
-    plan.recordSummarySkippedAtCeiling();
+            List.of(), List.of(), List.of(), true, null, null, null, null);
+    plan.recordSummaryDegradation(SummaryDegradation.SKIPPED_AT_CEILING);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
     assertEquals(0, result.omittedFiles());
     assertFalse(result.truncated());
     assertEquals(ReviewState.APPROVE, result.reviewState());
-    assertTrue(result.truncation().summarySkippedAtCeiling());
+    assertEquals(SummaryDegradation.SKIPPED_AT_CEILING, result.truncation().summaryDegradation());
     assertTrue(result.summaryMarkdown().contains("**Summary skipped.**"), result.summaryMarkdown());
     assertTrue(
         result.summaryMarkdown().contains("REVIEW_MAX_TOKENS_PER_REVIEW"),
@@ -346,8 +346,8 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(0);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of("big.java"), List.of(), true, null, null, null, null, null);
-    plan.recordSummarySkippedAtCeiling();
+            List.of(), List.of("big.java"), List.of(), true, null, null, null, null);
+    plan.recordSummaryDegradation(SummaryDegradation.SKIPPED_AT_CEILING);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -372,8 +372,8 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(0);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of("big.java"), List.of(), true, null, null, null, null, null);
-    plan.recordSummaryResponseCut();
+            List.of(), List.of("big.java"), List.of(), true, null, null, null, null);
+    plan.recordSummaryDegradation(SummaryDegradation.RESPONSE_CUT);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -412,7 +412,7 @@ class VerdictBuilderTest {
             false,
             true,
             new ReviewResult.TruncationDetail(
-                List.of(), List.of(), List.of(), List.of(), true, false));
+                List.of(), List.of(), List.of(), List.of(), SummaryDegradation.RESPONSE_CUT));
 
     var checkSummary = VerdictBuilder.checkSummaryForResult(result);
 
@@ -427,7 +427,7 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(0);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of("huge.java"), true, null, null, null, null, null);
+            List.of(), List.of(), List.of("huge.java"), true, null, null, null, null);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -440,15 +440,7 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(0);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(),
-            List.of("big.java"),
-            List.of("huge.java"),
-            true,
-            null,
-            null,
-            null,
-            null,
-            null);
+            List.of(), List.of("big.java"), List.of("huge.java"), true, null, null, null, null);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -467,7 +459,7 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(0); // reviewable: a.java
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of("a.java"), List.of(), true, null, null, null, null, null);
+            List.of(), List.of("a.java"), List.of(), true, null, null, null, null);
     var rowsCaptor = ArgumentCaptor.forClass(List.class);
 
     builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -491,7 +483,7 @@ class VerdictBuilderTest {
                 new FileDiff("skipped.java", "modified", 1, 0, 1, "")));
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
     plan.recordSpendCeilingSkippedFiles(List.of("skipped.java"));
     var rowsCaptor = ArgumentCaptor.forClass(List.class);
 
@@ -521,7 +513,7 @@ class VerdictBuilderTest {
                 new FileDiff("a.java", "modified", 1, 0, 1, "")));
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of("a.java"), List.of(), true, null, null, null, null, null);
+            List.of(), List.of("a.java"), List.of(), true, null, null, null, null);
     var rowsCaptor = ArgumentCaptor.forClass(List.class);
 
     builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
@@ -598,7 +590,7 @@ class VerdictBuilderTest {
             BlockingStrictness.BALANCED);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
 
     var result =
         realBuilder.build(
@@ -619,7 +611,7 @@ class VerdictBuilderTest {
             BlockingStrictness.BALANCED);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
     var ctx =
         new ReviewContextLoader.ReviewContext(
             List.of(),
@@ -766,7 +758,6 @@ class VerdictBuilderTest {
             null,
             null,
             null,
-            null,
             null);
 
     var result =
@@ -787,7 +778,7 @@ class VerdictBuilderTest {
     // record of what the model saw and must still be the material the decline is checked against.
     var legacyPlan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), false, null, null, null, null, null);
+            List.of(), List.of(), List.of(), false, null, null, null, null);
 
     var result =
         builderWithRealAnalyzer(summaryGenerator)
@@ -808,7 +799,7 @@ class VerdictBuilderTest {
     // would yield nothing; ctx.diff() is the fallback the re-check must use.
     var emptyBudgetedPlan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of("big.java"), List.of(), true, null, null, null, null, null);
+            List.of(), List.of("big.java"), List.of(), true, null, null, null, null);
 
     var result =
         builderWithRealAnalyzer(summaryGenerator)
@@ -826,7 +817,7 @@ class VerdictBuilderTest {
     var ctx = contextWithLineCapOmissions(2);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), false, null, null, null, null, null);
+            List.of(), List.of(), List.of(), false, null, null, null, null);
 
     var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -843,7 +834,7 @@ class VerdictBuilderTest {
 
   private static final DiffBudgetPlanner.BudgetPlan FULL_COVERAGE =
       new DiffBudgetPlanner.BudgetPlan(
-          List.of(), List.of(), List.of(), true, null, null, null, null, null);
+          List.of(), List.of(), List.of(), true, null, null, null, null);
 
   private VerdictBuilder builderWith(CiGatingMode mode) {
     return new VerdictBuilder(
@@ -1019,7 +1010,7 @@ class VerdictBuilderTest {
             null);
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), false, null, null, null, null, null);
+            List.of(), List.of(), List.of(), false, null, null, null, null);
 
     builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
 
@@ -1050,7 +1041,7 @@ class VerdictBuilderTest {
             response,
             CI_CLEAR,
             new DiffBudgetPlanner.BudgetPlan(
-                List.of(), List.of(), List.of(), false, null, null, null, null, null));
+                List.of(), List.of(), List.of(), false, null, null, null, null));
 
     assertEquals(ReviewState.REQUEST_CHANGES, result.reviewState());
   }
@@ -1079,7 +1070,7 @@ class VerdictBuilderTest {
             response,
             CI_CLEAR,
             new DiffBudgetPlanner.BudgetPlan(
-                List.of(), List.of(), List.of(), false, null, null, null, null, null));
+                List.of(), List.of(), List.of(), false, null, null, null, null));
 
     assertEquals(ReviewState.COMMENT, result.reviewState());
   }
@@ -1204,7 +1195,7 @@ class VerdictBuilderTest {
             response,
             CI_CLEAR,
             new DiffBudgetPlanner.BudgetPlan(
-                List.of(), List.of(), List.of(), false, null, null, null, null, null));
+                List.of(), List.of(), List.of(), false, null, null, null, null));
 
     assertEquals(ReviewState.COMMENT, result.reviewState());
   }
@@ -1278,7 +1269,7 @@ class VerdictBuilderTest {
   void unresolvedCountAcrossAZeroFindingRoundStaysAtTheOneRealFinding() {
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
     var stillUnresolved =
         new ReviewResponse(
             List.of(),
@@ -1304,7 +1295,7 @@ class VerdictBuilderTest {
   void resolvedPriorFindingNoLongerPhantomHoldsApproveAfterAZeroFindingRound() {
     var plan =
         new DiffBudgetPlanner.BudgetPlan(
-            List.of(), List.of(), List.of(), true, null, null, null, null, null);
+            List.of(), List.of(), List.of(), true, null, null, null, null);
     var resolvedNow =
         new ReviewResponse(
             List.of(),


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor

## Description

`summaryResponseCut` and `summarySkippedAtCeiling` were two mutually exclusive booleans set on disjoint control paths (`salvagedOrCountsOnlySummary` vs `countsOnlySummary`). The pair made the meaningless both-true state representable, forced ordered `else if` chains at the render sites, and duplicated the entire AtomicBoolean recorder/accessor/defensive-snapshot apparatus on `BudgetPlan`.

This replaces the pair with a single `SummaryDegradation` enum (`NONE` / `RESPONSE_CUT` / `SKIPPED_AT_CEILING`):

- **BudgetPlan**: one `AtomicReference<SummaryDegradation>` component with one recorder (`recordSummaryDegradation`), one value accessor (`summaryDegradation()`) and one defensive snapshot accessor, replacing both AtomicBoolean apparatuses — the canonical constructor shrinks from 9 to 8 args.
- **TruncationDetail**: one enum component replacing both booleans — the canonical constructor shrinks from 6 to 5 args. The `isEmpty()` / `hasFileGaps()` guards (and the `truncationDisclosure` gap-only guard built on them) are preserved verbatim: a degradation still defeats `isEmpty()`, still does not create a file gap.
- **Render sites** switch on the enum: `VerdictBuilder`'s banner selection and `truncationSuffixFor`, plus the shared `ReviewResult.coverageGapClause` and `coverageGapBrief`.
- Recording sites in `FindingPipeline` pass the matching constant; a single slot makes the impossible cut-and-skipped-at-once state unrepresentable by construction.

## Related Issues

Fixes #527

## How Has This Been Tested?

- [x] Unit tests

Behavior-preserving: every rendered string stays byte-identical — no rendering test's expected strings changed (the test diff touches only constructor arities, recorder calls, and flag-accessor assertions, all migrated mechanically to the enum). Full suite green: 2594 tests, 0 failures (one fewer than before only because the four per-boolean plan-apparatus tests consolidated into three enum-slot tests covering the same contracts: live recording, defensive snapshot, caller-supplied slot staying live, and no approval hold).

Gates: `spotless:apply` clean; `clean compile spotbugs:check spotless:check` — BugInstance size is 0; jacoco ∩ diff on all changed main code (including the new `SummaryDegradation.java`): 0 missed instructions, 0 missed branches.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Originally stacked on #530 (the degenerate-lane ceiling catch, whose recording site this refactor also migrates); #530 has since merged, so this targets `release/v0.6.0` directly, rebased on top of it. Diff is scoped to #527 only.