### PR TITLE
fix(review): say why a walkthrough row has no summary

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -686,6 +686,16 @@ public class FindingPipeline {
    * single finding is serialized. The overview gets at most half of what remains after the
    * templates and inherited sections (which fit every batch call by construction), leaving the
    * other half for the findings JSON; dropped rows are rolled up by count.
+   *
+   * <p>The clamp keeps a prefix, so what it drops is the tail — a row the walkthrough renders could
+   * in principle be one the summary prompt never saw, leaving it ungrounded (#547). Measured
+   * against the largest PR on record (devops-thiago/ThrillhouseBot#532, 170 changed files) at the
+   * shipped defaults, that gap does not open: the per-call budget is {@code 48000 * 0.9 - 8192 =
+   * 35008} tokens and the summary prompt's fixed sections cost ~1208, so the overview's half share
+   * is ~16900 — while all 170 rows cost 5188, under a third of it. Nothing is clamped, and the
+   * walkthrough renders at most {@link PrReviewPrompts#MAX_FILE_SUMMARIES} rows, so every rendered
+   * row is grounded with a wide margin. Pinned by {@code
+   * FindingPipelineTest#aPr532SizedOverviewKeepsFarMoreRowsThanTheWalkthroughRenders}.
    */
   private String clampOverview(String overview, AiReviewService.PromptInputs promptInputs) {
     var budget = budgetPlanner.perCallInputBudget();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -81,6 +81,15 @@ public class PrSummaryGenerator {
   static final String PURE_RENAME_SUMMARY = "Pure rename — content unchanged";
 
   /**
+   * Summary cell for a reviewed row the model returned no per-file note for. The bare "-" it
+   * replaces was indistinguishable from a rendering bug: it stated nothing about why the cell was
+   * empty, on exactly the rows a large PR leaves unsummarized (#547). Says the reason instead, for
+   * the same reason {@link #PURE_RENAME_SUMMARY} does — the two cover the whole unsummarized set,
+   * one row per cause.
+   */
+  static final String NO_MODEL_SUMMARY = "Not summarized — no model summary for this file";
+
+  /**
    * One changed file in the walkthrough: its path, the diff's authoritative change type, and
    * whether it is a pure rename — renamed with no content change, hence never sent to the model and
    * never carrying a model summary.
@@ -435,14 +444,16 @@ public class PrSummaryGenerator {
   }
 
   /**
-   * The walkthrough's Summary cell. The model's note wins whenever it supplied one; otherwise a
-   * pure rename says why it has none, and every other unsummarized row keeps the bare dash.
+   * The walkthrough's Summary cell. The model's note wins whenever it supplied one; otherwise the
+   * row states why it has none — a pure rename was never sent to the model, and any other row
+   * simply got no note back. No cell is ever left as a bare dash, which said nothing about which of
+   * the two it was (#547).
    */
   private static String summaryCell(ChangedFile file, String summary) {
     if (!summary.isBlank()) {
       return MarkdownSafe.tableCell(summary.strip());
     }
-    return file.pureRename() ? PURE_RENAME_SUMMARY : "-";
+    return file.pureRename() ? PURE_RENAME_SUMMARY : NO_MODEL_SUMMARY;
   }
 
   /** Indexes the model's per-file notes by path; a duplicate path keeps the first note. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -983,6 +983,53 @@ class FindingPipelineTest {
         captor.getValue().changedFiles());
   }
 
+  /**
+   * #547 — the clamp keeps a prefix and drops the tail, so a walkthrough row could in principle be
+   * one the summary prompt never saw. Pins that it is not: at the shipped budget defaults, a PR the
+   * size of devops-thiago/ThrillhouseBot#532 (170 changed files) is not clamped at all, so every
+   * one of the {@link PrSummaryGenerator#MAX_FILE_ROWS} rows the walkthrough renders is grounded.
+   * The bound guarded here is the render bound, not the file count: shrinking the overview's share
+   * below it would reopen the ungrounded-row gap #536 set out to close.
+   */
+  @Test
+  void aPr532SizedOverviewKeepsFarMoreRowsThanTheWalkthroughRenders() {
+    var session = ReviewSession.create("owner/repo", 1, "Release/v0.6.0", "sha");
+    var files = new ArrayList<FileDiff>();
+    for (var i = 0; i < 170; i++) {
+      files.add(
+          new FileDiff(
+              String.format(
+                  "src/main/java/dev/thiagogonzaga/thrillhousebot/review/Component%03d.java", i),
+              "modified",
+              123,
+              45,
+              168,
+              ""));
+    }
+    var ctx = reviewContext(List.of(), files, null);
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    // The shipped defaults: max-input-tokens 48000 * token-safety-margin 0.9 - output buffer 8192.
+    when(budgetPlanner.perCallInputBudget()).thenReturn((int) (48_000 * 0.9) - 8_192);
+    when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
+    when(aiReviewService.summarize(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+
+    var overview = captor.getValue().changedFiles();
+    assertFalse(overview.contains("more changed files"), overview);
+    var rows = 0;
+    for (var line : overview.split("\n")) {
+      if (line.contains(" (modified, +123 -45)")) {
+        rows++;
+      }
+    }
+    assertEquals(files.size(), rows, overview);
+    assertTrue(rows >= PrSummaryGenerator.MAX_FILE_ROWS, "rendered rows must all be grounded");
+  }
+
   @Test
   void overviewIsWithheldWhenTheInheritedSectionsExhaustTheBudget() {
     var session = ReviewSession.create("owner/repo", 1, "Huge PR", "sha");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -607,8 +607,13 @@ class PrSummaryGeneratorTest {
     assertTrue(summary.contains("| `src/B.java` | Added | New cache wrapper |"));
   }
 
+  /**
+   * #547 — a row the model returned no note for used to render a bare "-", which reads as a
+   * rendering bug rather than the honest "nothing came back for this file". It states the reason
+   * now, exactly as the pure-rename row does.
+   */
   @Test
-  void shouldRenderDashWhenFileHasNoMatchingSummary() {
+  void shouldExplainTheMissingSummaryWhenFileHasNoMatchingSummary() {
     var changedFiles = List.of(new PrSummaryGenerator.ChangedFile("src/A.java", "modified"));
     var aiSummary = summaryWithFiles(new ReviewResponse.FileSummary("src/Other.java", "unrelated"));
     var result =
@@ -617,7 +622,38 @@ class PrSummaryGeneratorTest {
 
     var summary = generator.generate(1, 1, 0, changedFiles, aiSummary, result);
 
-    assertTrue(summary.contains("| `src/A.java` | Modified | - |"));
+    assertTrue(
+        summary.contains(
+            "| `src/A.java` | Modified | " + PrSummaryGenerator.NO_MODEL_SUMMARY + " |"),
+        summary);
+    assertFalse(summary.contains("| `src/A.java` | Modified | - |"), summary);
+  }
+
+  /**
+   * #547 — the walkthrough is rendered from the diff, not from the model's reply, so a summary call
+   * that returned no summary object at all still produces rows. Every one of them must say why it
+   * is empty rather than rendering a wall of dashes.
+   */
+  @Test
+  void shouldExplainEveryRowWhenNoSummaryObjectCameBackAtAll() {
+    var changedFiles =
+        List.of(
+            new PrSummaryGenerator.ChangedFile("src/A.java", "modified"),
+            new PrSummaryGenerator.ChangedFile("src/B.java", "added"));
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
+
+    var summary = generator.generate(2, 1, 0, changedFiles, null, result);
+
+    assertTrue(
+        summary.contains(
+            "| `src/A.java` | Modified | " + PrSummaryGenerator.NO_MODEL_SUMMARY + " |"),
+        summary);
+    assertTrue(
+        summary.contains("| `src/B.java` | Added | " + PrSummaryGenerator.NO_MODEL_SUMMARY + " |"),
+        summary);
+    assertFalse(summary.contains(" | - |"), summary);
   }
 
   @Test
@@ -638,8 +674,12 @@ class PrSummaryGeneratorTest {
         summary.contains(
             "| `src/Moved.java` | Renamed | " + PrSummaryGenerator.PURE_RENAME_SUMMARY + " |"),
         summary);
-    // A rename that also changed content WAS reviewed, so an absent summary stays a bare dash.
-    assertTrue(summary.contains("| `src/Edited.java` | Renamed | - |"), summary);
+    // A rename that also changed content WAS reviewed, so its absent summary carries the other
+    // reason — the model simply returned no note — not the pure-rename one (#547).
+    assertTrue(
+        summary.contains(
+            "| `src/Edited.java` | Renamed | " + PrSummaryGenerator.NO_MODEL_SUMMARY + " |"),
+        summary);
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

#547 asks whether the per-file rows past `clampOverview` leave the walkthrough ungrounded on a
very large PR, and asks to measure before fixing. Measured first.

### The measurement

Harness: the real `FindingPipeline.run` seam with the real `TokenCounter` (cl100k_base) and the
real `PrReviewPrompts.SUMMARY_*` templates, fed the actual changed-file list of
devops-thiago/ThrillhouseBot#532 pulled from the API (GitHub reports **170** changed files for it,
not the 100 the issue estimated — 100 is one API page). The overview it produced was captured off
the `summarize` call and its per-file rows counted.

| quantity | value |
|---|---|
| `perCallInputBudget` at shipped defaults (`48000 * 0.9 - 8192`) | **35008** tokens |
| `SUMMARY_SYSTEM + SUMMARY_USER` | 1208 tokens |
| overview's half share, i.e. `(35008 - 1208) / 2` | **~16900** tokens |
| cost of the full 170-row overview | **5188** tokens (31% of the share) |
| per-file rows surviving the clamp | **170 of 170** — nothing dropped |
| rows the walkthrough renders (`MAX_FILE_SUMMARIES`) | **20** |

The clamp is not close to binding. Repeating the run with a 2000- and an 8000-token PR context
still leaves all 170 rows. Sweeping `perCallInputBudget` downward, the clamp starts dropping rows
only below **~11650**, and only below **~2600** does it admit fewer than the 20 rows the
walkthrough renders — a `max-input-tokens` under ~12k, where the review call itself would already
be degenerate.

The ordering also lines up, which is what makes the margin meaningful: `clampOverview` keeps a
*prefix* of `ctx.reviewableFiles()`, and `VerdictBuilder.overviewFiles` builds the walkthrough as
`reviewableFiles ++ pureRenames` — so the first 20 rendered rows are exactly the first 20 rows the
prompt saw. (The pure renames appended after them never needed a model summary anyway.)

### So: no fix for the budget

Per the issue's own instruction, the gap does not exist at any usable configuration, so this PR
does not invent a reservation for it. Instead:

- a regression test pins the relationship at the shipped defaults — a #532-sized overview is not
  clamped at all, and in particular keeps at least `PrSummaryGenerator.MAX_FILE_ROWS` rows;
- `clampOverview`'s javadoc records the measurement, so a future narrowing of the overview's share
  is weighed against the render bound rather than against nothing.

### What was real: the row wording

The other half of the issue stands on its own. A walkthrough row the model returned no note for
rendered a bare `-`, which states nothing about *why* the cell is empty and reads as a rendering
bug — the same complaint #536 fixed for pure renames. It now says the reason:

    | `src/A.java` | Modified | Not summarized — no model summary for this file |

`PURE_RENAME_SUMMARY` still wins for a pure rename (it has the more specific reason), and a model
note still wins over both. Between them the two strings cover the whole unsummarized set, so no
walkthrough cell is ever a bare dash again — including on the counts-only degradation lanes, where
no summary object comes back at all and every row used to be a dash.

## Related Issues

Fixes #547

Follow-up to #536 / #544. #544 merged into `release/v0.6.0` while this was being prepared, so this
branch is based on `release/v0.6.0` directly and targets it — no re-targeting needed.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**Red proof.** With the tests in place and `summaryCell` still returning `"-"`:

```
[ERROR] Tests run: 56, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 0.089 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.PrSummaryGeneratorTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.PrSummaryGeneratorTest.shouldExplainPureRenameRowInsteadOfRenderingBareDash -- Time elapsed: 0.006 s <<< FAILURE!
 ==> expected: <true> but was: <false>
[ERROR] dev.thiagogonzaga.thrillhousebot.review.PrSummaryGeneratorTest.shouldExplainTheMissingSummaryWhenFileHasNoMatchingSummary -- Time elapsed: 0 s <<< FAILURE!
 ==> expected: <true> but was: <false>
[ERROR] dev.thiagogonzaga.thrillhousebot.review.PrSummaryGeneratorTest.shouldExplainEveryRowWhenNoSummaryObjectCameBackAtAll -- Time elapsed: 0.001 s <<< FAILURE!
 ==> expected: <true> but was: <false>
```

with the rendered table in the failure message showing exactly the reported symptom:

```
### Changed Files
| File | Change | Summary |
|------|--------|---------|
| `src/A.java` | Modified | - |
```

The pinning test `aPr532SizedOverviewKeepsFarMoreRowsThanTheWalkthroughRenders` is a
characterization test by design and is green on unchanged production code — it exists to fail if
the overview's budget share is ever narrowed below the render bound.

**Gates.**

- `./mvnw -B spotless:apply` — clean
- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, `BUILD SUCCESS`
- `./mvnw -B clean test` — `Tests run: 2624, Failures: 0, Errors: 0, Skipped: 0`
- jacoco ∩ `git diff -U0 e6e6c1d...HEAD` on changed main code — 1 executable changed line, **0
  uncovered lines and 0 uncovered branches**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Raw harness output (`MEASURE` lines emitted by the temporary measurement run, since deleted):

```
=== MEASURE: PR532 file count = 170
=== MEASURE: perCallInputBudget = 35008
=== MEASURE: SUMMARY_SYSTEM+SUMMARY_USER tokens = 1208
--- overviewBudget = 16900 tokens; full overview costs 5188 tokens
=== MEASURE: prContext≈0 tokens -> per-file rows in prompt = 170
--- overviewBudget = 15899 tokens; full overview costs 5188 tokens
=== MEASURE: prContext≈2001 tokens -> per-file rows in prompt = 170
--- overviewBudget = 12899 tokens; full overview costs 5188 tokens
=== MEASURE: prContext≈8001 tokens -> per-file rows in prompt = 170
=== MEASURE: smallest budget admitting ALL 170 rows ≈ 11650
=== MEASURE: smallest budget admitting >= 20 rows ≈ 2600
```

## Additional Notes

Scope held to `FindingPipeline` (the `clampOverview` javadoc only), `PrSummaryGenerator` row
rendering, and their tests. `FollowUpAnalyzer`, `MaintainerReplyService` and `ReviewResult`'s
unresolved-message text are untouched.
