### PR TITLE
perf(config): resolve DNS off the event loop with the async resolver

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,24 @@
 # Server
 quarkus.http.port=${PORT:8080}
 
+# DNS — resolve hostnames with Vert.x's async (Netty) resolver rather than the JDK's blocking one.
+# Quarkus defaults quarkus.vertx.use-async-dns to false, and on that default VertxCoreRecorder sets
+# vertx.disableDnsResolver=true, which leaves Netty on DefaultNameResolver -> InetAddress.getByName:
+# a blocking lookup run on whichever event-loop thread is opening the connection. Every outbound
+# call the bot makes goes through it — the langchain4j OpenAI client and the GitHub REST clients are
+# all Quarkus REST clients over the Vert.x HTTP client — so under concurrent reviews the
+# BlockedThreadChecker caught event loops parked for seconds on a name lookup (2285 ms and 2901 ms
+# on vert.x-eventloop-thread-2), freezing unrelated work sharing that thread: other reviews, webhook
+# intake, dashboard sockets. The async resolver takes name resolution off the event loop entirely.
+quarkus.vertx.use-async-dns=true
+# Floor the resolver's positive cache at 30s — the JVM's own default networkaddress.cache.ttl — so
+# swapping resolvers cannot make the bot query DNS *more* often than it used to: the JDK path cached
+# every hit for 30s no matter what the record said, while Netty honours short record TTLs literally.
+# The bot talks to a small fixed set of hosts (the AI base URL, api.github.com), so this turns nearly
+# every lookup into a cache hit. Negative results stay uncached (Quarkus default 0): a failed lookup
+# retries immediately, and now costs no event-loop time when it does.
+quarkus.vertx.resolver.cache-min-time-to-live=30
+
 # Outbound HTTP and dashboard WebSocket keepalive (tune for slow proxies / idle timeouts)
 thrillhousebot.http-connect-timeout=${HTTP_CONNECT_TIMEOUT:10s}
 thrillhousebot.http-request-timeout=${HTTP_REQUEST_TIMEOUT:10s}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/AsyncDnsResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/AsyncDnsResolverTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import io.netty.resolver.DefaultAddressResolverGroup;
