### PR TITLE
fix(commands): reply instead of declining a command in silence

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandService.java
@@ -43,6 +43,13 @@ import org.slf4j.LoggerFactory;
  * /describe}, {@code /changelog}, {@code /add-docs}, {@code /improve}, {@code /generate-tests},
  * {@code /resolve}, {@code /pause}, {@code /resume}. Work runs on the shared review executor so the
  * webhook 200-ack thread is never blocked by GitHub API calls.
+ *
+ * <p>Every recognized command is acknowledged with a 👀 reaction before it reaches here, so a path
+ * that ends without posting reads on the PR as a hang. The rule these handlers follow is therefore:
+ * an acknowledged command produces exactly one visible reply — the requested output, or a one-line
+ * notice saying why there is none (paused, switched off, already satisfied, nothing to say). The
+ * single deliberate exception is a command from someone without write access: replying there would
+ * let any commenter make the bot post, so those stay silent and are only logged.
  */
 @ApplicationScoped
 public class CommentCommandService {
@@ -54,6 +61,15 @@ public class CommentCommandService {
   /** Posted when a review-generating command lands on a paused PR. */
   static final String PAUSED_NOTICE =
       "⏸️ ThrillhouseBot is paused on this PR. Comment `/resume` to re-enable reviews.";
+
+  /**
+   * Posted when {@code /summary} declines because the PR already carries a bot summary. The command
+   * only regenerates a summary that is missing, so the way to get a fresh one is to delete the
+   * existing comment first.
+   */
+  static final String SUMMARY_ALREADY_PRESENT =
+      "📋 A ThrillhouseBot summary is already on this PR, so `/summary` did nothing. "
+          + "Delete that summary comment and comment `/summary` again to regenerate it.";
 
   static final String HELP_TEXT =
       """
@@ -197,10 +213,11 @@ public class CommentCommandService {
     }
     if (contextLoader.botSummaryCommentExists(auth, ctx.owner(), ctx.repo(), ctx.prNumber())) {
       log.info(
-          "Ignoring /summary — a summary comment is already present on {}/{} #{}",
+          "Declining /summary — a summary comment is already present on {}/{} #{}",
           ctx.owner(),
           ctx.repo(),
           num(ctx));
+      postComment(auth, ctx, SUMMARY_ALREADY_PRESENT);
       return;
     }
     log.info(
@@ -248,10 +265,7 @@ public class CommentCommandService {
             ctx.defaultBranch(),
             ctx.installationId(),
             auth);
-    if (suggestion == null) {
-      return;
-    }
-    postComment(auth, ctx, suggestion);
+    postComment(auth, ctx, suggestion != null ? suggestion : noOutputNotice("/describe"));
   }
 
   private void handleChangelog(CommandContext ctx, String auth) {
@@ -277,19 +291,16 @@ public class CommentCommandService {
             ctx.defaultBranch(),
             ctx.installationId(),
             auth);
-    if (entry == null) {
-      return;
-    }
-    postComment(auth, ctx, entry);
+    postComment(auth, ctx, entry != null ? entry : noOutputNotice("/changelog"));
   }
 
   private void handleAddDocs(CommandContext ctx, String auth) {
-    if (!config.review().addDocsEnabled()) {
-      log.info("Ignoring /add-docs on PR #{} — the command is disabled", num(ctx));
-      return;
-    }
     if (!authorized(ctx)) {
       log.info("Ignoring unauthorized /add-docs from @{} on PR #{}", ctx.login(), num(ctx));
+      return;
+    }
+    if (!config.review().addDocsEnabled()) {
+      declineAsDisabled(ctx, auth, "/add-docs", "add-docs-enabled");
       return;
     }
     if (prPauseService.isPaused(ctx.owner(), ctx.repo(), ctx.prNumber())) {
@@ -308,12 +319,12 @@ public class CommentCommandService {
   }
 
   private void handleImprove(CommandContext ctx, String auth) {
-    if (!config.review().improveEnabled()) {
-      log.info("Ignoring /improve on PR #{} — the command is disabled", num(ctx));
-      return;
-    }
     if (!authorized(ctx)) {
       log.info("Ignoring unauthorized /improve from @{} on PR #{}", ctx.login(), num(ctx));
+      return;
+    }
+    if (!config.review().improveEnabled()) {
+      declineAsDisabled(ctx, auth, "/improve", "improve-enabled");
       return;
     }
     if (prPauseService.isPaused(ctx.owner(), ctx.repo(), ctx.prNumber())) {
@@ -333,12 +344,12 @@ public class CommentCommandService {
   }
 
   private void handleGenerateTests(CommandContext ctx, String auth) {
-    if (!config.review().generateTestsEnabled()) {
-      log.info("Ignoring /generate-tests on PR #{} — the command is disabled", num(ctx));
-      return;
-    }
     if (!authorized(ctx)) {
       log.info("Ignoring unauthorized /generate-tests from @{} on PR #{}", ctx.login(), num(ctx));
+      return;
+    }
+    if (!config.review().generateTestsEnabled()) {
+      declineAsDisabled(ctx, auth, "/generate-tests", "generate-tests-enabled");
       return;
     }
     if (prPauseService.isPaused(ctx.owner(), ctx.repo(), ctx.prNumber())) {
@@ -359,10 +370,7 @@ public class CommentCommandService {
             ctx.defaultBranch(),
             ctx.installationId(),
             auth);
-    if (suggestion == null) {
-      return;
-    }
-    postComment(auth, ctx, suggestion);
+    postComment(auth, ctx, suggestion != null ? suggestion : noOutputNotice("/generate-tests"));
   }
 
   private void handleResolve(CommandContext ctx, String auth) {
@@ -471,6 +479,41 @@ public class CommentCommandService {
       }
     }
     return ids;
+  }
+
+  /**
+   * Logs and answers a command that is switched off for this deployment, naming the config key an
+   * administrator would flip. The kill-switch check sits after the authorization check in every
+   * handler precisely so this reply exists: a notice posted before authorization would let any
+   * commenter make the bot speak on a repository whose maintainers turned the command off.
+   */
+  private void declineAsDisabled(
+      CommandContext ctx, String auth, String command, String configKey) {
+    log.info("Declining {} on PR #{} — the command is disabled", command, num(ctx));
+    postComment(
+        auth,
+        ctx,
+        "🚫 `"
+            + command
+            + "` is disabled on this ThrillhouseBot deployment. An administrator can turn it back"
+            + " on with `thrillhousebot.review."
+            + configKey
+            + "=true`.");
+  }
+
+  /**
+   * The reply for a generator that produced nothing to post. The two causes are indistinguishable
+   * from here — the generators return {@code null} both when the PR gave them nothing worth saying
+   * and when every batch call failed — so the notice names both rather than assert a verdict the
+   * caller cannot support.
+   */
+  private static String noOutputNotice(String command) {
+    return "🤖 ThrillhouseBot has no `"
+        + command
+        + "` output to post for this PR — it found nothing to suggest, or the generation did not"
+        + " complete. Re-run `"
+        + command
+        + "` to try again.";
   }
 
   private boolean authorized(CommandContext ctx) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/CommentCommandServiceTest.java
@@ -155,15 +155,19 @@ class CommentCommandServiceTest {
   }
 
   @Test
-  void summaryIsNoOpWhenSummaryCommentIsLiveOnPr() {
+  void summaryExplainsItselfWhenSummaryCommentIsLiveOnPr() {
     authorize(true);
     when(prPauseService.isPaused("owner", "repo", 7)).thenReturn(false);
     when(contextLoader.botSummaryCommentExists("token", "owner", "repo", 7)).thenReturn(true);
 
     service.handle(ctx(CommentCommand.SUMMARY));
 
+    // The command was acknowledged with 👀 before it got here, so declining in silence reads as a
+    // hang: the decline has to be stated, along with the way to get a fresh summary anyway.
     verify(reviewDispatcher, never()).dispatch(any());
-    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+    assertTrue(postedBody().contains("summary is already on this PR"), postedBody());
+    assertTrue(postedBody().contains("Delete that summary comment"), postedBody());
+    assertTrue(postedBody().contains("`/summary` again"), postedBody());
   }
 
   @Test
@@ -202,7 +206,7 @@ class CommentCommandServiceTest {
   }
 
   @Test
-  void describePostsNothingWhenGeneratorReturnsNull() {
+  void describeSaysSoWhenGeneratorReturnsNothing() {
     authorize(true);
     when(prPauseService.isPaused("owner", "repo", 7)).thenReturn(false);
     when(descriptionGenerator.generate("owner", "repo", 7, "main", 12345L, "token"))
@@ -210,7 +214,8 @@ class CommentCommandServiceTest {
 
     service.handle(ctx(CommentCommand.DESCRIBE));
 
-    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+    assertTrue(postedBody().contains("`/describe`"), postedBody());
+    assertTrue(postedBody().contains("no `/describe` output to post"), postedBody());
   }
 
   @Test
@@ -248,14 +253,14 @@ class CommentCommandServiceTest {
   }
 
   @Test
-  void changelogPostsNothingWhenGeneratorReturnsNull() {
+  void changelogSaysSoWhenGeneratorReturnsNothing() {
     authorize(true);
     when(prPauseService.isPaused("owner", "repo", 7)).thenReturn(false);
     when(changelogGenerator.generate("owner", "repo", 7, "main", 12345L, "token")).thenReturn(null);
 
     service.handle(ctx(CommentCommand.CHANGELOG));
 
-    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+    assertTrue(postedBody().contains("no `/changelog` output to post"), postedBody());
   }
 
   @Test
@@ -315,13 +320,27 @@ class CommentCommandServiceTest {
   }
 
   @Test
-  void addDocsIgnoredWhenDisabled() {
+  void addDocsSaysSoWhenDisabled() {
+    authorize(true);
     when(reviewConfig.addDocsEnabled()).thenReturn(false);
 
     service.handle(ctx(CommentCommand.ADD_DOCS));
 
     verifyNoInteractions(docGenerationService);
-    verifyNoInteractions(authorizer);
+    assertTrue(postedBody().contains("`/add-docs` is disabled"), postedBody());
+    assertTrue(postedBody().contains("thrillhousebot.review.add-docs-enabled=true"), postedBody());
+  }
+
+  @Test
+  void addDocsStaysSilentWhenDisabledAndUnauthorized() {
+    // The kill-switch notice is gated behind write access: otherwise any commenter could make the
+    // bot post on a repository whose maintainers switched the command off.
+    authorize(false);
+    when(reviewConfig.addDocsEnabled()).thenReturn(false);
+
+    service.handle(ctx(CommentCommand.ADD_DOCS));
+
+    verifyNoInteractions(docGenerationService);
     verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
   }
 
@@ -360,14 +379,15 @@ class CommentCommandServiceTest {
   }
 
   @Test
-  void improveIgnoredWhenDisabled() {
+  void improveSaysSoWhenDisabled() {
+    authorize(true);
     when(reviewConfig.improveEnabled()).thenReturn(false);
 
     service.handle(ctx(CommentCommand.IMPROVE));
 
     verifyNoInteractions(improvementService);
-    verifyNoInteractions(authorizer);
-    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+    assertTrue(postedBody().contains("`/improve` is disabled"), postedBody());
+    assertTrue(postedBody().contains("thrillhousebot.review.improve-enabled=true"), postedBody());
   }
 
   @Test
@@ -390,14 +410,14 @@ class CommentCommandServiceTest {
   }
 
   @Test
-  void generateTestsPostsNothingWhenGeneratorReturnsNull() {
+  void generateTestsSaysSoWhenGeneratorReturnsNothing() {
     authorize(true);
     when(prPauseService.isPaused("owner", "repo", 7)).thenReturn(false);
     when(testGenerator.generate("owner", "repo", 7, "main", 12345L, "token")).thenReturn(null);
 
     service.handle(ctx(CommentCommand.GENERATE_TESTS));
 
-    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+    assertTrue(postedBody().contains("no `/generate-tests` output to post"), postedBody());
   }
 
   @Test
@@ -423,14 +443,16 @@ class CommentCommandServiceTest {
   }
 
   @Test
-  void generateTestsIgnoredWhenDisabled() {
+  void generateTestsSaysSoWhenDisabled() {
+    authorize(true);
     when(reviewConfig.generateTestsEnabled()).thenReturn(false);
 
     service.handle(ctx(CommentCommand.GENERATE_TESTS));
 
     verifyNoInteractions(testGenerator);
-    verifyNoInteractions(authorizer);
-    verify(commentClient, never()).createComment(any(), any(), any(), any(), anyInt(), any());
+    assertTrue(postedBody().contains("`/generate-tests` is disabled"), postedBody());
+    assertTrue(
+        postedBody().contains("thrillhousebot.review.generate-tests-enabled=true"), postedBody());
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Every recognized comment command is acknowledged with a 👀 reaction *before* it runs, so any
handler that returns without posting leaves the commenter looking at an acknowledged command that
produced nothing — which reads as a hang, not as a decision.

`/summary` on a PR that already carries a summary did exactly that. The decline was deliberate and
logged (`Ignoring /summary — a summary comment is already present on <repo> #<n>`) but nothing
reached the PR. It now states the decline and how to get a fresh summary anyway:

> 📋 A ThrillhouseBot summary is already on this PR, so `/summary` did nothing. Delete that summary
> comment and comment `/summary` again to regenerate it.

**Audit of the same shape.** Five other paths acknowledged and then declined in silence; all are
now answered:

| Path | Was | Now |
|---|---|---|
| `/add-docs`, `/improve`, `/generate-tests` disabled by their kill switch | logged only | notice naming the config key an administrator would flip (`thrillhousebot.review.<key>=true`) |
| `/describe`, `/changelog`, `/generate-tests` whose generator returned nothing | nothing posted | notice saying there is no output, and to re-run |

Two decisions worth flagging for review:

- **The kill-switch check moved to *after* the authorization check** in all three handlers. Posting
  the "disabled" notice before authorizing would let any commenter make the bot speak on a
  repository whose maintainers switched the command off. Behaviour for authorized users is
  unchanged; unauthorized users now cost one permission lookup on a disabled command.
- **A command from someone without write access stays silent**, logged only. That is the one
  deliberate exception to the new rule, for the same anti-abuse reason, and it is now stated in the
  class contract and pinned by a test.

The generator-returned-nothing notice deliberately names both possible causes ("it found nothing to
suggest, or the generation did not complete"): the generators return `null` for both, and the
handler has no way to tell them apart, so asserting either one would be a claim this code cannot
support.

## Related Issues

Fixes #538

## How Has This Been Tested?

- [x] Unit tests

`CommentCommandServiceTest` — 7 tests written/updated against the unfixed code first. All 7 failed
in exactly the way the issue describes: the command runs, decides, and never posts.

```
Tests run: 45, Failures: 7, Errors: 0, Skipped: 0
  summaryExplainsItselfWhenSummaryCommentIsLiveOnPr
  describeSaysSoWhenGeneratorReturnsNothing
  changelogSaysSoWhenGeneratorReturnsNothing
  generateTestsSaysSoWhenGeneratorReturnsNothing
  addDocsSaysSoWhenDisabled
  improveSaysSoWhenDisabled
  generateTestsSaysSoWhenDisabled
```

Verbatim red output for the issue's own case:

```
dev.thiagogonzaga.thrillhousebot.webhook.CommentCommandServiceTest.summaryExplainsItselfWhenSummaryCommentIsLiveOnPr -- Time elapsed: 0.002 s <<< FAILURE!
Wanted but not invoked:
commentClient.createComment(
    <any>,
    <any>,
    "owner",
    "repo",
    7,
    <Capturing argument: CreateCommentRequest>
);
-> at dev.thiagogonzaga.thrillhousebot.webhook.CommentCommandServiceTest.postedBody(CommentCommandServiceTest.java:115)
Actually, there were zero interactions with this mock.

	at dev.thiagogonzaga.thrillhousebot.webhook.CommentCommandServiceTest.summaryExplainsItselfWhenSummaryCommentIsLiveOnPr(CommentCommandServiceTest.java:168)
```

Green after the fix: `Tests run: 45, Failures: 0, Errors: 0, Skipped: 0`.

Gates (Java 25):

- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` → `Tests run: 2595, Failures: 0, Errors: 0, Skipped: 0`
- Coverage ∩ `git diff -U0 abd76e5...HEAD` on changed main code → 17 executable changed lines,
  17 fully covered, **0 uncovered lines and 0 uncovered branches**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

`/add-docs` and `/improve` already post their own outcome from `DocGenerationService` /
`PrImprovementService`, so they need no reply here beyond the kill-switch case. No behaviour change
for any command that was already producing output.
