### PR TITLE
fix(review): skip a null filename instead of failing the plan

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -387,17 +387,17 @@ public class DiffBudgetPlanner {
       // header with no ```diff``` body — there is nothing for the model to read — so packing it
       // would count the file as fully reviewed and let an unbacked "resolved" claim through.
       // Omit it by name like an unclippable file: never packed, holds APPROVE, disclosed.
-      rendered.unclippable().add(file.filename());
+      recordName(rendered.unclippable(), file.filename());
       return;
     }
     var tokens = tokenCounter.estimateTokens(section);
     if (tokens > diffBudgetTokens) {
       var clipped = clipToBudget(section, diffBudgetTokens);
       if (clipped == null) {
-        rendered.unclippable().add(file.filename());
+        recordName(rendered.unclippable(), file.filename());
         return;
       }
-      rendered.clipped().add(file.filename());
+      recordName(rendered.clipped(), file.filename());
       section = clipped;
       tokens = tokenCounter.estimateTokens(clipped);
     }
@@ -409,6 +409,18 @@ public class DiffBudgetPlanner {
    * text diff too large to display). It survives {@link ReviewDiffFormatter#isPureRename} (which
    * needs a zero change count) yet has no diff to review, so it must be omitted, not packed.
    */
+  /**
+   * Records a coverage-gap filename, skipping a null one. {@code FileDiff.filename()} is not
+   * validated at construction, and a null name reaching the plan's name lists makes the {@code
+   * List.copyOf} in the {@link BudgetPlan} constructor throw — failing the whole review at plan
+   * time for a file the disclosure could not have named anyway.
+   */
+  private static void recordName(List<String> names, String filename) {
+    if (filename != null) {
+      names.add(filename);
+    }
+  }
+
   private static boolean isPatchlessWithChanges(GitHubPullRequestClient.FileDiff file) {
     var patch = file.patch();
     return (patch == null || patch.isBlank()) && file.additions() + file.deletions() > 0;

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -614,4 +614,18 @@ class DiffBudgetPlannerTest {
     assertEquals(List.of("src/App.java"), coveredFilenames(plan));
     assertTrue(plan.omittedFiles().isEmpty(), "pure rename must not appear as budget omission");
   }
+
+  @Test
+  void aPatchlessFileWithNoNameIsSkippedInsteadOfFailingThePlan() {
+    // GitHub returns a null/blank patch for binaries and oversized text diffs, and FileDiff does
+    // not validate its filename. A null name reaching the plan's omitted list makes List.copyOf in
+    // the BudgetPlan constructor throw, failing the whole review at plan time — for a file the
+    // disclosure could not have named anyway.
+    var files = Arrays.asList(new FileDiff(null, "modified", 7, 0, 7, ""));
+
+    var plan = planner.plan(files, 10000, 3);
+
+    assertTrue(plan.omittedFiles().isEmpty(), plan.omittedFiles().toString());
+    assertTrue(plan.clippedFiles().isEmpty(), plan.clippedFiles().toString());
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`DiffBudgetPlanner` recorded coverage-gap filenames without a null check. A patchless file — GitHub sends no patch for binaries and for text diffs too large to display — whose `filename()` is null pushed null into the plan's omitted list, and `List.copyOf` in the `BudgetPlan` constructor threw, failing the entire review at plan time for a file the disclosure could not have named anyway.

The three recording sites now go through a small helper that skips a null name, matching the null tolerance the rest of the pipeline already applies (`FindingPipeline.namesContain`, `recordUncoveredFiles`' null filter, the walkthrough row filter).

Found by the bot's own review of the release PR (#532), raised as a medium-confidence MEDIUM with the correct line, the correct mechanism and a correct suggested fix.

## Related Issues

Fixes #550

## How Has This Been Tested?

- [x] Unit tests

Red, against `e6e6c1d` with the new test in place:

```
java.lang.NullPointerException
	at dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlanner$BudgetPlan.<init>(DiffBudgetPlanner.java:100)
	at dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlanner.pack(DiffBudgetPlanner.java:457)
	at dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlanner.plan(DiffBudgetPlanner.java:338)
```

The existing suite missed this because the #471 tests construct `BudgetPlan` directly rather than going through `planner.plan`, and every patchless-omission test uses named files. The new test drives the real `planner.plan` with the #471 fixture shape.

Green with the fix; full suite `Tests run: 2623, Failures: 0, Errors: 0`. SpotBugs `BugInstance size is 0`, spotless clean. Coverage ∩ diff: zero uncovered lines and branches.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Whether GitHub can actually return a null filename is not the point of the fix: the codebase already decided null names are possible and guards them in three other places, so leaving this path unguarded is an inconsistency that costs an entire review when it fires.