### PR TITLE
fix(add-docs): tell an unusable model reply apart from nothing to document

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
@@ -83,6 +83,19 @@ public class DocGenerationService extends AbstractPrSuggestionGenerator {
           + "Please try `/add-docs` again.";
   static final String NOTHING_TO_DOCUMENT =
       "📝 ThrillhouseBot found no changed symbols that need documentation in this PR.";
+
+  /**
+   * Posted when the model named symbols but every entry it returned was missing a field a
+   * suggestion needs — no file, no positive line, no declaration line to anchor against, or no
+   * replacement. Neither neighbour fits: {@link #NOTHING_TO_DOCUMENT} would assert a verdict on the
+   * code ("no changed symbol needs a doc comment") that a run which never got a usable suggestion
+   * cannot support, and {@link #COULD_NOT_PLACE} would blame the diff for a reply that carried no
+   * anchor to place in the first place.
+   */
+  static final String UNUSABLE_SUGGESTIONS =
+      "📝 ThrillhouseBot drafted documentation for this PR, but every suggestion came back"
+          + " incomplete, so none could be posted. Please try `/add-docs` again.";
+
   static final String COULD_NOT_PLACE =
       "📝 ThrillhouseBot generated documentation but could not anchor it to the current diff. "
           + "This usually happens after a force-push — try `/add-docs` again.";
@@ -200,14 +213,21 @@ public class DocGenerationService extends AbstractPrSuggestionGenerator {
       }
       var outcome = postSuggestions(auth, task, pr.head().sha(), reviewable, generated.docs());
       postComment(auth, task, summaryMessage(generated, outcome, planned.plan()));
+      // The doc counts ride along with the posted counts on purpose: a run that posts nothing is
+      // otherwise indistinguishable in the log from one where the model returned nothing, from one
+      // whose entries were all incomplete, and from one whose docs would not anchor — which is
+      // exactly the question asked of every "/add-docs found nothing" report.
       Log.infof(
-          "/add-docs posted %d suggestion(s) and %d note(s) from %d batch(es) on %s/%s #%d",
+          "/add-docs posted %d suggestion(s) and %d note(s) from %d batch(es) on %s/%s #%d"
+              + " (model returned %d usable doc(s) and %d incomplete entry/entries)",
           outcome.suggestions(),
           outcome.notes(),
           planned.plan().batches().size(),
           task.owner(),
           task.repo(),
-          task.prNumber());
+          task.prNumber(),
+          generated.docs().size(),
+          generated.unusable());
     } catch (RuntimeException e) {
       Log.warnf(
           e, "Failed to handle /add-docs on %s/%s #%d", task.owner(), task.repo(), task.prNumber());
@@ -267,8 +287,14 @@ public class DocGenerationService extends AbstractPrSuggestionGenerator {
     }
   }
 
-  /** The docs merged across every batch, plus how many batch calls failed outright. */
-  private record Generated(List<DocGenerationResponse.DocSuggestion> docs, int failedBatches) {}
+  /**
+   * The docs merged across every batch, how many batch calls failed outright, and how many entries
+   * the model returned that carried too little to post. The last count is what lets an empty run
+   * distinguish "nothing needed documenting" from "the reply was unusable" — both reach the summary
+   * with an empty {@code docs} list, and only one of them is a statement about the code.
+   */
+  private record Generated(
+      List<DocGenerationResponse.DocSuggestion> docs, int failedBatches, int unusable) {}
 
   /**
    * The map step plus the local union reduce: one call per batch, docs merged in batch order. A
@@ -280,6 +306,7 @@ public class DocGenerationService extends AbstractPrSuggestionGenerator {
     var merged = new ArrayList<DocGenerationResponse.DocSuggestion>();
     var seen = new HashSet<String>();
     int failed = 0;
+    int unusable = 0;
     for (var batch : planned.plan().batches()) {
       var response = generateOne(planned, batch);
       if (response == null) {
@@ -293,7 +320,11 @@ public class DocGenerationService extends AbstractPrSuggestionGenerator {
         // first would throw on a malformed entry (losing every valid entry in the same reply), and
         // a non-postable entry consuming file:line would both block a later batch's valid
         // suggestion for that declaration and leave a malformed reply reported as COULD_NOT_PLACE.
-        if (doc.isPostable() && seen.add(doc.file().strip() + ":" + doc.line())) {
+        if (!doc.isPostable()) {
+          unusable++;
+          continue;
+        }
+        if (seen.add(doc.file().strip() + ":" + doc.line())) {
           merged.add(doc);
         }
       }
@@ -302,7 +333,7 @@ public class DocGenerationService extends AbstractPrSuggestionGenerator {
       Log.debugf("Every /add-docs batch failed — reporting the failure");
       return null;
     }
-    return new Generated(List.copyOf(merged), failed);
+    return new Generated(List.copyOf(merged), failed, unusable);
   }
 
   /** One batch's assistant call and parse, or {@code null} when either step fails. */
