### PR TITLE
refactor(review): rebalance the three dimensions the review under-reports

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -51,9 +51,42 @@ public final class PrReviewPrompts {
                diff is as much a finding as a code vulnerability — do not pass over it because it is
                declarative rather than executable.
             3. REGRESSIONS: Does this change break or remove existing behavior? Compare with base commit context.
-            4. COMMENT CONSISTENCY: Comments that contradict code. Outdated comments. Missing comments where logic is complex.
-               Excessive/obvious comments (e.g., "i++ // increment i"). TODO/FIXME without resolution.
-            5. CODE QUALITY: Maintainability, naming, DRY, error handling, performance.
+            4. COMMENT CONTRADICTS CODE: a comment that states something the code it documents does
+               NOT do is a defect, not a style note, and it is demonstrable from the diff alone —
+               both halves are right there. Report it when the comment asserts a fact the adjacent
+               code contradicts: a default, bound, unit, ordering, return value, thrown exception,
+               or condition that does not match; a comment left describing the behavior this very
+               change replaced; a doc line naming a parameter, field or method the code no longer
+               has. Quote the comment line and the code line that disagrees with it and name the
+               specific disagreement. Risk "medium" when a maintainer who trusted the comment would
+               get the behavior wrong (which is the usual case for a stale comment on changed code),
+               "low" when the contradiction is inert. Do not pass over a stale comment because the
+               code beside it is correct — the false statement IS the defect, and it outlives the
+               reviewer who could have caught it. Separately and far more weakly: missing comments
+               where logic is complex, excessive/obvious comments (e.g. "i++ // increment i"), and
+               TODO/FIXME without resolution are style observations — raise them only when the
+               project instructions ask for that level of detail.
+            5. CODE QUALITY AND ALGORITHMIC COMPLEXITY: maintainability, naming, DRY, error
+               handling — and, as a claim class of its own, the cost of code the diff ADDS. The
+               shapes below are quadratic (or worse) in an input the diff does not bound, and the SHAPE
+               ITSELF, visible in the diff, is the evidence; you do NOT also have to demonstrate
+               that the input is large:
+               (a) a linear membership or lookup test inside a loop — contains / indexOf / includes
+                   / a find / a nested scan — where both the loop and the scanned collection are
+                   sized by the same input. Building a result list and scanning it to skip
+                   duplicates is the canonical case: it is O(n^2), and a set or map makes it O(n).
+               (b) a nested loop pair over the same or another input-sized collection.
+               (c) work re-done per iteration that does not vary with the iteration: re-sorting,
+                   re-compiling a regex, re-reading a file, or issuing one query per element (an
+                   N+1) where one batched call would do.
+               (d) a linear-time operation applied once per element — string concatenation building
+                   a result in a loop, insertion at the head of an array, an O(n) copy per append.
+               Report these at risk "medium", or "high" when the collection is request- or
+               user-sized AND the path is a hot one, and name the concrete better structure in the
+               description (a set for the membership test, one pass instead of two, hoisting the
+               invariant out of the loop). NOT a finding when the diff itself shows the bound is
+               fixed and small — iteration over a literal, an enum's values, a constant-size array —
+               or when a comment justifies the choice.
             6. PAGINATION / TRUNCATION: When the diff adds or changes a call that lists a paginated
                collection — a GitHub REST endpoint (e.g. .../comments, .../reviews, .../files,
                .../issues) or a GraphQL connection (a first:/nodes field) — and its result is then
@@ -94,7 +127,15 @@ public final class PrReviewPrompts {
                or "medium" (the green test looks like proof but the stub is unfaithful). Do not
                invent the real method's body when it is not in the provided material — omit the
                finding or phrase a verification request only when the mock's impossibility is
-               already demonstrable from what is shown. A green test whose mocks contradict the
+               already demonstrable from what is shown. The SIGNATURE alone is enough when the
+               signature is what the stub violates: a stub returning null where the return type or
+               a nullability annotation forbids it, one throwing a checked exception the method
+               does not declare, one returning a value the declared type or documented range
+               excludes. "The body is not shown" does not excuse those. Report a demonstrated
+               contradiction at risk "medium" — the suite is green and the production path is
+               nonetheless untested, which is precisely the failure nobody notices — and note that
+               the mandated low/medium CONFIDENCE describes how firmly you may word the claim, not
+               whether the finding is worth emitting. A green test whose mocks contradict the
                real collaborator is not evidence the production path works.
             9. PRODUCER → CONSUMER CONTRACT: hunks are judged locally, so a change can be correct
                line by line and still wrong end to end. Once per PR, for the change's PRIMARY new
@@ -160,9 +201,13 @@ public final class PrReviewPrompts {
               says it hardens RBAC but widens it, that adds a securityContext but leaves a container
               privileged). "Will fail at runtime" is not the only path to this level; "will fail at
               apply/validation time, shown in the diff" counts equally.
-            - "medium": a real correctness or maintainability concern. Performance findings need
-              evidence of scale in the diff (unbounded data, hot paths) — a one-time task over a
-              handful of rows is not a finding.
+            - "medium": a real correctness or maintainability concern — the level the claim classes
+              defined by dimensions 4, 5 and 8 land on by default once their own evidence
+              requirement is met. Performance findings do need evidence of scale, and an added
+              quadratic shape over a collection the diff does not bound IS that evidence
+              (dimension 5): the nested scan is the demonstration, and waiting to be shown the
+              collection is large is how a real O(n^2) goes unreported. What is not a finding is a
+              one-time task over a bound the diff itself shows to be fixed and small.
             - "low": rarely worth reporting — prefer omitting it unless the project instructions
               ask for that level of detail, or it is a config-key documentation gap under
               dimension 10. Cosmetic phrasing nitpicks (documentation-vs-code
@@ -171,7 +216,22 @@ public final class PrReviewPrompts {
               a real finding, not a nitpick, and belongs at its impact-based severity above. So is
               a config-key documentation gap under dimension 10: an omitted type, separator, unit,
               allowed value or default is a correctness gap for whoever sets the key, not a
-              phrasing nitpick. Prose style, tone and ordering remain nitpicks.
+              phrasing nitpick. So is a comment that states behavior the code does not have
+              (dimension 4): that is a false statement, not a wording preference.
+              Prose style, tone and ordering remain nitpicks.
+
+            Severity is not confidence, and neither one is a reason to stay silent:
+            - Emit a finding whose defect you can demonstrate from the provided material even when
+              the confidence rules cap it at "medium" or "low". Those rules govern how you WORD the
+              claim — verification request rather than settled fact — not whether the finding
+              exists. "Omit rather than guess" applies when you are unsure the issue is REAL; it
+              does not apply when the defect is demonstrable and only its impact is uncertain.
+            - Three claim classes are under-reported for exactly that reason, because each reads at
+              first glance like a nitpick: a comment contradicting the code (dimension 4), an added
+              quadratic shape (dimension 5), and a stub that contradicts the real collaborator
+              (dimension 8). Each is demonstrable by quoting two lines from the provided material.
+              When you have those two lines, report it — do not trade it away against the
+              low-severity omission guidance above.
 
             Confidence calibration:
             - confidence "high" means another reviewer could confirm the issue using only the
@@ -272,6 +332,19 @@ public final class PrReviewPrompts {
               visible, or you cannot name that case, the finding is invalid. Raise it for the
               structure the change is about, not for every local variable that crosses a hunk
               boundary.
+            - A comment-contradiction claim (dimension 4) must quote the comment and the code line
+              it contradicts, both verbatim from the provided material, and state what the comment
+              asserts that the code does not do. A comment that is merely terse, incomplete,
+              differently worded, or about a neighbouring concern is not a contradiction, and
+              neither is one whose subject is not visible in the provided material.
+            - An algorithmic-complexity claim (dimension 5) must quote both levels from the diff —
+              the outer loop and the inner scan, nested loop, or per-element linear operation — and
+              name the ONE input whose size drives both; say "O(n^2)" only when the same n drives
+              both levels, and otherwise state the cost in words rather than guessing a class. If
+              the diff shows either level bounded by a literal, an enum, a constant, or a small
+              fixed collection, the finding is invalid. A single pass, or a lookup that is already
+              hashed (a set/map membership test), is not quadratic — check which it is before
+              claiming it.
             - A config-key documentation-completeness claim (dimension 10) must quote the
               documented line from the diff AND the definition line — from the diff or from the
               config-key definitions section — that establishes the omitted fact, and name which
@@ -659,13 +732,17 @@ public final class PrReviewPrompts {
               internally and never propagates to its caller, or returns a value the real
               signature/contract disallows.
             - Anchor at the mock/stub line, quote it, and name the contradicting real-method
-              line in the description. Use confidence "low" or "medium" and leave
-              suggestion_old/suggestion_new empty unless the faithful stub (or the production
-              fix) is obvious from the provided material.
+              line in the description. Use risk "medium" for a demonstrated contradiction, with
+              confidence "low" or "medium" — the confidence governs the wording, not whether to
+              emit — and leave suggestion_old/suggestion_new empty unless the faithful stub (or
+              the production fix) is obvious from the provided material.
             - When the real method's body is not in the provided material, do not invent it:
               omit a mock-fidelity finding, or phrase a verification request only if the
               impossibility is already demonstrable from what is shown. Broader cross-file
-              retrieval of collaborator sources is out of scope for this check alone.
+              retrieval of collaborator sources is out of scope for this check alone. The
+              declared SIGNATURE counts as shown material: a stub that returns null against a
+              non-null contract, throws a checked exception the method does not declare, or
+              returns a value the declared type excludes is contradicted by the signature alone.
             - A faithful stub that matches the real contract is not a finding."""
           .stripIndent();
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -26,8 +26,10 @@ import org.junit.jupiter.api.Test;
  * must demonstrably hit the claimed path before it can invalidate a finding — #116), the symmetric
  * exact-arithmetic / "test fails" cap (#97), the heuristic failure-mode characterization pass with
  * its verifier exemption (#123), the producer→consumer data-flow contract dimension (#117), the
- * config-key documentation-completeness claim class and its narrowing guards (#109), and the
- * summary call's whole-change-set grounding (#335). These assertions are intentionally coarse —
+ * config-key documentation-completeness claim class and its narrowing guards (#109), the summary
+ * call's whole-change-set grounding (#335), and the rebalancing of the three dimensions a
+ * controlled four-language corpus measured as under-reported — comment-contradicts-code, added
+ * algorithmic complexity, and mock fidelity (#537). These assertions are intentionally coarse —
  * they check intent survives, not exact wording; an intentional rewording should update the
  * matching anchor.
  *
@@ -666,6 +668,125 @@ class PrReviewPromptsContentTest {
         req,
         "not evidence in the other direction",
         "absence from the list must never be read as proof a line is covered");
+  }
+
+  @Test
+  void commentContradictionIsAClaimClassRatherThanAStyleNote() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "4. COMMENT CONTRADICTS CODE",
+        "dimension 4 must lead with the contradiction claim class, not the comment-style list");
+    assertContains(
+        sys,
+        "is a defect, not a style note",
+        "a comment contradicting the code must not read as a style observation (#537)");
+    assertContains(
+        sys,
+        "the false statement IS the defect",
+        "a stale comment beside correct code must still be reportable (#537)");
+    assertContains(
+        sys,
+        "are style observations — raise them only when",
+        "missing/obvious comments and TODOs must stay the weak half of dimension 4 (#537)");
+    // The nitpick exclusion must not swallow the claim class it sits next to.
+    assertContains(
+        sys,
+        "that is a false statement, not a wording preference",
+        "the phrasing-nitpick exclusion must carve out dimension 4 (#537)");
+  }
+
+  @Test
+  void addedQuadraticComplexityIsReportableFromTheShapeAlone() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "ALGORITHMIC COMPLEXITY",
+        "dimension 5 must name algorithmic complexity as its own claim class (#537)");
+    assertContains(
+        sys,
+        "ITSELF, visible in the diff, is the evidence; you do NOT also have to demonstrate",
+        "the nested shape itself must count as the evidence of scale (#537)");
+    assertContains(
+        sys,
+        "you do NOT also have to demonstrate",
+        "a complexity finding must not wait to be shown the collection is large (#537)");
+    assertContains(
+        sys,
+        "duplicates is the canonical case: it is O(n^2), and a set or map makes it O(n)",
+        "the O(n^2) dedupe the corpus planted must be named outright (#537)");
+    // The severity rule is the other half of the brake and has to agree.
+    assertContains(
+        sys,
+        "quadratic shape over a collection the diff does not bound IS that evidence",
+        "the medium-severity rule must stop demanding separate evidence of scale (#537)");
+    assertContains(
+        sys,
+        "NOT a finding when the diff itself shows the bound is",
+        "a fixed small bound must still exclude the finding — precision is unchanged (#537)");
+  }
+
+  @Test
+  void mockFidelityIsReportableFromTheSignatureAndLandsAtMedium() {
+    assertContains(
+        PrReviewPrompts.SYSTEM,
+        "The SIGNATURE alone is enough when the",
+        "a stub contradicting the declared signature must be reportable (#537)");
+    assertContains(
+        PrReviewPrompts.SYSTEM,
+        "contradiction at risk \"medium\" — the suite is green",
+        "a demonstrated mock contradiction must land at medium, not low (#537)");
+    assertContains(
+        PrReviewPrompts.MOCK_FIDELITY_REQUEST,
+        "the confidence governs the wording, not whether to",
+        "the injected mock-fidelity block must agree with dimension 8 (#537)");
+    assertContains(
+        PrReviewPrompts.MOCK_FIDELITY_REQUEST,
+        "declared SIGNATURE counts as shown material",
+        "the injected block must accept the signature as evidence (#537)");
+  }
+
+  @Test
+  void confidenceCapsGovernWordingRatherThanWhetherToReport() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "Severity is not confidence, and neither one is a reason to stay silent",
+        "the omission guidance must stop absorbing demonstrable low-confidence findings (#537)");
+    assertContains(
+        sys,
+        "\"Omit rather than guess\" applies when you are unsure the issue is REAL",
+        "the omit rule must be scoped to doubt about the defect, not about its impact (#537)");
+    assertContains(
+        sys,
+        "When you have those two lines, report it",
+        "the three under-reported classes must be named with their evidence bar (#537)");
+  }
+
+  @Test
+  void rebalancedDimensionsKeepTheirOwnEvidenceRequirements() {
+    String sys = PrReviewPrompts.SYSTEM;
+    // Precision came in at zero false positives; each widened class carries its own self-check.
+    assertContains(
+        sys,
+        "A comment-contradiction claim (dimension 4) must quote the comment and the code line",
+        "a comment-contradiction claim must quote both halves (#537)");
+    assertContains(
+        sys,
+        "or about a neighbouring concern is not a contradiction",
+        "a terse or unshown comment must not become a contradiction claim (#537)");
+    assertContains(
+        sys,
+        "An algorithmic-complexity claim (dimension 5) must quote both levels from the diff",
+        "a complexity claim must quote the outer loop and the inner scan (#537)");
+    assertContains(
+        sys,
+        "name the ONE input whose size drives both",
+        "a complexity claim must trace one n through both levels (#537)");
+    assertContains(
+        sys,
+        "the finding is invalid. A single pass, or a lookup that is already",
+        "a bounded level, or an already-hashed lookup, must invalidate the claim (#537)");
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor

## Description

Prompt-calibration only. The controlled four-language corpus in #537 measured perfect precision (zero of the planted decoys flagged, five unplanted real defects found) alongside three dimensions the review under-reports: performance/O(n²) at 0/4, mock fidelity at 1/4, comment-contradicts-code at 1/4. `/improve` on the same Go diff found the O(n²) dedupe the review missed, so the gap is what the review prompt says, not what the model can see.

Three brakes were doing it, and each is removed at the point where it fires — without touching a single self-check or confidence rule.

**Dimension 4 was a list, not a claim class.** "Comments that contradict code. Outdated comments. Missing comments where logic is complex. Excessive/obvious comments…" put a false statement about behavior in the same breath as `i++ // increment i`, and the whole line then read as style, which the low-severity guidance ("rarely worth reporting — prefer omitting it") absorbs. It is now `COMMENT CONTRADICTS CODE`: a defined claim class with its evidence (quote the comment, quote the code line that disagrees, name the disagreement), a medium default when a maintainer trusting the comment would get the behavior wrong, and an explicit instruction not to pass over a stale comment because the code beside it is correct. The genuinely weak items — missing comments, obvious comments, TODOs — stay, demoted to style observations. The phrasing-nitpick exclusion, which reads on "documentation-vs-code wording", now carves dimension 4 out explicitly.

**The performance brake was in the severity rule.** `"medium": … Performance findings need evidence of scale in the diff (unbounded data, hot paths)` asks for something a diff hunk almost never contains, so an added quadratic shape was structurally unreportable. Dimension 5 becomes `CODE QUALITY AND ALGORITHMIC COMPLEXITY` and enumerates the four shapes (linear membership test inside a loop; nested loop pair; loop-invariant work re-done per iteration / N+1; a linear operation applied per element), states that the shape itself is the evidence and that demonstrating the input is large is not additionally required, and names the corpus's exact case — building a list and scanning it to skip duplicates — outright. The medium bullet now says the quadratic shape IS the evidence of scale. The exclusion survives inverted: not a finding when the diff itself shows the bound is fixed and small.

**Dimension 8 conflated confidence with worth.** It mandates confidence "low"/"medium" and requires the real method's body in the provided material; a low-confidence finding then met "prefer omitting it" and lost. It now says a demonstrated contradiction is risk **medium**, that the mandated low/medium confidence governs how firmly the claim is worded rather than whether it is emitted, and that the declared signature is sufficient evidence when the signature is what the stub violates (null against a non-null contract, a checked exception the method does not declare, a value the declared type excludes). The injected `MOCK_FIDELITY_REQUEST` block was updated to match, so the two cannot drift.

**And the shared root**, stated once for all three: severity is not confidence, and neither is a reason to stay silent. "Omit rather than guess" is scoped to doubt about whether the defect is REAL — it does not apply when the defect is demonstrable and only its impact is uncertain.

### Precision is unchanged

Nothing in the self-check block, the confidence calibration, or the existing claim-class guards was weakened or removed — the diff only adds. Both widened classes arrive carrying their own self-check, in the same shape as the dimension 9 and 10 guards that already keep those honest:

- a comment-contradiction claim must quote the comment and the contradicting code line verbatim and state what the comment asserts that the code does not do; terse, incomplete, differently-worded, or not-visible comments are explicitly not contradictions;
- a complexity claim must quote **both** levels and name the one input whose size drives both, may say "O(n²)" only when the same n drives both, and is invalid when either level is bounded by a literal, enum, or constant — with a reminder that a single pass or an already-hashed lookup is not quadratic.

## Related Issues

Fixes #537

Stacked on #544 (issue #536); both touch `PrReviewPrompts.java`. Review/merge #544 first.

## How Has This Been Tested?

- [x] Unit tests

Prompt-text changes are exempt from red/green proof; there is no behavior-bearing code change in this PR (the diff is prompt string constants plus their pinning tests). Five new `PrReviewPromptsContentTest` cases anchor each half of the rebalance — the claim-class headers, the shape-is-the-evidence statement, the medium-severity defaults, the confidence-is-not-omission rule, and both new self-checks — so a future edit cannot silently revert them.

Gates:

- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` → `Tests run: 2612, Failures: 0, Errors: 0, Skipped: 0`
- jacoco ∩ `git diff -U0 6cad7ee...HEAD` over changed main code → zero changed executable lines (the text blocks are compile-time constants and emit no bytecode), so zero uncovered lines and zero uncovered branches

### Recommended follow-up

The issue asks for a re-run of the same corpus against the new matrix. That needs the corpus regenerated and live model calls, so it is not part of this PR; the caveat in the issue still stands too — the original numbers were taken with the verification stage not executing, so the re-measurement should confirm verification is running first.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
