### PR TITLE
fix(review): fill the walkthrough file summaries on large PRs

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -16,6 +16,7 @@
 package dev.thiagogonzaga.thrillhousebot.review;
 
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import dev.thiagogonzaga.thrillhousebot.review.ai.PrReviewPrompts;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -64,11 +65,33 @@ public class PrSummaryGenerator {
   /**
    * Upper bound on rows in the changed-files walkthrough. Keeps the comment within GitHub's size
    * budget on large PRs; any files beyond this are rolled up into a trailing "… and N more" note.
+   *
+   * <p>Read from {@link PrReviewPrompts#MAX_FILE_SUMMARIES} so the number of rows rendered and the
+   * number of per-file summaries the prompt asks the model for cannot drift apart: a smaller prompt
+   * cap would guarantee rows no response could ever fill (#536).
    */
-  static final int MAX_FILE_ROWS = 20;
+  static final int MAX_FILE_ROWS = PrReviewPrompts.MAX_FILE_SUMMARIES;
 
-  /** One changed file in the walkthrough: its path and the diff's authoritative change type. */
-  public record ChangedFile(String path, String changeType) {}
+  /**
+   * Summary cell for a pure-rename row. A pure rename is excluded from AI review by design (its
+   * content is unchanged, so there is nothing to review), which means the model never returns a
+   * summary for it — rendering the bare "-" made that correct behavior read as a failed summary
+   * (#536), so the row states the reason instead.
+   */
+  static final String PURE_RENAME_SUMMARY = "Pure rename — content unchanged";
+
+  /**
+   * One changed file in the walkthrough: its path, the diff's authoritative change type, and
+   * whether it is a pure rename — renamed with no content change, hence never sent to the model and
+   * never carrying a model summary.
+   */
+  public record ChangedFile(String path, String changeType, boolean pureRename) {
+
+    /** A row whose pure-rename status is not distinguished; treated as ordinary content change. */
+    public ChangedFile(String path, String changeType) {
+      this(path, changeType, false);
+    }
+  }
 
   /**
    * Upper bound on the rendered Mermaid source. A diagram larger than this is dropped rather than
@@ -400,7 +423,7 @@ public class PrSummaryGenerator {
           .append("` | ")
           .append(changeTypeLabel(file.changeType()))
           .append(" | ")
-          .append(summary.isBlank() ? "-" : MarkdownSafe.tableCell(summary.strip()))
+          .append(summaryCell(file, summary))
           .append(" |\n");
     }
     int rowsShown = Math.min(changedFiles.size(), MAX_FILE_ROWS);
@@ -409,6 +432,17 @@ public class PrSummaryGenerator {
       sb.append("\n_…and ").append(overflow).append(" more file(s)._\n");
     }
     sb.append("\n");
+  }
+
+  /**
+   * The walkthrough's Summary cell. The model's note wins whenever it supplied one; otherwise a
+   * pure rename says why it has none, and every other unsummarized row keeps the bare dash.
+   */
+  private static String summaryCell(ChangedFile file, String summary) {
+    if (!summary.isBlank()) {
+      return MarkdownSafe.tableCell(summary.strip());
+    }
+    return file.pureRename() ? PURE_RENAME_SUMMARY : "-";
   }
 
   /** Indexes the model's per-file notes by path; a duplicate path keeps the first note. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -427,12 +427,17 @@ public class VerdictBuilder {
   }
 
   /**
-   * Projects the reviewed diff onto the (path, change type) rows the summary walkthrough renders.
+   * Projects the reviewed diff onto the (path, change type, pure-rename) rows the summary
+   * walkthrough renders. The pure-rename flag travels with the row so the walkthrough can say why
+   * such a file carries no model summary instead of rendering a bare dash (#536).
    */
   static List<PrSummaryGenerator.ChangedFile> toChangedFiles(
       List<GitHubPullRequestClient.FileDiff> files) {
     return files.stream()
-        .map(f -> new PrSummaryGenerator.ChangedFile(f.filename(), f.status()))
+        .map(
+            f ->
+                new PrSummaryGenerator.ChangedFile(
+                    f.filename(), f.status(), ReviewDiffFormatter.isPureRename(f)))
         .toList();
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -18,6 +18,16 @@ package dev.thiagogonzaga.thrillhousebot.review.ai;
 /** Shared prompt text for blocking and streaming PR review calls. */
 public final class PrReviewPrompts {
 
+  /**
+   * Cap on the {@code summary.file_summaries} entries the prompts ask for. Deliberately the same
+   * number as the walkthrough table's row bound ({@code PrSummaryGenerator.MAX_FILE_ROWS}, which
+   * reads it from here): a cap below the render width guarantees rows the model was never asked to
+   * summarize, which is how a walkthrough ends up with dashes in rows a correct response could have
+   * filled (#536). The prompt text repeats the number in prose, and {@code
+   * PrReviewPromptsContentTest} pins that prose to this constant.
+   */
+  public static final int MAX_FILE_SUMMARIES = 20;
+
   public static final String SYSTEM =
       """
             You are ThrillhouseBot, a code review assistant.
@@ -345,12 +355,16 @@ public final class PrReviewPrompts {
               producer→consumer trace whose end-to-end behavior is the inverse of the stated
               intent — dimension 9). Empty array when there is no description or no mismatch.
             - file_summaries: an array of { path, summary } objects, one per changed file, that gives
-              reviewers a file-by-file walkthrough. "path" must match the file path exactly as it
-              appears in the diff; "summary" is a single line (max ~100 chars) describing what
-              changed in that file and why, derived from the diff — not the file name. Cover the
-              most significant files first and cap the array at 15 entries; for a larger PR,
-              summarize the 15 most impactful files and omit purely mechanical ones (generated
-              code, lockfiles, bulk renames). Empty array when nothing is worth calling out.
+              reviewers a file-by-file walkthrough. The object keys must be spelled exactly "path"
+              and "summary" — "file", "filename" and "description" are silently discarded — and the
+              field itself must be an ARRAY, never an object keyed by path. "path" must match the
+              file path exactly as it appears in the diff; "summary" is a single line (max ~100
+              chars) describing what changed in that file and why, derived from the diff — not the
+              file name. Cover the most significant files first and cap the array at 20 entries;
+              for a larger PR, summarize the 20 most impactful files and omit purely mechanical
+              ones (generated code, lockfiles, bulk renames). This field is what fills the rendered
+              walkthrough table, so emit an entry for every changed file up to that cap; an empty
+              array leaves every row of that table blank.
             - suggested_labels: ONLY when an "Available Repository Labels" section is provided,
               a JSON array of label names that best categorize this PR — area, change type, risk.
               Follow that section's guidance on which labels you may use, pick the few most
@@ -473,9 +487,26 @@ public final class PrReviewPrompts {
               between what the author claims and what the change does — including a description
               whose scope is narrower than the change itself (it covers one component, or far fewer
               files than the PR scope totals report). Empty array otherwise.
-            - file_summaries: an array of { path, summary } objects giving a file-by-file
-              walkthrough. "path" must match a changed-file path exactly; "summary" is a single line
-              (max ~100 chars) on what changed in that file. Most impactful first, cap at 15.
+            - file_summaries: REQUIRED, and the field this call most often gets wrong. It is an
+              array of { path, summary } objects that fills the rendered file-by-file walkthrough
+              table; omitting it, or emitting [], leaves every row of that table blank, which is
+              worse than a rough line. You do not see the diff — and you are not being asked to
+              describe it hunk by hunk. Write each line from the material you DO have: the
+              changed-file list below (its path, change status, +added/-deleted counts and the
+              directory breakdown), the findings already computed for that path, and the PR title
+              and description. A one-line statement of that file's role in this change, at that
+              level of detail, is what is wanted and is NOT invention. What would be invention is
+              naming methods, values or behavior the material does not show — so stay at the
+              granularity the file list and findings justify, and prefer a rougher true line over
+              no line at all. "path" must match a path from the changed-file list below EXACTLY,
+              character for character (no a/ or b/ prefix, no truncation). The object keys must be
+              spelled exactly "path" and "summary" — "file", "filename" and "description" are
+              silently discarded — and the field itself must be an ARRAY, never an object keyed by
+              path. "summary" is a single line, max ~100 chars. One entry per listed file, most
+              impactful first, capped at 20 entries; when the list is longer than that, cover the
+              20 most impactful and skip purely mechanical ones (generated code, lockfiles, bulk
+              renames). Files the list marks as pure renames, omitted, or not reviewed need no
+              entry.
             - suggested_labels: ONLY when an "Available Repository Labels" section is provided, a
               JSON array of the few most relevant label names (typically 1-3); follow that section's
               guidance and emit an empty array if none apply. Omit the field entirely otherwise.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -429,8 +429,8 @@ public final class PrReviewPrompts {
               intent — dimension 9). Empty array when there is no description or no mismatch.
             - file_summaries: an array of { path, summary } objects, one per changed file, that gives
               reviewers a file-by-file walkthrough. The object keys must be spelled exactly "path"
-              and "summary" — "file", "filename" and "description" are silently discarded — and the
-              field itself must be an ARRAY, never an object keyed by path. "path" must match the
+              and "summary" — not "file", "filename" or "description" — and the field itself
+              must be an ARRAY, never an object keyed by path. "path" must match the
               file path exactly as it appears in the diff; "summary" is a single line (max ~100
               chars) describing what changed in that file and why, derived from the diff — not the
               file name. Cover the most significant files first and cap the array at 20 entries;
@@ -573,8 +573,8 @@ public final class PrReviewPrompts {
               granularity the file list and findings justify, and prefer a rougher true line over
               no line at all. "path" must match a path from the changed-file list below EXACTLY,
               character for character (no a/ or b/ prefix, no truncation). The object keys must be
-              spelled exactly "path" and "summary" — "file", "filename" and "description" are
-              silently discarded — and the field itself must be an ARRAY, never an object keyed by
+              spelled exactly "path" and "summary" — not "file", "filename" or "description" —
+              and the field itself must be an ARRAY, never an object keyed by
               path. "summary" is a single line, max ~100 chars. One entry per listed file, most
               impactful first, capped at 20 entries; when the list is longer than that, cover the
               20 most impactful and skip purely mechanical ones (generated code, lockfiles, bulk

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -51,9 +51,42 @@ public final class PrReviewPrompts {
                diff is as much a finding as a code vulnerability — do not pass over it because it is
                declarative rather than executable.
             3. REGRESSIONS: Does this change break or remove existing behavior? Compare with base commit context.
-            4. COMMENT CONSISTENCY: Comments that contradict code. Outdated comments. Missing comments where logic is complex.
-               Excessive/obvious comments (e.g., "i++ // increment i"). TODO/FIXME without resolution.
-            5. CODE QUALITY: Maintainability, naming, DRY, error handling, performance.
+            4. COMMENT CONTRADICTS CODE: a comment that states something the code it documents does
+               NOT do is a defect, not a style note, and it is demonstrable from the diff alone —
+               both halves are right there. Report it when the comment asserts a fact the adjacent
+               code contradicts: a default, bound, unit, ordering, return value, thrown exception,
+               or condition that does not match; a comment left describing the behavior this very
+               change replaced; a doc line naming a parameter, field or method the code no longer
+               has. Quote the comment line and the code line that disagrees with it and name the
+               specific disagreement. Risk "medium" when a maintainer who trusted the comment would
+               get the behavior wrong (which is the usual case for a stale comment on changed code),
+               "low" when the contradiction is inert. Do not pass over a stale comment because the
+               code beside it is correct — the false statement IS the defect, and it outlives the
+               reviewer who could have caught it. Separately and far more weakly: missing comments
+               where logic is complex, excessive/obvious comments (e.g. "i++ // increment i"), and
+               TODO/FIXME without resolution are style observations — raise them only when the
+               project instructions ask for that level of detail.
+            5. CODE QUALITY AND ALGORITHMIC COMPLEXITY: maintainability, naming, DRY, error
+               handling — and, as a claim class of its own, the cost of code the diff ADDS. The
+               shapes below are quadratic (or worse) in an input the diff does not bound, and the SHAPE
+               ITSELF, visible in the diff, is the evidence; you do NOT also have to demonstrate
+               that the input is large:
+               (a) a linear membership or lookup test inside a loop — contains / indexOf / includes
+                   / a find / a nested scan — where both the loop and the scanned collection are
+                   sized by the same input. Building a result list and scanning it to skip
+                   duplicates is the canonical case: it is O(n^2), and a set or map makes it O(n).
+               (b) a nested loop pair over the same or another input-sized collection.
+               (c) work re-done per iteration that does not vary with the iteration: re-sorting,
+                   re-compiling a regex, re-reading a file, or issuing one query per element (an
+                   N+1) where one batched call would do.
+               (d) a linear-time operation applied once per element — string concatenation building
+                   a result in a loop, insertion at the head of an array, an O(n) copy per append.
+               Report these at risk "medium", or "high" when the collection is request- or
+               user-sized AND the path is a hot one, and name the concrete better structure in the
+               description (a set for the membership test, one pass instead of two, hoisting the
+               invariant out of the loop). NOT a finding when the diff itself shows the bound is
+               fixed and small — iteration over a literal, an enum's values, a constant-size array —
+               or when a comment justifies the choice.
             6. PAGINATION / TRUNCATION: When the diff adds or changes a call that lists a paginated
                collection — a GitHub REST endpoint (e.g. .../comments, .../reviews, .../files,
                .../issues) or a GraphQL connection (a first:/nodes field) — and its result is then
@@ -94,7 +127,15 @@ public final class PrReviewPrompts {
                or "medium" (the green test looks like proof but the stub is unfaithful). Do not
                invent the real method's body when it is not in the provided material — omit the
                finding or phrase a verification request only when the mock's impossibility is
-               already demonstrable from what is shown. A green test whose mocks contradict the
+               already demonstrable from what is shown. The SIGNATURE alone is enough when the
+               signature is what the stub violates: a stub returning null where the return type or
+               a nullability annotation forbids it, one throwing a checked exception the method
+               does not declare, one returning a value the declared type or documented range
+               excludes. "The body is not shown" does not excuse those. Report a demonstrated
+               contradiction at risk "medium" — the suite is green and the production path is
+               nonetheless untested, which is precisely the failure nobody notices — and note that
+               the mandated low/medium CONFIDENCE describes how firmly you may word the claim, not
+               whether the finding is worth emitting. A green test whose mocks contradict the
                real collaborator is not evidence the production path works.
             9. PRODUCER → CONSUMER CONTRACT: hunks are judged locally, so a change can be correct
                line by line and still wrong end to end. Once per PR, for the change's PRIMARY new
@@ -160,9 +201,13 @@ public final class PrReviewPrompts {
               says it hardens RBAC but widens it, that adds a securityContext but leaves a container
               privileged). "Will fail at runtime" is not the only path to this level; "will fail at
               apply/validation time, shown in the diff" counts equally.
-            - "medium": a real correctness or maintainability concern. Performance findings need
-              evidence of scale in the diff (unbounded data, hot paths) — a one-time task over a
-              handful of rows is not a finding.
+            - "medium": a real correctness or maintainability concern — the level the claim classes
+              defined by dimensions 4, 5 and 8 land on by default once their own evidence
+              requirement is met. Performance findings do need evidence of scale, and an added
+              quadratic shape over a collection the diff does not bound IS that evidence
+              (dimension 5): the nested scan is the demonstration, and waiting to be shown the
+              collection is large is how a real O(n^2) goes unreported. What is not a finding is a
+              one-time task over a bound the diff itself shows to be fixed and small.
             - "low": rarely worth reporting — prefer omitting it unless the project instructions
               ask for that level of detail, or it is a config-key documentation gap under
               dimension 10. Cosmetic phrasing nitpicks (documentation-vs-code
@@ -171,7 +216,22 @@ public final class PrReviewPrompts {
               a real finding, not a nitpick, and belongs at its impact-based severity above. So is
               a config-key documentation gap under dimension 10: an omitted type, separator, unit,
               allowed value or default is a correctness gap for whoever sets the key, not a
-              phrasing nitpick. Prose style, tone and ordering remain nitpicks.
+              phrasing nitpick. So is a comment that states behavior the code does not have
+              (dimension 4): that is a false statement, not a wording preference.
+              Prose style, tone and ordering remain nitpicks.
+
+            Severity is not confidence, and neither one is a reason to stay silent:
+            - Emit a finding whose defect you can demonstrate from the provided material even when
+              the confidence rules cap it at "medium" or "low". Those rules govern how you WORD the
+              claim — verification request rather than settled fact — not whether the finding
+              exists. "Omit rather than guess" applies when you are unsure the issue is REAL; it
+              does not apply when the defect is demonstrable and only its impact is uncertain.
+            - Three claim classes are under-reported for exactly that reason, because each reads at
+              first glance like a nitpick: a comment contradicting the code (dimension 4), an added
+              quadratic shape (dimension 5), and a stub that contradicts the real collaborator
+              (dimension 8). Each is demonstrable by quoting two lines from the provided material.
+              When you have those two lines, report it — do not trade it away against the
+              low-severity omission guidance above.
 
             Confidence calibration:
             - confidence "high" means another reviewer could confirm the issue using only the
@@ -272,6 +332,19 @@ public final class PrReviewPrompts {
               visible, or you cannot name that case, the finding is invalid. Raise it for the
               structure the change is about, not for every local variable that crosses a hunk
               boundary.
+            - A comment-contradiction claim (dimension 4) must quote the comment and the code line
+              it contradicts, both verbatim from the provided material, and state what the comment
+              asserts that the code does not do. A comment that is merely terse, incomplete,
+              differently worded, or about a neighbouring concern is not a contradiction, and
+              neither is one whose subject is not visible in the provided material.
+            - An algorithmic-complexity claim (dimension 5) must quote both levels from the diff —
+              the outer loop and the inner scan, nested loop, or per-element linear operation — and
+              name the ONE input whose size drives both; say "O(n^2)" only when the same n drives
+              both levels, and otherwise state the cost in words rather than guessing a class. If
+              the diff shows either level bounded by a literal, an enum, a constant, or a small
+              fixed collection, the finding is invalid. A single pass, or a lookup that is already
+              hashed (a set/map membership test), is not quadratic — check which it is before
+              claiming it.
             - A config-key documentation-completeness claim (dimension 10) must quote the
               documented line from the diff AND the definition line — from the diff or from the
               config-key definitions section — that establishes the omitted fact, and name which
@@ -659,13 +732,17 @@ public final class PrReviewPrompts {
               internally and never propagates to its caller, or returns a value the real
               signature/contract disallows.
             - Anchor at the mock/stub line, quote it, and name the contradicting real-method
-              line in the description. Use confidence "low" or "medium" and leave
-              suggestion_old/suggestion_new empty unless the faithful stub (or the production
-              fix) is obvious from the provided material.
+              line in the description. Use risk "medium" for a demonstrated contradiction, with
+              confidence "low" or "medium" — the confidence governs the wording, not whether to
+              emit — and leave suggestion_old/suggestion_new empty unless the faithful stub (or
+              the production fix) is obvious from the provided material.
             - When the real method's body is not in the provided material, do not invent it:
               omit a mock-fidelity finding, or phrase a verification request only if the
               impossibility is already demonstrable from what is shown. Broader cross-file
-              retrieval of collaborator sources is out of scope for this check alone.
+              retrieval of collaborator sources is out of scope for this check alone. The
+              declared SIGNATURE counts as shown material: a stub that returns null against a
+              non-null contract, throws a checked exception the method does not declare, or
+              returns a value the declared type excludes is contradicted by the signature alone.
             - A faithful stub that matches the real contract is not a finding."""
           .stripIndent();
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
@@ -26,6 +26,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 @ApplicationScoped
 public class ReviewResponseParser {
@@ -33,6 +34,20 @@ public class ReviewResponseParser {
   private static final String PREVIOUS_FINDINGS_STATUS = "previous_findings_status";
   private static final String SUMMARY = "summary";
   private static final String DESCRIPTION_GAPS = "description_gaps";
+  private static final String FILE_SUMMARIES = "file_summaries";
+  private static final String PATH = "path";
+
+  /**
+   * Keys a mis-shaped {@code file_summaries} entry may carry the path under, most canonical first.
+   * Jackson ignores unknown properties, so an entry keyed {@code file} maps to a FileSummary with a
+   * null path — which the walkthrough renderer then drops without a word (#536).
+   */
+  private static final List<String> PATH_KEYS =
+      List.of(PATH, "file", "filename", "file_path", "filepath", "file_name");
+
+  /** Keys a mis-shaped {@code file_summaries} entry may carry the one-line summary under. */
+  private static final List<String> SUMMARY_KEYS =
+      List.of(SUMMARY, "description", "change", "changes", "note", "text");
 
   private final ObjectMapper mapper;
 
@@ -53,6 +68,7 @@ public class ReviewResponseParser {
     }
     normalizePreviousFindingsStatus(root);
     normalizeDescriptionGaps(root);
+    normalizeFileSummaries(root);
     try {
       return mapper.treeToValue(root, ReviewResponse.class);
     } catch (JsonProcessingException e) {
@@ -224,6 +240,122 @@ public class ReviewResponseParser {
   }
 
   /**
+   * Models sometimes emit {@code summary.file_summaries} in a shape the schema does not accept: a
+   * map keyed by path ({@code {"src/A.java": "adds X"}}), entries keyed {@code file}/{@code
+   * description} rather than {@code path}/{@code summary}, {@code "path: summary"} strings, or a
+   * single object where the array belongs. Both ways that fails are silent. An unrecognized key is
+   * ignored by Jackson, leaving a null {@code path} that the walkthrough renderer drops — so every
+   * row renders "-" and nothing says why. A non-array node fails schema mapping instead, and the
+   * salvage in {@link #parseWithoutSummary} then discards the WHOLE summary, taking pr_purpose and
+   * the description gaps with it. Normalize to the array-of-{path, summary} form so a recoverable
+   * shape still fills the walkthrough, and log what could not be recovered (#536).
+   */
+  private void normalizeFileSummaries(JsonNode root) {
+    if (!(root instanceof ObjectNode rootObject)
+        || !(rootObject.get(SUMMARY) instanceof ObjectNode summary)) {
+      return;
+    }
+    var fileSummaries = summary.get(FILE_SUMMARIES);
+    if (fileSummaries == null || fileSummaries.isNull()) {
+      return;
+    }
+    var normalized = mapper.createArrayNode();
+    var seen = 1;
+    if (fileSummaries.isArray()) {
+      if (conformsToFileSummarySchema(fileSummaries)) {
+        // Already-conforming arrays stay untouched
+        return;
+      }
+      seen = fileSummaries.size();
+      for (var entry : fileSummaries) {
+        addFileSummary(normalized, null, entry);
+      }
+    } else if (looksLikeFileSummary(fileSummaries)) {
+      // A single entry emitted where the array belongs
+      addFileSummary(normalized, null, fileSummaries);
+    } else if (fileSummaries.isObject()) {
+      // The map form: each property is one path and its summary
+      seen = fileSummaries.size();
+      for (var entry : fileSummaries.properties()) {
+        addFileSummary(normalized, entry.getKey(), entry.getValue());
+      }
+    }
+    // Anything else is a scalar where the walkthrough belongs: no (path, summary) pair at all.
+    Log.warnf(
+        "Review response file_summaries did not match the schema — recovered %d entr%s and dropped"
+            + " %d; unrecovered entries render as blank walkthrough rows",
+        normalized.size(), normalized.size() == 1 ? "y" : "ies", seen - normalized.size());
+    summary.set(FILE_SUMMARIES, normalized);
+  }
+
+  /**
+   * Whether every element already carries textual {@code path} and {@code summary} fields, so the
+   * array maps cleanly and must be left exactly as the model sent it. An empty array conforms.
+   */
+  private static boolean conformsToFileSummarySchema(JsonNode fileSummaries) {
+    for (var entry : fileSummaries) {
+      if (!entry.isObject() || !entry.path(PATH).isTextual() || !entry.path(SUMMARY).isTextual()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Whether the node is one walkthrough entry rather than the map form. The map form is keyed by
+   * real repository paths, which are never spelled {@code summary}/{@code description}/…, so a
+   * summary-ish field at the top level identifies a single entry unambiguously.
+   */
+  private static boolean looksLikeFileSummary(JsonNode node) {
+    return node.isObject() && firstTextual(node, SUMMARY_KEYS, null) != null;
+  }
+
+  /**
+   * Appends one recovered {@code {path, summary}} entry. {@code key} is the property name when the
+   * model emitted the map form (so the path lives in the key), else {@code null}. A textual value
+   * without such a key is read as {@code "path: summary"}. An element carrying no usable path or no
+   * usable summary is dropped rather than mapped to a half-null entry the renderer would silently
+   * skip.
+   */
+  private void addFileSummary(ArrayNode normalized, String key, JsonNode value) {
+    var path = key;
+    String summary = null;
+    if (value.isObject()) {
+      path = firstTextual(value, PATH_KEYS, path);
+      summary = firstTextual(value, SUMMARY_KEYS, null);
+    } else if (value.isTextual() && key != null) {
+      summary = value.asText();
+    } else if (value.isTextual()) {
+      var separator = value.asText().indexOf(':');
+      if (separator >= 0) {
+        path = value.asText().substring(0, separator);
+        summary = value.asText().substring(separator + 1);
+      }
+    }
+    if (usable(path) && usable(summary)) {
+      normalized.add(
+          mapper.createObjectNode().put(PATH, path.strip()).put(SUMMARY, summary.strip()));
+    }
+  }
+
+  /** Whether a recovered path or summary carries anything the walkthrough can render. */
+  private static boolean usable(String value) {
+    return value != null && !value.isBlank();
+  }
+
+  /**
+   * The first of {@code keys} present on {@code node} with a textual value, else {@code fallback}.
+   */
+  private static String firstTextual(JsonNode node, List<String> keys, String fallback) {
+    for (var key : keys) {
+      var value = node.get(key);
+      if (value != null && value.isTextual()) {
+        return value.asText();
+      }
+    }
+    return fallback;
+  }
+
    * Strips optional markdown fences and leading noise before the JSON object/array. An absent body
    * extracts to {@code ""}: "no response" is a soft failure every caller decides for itself (each
    * one guards the body before parsing), so this must not convert it into a {@code

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParser.java
@@ -356,6 +356,7 @@ public class ReviewResponseParser {
     return fallback;
   }
 
+  /**
    * Strips optional markdown fences and leading noise before the JSON object/array. An absent body
    * extracts to {@code ""}: "no response" is a soft failure every caller decides for itself (each
    * one guards the body before parsing), so this must not convert it into a {@code

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -621,6 +621,44 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
+  void shouldExplainPureRenameRowInsteadOfRenderingBareDash() {
+    var changedFiles =
+        List.of(
+            new PrSummaryGenerator.ChangedFile("src/Moved.java", "renamed", true),
+            new PrSummaryGenerator.ChangedFile("src/Edited.java", "renamed", false));
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
+
+    var summary = generator.generate(2, 0, 0, changedFiles, summaryWithFiles(), result);
+
+    // A pure rename is excluded from AI review by design, so it never carries a model summary:
+    // say so rather than rendering the "-" that reads as a missing summary (#536).
+    assertTrue(
+        summary.contains(
+            "| `src/Moved.java` | Renamed | " + PrSummaryGenerator.PURE_RENAME_SUMMARY + " |"),
+        summary);
+    // A rename that also changed content WAS reviewed, so an absent summary stays a bare dash.
+    assertTrue(summary.contains("| `src/Edited.java` | Renamed | - |"), summary);
+  }
+
+  @Test
+  void shouldPreferModelSummaryOverThePureRenameExplanation() {
+    var changedFiles =
+        List.of(new PrSummaryGenerator.ChangedFile("src/Moved.java", "renamed", true));
+    var aiSummary =
+        summaryWithFiles(new ReviewResponse.FileSummary("src/Moved.java", "Moved to the new pkg"));
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
+
+    var summary = generator.generate(1, 0, 0, changedFiles, aiSummary, result);
+
+    assertTrue(summary.contains("| `src/Moved.java` | Renamed | Moved to the new pkg |"), summary);
+    assertFalse(summary.contains(PrSummaryGenerator.PURE_RENAME_SUMMARY), summary);
+  }
+
+  @Test
   void shouldOmitChangedFilesSectionWhenNoFiles() {
     var result =
         new ReviewResult(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -669,6 +669,55 @@ class PrReviewPromptsContentTest {
   }
 
   @Test
+  void bothPromptsAskForAsManyFileSummariesAsTheWalkthroughRenders() {
+    assertContains(
+        PrReviewPrompts.SYSTEM,
+        "cap the array at " + PrReviewPrompts.MAX_FILE_SUMMARIES + " entries",
+        "the review prompt's file_summaries cap must be the walkthrough row bound (#536)");
+    assertContains(
+        PrReviewPrompts.SUMMARY_SYSTEM,
+        "capped at " + PrReviewPrompts.MAX_FILE_SUMMARIES + " entries",
+        "the summary prompt's file_summaries cap must be the walkthrough row bound (#536)");
+  }
+
+  @Test
+  void summaryPromptGroundsFileSummariesInTheMaterialThatCallActuallyHas() {
+    String sys = PrReviewPrompts.SUMMARY_SYSTEM;
+    // The collapse to "-" on large PRs is this call omitting the field: it is told it never sees
+    // the diff and must not invent, while the field is described as "what changed in that file".
+    assertContains(
+        sys,
+        "file_summaries: REQUIRED",
+        "the summary call must be told file_summaries is not optional (#536)");
+    assertContains(
+        sys,
+        "leaves every row of that table blank",
+        "the summary call must be told what omitting file_summaries costs (#536)");
+    assertContains(
+        sys,
+        "is what is wanted and is NOT invention",
+        "a file-list-grounded one-liner must be licensed against the do-not-invent rule (#536)");
+    assertContains(
+        sys,
+        "prefer a rougher true line over",
+        "the summary call must be told to say less rather than nothing (#536)");
+  }
+
+  @Test
+  void bothPromptsPinTheFileSummaryShapeThatSurvivesParsing() {
+    for (String prompt : new String[] {PrReviewPrompts.SYSTEM, PrReviewPrompts.SUMMARY_SYSTEM}) {
+      assertContains(
+          prompt,
+          "spelled exactly \"path\"",
+          "a mis-keyed entry is silently dropped, so the keys must be pinned (#536)");
+      assertContains(
+          prompt,
+          "must be an ARRAY, never an object keyed by",
+          "the map form fails schema mapping and costs the whole summary (#536)");
+    }
+  }
+
+  @Test
   void inDiffTestSelfCheckDoesNotSuppressAClaimAboutAnUncoveredLine() {
     String sys = PrReviewPrompts.SYSTEM;
     assertContains(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -26,8 +26,10 @@ import org.junit.jupiter.api.Test;
  * must demonstrably hit the claimed path before it can invalidate a finding — #116), the symmetric
  * exact-arithmetic / "test fails" cap (#97), the heuristic failure-mode characterization pass with
  * its verifier exemption (#123), the producer→consumer data-flow contract dimension (#117), the
- * config-key documentation-completeness claim class and its narrowing guards (#109), and the
- * summary call's whole-change-set grounding (#335). These assertions are intentionally coarse —
+ * config-key documentation-completeness claim class and its narrowing guards (#109), the summary
+ * call's whole-change-set grounding (#335), and the rebalancing of the three dimensions a
+ * controlled four-language corpus measured as under-reported — comment-contradicts-code, added
+ * algorithmic complexity, and mock fidelity (#537). These assertions are intentionally coarse —
  * they check intent survives, not exact wording; an intentional rewording should update the
  * matching anchor.
  *
@@ -666,6 +668,125 @@ class PrReviewPromptsContentTest {
         req,
         "not evidence in the other direction",
         "absence from the list must never be read as proof a line is covered");
+  }
+
+  @Test
+  void commentContradictionIsAClaimClassRatherThanAStyleNote() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "4. COMMENT CONTRADICTS CODE",
+        "dimension 4 must lead with the contradiction claim class, not the comment-style list");
+    assertContains(
+        sys,
+        "is a defect, not a style note",
+        "a comment contradicting the code must not read as a style observation (#537)");
+    assertContains(
+        sys,
+        "the false statement IS the defect",
+        "a stale comment beside correct code must still be reportable (#537)");
+    assertContains(
+        sys,
+        "are style observations — raise them only when",
+        "missing/obvious comments and TODOs must stay the weak half of dimension 4 (#537)");
+    // The nitpick exclusion must not swallow the claim class it sits next to.
+    assertContains(
+        sys,
+        "that is a false statement, not a wording preference",
+        "the phrasing-nitpick exclusion must carve out dimension 4 (#537)");
+  }
+
+  @Test
+  void addedQuadraticComplexityIsReportableFromTheShapeAlone() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "ALGORITHMIC COMPLEXITY",
+        "dimension 5 must name algorithmic complexity as its own claim class (#537)");
+    assertContains(
+        sys,
+        "ITSELF, visible in the diff, is the evidence; you do NOT also have to demonstrate",
+        "the nested shape itself must count as the evidence of scale (#537)");
+    assertContains(
+        sys,
+        "you do NOT also have to demonstrate",
+        "a complexity finding must not wait to be shown the collection is large (#537)");
+    assertContains(
+        sys,
+        "duplicates is the canonical case: it is O(n^2), and a set or map makes it O(n)",
+        "the O(n^2) dedupe the corpus planted must be named outright (#537)");
+    // The severity rule is the other half of the brake and has to agree.
+    assertContains(
+        sys,
+        "quadratic shape over a collection the diff does not bound IS that evidence",
+        "the medium-severity rule must stop demanding separate evidence of scale (#537)");
+    assertContains(
+        sys,
+        "NOT a finding when the diff itself shows the bound is",
+        "a fixed small bound must still exclude the finding — precision is unchanged (#537)");
+  }
+
+  @Test
+  void mockFidelityIsReportableFromTheSignatureAndLandsAtMedium() {
+    assertContains(
+        PrReviewPrompts.SYSTEM,
+        "The SIGNATURE alone is enough when the",
+        "a stub contradicting the declared signature must be reportable (#537)");
+    assertContains(
+        PrReviewPrompts.SYSTEM,
+        "contradiction at risk \"medium\" — the suite is green",
+        "a demonstrated mock contradiction must land at medium, not low (#537)");
+    assertContains(
+        PrReviewPrompts.MOCK_FIDELITY_REQUEST,
+        "the confidence governs the wording, not whether to",
+        "the injected mock-fidelity block must agree with dimension 8 (#537)");
+    assertContains(
+        PrReviewPrompts.MOCK_FIDELITY_REQUEST,
+        "declared SIGNATURE counts as shown material",
+        "the injected block must accept the signature as evidence (#537)");
+  }
+
+  @Test
+  void confidenceCapsGovernWordingRatherThanWhetherToReport() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "Severity is not confidence, and neither one is a reason to stay silent",
+        "the omission guidance must stop absorbing demonstrable low-confidence findings (#537)");
+    assertContains(
+        sys,
+        "\"Omit rather than guess\" applies when you are unsure the issue is REAL",
+        "the omit rule must be scoped to doubt about the defect, not about its impact (#537)");
+    assertContains(
+        sys,
+        "When you have those two lines, report it",
+        "the three under-reported classes must be named with their evidence bar (#537)");
+  }
+
+  @Test
+  void rebalancedDimensionsKeepTheirOwnEvidenceRequirements() {
+    String sys = PrReviewPrompts.SYSTEM;
+    // Precision came in at zero false positives; each widened class carries its own self-check.
+    assertContains(
+        sys,
+        "A comment-contradiction claim (dimension 4) must quote the comment and the code line",
+        "a comment-contradiction claim must quote both halves (#537)");
+    assertContains(
+        sys,
+        "or about a neighbouring concern is not a contradiction",
+        "a terse or unshown comment must not become a contradiction claim (#537)");
+    assertContains(
+        sys,
+        "An algorithmic-complexity claim (dimension 5) must quote both levels from the diff",
+        "a complexity claim must quote the outer loop and the inner scan (#537)");
+    assertContains(
+        sys,
+        "name the ONE input whose size drives both",
+        "a complexity claim must trace one n through both levels (#537)");
+    assertContains(
+        sys,
+        "the finding is invalid. A single pass, or a lookup that is already",
+        "a bounded level, or an already-hashed lookup, must invalidate the claim (#537)");
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParserTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewResponseParserTest.java
@@ -468,6 +468,165 @@ class ReviewResponseParserTest {
     assertFalse(ex.getMessage().contains("did not match the review schema"));
   }
 
+  /**
+   * The injected production mapper is Quarkus's, which ignores unknown properties. That is what
+   * makes a mis-keyed file_summaries entry silent: it maps to a FileSummary with a null path, which
+   * the walkthrough renderer then skips without a word (#536).
+   */
+  private static ReviewResponseParser lenientParser() {
+    var mapper = new ObjectMapper();
+    mapper.configure(
+        com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    return new ReviewResponseParser(mapper);
+  }
+
+  @Test
+  void shouldRecoverFileSummariesKeyedFileAndDescription() {
+    var response =
+        lenientParser()
+            .parse(
+                """
+                {"findings": [],
+                 "summary": {"total_findings": 0, "pr_purpose": "p",
+                   "file_summaries": [{"file": "src/A.java", "description": "adds a guard"},
+                                      {"filename": "src/B.java", "note": "new cache"}]}}
+                """);
+
+    var summaries = response.summary().fileSummaries();
+    assertEquals(2, summaries.size(), summaries.toString());
+    assertEquals("src/A.java", summaries.get(0).path());
+    assertEquals("adds a guard", summaries.get(0).summary());
+    assertEquals("src/B.java", summaries.get(1).path());
+    assertEquals("new cache", summaries.get(1).summary());
+  }
+
+  @Test
+  void shouldRecoverFileSummariesEmittedAsAMapKeyedByPath() {
+    var response =
+        parser.parse(
+            """
+            {"findings": [],
+             "summary": {"total_findings": 0, "pr_purpose": "p",
+               "file_summaries": {"src/A.java": "adds a guard",
+                                  "src/B.java": {"summary": "new cache"}}}}
+            """);
+
+    var summaries = response.summary().fileSummaries();
+    assertEquals(2, summaries.size(), summaries.toString());
+    assertEquals("src/A.java", summaries.get(0).path());
+    assertEquals("adds a guard", summaries.get(0).summary());
+    assertEquals("src/B.java", summaries.get(1).path());
+    assertEquals("new cache", summaries.get(1).summary());
+    // The rest of the summary survives the rewrite
+    assertEquals("p", response.summary().prPurpose());
+  }
+
+  @Test
+  void shouldRecoverFileSummariesEmittedAsPathColonSummaryStrings() {
+    var response =
+        parser.parse(
+            """
+            {"findings": [],
+             "summary": {"total_findings": 0,
+               "file_summaries": ["src/A.java: adds a guard", "no separator here"]}}
+            """);
+
+    var summaries = response.summary().fileSummaries();
+    assertEquals(1, summaries.size(), summaries.toString());
+    assertEquals("src/A.java", summaries.get(0).path());
+    assertEquals("adds a guard", summaries.get(0).summary());
+  }
+
+  @Test
+  void shouldWrapASingleFileSummaryObjectEmittedWhereTheArrayBelongs() {
+    var response =
+        parser.parse(
+            """
+            {"findings": [],
+             "summary": {"total_findings": 0,
+               "file_summaries": {"path": "src/A.java", "summary": "adds a guard"}}}
+            """);
+
+    var summaries = response.summary().fileSummaries();
+    assertEquals(1, summaries.size(), summaries.toString());
+    assertEquals("src/A.java", summaries.get(0).path());
+    assertEquals("adds a guard", summaries.get(0).summary());
+  }
+
+  @Test
+  void shouldDropHalfEntriesButKeepTheUsableOnesAndTheSummary() {
+    // Every way half an entry can arrive: no path, no summary, not an object at all, a blank path,
+    // a non-textual path key ahead of a usable one, and a blank summary.
+    var response =
+        lenientParser()
+            .parse(
+                """
+                {"findings": [],
+                 "summary": {"total_findings": 0, "pr_purpose": "p",
+                   "file_summaries": [{"summary": "no path"}, {"path": "src/A.java"}, 7,
+                                      {"file": "   ", "description": "blank path"},
+                                      {"file": 12, "filename": "src/B.java", "note": "kept"},
+                                      {"path": "src/C.java", "summary": "  "}]}}
+                """);
+
+    var summaries = response.summary().fileSummaries();
+    assertEquals(1, summaries.size(), summaries.toString());
+    assertEquals("src/B.java", summaries.get(0).path());
+    assertEquals("kept", summaries.get(0).summary());
+    assertEquals("p", response.summary().prPurpose());
+  }
+
+  @Test
+  void shouldRewriteAnArrayWhoseFirstEntryBreaksTheSchemaInAnyWay() {
+    // The conformance check short-circuits on the first offender, so each way an entry can fail it
+    // has to lead its own payload.
+    for (String entries :
+        new String[] {"7", "{\"summary\": \"x\"}", "{\"path\": \"src/A.java\", \"summary\": 7}"}) {
+      var response =
+          lenientParser()
+              .parse(
+                  "{\"findings\":[],\"summary\":{\"total_findings\":0,\"pr_purpose\":\"p\","
+                      + "\"file_summaries\":["
+                      + entries
+                      + "]}}");
+
+      assertNotNull(response.summary(), entries);
+      assertTrue(response.summary().fileSummaries().isEmpty(), entries);
+    }
+  }
+
+  @Test
+  void shouldKeepTheSummaryWhenFileSummariesIsAScalar() {
+    // Without normalization this fails schema mapping, and the salvage drops the WHOLE summary.
+    var response =
+        parser.parse(
+            """
+            {"findings": [],
+             "summary": {"total_findings": 0, "pr_purpose": "p", "overall_assessment": "ok",
+               "file_summaries": "nothing worth calling out"}}
+            """);
+
+    assertNotNull(response.summary(), "the summary object must survive a mis-shaped field");
+    assertEquals("p", response.summary().prPurpose());
+    assertTrue(response.summary().fileSummaries().isEmpty());
+  }
+
+  @Test
+  void shouldLeaveNullAndConformingFileSummariesUntouched() {
+    var withNull =
+        parser.parse(
+            "{\"findings\":[],\"summary\":{\"total_findings\":0,\"file_summaries\":null}}");
+    assertTrue(withNull.summary().fileSummaries().isEmpty());
+
+    var conforming =
+        parser.parse(
+            "{\"findings\":[],\"summary\":{\"total_findings\":0,\"file_summaries\":"
+                + "[{\"path\":\"src/A.java\",\"summary\":\"\"}]}}");
+    assertEquals(1, conforming.summary().fileSummaries().size());
+    // A conforming-but-blank summary is not rewritten away; the renderer decides how to show it.
+    assertEquals("", conforming.summary().fileSummaries().get(0).summary());
+  }
+
   @Test
   void shouldLeaveFullyValidResponseUnchanged() throws Exception {
     var raw =


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

On a large PR the file-by-file walkthrough rendered every row with `-`. Diagnosis first, then three fixes.

### Root cause

The dashboard/DB was not reachable from this machine, so the diagnosis is read off the artifact the run actually posted plus the parser. The summary comment on #532 (169 files) shows:

- `pr_purpose` rendered → the `summary` object mapped cleanly, so the `parseWithoutSummary` salvage (which drops the whole summary node) did not fire;
- the Control-Flow Diagram rendered → `walkthrough_diagram`, which the summary prompt lists **after** `file_summaries`, was present, so the response was not cut short before reaching the field.

The only remaining explanation is that the multi-call summary pass **omitted `file_summaries` outright** — and its prompt gives it every reason to. `SUMMARY_SYSTEM` tells that call "You do not see the diff", forbids inventing anything, and then asks for "a single line on what changed in that file", which the diff is the only source for. A model obeying both instructions emits nothing. That also explains the size split exactly: small PRs take the single-call path, whose `SYSTEM` prompt does see the diff, and their rows carry real summaries.

Two silent drops sat behind it in the parser, and both are live in production even though the shape is recoverable:

- an entry keyed `file`/`description` instead of `path`/`summary` maps — Quarkus's ObjectMapper ignores unknown properties — to a `FileSummary` with a **null path**, which `summariesByPath` filters out without a word, so every row shows `-`;
- a map or scalar where the array belongs fails schema mapping, at which point the #510 salvage discards the **whole** summary, taking `pr_purpose` and the description gaps with it.

### Fixes

1. **`SUMMARY_SYSTEM`**: `file_summaries` is now marked REQUIRED and grounded in the material that call actually holds — the authoritative changed-file list with statuses, ±counts and directory breakdown, the computed findings, and the PR description — with an explicit statement that a line at that granularity is wanted and is *not* invention, that inventing means naming behavior the material does not show, and that omitting the field blanks every row of the rendered table.
2. **Parser tolerance**: `normalizeFileSummaries` recovers the map form, key aliases (`file`/`filename`/`file_path`, `description`/`note`/`change`/`text`), `"path: summary"` strings, and a single entry emitted where the array belongs; entries carrying no usable pair are dropped and the count is logged instead of vanishing. Both prompts now also pin the key spelling and the array shape.
3. **Cap vs. render**: the prompt capped the array at 15 while the walkthrough renders 20 rows, so five rows could never be filled by any correct response. `PrSummaryGenerator.MAX_FILE_ROWS` now reads `PrReviewPrompts.MAX_FILE_SUMMARIES`, and a content test pins the prompt prose to the same constant.
4. **Pure renames**: a pure rename is excluded from AI review by design, so it never carries a model summary; its `-` read as a failure. The pure-rename flag now travels with the walkthrough row (`ChangedFile`) and the cell renders `Pure rename — content unchanged`. A rename that also changed content was reviewed, so it keeps the bare dash.

### Note on scope

`VerdictBuilder.toChangedFiles` is outside the assigned lane; it is the one place that builds `ChangedFile`, so the pure-rename flag cannot reach the renderer without it. The touch is confined to that three-line method (`ReviewDiffFormatter.isPureRename(f)` passed as the new component) and its Javadoc.

## Related Issues

Fixes #536

## How Has This Been Tested?

- [x] Unit tests

Red/green proof, parser tolerance (`ReviewResponseParser.java` reverted, tests kept):

```
[ERROR] Tests run: 45, Failures: 2, Errors: 4, Skipped: 0
[ERROR]   ReviewResponseParserTest.shouldRecoverFileSummariesKeyedFileAndDescription:489 expected: <src/A.java> but was: <null>
[ERROR]   ReviewResponseParserTest.shouldKeepTheSummaryWhenFileSummariesIsAScalar:577 the summary object must survive a mis-shaped field ==> expected: not <null>
[ERROR]   ReviewResponseParserTest.shouldRecoverFileSummariesEmittedAsAMapKeyedByPath:506 NullPointer Cannot invoke "dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse$Summary.fileSummaries()" because the return value of "dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse.summary()" is null
[ERROR]   ReviewResponseParserTest.shouldRecoverFileSummariesEmittedAsPathColonSummaryStrings:526 NullPointer Cannot invoke "...ReviewResponse$Summary.fileSummaries()" because the return value of "...ReviewResponse.summary()" is null
[ERROR]   ReviewResponseParserTest.shouldWrapASingleFileSummaryObjectEmittedWhereTheArrayBelongs:542 NullPointer Cannot invoke "...ReviewResponse$Summary.fileSummaries()" because the return value of "...ReviewResponse.summary()" is null
[ERROR]   ReviewResponseParserTest.shouldDropHalfEntriesButKeepTheUsableOnesAndTheSummary:560 NullPointer Cannot invoke "...ReviewResponse$Summary.fileSummaries()" because the return value of "...ReviewResponse.summary()" is null
```

The first line is the exact silent drop this issue reports: with the production (unknown-property-tolerant) mapper the entry survives Jackson with `path == null` and the renderer skips it. The rest are the shapes that cost the entire summary object.

Red/green proof, pure-rename cell (`summaryCell` reverted to `return "-";`):

```
[ERROR] PrSummaryGeneratorTest.shouldExplainPureRenameRowInsteadOfRenderingBareDash:637 ## 🤖 ThrillhouseBot PR Summary
...
### Changed Files
| File | Change | Summary |
|------|--------|---------|
| `src/Moved.java` | Renamed | - |
| `src/Edited.java` | Renamed | - |
```

Red/green proof, cap agreement (`MAX_FILE_SUMMARIES` forced back to 15):

```
[ERROR] PrReviewPromptsContentTest.bothPromptsAskForAsManyFileSummariesAsTheWalkthroughRenders:673->assertContains:40 the review prompt's file_summaries cap must be the walkthrough row bound (#536) — missing marker: "cap the array at 15 entries" ==> expected: <true> but was: <false>
[ERROR] PrSummaryGeneratorTest.changesOverviewUsesAuthoritativeTotalsWhenReviewableCountsDiverge:714 expected: <true> but was: <false>
```

Gates:

- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` → `Tests run: 2607, Failures: 0, Errors: 0, Skipped: 0`
- jacoco ∩ `git diff -U0 abd76e5...HEAD` over changed main code → 69 changed executable lines, zero uncovered lines and zero uncovered branches

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The remaining prompt-side risk is that the model still under-fills the array on very wide PRs; the rollup row (`…and N more file(s)`) already covers what the table cannot show.