+import io.netty.resolver.dns.DnsAddressResolverGroup;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.VertxInternal;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Every outbound call the bot makes — the langchain4j OpenAI client and the GitHub REST clients are
+ * all Quarkus REST clients over the Vert.x HTTP client — resolves its hostname through the Vert.x
+ * address resolver. Quarkus leaves {@code quarkus.vertx.use-async-dns} false by default, which sets
+ * {@code vertx.disableDnsResolver=true} and hands Netty the JDK-backed {@link
+ * DefaultAddressResolverGroup}, whose {@code DefaultNameResolver} calls {@code
+ * InetAddress.getByName} on the event-loop thread opening the connection. That is what parked event
+ * loops for seconds under concurrent reviews. These tests assert the resolved runtime rather than
+ * the property text, so the {@code quarkus.vertx.*} wiring in {@code application.properties} is
+ * covered too.
+ */
+@QuarkusTest
+class AsyncDnsResolverTest {
+
+  @Inject Vertx vertx;
+
+  @Test
+  void hostnamesResolveThroughTheAsyncResolverNotTheBlockingJdkOne() {
+    var group = ((VertxInternal) vertx).nettyAddressResolverGroup();
+
+    assertNotSame(DefaultAddressResolverGroup.INSTANCE, group);
+    assertInstanceOf(DnsAddressResolverGroup.class, group);
+  }
+
+  @Test
+  void positiveCacheIsFlooredAtTheJvmDefaultDnsTtl() {
+    assertEquals(
+        30,
+        ConfigProvider.getConfig()
+            .getValue("quarkus.vertx.resolver.cache-min-time-to-live", Integer.class));
+  }
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [x] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

### Why the blocking resolver was in play

Quarkus ships `quarkus.vertx.use-async-dns` defaulting to `false` (`VertxConfiguration.useAsyncDNS()` carries `@WithDefault("false")`). On that default `VertxCoreRecorder` sets the system property `vertx.disableDnsResolver=true`, so Vert.x installs Netty's `DefaultAddressResolverGroup` instead of `DnsAddressResolverGroup`. `DefaultAddressResolverGroup` resolves through `DefaultNameResolver` → `InetAddress.getByName`, a **blocking** JDK lookup executed on whichever event-loop thread is opening the connection — exactly the frames in the production warning.

### Which client was resolving

Both, and they share one resolver. The langchain4j OpenAI client (`quarkus-langchain4j-openai`) and the GitHub REST clients (`@RegisterRestClient(configKey = "github-api")`, `GitHubTokenApi`, `GitHubGraphQLClient`, …) are all Quarkus REST clients running on the Vert.x HTTP client, so every one of them resolves through `VertxInternal.nettyAddressResolverGroup()`. The fix is one setting because there is one resolver, and the running instance is asserted directly rather than per client.

The JDK `java.net.http.HttpClient` (`HttpClientProducer` → `AuthResource`, dashboard OAuth) is a separate story and is **not** the reported stall: it does not use the Vert.x resolver, and its `send()` calls sit in JAX-RS methods returning `Response`, which Quarkus REST dispatches to worker threads. Nothing on that path can park an event loop, so it needs no change.

### The change

Two lines in `src/main/resources/application.properties`:

- **`quarkus.vertx.use-async-dns=true`** — the fix. Vert.x installs the Netty async resolver, so name resolution never runs on the calling event loop. `io.netty:netty-resolver-dns` is already on the runtime classpath (4.1.136.Final, via `vertx-core` 4.5.30), so this pulls in no new dependency. `/etc/hosts` still resolves: Vert.x's `DnsResolverProvider` registers itself as the `hostsFileEntriesResolver` on the `DnsNameResolverBuilder`, so `localhost` and container host entries keep working, and inside Docker the resolver reads the embedded DNS server from `/etc/resolv.conf` as before.
- **`quarkus.vertx.resolver.cache-min-time-to-live=30`** — the caching half. Quarkus defaults this to `0`, which means Netty honours short record TTLs literally, while the JDK path it replaces cached every hit for 30s (`networkaddress.cache.ttl`) no matter what the record said. Without a floor, switching resolvers could make the bot query DNS *more* often than before. 30s matches the JVM default exactly, so caching cannot regress, and since the bot talks to a small fixed set of hosts (the AI base URL, `api.github.com`) nearly every lookup becomes a cache hit. `cache-negative-time-to-live` is deliberately left at the Quarkus default `0`: a failed lookup retries immediately rather than pinning an outage for 10s the way the JDK did, and it now costs no event-loop time when it does.

**Not deployment-only.** No JVM flag or image change is needed — `vertx.disableDnsResolver` is set by the Quarkus recorder from application config, so overriding it in the JVM command line would be fighting the recorder. Both properties are ordinary Quarkus config keys, so an operator can still override them per environment via `QUARKUS_VERTX_USE_ASYNC_DNS` / `QUARKUS_VERTX_RESOLVER_CACHE_MIN_TIME_TO_LIVE` without a rebuild. No new ThrillhouseBot knob was introduced, so `.env.example` and the docs are unchanged.

## Related Issues

Fixes #535

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

`AsyncDnsResolverTest` is a `@QuarkusTest` that asserts the **resolved runtime**, not the property text: it reaches into the injected `Vertx` for `VertxInternal.nettyAddressResolverGroup()` and requires it to be a `DnsAddressResolverGroup` and not the blocking `DefaultAddressResolverGroup.INSTANCE` from the production stack trace. A second test pins the cache floor through `ConfigProvider`, so the `quarkus.vertx.*` wiring in `application.properties` is covered as well.

### Red output on unfixed code

With `src/main/resources/application.properties` reverted to `abd76e5` and the new test in place:

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 2.316 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.config.AsyncDnsResolverTest
[ERROR] dev.thiagogonzaga.thrillhousebot.config.AsyncDnsResolverTest.hostnamesResolveThroughTheAsyncResolverNotTheBlockingJdkOne -- Time elapsed: 0.235 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: not same but was: <io.netty.resolver.DefaultAddressResolverGroup@1d4cf8ea>
	at org.junit.jupiter.api.Assertions.assertNotSame(Assertions.java:3003)
	at dev.thiagogonzaga.thrillhousebot.config.AsyncDnsResolverTest.hostnamesResolveThroughTheAsyncResolverNotTheBlockingJdkOne(AsyncDnsResolverTest.java:51)

[ERROR] dev.thiagogonzaga.thrillhousebot.config.AsyncDnsResolverTest.positiveCacheIsFlooredAtTheJvmDefaultDnsTtl -- Time elapsed: 0.002 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <30> but was: <0>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:576)
	at dev.thiagogonzaga.thrillhousebot.config.AsyncDnsResolverTest.positiveCacheIsFlooredAtTheJvmDefaultDnsTtl(AsyncDnsResolverTest.java:57)
```

The first failure is the bug itself: the resolver group the app boots with **is** `DefaultAddressResolverGroup`, the one whose `DefaultNameResolver` appears in the reported stack. With the fix both pass.

### How an operator verifies the stalls are gone

1. Deploy and reproduce the original load: several PRs reviewing concurrently plus a burst of on-demand commands.
2. Watch the logs for `io.vertx.core.impl.BlockedThreadChecker`. The observable is the absence of warnings whose stack contains `java.net.InetAddress.getByName` / `io.netty.resolver.DefaultNameResolver.doResolve` on a `vert.x-eventloop-thread-*`. Nothing else about the checker changes, so an unrelated blocking call would still be reported — this only removes the DNS frames.
3. Confirm the resolver actually swapped, independently of load: the JVM must **not** have `vertx.disableDnsResolver=true` any more. `quarkus.vertx.use-async-dns` is the only thing that sets it.
4. Roll back without a redeploy if the environment's DNS misbehaves: set `QUARKUS_VERTX_USE_ASYNC_DNS=false` and restart to get the previous (blocking) behaviour back.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Gates, Java 25:

- `./mvnw -B spotless:apply` → BUILD SUCCESS
- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` → `Tests run: 2596, Failures: 0, Errors: 0, Skipped: 0`

Coverage: the diff against `abd76e5` touches `src/main/resources/application.properties` and one new test file — zero main-code Java lines changed, so the jacoco ∩ diff intersection is empty (no uncovered lines, no uncovered branches).

## Additional Notes

Correctness is unchanged; this is a latency/throughput fix. One environment-shaped caveat worth knowing: on macOS the Netty async resolver has no native `libresolv` binding unless `netty-resolver-dns-native-macos` is added, so a local dev run falls back to parsing `/etc/resolv.conf` and will not see DNS entries configured only through System Settings. Production runs on Linux in a container, where `/etc/resolv.conf` is authoritative, so the deployed path is unaffected — and the test suite passes on macOS either way since it resolves no external names.