@@ -488,14 +519,14 @@ public class DocGenerationService extends AbstractPrSuggestionGenerator {
    */
   private String summaryMessage(
       Generated generated, DocPostOutcome outcome, DiffBudgetPlanner.BudgetPlan plan) {
-    return baseSummaryMessage(generated.docs(), outcome)
+    return baseSummaryMessage(generated, outcome)
         + batchFailureNote(
             generated.failedBatches(), COMMAND, "the symbols in them are not documented here.")
         + disclosure(plan);
   }
 
-  private String baseSummaryMessage(
-      List<DocGenerationResponse.DocSuggestion> docs, DocPostOutcome outcome) {
+  private String baseSummaryMessage(Generated generated, DocPostOutcome outcome) {
+    var docs = generated.docs();
     int suggestions = outcome.suggestions();
     int notes = outcome.notes();
     String capSuffix =
@@ -534,7 +565,12 @@ public class DocGenerationService extends AbstractPrSuggestionGenerator {
           + outcome.skippedByCap()
           + "** changed symbol(s) were not documented. Raise the comment cap or re-run `/add-docs`.";
     }
-    return docs.isEmpty() ? NOTHING_TO_DOCUMENT : COULD_NOT_PLACE;
+    if (!docs.isEmpty()) {
+      return COULD_NOT_PLACE;
+    }
+    // Nothing usable came back. Only a run where the model returned no entries at all can claim
+    // there was nothing to document; one whose entries were all incomplete says so instead.
+    return generated.unusable() > 0 ? UNUSABLE_SUGGESTIONS : NOTHING_TO_DOCUMENT;
   }
 
   // Command-specific guidance for the repository-instructions section.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGeneratorPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGeneratorPrompts.java
@@ -35,7 +35,10 @@ public final class DocGeneratorPrompts {
               appropriate.
             - JavaScript/TypeScript: JSDoc/TSDoc (/** ... */).
             - Python: a triple-quoted docstring as the first statement inside the def/class body.
-            - Go: a // comment line beginning with the symbol's name, directly above it.
+            - Go: a // comment line beginning with the symbol's name, directly above it. Exported
+              (capitalized) identifiers — including types, struct fields where they are not
+              self-evident, and methods — are the ones the convention covers; a package comment
+              above the `package` clause documents the package, not the symbols in the file.
             - Rust: /// doc comments above the item.
             - C/C++/C#: the project's prevailing doc-comment style visible in the diff.
             When the project stack or repository instructions imply a different convention, follow
@@ -62,6 +65,9 @@ public final class DocGeneratorPrompts {
               never invent line numbers or quote code that is not present.
             - Skip symbols that already have an adequate doc comment, trivial private helpers whose
               intent is obvious, and pure test methods unless they need explanation.
+            - Judge each symbol on its own. A neighbouring declaration that already carries a doc
+              comment says nothing about the one beside it, and a file that is mostly documented can
+              still have symbols that are not — decide per symbol, never per file.
             - Describe what the symbol does, its parameters and return value, and notable side
               effects or thrown errors — grounded ONLY in the code shown. Do not speculate about
               behavior you cannot see.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationServiceTest.java
@@ -423,8 +423,9 @@ class DocGenerationServiceTest {
   static Stream<Arguments> unpostableSuggestions() {
     // A postable doc the anchor resolver cannot place yields COULD_NOT_PLACE — real documentation
     // was generated but did not map onto the diff. A non-postable (malformed) entry never reaches
-    // the merged list at all, so the run is empty of usable docs and reports NOTHING_TO_DOCUMENT
-    // rather than the force-push wording, which would misdescribe a simply malformed reply.
+    // the merged list at all, so the run has no usable docs and reports UNUSABLE_SUGGESTIONS: the
+    // force-push wording would misdescribe a reply that carried no anchor, and NOTHING_TO_DOCUMENT
+    // would turn a broken reply into a verdict that the code needs no documentation.
     return Stream.of(
         arguments(
             "declaration line is not in the diff",
@@ -447,14 +448,14 @@ class DocGenerationServiceTest {
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"public int bar(int x) {","suggestion_new":""}]}
             """,
-            DocGenerationService.NOTHING_TO_DOCUMENT),
+            DocGenerationService.UNUSABLE_SUGGESTIONS),
         arguments(
             "suggestion_old is omitted (no anchor to verify against)",
             """
             {"docs":[{"file":"src/Foo.java","line":1,"symbol":"bar",
             "suggestion_old":"","suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
             """,
-            DocGenerationService.NOTHING_TO_DOCUMENT),
+            DocGenerationService.UNUSABLE_SUGGESTIONS),
         arguments(
             "file is not part of the diff",
             """
@@ -463,6 +464,33 @@ class DocGenerationServiceTest {
             "suggestion_new":"/** d */\\npublic int bar(int x) {"}]}
             """,
             DocGenerationService.COULD_NOT_PLACE));
+  }
+
+  @Test
+  void separatesAnUnusableReplyFromAVerdictThatNothingNeedsDocumentation() {
+    // The model named two symbols and returned neither a declaration line nor a replacement for
+    // them. Reporting NOTHING_TO_DOCUMENT here asserts something about the code — that no changed
+    // symbol needs a doc comment — which this run has no basis for: the model found symbols, the
+    // reply was just unusable. That conflation is what makes an empty /add-docs run impossible to
+    // tell apart from a working one that genuinely had nothing to say.
+    prWithFiles(fooWithPatch());
+    when(docGenerator.generate(any(), any(), any(), any()))
+        .thenReturn(
+            aiOk(
+                """
+                {"docs":[
+                  {"file":"src/Foo.java","line":1,"symbol":"bar","suggestion_old":"",
+                   "suggestion_new":""},
+                  {"file":"src/Foo.java","line":2,"symbol":"baz","suggestion_old":"",
+                   "suggestion_new":""}]}
+                """));
+
+    service.handle(task());
+
+    verify(reviewClient, never())
+        .createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
+    assertNotEquals(DocGenerationService.NOTHING_TO_DOCUMENT, postedSummary());
+    assertTrue(postedSummary().contains("came back incomplete"), postedSummary());
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

### Diagnosis first: the Go run was correct

The issue asks whether symbol extraction understands Go declarations at all, or whether the model
declined. Neither. **There is no code-side symbol extraction** — `/add-docs` sends batched diff text
to the model and parses the symbols back out of the JSON reply — and on ThrillhouseBot-test #7 there
was genuinely nothing to document.

Evidence, from the PR the issue cites:

1. **Every exported Go symbol in #7 already carries an idiomatic doc comment.** The four the issue
   names are all documented at their declaration:

   ```go
   // NewStore builds an empty Store ready to accept issues.
   func NewStore() *Store {

   // AddLabel records that label applies to issueID, updating both the
   // issue's own Labels slice and the store's label index used by the
   // label-lookup endpoint.
   func (s *Store) AddLabel(issueID int64, label string) {

   // ListOpenIssues fetches the open issues for the given "owner/repo".
   func (c *Client) ListOpenIssues(repo string) ([]Issue, error) {

   // SyncRepos fetches open issues for every repo and writes them into
   // st. Each repo is synced concurrently so a slow or unreachable repo
   // doesn't delay the others.
   func SyncRepos(client GithubClient, st *store.Store, repos []string) {
   ```

   So do `NewClient`, `Load`, and the exported types `Issue`, `Store`, `Client`, `Config`,
   `GithubClient`. The only undocumented declarations in the whole PR are `main` and the unexported
   helpers `syncOne`, `containsID`, `healthHandler`, `issuesHandler` — which the prompt explicitly
   tells the model to skip. The issue's premise that the symbols lack doc comments does not hold.

2. **The Python comparison is not comparable.** #8's 3 suggestions were all on `__init__` methods
   (`IssueStore.__init__`, `GitHubClient.__init__`, `Config.__init__`) — the only public callables
   in that PR without a docstring. Both runs applied the same rule and got different answers because
   the inputs differed.

3. **The Go diff reached the model with working line anchors.** `/improve` on the same PR minutes
   earlier posted 9 inline suggestions on Go declaration lines across all four packages, including
   one titled *"Correct the stale retry documentation"* on `internal/githubapi/client.go:37` — the
   model was reading the Go doc comments. Go files are not filtered anywhere: `.go` appears in the
   default ignore globs only as `**/*.pb.go`, and `internal/` is not an ignored directory.

So this is not a dispatch failure, not an extraction gap, and not a model refusal — `{"docs": []}`
was the right answer.

### What is actually broken

Establishing the above required reconstructing the PR by hand, and that is the real defect.
`NOTHING_TO_DOCUMENT` — *"found no changed symbols that need documentation in this PR"* — is posted
in two very different states:

- the model returned no entries at all (a claim about the code, correct on #7), and
- the model **named symbols** but every entry was missing the file, line, declaration line, or
  replacement a suggestion needs.

In the second state, non-postable entries are dropped in `generateEachBatch` before the summary is
chosen, so a broken reply is reported as a verdict that the PR needs no documentation. The existing
parameterized test pinned exactly that, and its comment shows the choice was made only because
`COULD_NOT_PLACE`'s force-push wording was the wrong neighbour — both options were wrong.

This PR gives that state its own outcome, counts the incomplete entries, and puts the counts on the
run's log line so the next *"/add-docs found nothing"* report can be answered from the log rather
than from the PR:

```
/add-docs posted 0 suggestion(s) and 0 note(s) from 1 batch(es) on <repo> #7 (model returned 0 usable doc(s) and 0 incomplete entry/entries)
```

Had that line existed on 2026-08-11, `0 usable / 0 incomplete` would have closed this issue in one
read.

### Prompt material for Go

Two facts added, both precision-preserving — neither would have changed the #7 outcome, and neither
loosens the "already documented → skip" rule that made #7 correct:

- the Go convention covers **exported (capitalized)** identifiers, and a package comment above the
  `package` clause documents the package, not the file's symbols;
- **judge each symbol on its own** — a documented neighbour says nothing about the declaration
  beside it, and a mostly documented file can still have undocumented symbols. This targets the
  issue's own hypothesis ("the model declined because a handful of neighbouring functions already
  had comments") without inviting duplicate docs.

I deliberately did **not** make the Go rule more aggressive. On the evidence above the model's
judgement was right, and telling it to document already-documented exported symbols would have
turned a correct empty run into noise on every Go PR.

## Related Issues

Fixes #539

## How Has This Been Tested?

- [x] Unit tests

New test written against unfixed code: the model names two symbols and returns neither a declaration
line nor a replacement for them, so the run has no basis for a verdict about the code. Verbatim red:

```
dev.thiagogonzaga.thrillhousebot.review.DocGenerationServiceTest.separatesAnUnusableReplyFromAVerdictThatNothingNeedsDocumentation -- Time elapsed: 0.061 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: not equal but was: <📝 ThrillhouseBot found no changed symbols that need documentation in this PR.>
	at org.junit.jupiter.api.Assertions.assertNotEquals(Assertions.java:2920)
	at dev.thiagogonzaga.thrillhousebot.review.DocGenerationServiceTest.separatesAnUnusableReplyFromAVerdictThatNothingNeedsDocumentation(DocGenerationServiceTest.java:491)
```

`Tests run: 48, Failures: 1` before the fix; `Tests run: 48, Failures: 0` after. The two
`unpostableSuggestions` rows that pinned the old conflation now expect the new outcome;
`reportsNothingToDocumentOnEmptyResult` is unchanged, so the genuine "nothing to document" verdict
still reads exactly as it did on #7.

Gates (Java 25):

- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` → `Tests run: 2595, Failures: 0, Errors: 0, Skipped: 0`
- Coverage ∩ `git diff -U0 abd76e5...HEAD` on changed main code → 15 executable changed lines,
  15 fully covered, **0 uncovered lines and 0 uncovered branches**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The prompt additions grow the per-call shared overhead by a few dozen tokens, which the batch
planner already subtracts before sizing batches (`DocGeneratorPrompts.systemPrompt()` is passed to
`planBatches`), so no batch can silently overflow because of them.
