### PR TITLE
fix(review): name the cap that applies and soft-fail an absent verifier body

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
@@ -296,11 +296,17 @@ public abstract class AbstractPrSuggestionGenerator {
    * RuntimeException}, degrades to {@code null} (post nothing); a usable reply is returned
    * stripped. {@code command} labels the operation in logs (e.g. {@code "/describe"}). Subclasses
    * supply the actual call (and apply any command-specific post-filtering to the result).
+   *
+   * <p>Every subclass's assistant is bound to the default model ({@code /describe}, {@code
+   * /improve}, {@code /changelog}, {@code /generate-tests}, {@code /add-docs}), so a truncation
+   * here is capped by the active model's {@code max-output-tokens} — the concise-bound calls
+   * (summary, verifier, replies) do not come through this path.
    */
   protected String callAssistant(String command, Supplier<Result<String>> assistantCall) {
     try {
       String suggestion =
-          AiResponses.textOrThrowOnTruncation(assistantCall.get(), command + " assistant");
+          AiResponses.textOrThrowOnTruncation(
+              assistantCall.get(), command + " assistant", AiResponses.ModelLane.ACTIVE);
       if (suggestion == null || suggestion.isBlank()) {
         Log.debugf("%s assistant produced an empty suggestion — posting nothing", command);
         return null;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
@@ -229,7 +229,10 @@ public class MaintainerReplyService {
                   // codeContext is the diff/hunk under discussion: fence it byte-exact.
                   PromptTemplateEscaper.fence(codeContext),
                   PromptTemplateEscaper.escape(thread)),
-              "Maintainer reply");
+              "Maintainer reply",
+              // ReplyAssistant is bound to the concise named model, so the cap that can cut this
+              // call is REVIEW_CONCISE_MAX_OUTPUT_TOKENS, not the active model's.
+              AiResponses.ModelLane.CONCISE);
       if (reply == null || reply.isBlank()) {
         Log.debug("Reply assistant produced an empty reply — posting nothing");
         return null;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponses.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponses.java
@@ -33,14 +33,59 @@ public final class AiResponses {
   private AiResponses() {}
 
   /**
+   * Which model binding the unwrapped call runs on. The two bindings are capped by different knobs,
+   * and a truncation remedy only helps an operator when it names the one that actually applies — so
+   * every call site states its lane instead of inheriting a default. A {@link Result} carries no
+   * trace of the model that produced it, and the implicit "active model" wording this helper used
+   * to apply to every blocking call told operators of the concise-bound lanes to raise a cap that
+   * does not bound them.
+   */
+  public enum ModelLane {
+
+    /** The default binding, capped by the active model's {@code max-output-tokens}. */
+    ACTIVE(
+        "Raise the active model's max-output-tokens, or leave it unset to use the provider"
+            + " default."),
+
+    /**
+     * The {@code concise} named binding — the summary, verifier and reply calls — capped by {@code
+     * REVIEW_CONCISE_MAX_OUTPUT_TOKENS}. The active model's {@code max-output-tokens} is
+     * deliberately never applied to it (see {@link ChatModelCustomizers}), so naming that knob here
+     * would send the operator to a setting with no effect on this call.
+     */
+    CONCISE(
+        "This call runs on the concise named model, so raise REVIEW_CONCISE_MAX_OUTPUT_TOKENS (the"
+            + " active model's max-output-tokens does not cap it), or leave it unset to use the"
+            + " provider default.");
+
+    private final String remedy;
+
+    ModelLane(String remedy) {
+      this.remedy = remedy;
+    }
+
+    /** The operator instruction naming the response cap that applies to this lane. */
+    String remedy() {
+      return remedy;
+    }
+  }
+
+  /**
    * Returns the response text, or throws {@link AiResponseTruncatedException} when the model
    * stopped at its response-length cap. {@code what} names the call for the operator ("/improve",
-   * "Finding verification"), since the exception is what the caller logs.
+   * "Finding verification"), since the exception is what the caller logs; {@code lane} names the
+   * model binding the call ran on, so the message and the exception's {@link
+   * AiResponseTruncatedException#conciseModelImplicated() concise flag} point at the cap that
+   * actually cut it.
    *
-   * <p>A {@code null} result passes through as {@code null}: the callers already treat "no
-   * response" as a soft failure, and that is not the same condition as a truncation.
+   * <p>A {@code null} result, and a completed response with no content body, both pass through as
+   * {@code null}. "No response" is not a truncation, and each caller owns what it costs them: the
+   * {@code /describe}-family generators and the maintainer-reply lane post nothing, and the
+   * verifier keeps its unverified findings. It is a real case, not a defensive one — a reasoning
+   * model can spend its whole output budget on reasoning tokens and return an empty body with no
+   * length stop to show for it.
    */
-  public static String textOrThrowOnTruncation(Result<String> result, String what) {
+  public static String textOrThrowOnTruncation(Result<String> result, String what, ModelLane lane) {
     if (result == null) {
       return null;
     }
@@ -48,8 +93,10 @@ public final class AiResponses {
       throw new AiResponseTruncatedException(
           what
               + " stopped at the model's response-length cap (finish_reason=length), so the"
-              + " response is incomplete. Raise the active model's max-output-tokens, or leave it"
-              + " unset to use the provider default.");
+              + " response is incomplete. "
+              + lane.remedy(),
+          null,
+          lane == ModelLane.CONCISE);
     }
     return result.content();
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -113,7 +113,20 @@ public class FindingVerificationService {
               previousFindings == null ? "" : previousFindings);
       // Meter before unwrapping: a truncated response was still billed, so its spend counts.
       recordVerifierUsage(ledgerSessionId, result);
-      var raw = AiResponses.textOrThrowOnTruncation(result, "Finding verification");
+      var raw =
+          AiResponses.textOrThrowOnTruncation(
+              result, "Finding verification", AiResponses.ModelLane.CONCISE);
+      if (raw == null || raw.isBlank()) {
+        // The unwrap helper's documented "no response" soft failure, which this caller has to
+        // honour like every other one: a reasoning model can spend the whole output budget on
+        // reasoning tokens and return an empty body with no length stop. Keeping the unverified
+        // findings is this service's error contract; handing the absent body to the JSON
+        // extraction instead reported an expected outcome as a verification fault.
+        Log.warnf(
+            "Finding verification returned no response body — keeping the %d unverified finding(s)",
+            screened.findings().size());
+        return screened;
+      }
       var verdicts =
           mapper.readValue(ReviewResponseParser.extractJson(raw), VerificationResponse.class);
       return apply(screened, verdicts);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
@@ -223,8 +223,16 @@ public class ReviewResponseParser {
     return parts.isEmpty() ? gap.toString() : String.join(": ", parts);
   }
 
-  /** Strips optional markdown fences and leading noise before the JSON object/array. */
+  /**
+   * Strips optional markdown fences and leading noise before the JSON object/array. An absent body
+   * extracts to {@code ""}: "no response" is a soft failure every caller decides for itself (each
+   * one guards the body before parsing), so this must not convert it into a {@code
+   * NullPointerException} raised from inside the extraction.
+   */
   static String extractJson(String raw) {
+    if (raw == null) {
+      return "";
+    }
     var trimmed = raw.strip();
 
     if (trimmed.startsWith("```")) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponsesTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponsesTest.java
@@ -15,13 +15,16 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiNoContent;
 import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiOk;
 import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiTruncated;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import dev.thiagogonzaga.thrillhousebot.review.ai.AiResponses.ModelLane;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,13 +35,22 @@ class AiResponsesTest {
 
   @Test
   void returnsTheTextOfACompletedResponse() {
-    assertEquals("{\"docs\":[]}", AiResponses.textOrThrowOnTruncation(aiOk("{\"docs\":[]}"), "X"));
+    assertEquals(
+        "{\"docs\":[]}",
+        AiResponses.textOrThrowOnTruncation(aiOk("{\"docs\":[]}"), "X", ModelLane.ACTIVE));
   }
 
   @Test
   void passesANullResultThrough() {
     // "no response" is a different condition from "cut short" and the callers already handle it.
-    assertNull(AiResponses.textOrThrowOnTruncation(null, "X"));
+    assertNull(AiResponses.textOrThrowOnTruncation(null, "X", ModelLane.ACTIVE));
+  }
+
+  @Test
+  void passesAnAbsentContentBodyThrough() {
+    // A reasoning model can burn the whole output budget on reasoning tokens and complete with no
+    // content and no length stop. That is the same "no response" soft failure, not a truncation.
+    assertNull(AiResponses.textOrThrowOnTruncation(aiNoContent(), "X", ModelLane.CONCISE));
   }
 
   @Test
@@ -49,11 +61,51 @@ class AiResponsesTest {
         assertThrows(
             AiResponseTruncatedException.class,
             () ->
-                AiResponses.textOrThrowOnTruncation(aiTruncated("{\"docs\":[{\"file\":\"A"), "X"));
+                AiResponses.textOrThrowOnTruncation(
+                    aiTruncated("{\"docs\":[{\"file\":\"A"), "X", ModelLane.ACTIVE));
 
     assertTrue(
         thrown.getMessage().contains("max-output-tokens"),
         "the message must name the knob an operator can change: " + thrown.getMessage());
+  }
+
+  @Test
+  void namesTheActiveModelsCapForACallOnTheDefaultModel() {
+    var thrown =
+        assertThrows(
+            AiResponseTruncatedException.class,
+            () ->
+                AiResponses.textOrThrowOnTruncation(
+                    aiTruncated("partial"), "/improve assistant", ModelLane.ACTIVE));
+
+    assertTrue(
+        thrown.getMessage().contains("Raise the active model's max-output-tokens"),
+        thrown.getMessage());
+    assertFalse(
+        thrown.getMessage().contains("REVIEW_CONCISE_MAX_OUTPUT_TOKENS"),
+        "the concise cap does not bound a default-model call: " + thrown.getMessage());
+    assertFalse(thrown.conciseModelImplicated(), "the call did not run on the concise model");
+  }
+
+  @Test
+  void namesTheConciseCapForACallOnTheConciseModel() {
+    // The concise named model never receives the active model's max-output-tokens, so telling the
+    // operator to raise it would send them to a setting that cannot affect this call.
+    var thrown =
+        assertThrows(
+            AiResponseTruncatedException.class,
+            () ->
+                AiResponses.textOrThrowOnTruncation(
+                    aiTruncated("{\"verdicts\":[{\"id"),
+                    "Finding verification",
+                    ModelLane.CONCISE));
+
+    assertTrue(
+        thrown.getMessage().contains("raise REVIEW_CONCISE_MAX_OUTPUT_TOKENS"),
+        "the message must name the knob that actually caps this lane: " + thrown.getMessage());
+    assertTrue(
+        thrown.conciseModelImplicated(),
+        "the failure must carry the concise flag so downstream copy names the same knob");
   }
 
   @Test
@@ -62,7 +114,8 @@ class AiResponsesTest {
         assertThrows(
             AiResponseTruncatedException.class,
             () ->
-                AiResponses.textOrThrowOnTruncation(aiTruncated("partial"), "/improve assistant"));
+                AiResponses.textOrThrowOnTruncation(
+                    aiTruncated("partial"), "/improve assistant", ModelLane.ACTIVE));
 
     assertTrue(thrown.getMessage().startsWith("/improve assistant"), thrown.getMessage());
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResults.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResults.java
@@ -39,4 +39,13 @@ public final class AiResults {
   public static Result<String> aiTruncated(String partialText) {
     return Result.<String>builder().content(partialText).finishReason(FinishReason.LENGTH).build();
   }
+
+  /**
+   * A completed response carrying no content body at all — the "no response" case a reasoning model
+   * produces when its whole output budget went to reasoning tokens, with no length stop to show for
+   * it (#534).
+   */
+  public static Result<String> aiNoContent() {
+    return Result.<String>builder().finishReason(FinishReason.STOP).build();
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ConciseModelTruncationTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ConciseModelTruncationTest.java
@@ -90,9 +90,17 @@ class ConciseModelTruncationTest {
 
     var result = findingVerifier.verify("[]", "diff", "", "");
 
-    assertThrows(
-        AiResponseTruncatedException.class,
-        () -> AiResponses.textOrThrowOnTruncation(result, "Finding verification"));
+    var thrown =
+        assertThrows(
+            AiResponseTruncatedException.class,
+            () ->
+                AiResponses.textOrThrowOnTruncation(
+                    result, "Finding verification", AiResponses.ModelLane.CONCISE));
+
+    assertTrue(
+        thrown.getMessage().contains("REVIEW_CONCISE_MAX_OUTPUT_TOKENS"),
+        "the verifier runs on the concise model, so its cap is the one to name: "
+            + thrown.getMessage());
   }
 
   @Test
@@ -102,9 +110,17 @@ class ConciseModelTruncationTest {
 
     var result = replyAssistant.reply("question", "", "", "", "");
 
-    assertThrows(
-        AiResponseTruncatedException.class,
-        () -> AiResponses.textOrThrowOnTruncation(result, "Maintainer reply"));
+    var thrown =
+        assertThrows(
+            AiResponseTruncatedException.class,
+            () ->
+                AiResponses.textOrThrowOnTruncation(
+                    result, "Maintainer reply", AiResponses.ModelLane.CONCISE));
+
+    assertTrue(
+        thrown.getMessage().contains("REVIEW_CONCISE_MAX_OUTPUT_TOKENS"),
+        "the reply lane runs on the concise model, so its cap is the one to name: "
+            + thrown.getMessage());
   }
 
   private static ChatResponse lengthStoppedResponse(String partialText) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
+import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiNoContent;
 import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiOk;
 import static dev.thiagogonzaga.thrillhousebot.review.ai.AiResults.aiTruncated;
 import static org.junit.jupiter.api.Assertions.*;
@@ -353,6 +354,45 @@ class FindingVerificationServiceTest {
     assertEquals(1, result.findings().size());
     assertEquals("critical", result.findings().get(0).risk());
     assertEquals("high", result.findings().get(0).confidence());
+  }
+
+  @Test
+  void keepsUnverifiedFindingsWithoutParsingWhenTheModelReturnsNoBody() {
+    // #534: with the whole output budget spent on reasoning tokens the provider returns a completed
+    // response with no content body. That is the unwrap helper's documented "no response" soft
+    // failure, but the body went straight into the JSON extraction, which raised "Cannot invoke
+    // String.strip() because raw is null". The findings survive either way — the fail-open catch
+    // caught the NPE — so what this pins is that an absent body never reaches the extraction.
+    ReviewResponse original = response(finding("critical", "high", "Unverified"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(aiNoContent());
+
+    try (var parser = mockStatic(ReviewResponseParser.class)) {
+      var result = service.verify(SESSION, original, "diff", "stack", "");
+
+      assertEquals(1, result.findings().size());
+      assertEquals("critical", result.findings().get(0).risk());
+      assertEquals("high", result.findings().get(0).confidence());
+      parser.verify(() -> ReviewResponseParser.extractJson(any()), never());
+    }
+  }
+
+  @Test
+  void keepsUnverifiedFindingsWithoutParsingWhenTheModelReturnsABlankBody() {
+    // Same soft failure as an absent body, and it must not be reported as a parse fault either:
+    // whitespace is what the provider returns when the content field came back empty rather than
+    // missing.
+    ReviewResponse original = response(finding("high", "high", "Unverified"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(aiOk("   "));
+
+    try (var parser = mockStatic(ReviewResponseParser.class)) {
+      var result = service.verify(SESSION, original, "diff", "stack", "");
+
+      assertEquals(1, result.findings().size());
+      assertEquals("high", result.findings().get(0).risk());
+      parser.verify(() -> ReviewResponseParser.extractJson(any()), never());
+    }
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParserTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParserTest.java
@@ -217,6 +217,14 @@ class ReviewResponseParserTest {
   }
 
   @Test
+  void shouldYieldEmptyExtractionForAnAbsentBody() {
+    // #534: a model can return no content at all (a reasoning model that spent its whole output
+    // budget on reasoning tokens). Every caller treats "no response" as its own soft failure, so
+    // the extraction must not turn it into a NullPointerException inside the strip.
+    assertEquals("", ReviewResponseParser.extractJson(null));
+  }
+
+  @Test
   void shouldStripLeadingNoiseBeforeJsonObject() {
     String json = ReviewResponseParser.extractJson("Here is the payload: {\"findings\":[]}");
     assertEquals("{\"findings\":[]}", json);


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Two defects in the blocking response-unwrap lane, in the same files.

**#533 — the truncation remedy named a knob that cannot affect the call.** `AiResponses.textOrThrowOnTruncation` always built `AiResponseTruncatedException` with the single-arg constructor, so `conciseModelImplicated` was always false and every blocking lane got the active-model wording. Two of the three callers are bound to the `concise` named model, whose cap is `REVIEW_CONCISE_MAX_OUTPUT_TOKENS` and which deliberately never receives the active model's `max-output-tokens` (`ChatModelCustomizers` applies every shared parameter to it *except* the response cap). Operators of those lanes were told to raise a setting with no effect on the call that failed — the same class of defect as #528.

Every caller now states its lane through a new `AiResponses.ModelLane`, which carries the remedy text and sets the concise flag. There is no defaulting overload: a `Result` carries no trace of the model that produced it, and the implicit default is exactly what made this bug silent.

Caller classification (all three checked):

| Caller | Assistant | Binding | Lane |
| --- | --- | --- | --- |
| `AbstractPrSuggestionGenerator#callAssistant` (`/describe`, `/improve`, `/changelog`, `/generate-tests`, `/add-docs`) | `PrDescribeAssistant`, `PrImproveAssistant`, `ChangelogAssistant`, `UnitTestAssistant`, `DocGenerator` | `@RegisterAiService` (default) | `ACTIVE` |
| `MaintainerReplyService#generateReply` | `ReplyAssistant` | `@RegisterAiService(modelName = "concise")` | `CONCISE` |
| `FindingVerificationService#verify` | `FindingVerifier` | `@RegisterAiService(modelName = "concise")` | `CONCISE` |

No blocking lane surfaces the message to users — all three log it and post nothing / keep findings — so this is operator-log copy only. The streaming summary lane already marked itself via `implicatingConciseModel()` and is unchanged.

**#534 — the verifier NPE'd on an absent body.** `FindingVerificationService` passed the unwrapped body straight into `ReviewResponseParser.extractJson`, which opens with `raw.strip()`. With the whole output budget spent on reasoning tokens the provider completes with no content and no length stop, so the body is null — and the helper's javadoc claim that "the callers already treat no response as a soft failure" was false for exactly this one. Checked every caller: the `/describe`-family generators (`suggestion == null || suggestion.isBlank()`) and the reply lane (`reply == null || reply.isBlank()`) did honour it; the verifier alone did not, and it is also the only lane that calls `mapper.readValue(extractJson(...))` inline instead of through a parser class that guards.

The verifier now keeps the unverified findings on an absent or blank body — its documented error contract — instead of routing an expected outcome through the fail-open catch as a verification fault. The helper's javadoc now states the contract and what each caller does with it, and `extractJson` yields `""` for an absent body rather than raising from inside the strip.

## Related Issues

Fixes #533
Fixes #534

## How Has This Been Tested?

- [x] Unit tests

### Red/green — #534, the NPE (red on the unmodified base `abd76e5`)

`ReviewResponseParserTest#shouldYieldEmptyExtractionForAnAbsentBody` reproduces the production frame verbatim:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponseParserTest.shouldYieldEmptyExtractionForAnAbsentBody -- Time elapsed: 0.195 s <<< ERROR!
java.lang.NullPointerException: Cannot invoke "String.strip()" because "raw" is null
	at dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponseParser.extractJson(ReviewResponseParser.java:228)
	at dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponseParserTest.shouldYieldEmptyExtractionForAnAbsentBody(ReviewResponseParserTest.java:224)
```

`FindingVerificationServiceTest#keepsUnverifiedFindingsWithoutParsingWhenTheModelReturnsNoBody` pins the caller. The findings survive either way (the fail-open catch caught the NPE), so it asserts the absent body never reaches the extraction:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.keepsUnverifiedFindingsWithoutParsingWhenTheModelReturnsNoBody -- Time elapsed: 1.232 s <<< FAILURE!
org.mockito.exceptions.verification.NeverWantedButInvoked:

ReviewResponseParser.class.extractJson(
    <any>
);
Never wanted here:
-> at dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponseParser.extractJson(ReviewResponseParser.java:228)
But invoked here:
-> at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService.verify(FindingVerificationService.java:118) with arguments: [null]
```

### Red/green — #533, the knob named per lane

The pre-fix API cannot express a lane, so the red run keeps the new signature and restores the pre-fix body (the single-arg constructor with the active-model wording) — i.e. exactly the code this PR replaces. `AiResponsesTest#namesTheConciseCapForACallOnTheConciseModel`:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.AiResponsesTest.namesTheConciseCapForACallOnTheConciseModel -- Time elapsed: 0.055 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the message must name the knob that actually caps this lane: Finding verification stopped at the model's response-length cap (finish_reason=length), so the response is incomplete. Raise the active model's max-output-tokens, or leave it unset to use the provider default. ==> expected: <true> but was: <false>
```

`ConciseModelTruncationTest` drives the real concise-bound AI services against mocked `@ModelName("concise")` model beans, and both lanes reproduce the reported log line:

```
[ERROR]   ConciseModelTruncationTest.aLengthStopOnTheConciseVerifierCallRaisesTheTruncationError:100 the verifier runs on the concise model, so its cap is the one to name: Finding verification stopped at the model's response-length cap (finish_reason=length), so the response is incomplete. Raise the active model's max-output-tokens, or leave it unset to use the provider default. ==> expected: <true> but was: <false>
[ERROR]   ConciseModelTruncationTest.aLengthStopOnTheConciseReplyCallRaisesTheTruncationError:120 the reply lane runs on the concise model, so its cap is the one to name: Maintainer reply stopped at the model's response-length cap (finish_reason=length), so the response is incomplete. Raise the active model's max-output-tokens, or leave it unset to use the provider default. ==> expected: <true> but was: <false>
```

The `ACTIVE` lane is pinned in the other direction: `namesTheActiveModelsCapForACallOnTheDefaultModel` asserts the default-model message keeps the active-model remedy, never mentions `REVIEW_CONCISE_MAX_OUTPUT_TOKENS`, and leaves the concise flag false.

### Gates

- `./mvnw -B spotless:apply` then `./mvnw -B clean compile spotbugs:check spotless:check` — BUILD SUCCESS, `BugInstance size is 0`
- `./mvnw -B clean test` — Tests run: 2600, Failures: 0, Errors: 0, Skipped: 0
- Coverage: jacoco ∩ `git diff -U0 abd76e5...HEAD` over changed main code — 18 executable changed lines, 0 uncovered lines, 0 uncovered branches

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Two call sites outside the nominal file scope were required and are one line plus a comment each: `MaintainerReplyService` and `AbstractPrSuggestionGenerator#callAssistant` are the other two callers of the helper, and #533 is not fixed for the reply lane without them. No behaviour outside the truncation message changed there.
