### PR TITLE
fix(review): let a maintainer clear a thread-less finding from the PR conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ guide, configuration reference, architecture, comparison, and the hosted
 - Inline code suggestions on review comments that you can apply with one click
 - Every finding is tagged `critical`, `high`, `medium`, or `low`
 - Follow-up reviews track whether earlier findings were addressed or justified
+- Every finding can be closed by a maintainer: reply on its review thread, or — for one raised below the inline-posting bar, which has no thread — comment `@thrillhousebot resolved <path>:<line> — <title>` on the PR
 - Maintainer 👍/👎 (and "not useful" replies) on finding comments are recorded for a future learnings pipeline — see [Finding feedback](https://devops-thiago.github.io/ThrillhouseBot/feedback/)
 - Conversational replies: `@thrillhousebot` it in a PR thread or finding reply and the bot answers in context
 - A summary comment on the first run, with a risk breakdown and a changed-files walkthrough
@@ -96,11 +97,20 @@ not a reaction.
 | `/resolve` | Resolve ThrillhouseBot's outstanding finding threads on the PR | write |
 | `/pause` | Silence the bot on the PR | write |
 | `/resume` | Re-enable the bot on a paused PR | write |
+| `@thrillhousebot resolved <path>:<line> — <title>` | Close a previous finding that has no review thread to reply on, so it stops holding approval — see [Clearing a finding with no thread](#clearing-a-finding-with-no-thread) | write |
 
 **Access** — every command except `/help` requires the commenter to hold write access to
 the repository (or to be named in
 `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS`), since reviews spend the operator's
 AI budget.
+
+**`@thrillhousebot resolved`** — a directive, not a slash command: it has no `/resolved`
+form, and it is read by the *next* review rather than acted on immediately (the bot replies
+with a short acknowledgement when it sees one). Do not confuse it with `/resolve`, which
+resolves GitHub review threads and does nothing to a finding that never opened one. Its
+access check is the commenter's GitHub `author_association` on that comment — `OWNER`,
+`MEMBER` or `COLLABORATOR` — and `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` does
+*not* extend it.
 
 **Pause** — while a PR is paused, ThrillhouseBot skips automatic reviews on new commits,
 ignores `/review`, `/summary`, `/describe`, `/changelog`, `/add-docs`, `/improve` and
@@ -371,6 +381,50 @@ of being recorded justified. It is deliberately conservative:
   unresolved previous finding; it never invents a new blocking finding.
 
 Set it to `false` to make a maintainer's reply final, unconditionally.
+
+### Clearing a finding with no thread
+
+Replying on a finding's review thread is the usual way to close it — but a
+**LOW**-confidence finding at **MEDIUM** or **LOW** risk never opens one. It is
+listed under **Things to double-check** in the summary instead, so there is no
+thread to reply on, while follow-up reviews keep reporting it unresolved and
+holding approval (`APPROVE` → `COMMENT`). To close one, comment on the PR
+conversation:
+
+```
+@thrillhousebot resolved src/main/java/com/example/Widget.java:42 — Missing null check
+```
+
+Closing a finding wrongly is worse than leaving it open, so the match is strict
+and **when the naming is ambiguous the finding stays held**. All of the
+following must hold:
+
+- **The comment carries `@thrillhousebot resolved`.** `resolve` (the thread
+  command) is not it, and a mention alone is not it — an ordinary question about
+  a finding is engagement, not a decision.
+- **You name the finding by *both* its `path:line` locator and its own content**
+  — its title, or its description when it has no title. Each **Things to
+  double-check** row already prints both, the title first and then the locator in
+  backticks, so copying the row is the reliable way to get them right. Naming only
+  one of the two clears nothing. Locators match whole, so `Widget.java:42` never
+  closes a different finding at `Widget.java:4`.
+- **You hold write access.** The comment's GitHub `author_association` must be
+  `OWNER`, `MEMBER` or `COLLABORATOR`; a fork-PR author's or a drive-by
+  commenter's comment is ignored. The bot's own comments are ignored too — its
+  summary reproduces every finding verbatim.
+- **Quoted text does not count.** Blockquote lines and fenced code blocks are
+  stripped before matching, so GitHub's *Quote reply* on the summary — which
+  reproduces every double-check row — clears nothing, and neither does a quoted
+  directive. Write the directive and the finding you mean in your own prose.
+  Inline code is kept, so the backticked `` `path:line` `` from the summary row
+  still matches.
+
+One comment may name several findings; each is matched independently, and one it
+does not name stays open. A finding with neither a title nor a description can
+never be named this way, so it stays held — fix it, or reply on its thread if it
+has one. The clearing is applied by the next review, which records the finding
+**resolved**; the bot posts a short acknowledgement when it sees the directive so
+you know it was read.
 
 ### Blocking strictness
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ not a reaction.
 | `/resolve` | Resolve ThrillhouseBot's outstanding finding threads on the PR | write |
 | `/pause` | Silence the bot on the PR | write |
 | `/resume` | Re-enable the bot on a paused PR | write |
-| `@thrillhousebot resolved <path>:<line> — <title>` | Close a previous finding that has no review thread to reply on, so it stops holding approval — see [Clearing a finding with no thread](#clearing-a-finding-with-no-thread) | write |
+| `@thrillhousebot resolved <path>:<line> — <title>` | Close a previous finding that has no review thread to reply on, so it stops holding approval (see **Clearing a finding with no thread** under Configuration) | write |
 
 **Access** — every command except `/help` requires the commenter to hold write access to
 the repository (or to be named in

--- a/README.md
+++ b/README.md
@@ -395,6 +395,10 @@ conversation:
 @thrillhousebot resolved src/main/java/com/example/Widget.java:42 — Missing null check
 ```
 
+Write it as plain text in the comment — pasted back inside a code fence or
+backticks it reads as documentation and does nothing (see the quoting rule
+below).
+
 Closing a finding wrongly is worse than leaving it open, so the match is strict
 and **when the naming is ambiguous the finding stays held**. All of the
 following must hold:
@@ -412,12 +416,16 @@ following must hold:
   `OWNER`, `MEMBER` or `COLLABORATOR`; a fork-PR author's or a drive-by
   commenter's comment is ignored. The bot's own comments are ignored too — its
   summary reproduces every finding verbatim.
-- **Quoted text does not count.** Blockquote lines and fenced code blocks are
-  stripped before matching, so GitHub's *Quote reply* on the summary — which
-  reproduces every double-check row — clears nothing, and neither does a quoted
-  directive. Write the directive and the finding you mean in your own prose.
-  Inline code is kept, so the backticked `` `path:line` `` from the summary row
-  still matches.
+- **You *use* the directive rather than quote it.** `@thrillhousebot resolved`
+  counts as an instruction only when those words are plain text. Marking them up
+  — as `` `@thrillhousebot resolved` ``, inside a fenced block, or on a `>`
+  quoted line — reads as documentation, so a comment that *explains* the feature
+  (the fenced example above, or a colleague pasting one) clears nothing. The
+  **locator and title may still be in backticks**, which is how the summary
+  prints them; only the directive words themselves may not be.
+- **Quoted blocks do not count at all.** Blockquote lines and fenced code are
+  dropped before anything is matched, so GitHub's *Quote reply* on the summary —
+  which reproduces every double-check row — names no finding either.
 
 One comment may name several findings; each is matched independently, and one it
 does not name stays open. A finding with neither a title nor a description can
@@ -425,6 +433,16 @@ never be named this way, so it stays held — fix it, or reply on its thread if 
 has one. The clearing is applied by the next review, which records the finding
 **resolved**; the bot posts a short acknowledgement when it sees the directive so
 you know it was read.
+
+**Conversation read ceiling.** A review reads the PR conversation in pages of
+100, up to 10 pages — 1000 comments — so one review can never turn a runaway
+thread into hundreds of API calls. GitHub serves these comments oldest first and
+offers no reverse order on that endpoint, so on a PR past the ceiling the
+**newest** comments are the ones left unread, and a directive among them will not
+clear anything that round. The bot logs a warning naming the ceiling whenever it
+is reached, so this shows up as a log line rather than as the feature quietly
+doing nothing; push a commit to re-review, or reply on the finding's thread if it
+has one.
 
 ### Blocking strictness
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
@@ -111,11 +111,31 @@ public interface GitHubCommentClient {
   /**
    * A PR conversation comment: the id (to edit the bot's own summary in place), plus the body and
    * author needed to spot it.
+   *
+   * <p>{@code authorAssociation} is GitHub's per-comment statement of the author's relationship to
+   * the repository ({@code OWNER}/{@code MEMBER}/{@code COLLABORATOR}/{@code CONTRIBUTOR}/{@code
+   * NONE}/…), carried for the same reason {@link GitHubReviewClient.PullRequestComment} carries it:
+   * the follow-up analyzer only lets a write-capable maintainer's conversation comment clear an
+   * approve hold, never a drive-by commenter's.
    */
-  record IssueComment(long id, String body, GitHubReviewClient.ReviewResponse.User user) {
+  record IssueComment(
+      long id,
+      String body,
+      GitHubReviewClient.ReviewResponse.User user,
+      @JsonProperty("author_association") String authorAssociation) {
+
+    /**
+     * Back-compat convenience for callers/tests that carry no author association. Defaults it to
+     * {@code null}, which the analyzer treats as not write-capable — the safe direction, since a
+     * comment with an unknown association must not clear a hold.
+     */
+    public IssueComment(long id, String body, GitHubReviewClient.ReviewResponse.User user) {
+      this(id, body, user, null);
+    }
+
     /** Convenience constructor for callers that never edit the comment. */
     public IssueComment(String body, GitHubReviewClient.ReviewResponse.User user) {
-      this(0, body, user);
+      this(0, body, user, null);
     }
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -747,28 +747,54 @@ public class FollowUpAnalyzer {
   /** Markdown blockquote lines — what GitHub's "Quote reply" produces. */
   private static final Pattern BLOCKQUOTE_LINE = Pattern.compile("(?m)^[ \\t]*>.*$");
 
+  /**
+   * Inline code spans, dropped only when looking for the directive token itself. The delimiter is
+   * {@code `+} rather than a single backtick so the double-backtick form documentation uses to show
+   * a span that itself contains a backtick is recognized too.
+   */
+  private static final Pattern INLINE_CODE = Pattern.compile("`+[^`\\n]*`+");
+
   /** Note recorded on a finding a maintainer cleared from the PR conversation. */
   static final String CONVERSATION_CLEARED_NOTE =
       "Cleared by a maintainer's @thrillhousebot resolved comment on the PR conversation.";
 
   /**
-   * Whether {@code body} is a maintainer's clearing directive — an {@code @thrillhousebot resolved}
-   * instruction written outside quoted context. Shared with {@link MaintainerReplyService} so the
-   * conversational-reply path recognizes exactly the text this analyzer acts on.
+   * Whether {@code body} <em>uses</em> the clearing directive, as opposed to quoting it. Shared
+   * with {@link MaintainerReplyService} so the conversational-reply path recognizes exactly the
+   * text this analyzer acts on.
+   *
+   * <p>The token is looked for in {@link #directiveText}: outside blockquotes, code fences <em>and
+   * inline code</em>. Explaining the feature to a colleague — "comment {@code `@thrillhousebot
+   * resolved src/A.java:10 — the title`}" — is documentation, not a decision, and a rule that fired
+   * on it would let the project's own docs close findings. Marking up the directive is the
+   * universal way to show rather than issue a command, so it is the line drawn here.
    */
   static boolean isClearDirective(String body) {
-    return body != null && CLEAR_DIRECTIVE.matcher(unquoted(body)).find();
+    return body != null && CLEAR_DIRECTIVE.matcher(directiveText(body)).find();
   }
 
   /**
-   * The comment body with quoted context removed: fenced code blocks and blockquote lines. Dropping
-   * blockquotes is what keeps GitHub's "Quote reply" from clearing findings — quoting the summary's
-   * "Things to double-check" list reproduces every row verbatim, and matching inside it would clear
-   * findings the maintainer never named. Inline code is deliberately <em>kept</em>: the summary
-   * prints each finding's locator as {@code `path:line`}, so a pasted row must stay matchable.
+   * The comment body with quoted <em>blocks</em> removed: fenced code and blockquote lines.
+   * Dropping blockquotes is what keeps GitHub's "Quote reply" from clearing findings — quoting the
+   * summary's "Things to double-check" list reproduces every row verbatim, and matching inside it
+   * would clear findings the maintainer never named.
+   *
+   * <p>Inline code is deliberately <em>kept</em> here: the summary prints each finding's locator as
+   * {@code `path:line`}, so a maintainer who copies the row must still be naming the finding. This
+   * is the text the locator and content are matched against, never the directive token.
    */
-  private static String unquoted(String body) {
+  private static String namingText(String body) {
     return BLOCKQUOTE_LINE.matcher(FENCED_CODE.matcher(body).replaceAll(" ")).replaceAll(" ");
+  }
+
+  /**
+   * The text the directive token must appear in: {@link #namingText} with inline code spans dropped
+   * too. Using the directive and quoting it are different acts, and only the first may clear a
+   * finding; keeping the two texts separate is what lets a comment carry a backticked locator (how
+   * the summary prints it) while a backticked <em>token</em> reads as documentation.
+   */
+  private static String directiveText(String body) {
+    return INLINE_CODE.matcher(namingText(body)).replaceAll(" ");
   }
 
   /**
@@ -787,9 +813,10 @@ public class FollowUpAnalyzer {
    *   <li>its author may hold write access ({@link #mayHoldWriteAccess}) — the same association
    *       prefilter the review-thread hatch applies, so a drive-by commenter on a public repo
    *       cannot clear a hold;
-   *   <li>it carries the {@link #CLEAR_DIRECTIVE} outside quoted context — an ordinary comment that
-   *       merely discusses a finding is engagement, not a decision, and the whole PR conversation
-   *       is one space rather than the finding's own thread;
+   *   <li>it <em>uses</em> the {@link #CLEAR_DIRECTIVE} rather than quoting it ({@link
+   *       #isClearDirective}: outside blockquotes, fences and inline code) — an ordinary comment
+   *       that merely discusses a finding is engagement, not a decision, and a comment that shows
+   *       the directive marked up is documentation, not an instruction;
    *   <li>it names <em>this</em> finding by BOTH its printed locator ({@code path:line}) and its
    *       own content (its title, or its description when it has no title) — the same
    *       content-anchoring the marked-thread hatch uses. A finding with neither title nor
@@ -817,10 +844,13 @@ public class FollowUpAnalyzer {
       if (!isMaintainerConversationComment(comment, botIdentity)) {
         continue;
       }
-      String body = unquoted(comment.body());
-      if (CLEAR_DIRECTIVE.matcher(body).find()
-          && namesLocator(body, locator)
-          && body.contains(anchor)) {
+      if (!isClearDirective(comment.body())) {
+        continue;
+      }
+      // The naming may sit in backticks (the shape the summary prints); only the directive token
+      // may not — see isClearDirective.
+      String body = namingText(comment.body());
+      if (namesLocator(body, locator) && body.contains(anchor)) {
         Log.infof(
             "Clearing previous finding '%s' (%s) — a maintainer named it in an"
                 + " @thrillhousebot resolved comment on the PR conversation",

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
@@ -35,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /** Analyzes follow-up reviews by comparing new findings against prior reviews. */
@@ -728,6 +730,189 @@ public class FollowUpAnalyzer {
         && WRITE_CAPABLE_ASSOCIATIONS.contains(authorAssociation.strip().toUpperCase(Locale.ROOT));
   }
 
+  /**
+   * The directive a maintainer writes in a PR conversation comment to clear findings the review
+   * threads cannot reach. Mirrors the {@code @thrillhousebot <word>} mention form every other
+   * command uses, but deliberately spells the word {@code resolved} rather than {@code resolve}, so
+   * it is not the existing {@code /resolve} command (which resolves GitHub review threads) under a
+   * second name — {@code TriggerDetector}'s {@code resolve} pattern ends in a word boundary and
+   * therefore does not fire on {@code resolved}.
+   */
+  private static final Pattern CLEAR_DIRECTIVE =
+      Pattern.compile("@thrillhousebot\\s+resolved\\b", Pattern.CASE_INSENSITIVE);
+
+  /** Fenced code blocks, dropped before a conversation comment is read as a directive. */
+  private static final Pattern FENCED_CODE = Pattern.compile("(?s)```.*?```|~~~.*?~~~");
+
+  /** Markdown blockquote lines — what GitHub's "Quote reply" produces. */
+  private static final Pattern BLOCKQUOTE_LINE = Pattern.compile("(?m)^[ \\t]*>.*$");
+
+  /** Note recorded on a finding a maintainer cleared from the PR conversation. */
+  static final String CONVERSATION_CLEARED_NOTE =
+      "Cleared by a maintainer's @thrillhousebot resolved comment on the PR conversation.";
+
+  /**
+   * Whether {@code body} is a maintainer's clearing directive — an {@code @thrillhousebot resolved}
+   * instruction written outside quoted context. Shared with {@link MaintainerReplyService} so the
+   * conversational-reply path recognizes exactly the text this analyzer acts on.
+   */
+  static boolean isClearDirective(String body) {
+    return body != null && CLEAR_DIRECTIVE.matcher(unquoted(body)).find();
+  }
+
+  /**
+   * The comment body with quoted context removed: fenced code blocks and blockquote lines. Dropping
+   * blockquotes is what keeps GitHub's "Quote reply" from clearing findings — quoting the summary's
+   * "Things to double-check" list reproduces every row verbatim, and matching inside it would clear
+   * findings the maintainer never named. Inline code is deliberately <em>kept</em>: the summary
+   * prints each finding's locator as {@code `path:line`}, so a pasted row must stay matchable.
+   */
+  private static String unquoted(String body) {
+    return BLOCKQUOTE_LINE.matcher(FENCED_CODE.matcher(body).replaceAll(" ")).replaceAll(" ");
+  }
+
+  /**
+   * Whether a maintainer cleared this finding from the PR conversation — the escape hatch for a
+   * finding that has no review thread to reply on, because {@link Finding#postsInline} routed it to
+   * the summary's "Things to double-check" instead of the diff (#548). Without it a low-confidence
+   * finding held by the backstop could never be closed by any maintainer action: the reply hatch
+   * (#133/#142) needs a thread, and there is none.
+   *
+   * <p>Over-clearing is the dangerous direction, so every leg below must hold and any one missing
+   * leaves the finding held:
+   *
+   * <ul>
+   *   <li>the comment is a human's, not the bot's — the bot's own summary lists every finding
+   *       verbatim, so reading it back would clear the whole round;
+   *   <li>its author may hold write access ({@link #mayHoldWriteAccess}) — the same association
+   *       prefilter the review-thread hatch applies, so a drive-by commenter on a public repo
+   *       cannot clear a hold;
+   *   <li>it carries the {@link #CLEAR_DIRECTIVE} outside quoted context — an ordinary comment that
+   *       merely discusses a finding is engagement, not a decision, and the whole PR conversation
+   *       is one space rather than the finding's own thread;
+   *   <li>it names <em>this</em> finding by BOTH its printed locator ({@code path:line}) and its
+   *       own content (its title, or its description when it has no title) — the same
+   *       content-anchoring the marked-thread hatch uses. A finding with neither title nor
+   *       description matches nothing and stays held.
+   * </ul>
+   *
+   * <p>Marker reuse cannot leak a clear across rounds: no {@code thrillhousebot:finding=N} marker
+   * is read here at all, so a pasted marker names nothing. The locator is the finding's own
+   * persisted {@code file}:{@code line} — the pair the summary printed for that round — so a
+   * same-titled finding at another location is not named by it either.
+   */
+  private static boolean clearedInConversation(
+      ReviewResponse.Finding finding,
+      List<GitHubCommentClient.IssueComment> conversationComments,
+      BotIdentity botIdentity) {
+    if (conversationComments == null || conversationComments.isEmpty() || finding.file() == null) {
+      return false;
+    }
+    String anchor = ownContentAnchor(finding);
+    if (anchor == null) {
+      return false;
+    }
+    String locator = finding.file() + ":" + finding.line();
+    for (var comment : conversationComments) {
+      if (!isMaintainerConversationComment(comment, botIdentity)) {
+        continue;
+      }
+      String body = unquoted(comment.body());
+      if (CLEAR_DIRECTIVE.matcher(body).find()
+          && namesLocator(body, locator)
+          && body.contains(anchor)) {
+        Log.infof(
+            "Clearing previous finding '%s' (%s) — a maintainer named it in an"
+                + " @thrillhousebot resolved comment on the PR conversation",
+            finding.title(), locator);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Whether {@code body} names {@code path:line} as a whole locator. A bare {@code contains} would
+   * let a comment about {@code src/A.java:10} clear the distinct finding at {@code src/A.java:1},
+   * whose locator is a prefix of it — an over-clear, and the direction that must never happen — so
+   * a match followed by another digit is skipped and the scan continues.
+   */
+  private static boolean namesLocator(String body, String locator) {
+    for (var at = body.indexOf(locator); at >= 0; at = body.indexOf(locator, at + 1)) {
+      var after = at + locator.length();
+      if (after >= body.length() || !Character.isDigit(body.charAt(after))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** A non-bot conversation comment with a body and a write-capable author association. */
+  private static boolean isMaintainerConversationComment(
+      GitHubCommentClient.IssueComment comment, BotIdentity botIdentity) {
+    return comment != null
+        && comment.body() != null
+        && comment.user() != null
+        && !botIdentity.matches(comment.user().login())
+        && mayHoldWriteAccess(comment.authorAssociation());
+  }
+
+  /**
+   * The text that identifies a finding in prose: its title, or its description when it has no
+   * usable title (the same fallback {@link #bodyCarriesOwnContent} uses, for the same reason — the
+   * bot renders a null title as the literal {@code "null"}, which names nothing). {@code null} when
+   * the finding carries neither, so it can never be cleared by content it does not have.
+   */
+  private static String ownContentAnchor(ReviewResponse.Finding finding) {
+    String title = finding.title();
+    if (title != null && !title.isBlank()) {
+      return title;
+    }
+    String description = finding.description();
+    return description == null || description.isBlank() ? null : description;
+  }
+
+  /**
+   * Rewrites a model-reported {@code unresolved} to {@code resolved} when a maintainer cleared that
+   * finding from the PR conversation ({@link #clearedInConversation}). The model never sees the
+   * conversation, so without this pass a finding the maintainer explicitly closed keeps being
+   * reported unresolved and keeps holding APPROVE — the same dead end the backstop had (#548).
+   *
+   * <p>Only {@code unresolved} entries are touched: a {@code justified}/{@code resolved}/{@code
+   * superseded} verdict is already an accounting, and an id outside the prior round names no
+   * finding to check.
+   */
+  public List<ReviewResponse.PreviousFindingStatus> clearNamedInConversation(
+      List<ReviewResponse.Finding> previous,
+      List<ReviewResponse.PreviousFindingStatus> statuses,
+      List<GitHubCommentClient.IssueComment> conversationComments,
+      BotIdentity botIdentity) {
+    if (statuses == null || statuses.isEmpty()) {
+      return statuses == null ? List.of() : statuses;
+    }
+    if (previous == null
+        || previous.isEmpty()
+        || conversationComments == null
+        || conversationComments.isEmpty()) {
+      return statuses;
+    }
+    var rewritten = new ArrayList<ReviewResponse.PreviousFindingStatus>(statuses.size());
+    for (var status : statuses) {
+      var id = status.id();
+      if (STATUS_UNRESOLVED.equalsIgnoreCase(status.status())
+          && id >= 1
+          && id <= previous.size()
+          && clearedInConversation(previous.get(id - 1), conversationComments, botIdentity)) {
+        rewritten.add(
+            new ReviewResponse.PreviousFindingStatus(
+                id, STATUS_RESOLVED, CONVERSATION_CLEARED_NOTE));
+      } else {
+        rewritten.add(status);
+      }
+    }
+    return rewritten;
+  }
+
   /** Maps each previous finding's prompt id to its bot root comment, for thread resolution. */
   public Map<Integer, Long> matchFindingThreads(
       String previousAiResponseJson,
@@ -1096,7 +1281,9 @@ public class FollowUpAnalyzer {
    * <p>It is downgrade-only — these statuses reach the APPROVE gate but never {@code outstanding},
    * so they can turn APPROVE into COMMENT, never into REQUEST_CHANGES. A maintainer reply on the
    * thread clears the hold (the human is engaged; defer to them, matching {@link
-   * #dropRepliedDuplicates}), as does the model marking the finding resolved/justified.
+   * #dropRepliedDuplicates}), as does the model marking the finding resolved/justified, as does an
+   * {@code @thrillhousebot resolved} comment naming the finding on the PR conversation — the hatch
+   * for a finding that has no thread to reply on ({@link #clearedInConversation}).
    *
    * @param priorAiResponseJsons every completed prior round's persisted AI response, newest first
    *     (as {@link
@@ -1149,13 +1336,39 @@ public class FollowUpAnalyzer {
       DiffLineResolver lineResolver,
       BotIdentity botIdentity,
       Map<String, String> renameTargets) {
+    return unreportedUnresolvedStatusesFromParsed(
+        priorAiResponses,
+        currentStatuses,
+        inlineComments,
+        List.of(),
+        lineResolver,
+        botIdentity,
+        renameTargets);
+  }
+
+  /**
+   * Conversation-aware variant used by the review verdict path. A finding that never posted inline
+   * ({@link Finding#postsInline}) has no thread for the reply hatch to reach, so its only
+   * maintainer-driven escape is an {@code @thrillhousebot resolved} comment on the PR conversation
+   * ({@link #clearedInConversation}); without it the backstop holds such a finding every round with
+   * no action able to clear it (#548).
+   */
+  public List<ReviewResult.PreviousFindingStatus> unreportedUnresolvedStatusesFromParsed(
+      List<ReviewResponse> priorAiResponses,
+      List<ReviewResponse.PreviousFindingStatus> currentStatuses,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      List<GitHubCommentClient.IssueComment> conversationComments,
+      DiffLineResolver lineResolver,
+      BotIdentity botIdentity,
+      Map<String, String> renameTargets) {
     if (priorAiResponses == null || priorAiResponses.isEmpty() || lineResolver == null) {
       return List.of();
     }
     var chrono = toChronological(priorAiResponses);
     var open = openFindingsAcrossRounds(chrono, currentStatuses);
     var clusters = clusterByIdentity(open);
-    return heldFromClusters(clusters, inlineComments, lineResolver, botIdentity, renameTargets);
+    return heldFromClusters(
+        clusters, inlineComments, conversationComments, lineResolver, botIdentity, renameTargets);
   }
 
   /**
@@ -1223,13 +1436,20 @@ public class FollowUpAnalyzer {
   private List<ReviewResult.PreviousFindingStatus> heldFromClusters(
       List<List<OpenFinding>> clusters,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
+      List<GitHubCommentClient.IssueComment> conversationComments,
       DiffLineResolver lineResolver,
       BotIdentity botIdentity,
       Map<String, String> renameTargets) {
     var held = new ArrayList<ReviewResult.PreviousFindingStatus>();
     for (var cluster : clusters) {
       OpenFinding target =
-          holdableTarget(cluster, inlineComments, lineResolver, botIdentity, renameTargets);
+          holdableTarget(
+              cluster,
+              inlineComments,
+              conversationComments,
+              lineResolver,
+              botIdentity,
+              renameTargets);
       if (target != null) {
         held.add(
             new ReviewResult.PreviousFindingStatus(
@@ -1242,11 +1462,12 @@ public class FollowUpAnalyzer {
   }
 
   /**
-   * The first still-present member of the cluster to hold, or {@code null} when its code is gone or
-   * a maintainer has replied on it. The reply is located by the round-relative marker ({@link
-   * OpenFinding#id()}) plus the finding's own content rather than by title, so a null-title
-   * finding's thread is still seen and a thread-less finding cannot bind to a different finding
-   * that reused the same marker index in another round.
+   * The first still-present member of the cluster to hold, or {@code null} when its code is gone, a
+   * maintainer has replied on its thread, or a maintainer cleared it from the PR conversation
+   * ({@link #clearedInConversation} — the only hatch a finding with no thread has, #548). The reply
+   * is located by the round-relative marker ({@link OpenFinding#id()}) plus the finding's own
+   * content rather than by title, so a null-title finding's thread is still seen and a thread-less
+   * finding cannot bind to a different finding that reused the same marker index in another round.
    *
    * <p>Presence is resolved through {@code renameTargets} the same way {@link #hasVanished} does:
    * the finding's flagged code lives at its rename target, not its pre-rename path, when the file
@@ -1255,21 +1476,23 @@ public class FollowUpAnalyzer {
   private OpenFinding holdableTarget(
       List<OpenFinding> cluster,
       List<GitHubReviewClient.PullRequestComment> inlineComments,
+      List<GitHubCommentClient.IssueComment> conversationComments,
       DiffLineResolver lineResolver,
       BotIdentity botIdentity,
       Map<String, String> renameTargets) {
     OpenFinding target = null;
-    boolean anyReplied = false;
+    boolean answered = false;
     for (var member : cluster) {
       var finding = member.finding();
       if (target == null && isStillPresent(finding, lineResolver, renameTargets)) {
         target = member;
       }
-      if (answeredRootComment(finding, member.id(), inlineComments, botIdentity) != null) {
-        anyReplied = true;
+      if (answeredRootComment(finding, member.id(), inlineComments, botIdentity) != null
+          || clearedInConversation(finding, conversationComments, botIdentity)) {
+        answered = true;
       }
     }
-    return anyReplied ? null : target;
+    return answered ? null : target;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
@@ -190,7 +190,31 @@ public class MaintainerReplyService {
         task.rootCommentId(), task.owner(), task.repo(), task.prNumber());
   }
 
+  /**
+   * Acknowledgement posted for an {@code @thrillhousebot resolved} comment. Deliberately
+   * deterministic prose rather than an assistant answer: the directive is an instruction the review
+   * path acts on, not a question, and a generated reply could contradict or overstate what it does.
+   * The wording is conditional because the clearing decision is made by the next review, which
+   * matches each named finding against its own {@code path:line} and title (#548).
+   */
+  static final String CLEAR_DIRECTIVE_ACK =
+      "Noted. Every previous finding your comment names by its `path:line` and title is treated as"
+          + " cleared from the next review onward; any it does not name stays open.";
+
   private void handleMention(String auth, ReplyTask task) {
+    if (FollowUpAnalyzer.isClearDirective(task.question())) {
+      commentClient.createComment(
+          auth,
+          ACCEPT,
+          task.owner(),
+          task.repo(),
+          task.prNumber(),
+          new GitHubCommentClient.CreateCommentRequest(CLEAR_DIRECTIVE_ACK));
+      Log.infof(
+          "Acknowledged a maintainer clear directive on %s/%s #%d",
+          task.owner(), task.repo(), task.prNumber());
+      return;
+    }
     var diff = fetchDiff(auth, task);
     String reply =
         generateReply(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
@@ -302,9 +302,12 @@ public class ReviewContextLoader {
             : List.of();
     // The PR conversation carries the only escape hatch a thread-less finding has: an
     // "@thrillhousebot resolved" comment naming it (#548). Fetched on the same gate as the inline
-    // comments — a first review has no prior finding to clear, so it never pays for the call.
+    // comments — a first review has no prior finding to clear, so it never pays for the call — and
+    // paginated, with the read ceiling disclosed rather than silently truncating the conversation.
     List<GitHubCommentClient.IssueComment> conversationComments =
-        hasContext ? fetchIssueComments(auth, req.owner(), req.repo(), req.prNumber()) : List.of();
+        hasContext
+            ? fetchConversationComments(auth, req.owner(), req.repo(), req.prNumber())
+            : List.of();
     List<ReviewResponse.Finding> previousFindingsSource =
         FollowUpAnalyzer.effectivePreviousFindings(priorAiResponses);
     // The review-body fallback is for sessions carrying no readable AI response at all. Once any
@@ -610,6 +613,54 @@ public class ReviewContextLoader {
       Log.debug("Could not fetch PR issue comments (continuing as if none exist)", e);
       return List.of();
     }
+  }
+
+  /**
+   * Hard ceiling on how much of a PR conversation one review reads: {@link
+   * GitHubCommentClient#MAX_COMMENT_PAGES} pages of {@link GitHubCommentClient#COMMENTS_PER_PAGE}.
+   * The walk is deliberately bounded rather than unbounded — a runaway thread must not turn one
+   * review into hundreds of API calls — so the bound is named here, disclosed in the log, and
+   * documented in the README next to the directive it limits.
+   */
+  static final int MAX_CONVERSATION_COMMENTS =
+      GitHubCommentClient.COMMENTS_PER_PAGE * GitHubCommentClient.MAX_COMMENT_PAGES;
+
+  /**
+   * Whether a conversation walk stopped at {@link #MAX_CONVERSATION_COMMENTS} rather than at the
+   * end of the thread. GitHub serves issue comments oldest first and offers no reverse order on
+   * this endpoint, so a capped walk keeps the <em>oldest</em> window and drops the newest — exactly
+   * where a freshly written clear directive lives. Reaching the ceiling therefore has to be said
+   * out loud instead of silently reading a partial conversation.
+   */
+  static boolean conversationWalkCapped(List<GitHubCommentClient.IssueComment> comments) {
+    return comments.size() >= MAX_CONVERSATION_COMMENTS;
+  }
+
+  /**
+   * The PR conversation the clear-directive scan reads (#548), oldest first. Same paginated fetch
+   * as everywhere else, plus the ceiling disclosure: past it the newest comments are unread, so a
+   * directive among them cannot clear a finding and the operator is told why rather than watching
+   * the feature quietly do nothing.
+   *
+   * <p>{@link #botSummaryCommentExists} deliberately keeps the plain fetch: the summary is posted
+   * on the first round, so it lives in the oldest window a capped walk retains.
+   */
+  List<GitHubCommentClient.IssueComment> fetchConversationComments(
+      String auth, String owner, String repo, int prNumber) {
+    var comments = fetchIssueComments(auth, owner, repo, prNumber);
+    if (conversationWalkCapped(comments)) {
+      Log.warnf(
+          "PR conversation on %s/%s #%d hit the %d-comment read ceiling (%d pages of %d): comments"
+              + " newer than that were not read, so an \"@thrillhousebot resolved\" directive among"
+              + " them cannot clear a finding this round",
+          owner,
+          repo,
+          prNumber,
+          MAX_CONVERSATION_COMMENTS,
+          GitHubCommentClient.MAX_COMMENT_PAGES,
+          GitHubCommentClient.COMMENTS_PER_PAGE);
+    }
+    return comments;
   }
 
   List<GitHubReviewClient.PullRequestComment> fetchPullRequestComments(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoader.java
@@ -133,7 +133,8 @@ public class ReviewContextLoader {
       String patchCoverage,
       List<GitHubPullRequestClient.FileDiff> reviewableFiles,
       Supplier<DiffLineResolver> lineResolverSupplier,
-      PrTotals prTotals) {
+      PrTotals prTotals,
+      List<GitHubCommentClient.IssueComment> conversationComments) {
     public ReviewContext {
       files = List.copyOf(files);
       priorReviews = List.copyOf(priorReviews);
@@ -142,6 +143,62 @@ public class ReviewContextLoader {
       inlineComments = List.copyOf(inlineComments);
       repoLabels = List.copyOf(repoLabels);
       reviewableFiles = List.copyOf(reviewableFiles);
+      conversationComments = List.copyOf(conversationComments);
+    }
+
+    /**
+     * Back-compat constructor for callers that carry no PR conversation comments. Defaults them to
+     * empty, which reads as "no maintainer cleared anything from the conversation" — the safe
+     * direction, since a missing list must never clear a hold.
+     */
+    @SuppressWarnings("java:S107")
+    public ReviewContext(
+        List<GitHubPullRequestClient.FileDiff> files,
+        String diff,
+        String baseComparison,
+        int omittedFiles,
+        List<GitHubReviewClient.ReviewResponse> priorReviews,
+        List<String> priorAiResponseJsons,
+        List<ReviewResponse> priorAiResponses,
+        boolean isFirstVisibleReview,
+        boolean hasContext,
+        String previousAiResponseJson,
+        List<GitHubReviewClient.PullRequestComment> inlineComments,
+        String previousFindings,
+        InstructionsResolver.ResolvedInstructions instructions,
+        PathScopedInstructions pathInstructions,
+        List<GitHubLabelClient.Label> repoLabels,
+        String projectStack,
+        String linkedIssuesContext,
+        String configKeyContext,
+        String patchCoverage,
+        List<GitHubPullRequestClient.FileDiff> reviewableFiles,
+        Supplier<DiffLineResolver> lineResolverSupplier,
+        PrTotals prTotals) {
+      this(
+          files,
+          diff,
+          baseComparison,
+          omittedFiles,
+          priorReviews,
+          priorAiResponseJsons,
+          priorAiResponses,
+          isFirstVisibleReview,
+          hasContext,
+          previousAiResponseJson,
+          inlineComments,
+          previousFindings,
+          instructions,
+          pathInstructions,
+          repoLabels,
+          projectStack,
+          linkedIssuesContext,
+          configKeyContext,
+          patchCoverage,
+          reviewableFiles,
+          lineResolverSupplier,
+          prTotals,
+          List.of());
     }
 
     /**
@@ -243,6 +300,11 @@ public class ReviewContextLoader {
         hasContext
             ? fetchPullRequestComments(auth, req.owner(), req.repo(), req.prNumber())
             : List.of();
+    // The PR conversation carries the only escape hatch a thread-less finding has: an
+    // "@thrillhousebot resolved" comment naming it (#548). Fetched on the same gate as the inline
+    // comments — a first review has no prior finding to clear, so it never pays for the call.
+    List<GitHubCommentClient.IssueComment> conversationComments =
+        hasContext ? fetchIssueComments(auth, req.owner(), req.repo(), req.prNumber()) : List.of();
     List<ReviewResponse.Finding> previousFindingsSource =
         FollowUpAnalyzer.effectivePreviousFindings(priorAiResponses);
     // The review-body fallback is for sessions carrying no readable AI response at all. Once any
@@ -301,7 +363,8 @@ public class ReviewContextLoader {
         patchCoverage,
         reviewableFiles,
         lineResolverSupplier,
-        prTotals);
+        prTotals,
+        conversationComments);
   }
 
   /** Thread-safe memoizing supplier — the resolver is built at most once per review context. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -242,8 +242,12 @@ public record ReviewResult(
     return previousStatuses.stream().filter(s -> "resolved".equalsIgnoreCase(s.status())).count();
   }
 
-  // A backstop-held finding may have no inline thread (its line was outside the diff when raised),
-  // hence the "where one exists" qualifier.
+  /**
+   * The "previous findings are still open" status line, which must state every way a maintainer can
+   * close one. A finding raised below the inline-posting bar has no review thread at all, so
+   * pointing only at threads left it uncloseable by any action (#548); the message now names the PR
+   * conversation directive that reaches it, instead of admitting the gap with a parenthetical.
+   */
   public static String unresolvedPreviousMessage(long unresolved) {
     return UNRESOLVED_PREVIOUS_PREFIX + unresolved + UNRESOLVED_PREVIOUS_SUFFIX;
   }
@@ -251,8 +255,10 @@ public record ReviewResult(
   private static final String UNRESOLVED_PREVIOUS_PREFIX = "No new issues in this revision, but ";
 
   private static final String UNRESOLVED_PREVIOUS_SUFFIX =
-      " previous finding(s) remain unresolved — fix them, or reply on their review thread (where"
-          + " one exists) with why they are deferred.";
+      " previous finding(s) remain unresolved — fix them, or reply on their review thread with why"
+          + " they are deferred. A finding listed only under \"Things to double-check\" has no"
+          + " thread: clear it by commenting `@thrillhousebot resolved path/to/File.java:42 —"
+          + " <the finding's title>` on this PR.";
 
   /**
    * Whether {@code text} is {@link #unresolvedPreviousMessage(long)} for some count — the bot's own

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -191,6 +191,12 @@ public class VerdictBuilder {
             ctx.inlineComments(),
             botIdentity,
             () -> reviewedCode(ctx, plan));
+    // A finding that never posted inline has no thread to reply on, so the only maintainer action
+    // that can close it is an "@thrillhousebot resolved" comment naming it on the PR conversation
+    // (#548). The model never sees that conversation, so its "unresolved" is rewritten here.
+    effectiveStatuses =
+        followUpAnalyzer.clearNamedInConversation(
+            ctx.previousFindingsList(), effectiveStatuses, ctx.conversationComments(), botIdentity);
     var effectiveResponse =
         new ReviewResponse(aiResponse.findings(), effectiveStatuses, aiResponse.summary());
     var unresolvedPrevious =
@@ -204,6 +210,7 @@ public class VerdictBuilder {
                 ctx.priorAiResponses(),
                 effectiveStatuses,
                 ctx.inlineComments(),
+                ctx.conversationComments(),
                 ctx.lineResolver(),
                 botIdentity,
                 currentRenameTargets)

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -3009,5 +3009,61 @@ class FollowUpAnalyzerTest {
         "the thread-resolving command must not be read as a finding clear");
     assertFalse(FollowUpAnalyzer.isClearDirective("> @thrillhousebot resolved"));
     assertFalse(FollowUpAnalyzer.isClearDirective("```\n@thrillhousebot resolved\n```"));
+    assertFalse(
+        FollowUpAnalyzer.isClearDirective("write `@thrillhousebot resolved src/A.java:10 — title`"),
+        "a marked-up directive is documentation, not an instruction");
+    assertTrue(
+        FollowUpAnalyzer.isClearDirective("@thrillhousebot resolved `src/A.java:10` — title"),
+        "a backticked locator is how the summary prints it and must still be a directive");
+  }
+
+  /**
+   * The README, the PR description and any comment explaining the feature all show the directive
+   * marked up. A rule that fired on those would let the project's own documentation close findings
+   * — the over-clear direction — so quoting the directive must clear nothing, while the locator
+   * stays matchable in backticks because that is the shape the summary prints.
+   */
+  static Stream<Arguments> documentedDirectiveCases() {
+    return Stream.of(
+        arguments(
+            "inline-code directive with the naming inside it",
+            "To close it, comment `@thrillhousebot resolved src/A.java:10 — SQL injection`.",
+            false),
+        arguments(
+            "inline-code directive with the naming outside it",
+            "Write `@thrillhousebot resolved` and then src/A.java:10 — SQL injection.",
+            false),
+        arguments(
+            "double-backtick directive, as docs showing a span",
+            "Use ``@thrillhousebot resolved`` for src/A.java:10 — SQL injection.",
+            false),
+        arguments(
+            "fenced example",
+            """
+            Like this:
+
+            ```
+            @thrillhousebot resolved src/A.java:10 — SQL injection
+            ```
+            """,
+            false),
+        arguments(
+            "a real directive naming a backticked locator",
+            "@thrillhousebot resolved `src/A.java:10` — SQL injection",
+            true),
+        arguments(
+            "a real directive naming a plain locator",
+            "@thrillhousebot resolved src/A.java:10 — SQL injection",
+            true));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("documentedDirectiveCases")
+  void backstopShouldSeparateUsingTheDirectiveFromQuotingIt(
+      String name, String body, boolean clears) {
+    assertEquals(
+        clears ? List.of(2) : List.of(1, 2),
+        heldIds(backstopWith(List.of(maintainerSays(body)))),
+        name);
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import java.util.ArrayList;
@@ -2662,5 +2663,351 @@ class FollowUpAnalyzerTest {
             .get(0)
             .status(),
         "the injected constructor must honour thrillhousebot.review.decline-recheck-enabled");
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // #548 — a finding that never posted inline has no review thread, so the reply hatch (#133/#142)
+  // cannot reach it. The PR conversation is its only escape. Over-clearing is the dangerous
+  // direction, so each case below pins one leg of the recognition.
+  // ---------------------------------------------------------------------------------------------
+
+  /** Names the first PREVIOUS_JSON finding exactly as the summary prints it. */
+  private static final String CLEARS_FINDING_ONE =
+      "@thrillhousebot resolved `src/A.java:10` — SQL injection (fixed in abc123)";
+
+  private static GitHubCommentClient.IssueComment conversationComment(
+      String body, String author, String association) {
+    return new GitHubCommentClient.IssueComment(
+        900L, body, new GitHubReviewClient.ReviewResponse.User(author), association);
+  }
+
+  /** A write-capable maintainer's PR conversation comment. */
+  private static GitHubCommentClient.IssueComment maintainerSays(String body) {
+    return conversationComment(body, "maintainer", "MEMBER");
+  }
+
+  /** The backstop over PREVIOUS_JSON with both findings still present in the diff. */
+  private List<ReviewResult.PreviousFindingStatus> backstopWith(
+      List<GitHubCommentClient.IssueComment> conversation) {
+    return backstopWith(PREVIOUS_JSON, conversation);
+  }
+
+  private List<ReviewResult.PreviousFindingStatus> backstopWith(
+      String roundJson, List<GitHubCommentClient.IssueComment> conversation) {
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(10), "src/B.java", patch(5)));
+    return analyzer.unreportedUnresolvedStatusesFromParsed(
+        analyzer.parsePreviousResponses(List.of(roundJson)),
+        List.of(),
+        List.of(),
+        conversation,
+        resolver,
+        BOT_ID,
+        Map.of());
+  }
+
+  @Test
+  void backstopShouldClearOnlyTheThreadlessFindingTheConversationNames() {
+    var held = backstopWith(List.of(maintainerSays(CLEARS_FINDING_ONE)));
+
+    assertEquals(
+        List.of(2),
+        heldIds(held),
+        "the named finding must be cleared and the one it does not name must stay held");
+  }
+
+  @Test
+  void backstopShouldScopeAConversationClearToTheNamedLocator() {
+    // Two findings sharing a title in different files: the locator, not the title, decides which
+    // one the maintainer named — the same discipline that keeps a recurring marker index from
+    // binding a clear to another round's finding.
+    var sameTitleTwice =
+        """
+        {"findings": [
+          {"risk": "low", "file": "src/A.java", "line": 10, "title": "Missing null check",
+           "description": "may NPE"},
+          {"risk": "low", "file": "src/B.java", "line": 5, "title": "Missing null check",
+           "description": "may NPE"}
+        ]}
+        """;
+
+    var held =
+        backstopWith(
+            sameTitleTwice,
+            List.of(maintainerSays("@thrillhousebot resolved `src/A.java:10` Missing null check")));
+
+    assertEquals(List.of(2), heldIds(held));
+  }
+
+  static Stream<Arguments> conversationCommentsThatClearNothing() {
+    return Stream.of(
+        arguments("directive naming no finding", "@thrillhousebot resolved — thanks, all good now"),
+        arguments(
+            "a pasted marker names nothing across rounds",
+            "@thrillhousebot resolved <!-- thrillhousebot:finding=1 -->"),
+        arguments(
+            "another round's locator for the same title",
+            "@thrillhousebot resolved `src/A.java:99` — SQL injection"),
+        arguments(
+            "one finding's locator with another finding's title",
+            "@thrillhousebot resolved `src/A.java:10` — Missing null check"),
+        arguments(
+            "GitHub quote-reply reproducing every summary row",
+            """
+            > ### Things to double-check
+            > - **CRITICAL:** SQL injection (`src/A.java:10`)
+            > - **MEDIUM:** Missing null check (`src/B.java:5`)
+
+            @thrillhousebot resolved
+            """),
+        arguments(
+            "the directive quoted while the findings are named",
+            """
+            Someone told me to write:
+            > @thrillhousebot resolved
+
+            about `src/A.java:10` — SQL injection and `src/B.java:5` — Missing null check.
+            """),
+        arguments(
+            "the directive fenced while the findings are named",
+            """
+            ```
+            @thrillhousebot resolved
+            ```
+            `src/A.java:10` — SQL injection, `src/B.java:5` — Missing null check
+            """),
+        arguments(
+            "findings named with no directive at all",
+            "Fixed `src/A.java:10` — SQL injection and `src/B.java:5` — Missing null check."),
+        arguments(
+            "the thread-resolving command is not a clear directive",
+            "@thrillhousebot resolve `src/A.java:10` — SQL injection"));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("conversationCommentsThatClearNothing")
+  void backstopShouldClearNothingWhenTheConversationDoesNotNameTheFinding(
+      String name, String body) {
+    assertEquals(
+        List.of(1, 2),
+        heldIds(backstopWith(List.of(maintainerSays(body)))),
+        name + " must clear nothing");
+  }
+
+  static Stream<Arguments> conversationCommentsThatCannotDecide() {
+    return Stream.of(
+        arguments("fork-PR author", conversationComment(CLEARS_FINDING_ONE, "outsider", "NONE")),
+        arguments(
+            "contributor without write access",
+            conversationComment(CLEARS_FINDING_ONE, "outsider", "CONTRIBUTOR")),
+        arguments(
+            "absent author association", conversationComment(CLEARS_FINDING_ONE, "someone", null)),
+        arguments(
+            "the bot quoting its own summary",
+            conversationComment(CLEARS_FINDING_ONE, BOT, "OWNER")),
+        arguments(
+            "comment with no author object",
+            new GitHubCommentClient.IssueComment(900L, CLEARS_FINDING_ONE, null, "OWNER")),
+        arguments("comment with no body", conversationComment(null, "maintainer", "OWNER")));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("conversationCommentsThatCannotDecide")
+  void backstopShouldIgnoreAClearDirectiveFromAnIneligibleComment(
+      String name, GitHubCommentClient.IssueComment comment) {
+    assertEquals(
+        List.of(1, 2), heldIds(backstopWith(List.of(comment))), name + " must not clear a hold");
+  }
+
+  @Test
+  void backstopShouldIgnoreAnAbsentConversationEntry() {
+    // Defensive: a null element cannot survive the ReviewContext copy, but the analyzer is called
+    // directly by other paths and must never dereference one.
+    var conversation = new ArrayList<GitHubCommentClient.IssueComment>();
+    conversation.add(null);
+    conversation.add(maintainerSays(CLEARS_FINDING_ONE));
+
+    assertEquals(List.of(2), heldIds(backstopWith(conversation)));
+  }
+
+  @Test
+  void backstopShouldTreatAnAbsentConversationAsNoClear() {
+    assertEquals(List.of(1, 2), heldIds(backstopWith(null)));
+  }
+
+  static Stream<Arguments> contentAnchorCases() {
+    return Stream.of(
+        arguments(
+            "title", "\"Missing bound check\"", "\"guards nothing\"", "Missing bound check", true),
+        arguments(
+            "description when the title is null",
+            "null",
+            "\"guards nothing\"",
+            "guards nothing",
+            true),
+        arguments(
+            "description when the title is blank",
+            "\"  \"",
+            "\"guards nothing\"",
+            "guards nothing",
+            true),
+        arguments("neither title nor description", "null", "null", "src/A.java", false),
+        arguments("blank title and blank description", "\"  \"", "\"  \"", "src/A.java", false));
+  }
+
+  @ParameterizedTest(name = "cleared by {0}: {4}")
+  @MethodSource("contentAnchorCases")
+  void backstopShouldClearOnlyOnTheFindingsOwnContent(
+      String name, String titleJson, String descriptionJson, String quoted, boolean cleared) {
+    var json =
+        "{\"findings\": [{\"risk\": \"low\", \"file\": \"src/A.java\", \"line\": 10, \"title\": "
+            + titleJson
+            + ", \"description\": "
+            + descriptionJson
+            + "}]}";
+
+    var held =
+        backstopWith(
+            json, List.of(maintainerSays("@thrillhousebot resolved `src/A.java:10` — " + quoted)));
+
+    assertEquals(
+        cleared ? List.of() : List.of(1),
+        heldIds(held),
+        name + " — a finding with no content of its own must stay held");
+  }
+
+  /** One low finding at src/A.java:1, whose locator is a prefix of src/A.java:10's. */
+  private static final String FINDING_AT_LINE_ONE =
+      """
+      {"findings": [
+        {"risk": "low", "file": "src/A.java", "line": 1, "title": "SQL injection",
+         "description": "raw query"}
+      ]}
+      """;
+
+  static Stream<Arguments> prefixLocatorCases() {
+    return Stream.of(
+        arguments(
+            "a longer line number must not clear the shorter one",
+            "@thrillhousebot resolved `src/A.java:10` — SQL injection",
+            false),
+        arguments(
+            "a later whole match still counts",
+            "@thrillhousebot resolved src/A.java:10 and src/A.java:1 — SQL injection",
+            true),
+        arguments(
+            "a match ending the comment counts",
+            "@thrillhousebot resolved SQL injection at src/A.java:1",
+            true));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("prefixLocatorCases")
+  void backstopShouldMatchWholeLocatorsOnly(String name, String body, boolean cleared) {
+    var resolver = new DiffLineResolver(Map.of("src/A.java", patch(1)));
+    var held =
+        analyzer.unreportedUnresolvedStatusesFromParsed(
+            analyzer.parsePreviousResponses(List.of(FINDING_AT_LINE_ONE)),
+            List.of(),
+            List.of(),
+            List.of(maintainerSays(body)),
+            resolver,
+            BOT_ID,
+            Map.of());
+
+    assertEquals(cleared ? List.of() : List.of(1), heldIds(held), name);
+  }
+
+  private List<ReviewResponse.Finding> previousFindings() {
+    return analyzer.parseResponse(PREVIOUS_JSON).findings();
+  }
+
+  private static List<ReviewResponse.PreviousFindingStatus> bothUnresolved() {
+    return List.of(
+        new ReviewResponse.PreviousFindingStatus(1, "unresolved", "still present"),
+        new ReviewResponse.PreviousFindingStatus(2, "unresolved", "still present"));
+  }
+
+  @Test
+  void clearNamedInConversationShouldCloseOnlyTheModelReportedFindingThatWasNamed() {
+    var rewritten =
+        analyzer.clearNamedInConversation(
+            previousFindings(),
+            bothUnresolved(),
+            List.of(maintainerSays(CLEARS_FINDING_ONE)),
+            BOT_ID);
+
+    assertEquals(
+        List.of("resolved", "unresolved"),
+        rewritten.stream().map(ReviewResponse.PreviousFindingStatus::status).toList());
+    assertEquals(FollowUpAnalyzer.CONVERSATION_CLEARED_NOTE, rewritten.get(0).note());
+    assertEquals("still present", rewritten.get(1).note(), "an unnamed finding keeps its note");
+  }
+
+  @Test
+  void clearNamedInConversationShouldLeaveNonUnresolvedAndUnplaceableStatusesAlone() {
+    var statuses =
+        List.of(
+            new ReviewResponse.PreviousFindingStatus(1, "justified", "intentional"),
+            new ReviewResponse.PreviousFindingStatus(9, "unresolved", "out of range"),
+            new ReviewResponse.PreviousFindingStatus(0, "unresolved", "out of range"));
+
+    assertEquals(
+        statuses,
+        analyzer.clearNamedInConversation(
+            previousFindings(), statuses, List.of(maintainerSays(CLEARS_FINDING_ONE)), BOT_ID),
+        "only an in-range unresolved status may be rewritten by a conversation clear");
+  }
+
+  @Test
+  void clearNamedInConversationShouldPassStatusesThroughWithNothingToMatchAgainst() {
+    var statuses = bothUnresolved();
+    var conversation = List.of(maintainerSays(CLEARS_FINDING_ONE));
+
+    assertEquals(List.of(), analyzer.clearNamedInConversation(null, null, conversation, BOT_ID));
+    assertEquals(
+        List.of(),
+        analyzer.clearNamedInConversation(previousFindings(), List.of(), conversation, BOT_ID));
+    assertSame(
+        statuses,
+        analyzer.clearNamedInConversation(null, statuses, conversation, BOT_ID),
+        "no prior round means no finding to name");
+    assertSame(
+        statuses, analyzer.clearNamedInConversation(List.of(), statuses, conversation, BOT_ID));
+    assertSame(
+        statuses, analyzer.clearNamedInConversation(previousFindings(), statuses, null, BOT_ID));
+    assertSame(
+        statuses,
+        analyzer.clearNamedInConversation(previousFindings(), statuses, List.of(), BOT_ID));
+  }
+
+  @Test
+  void clearNamedInConversationShouldHoldAFindingWithNoFile() {
+    var json =
+        "{\"findings\": [{\"risk\": \"low\", \"file\": null, \"line\": 10,"
+            + " \"title\": \"SQL injection\", \"description\": \"raw query\"}]}";
+    var statuses = List.of(new ReviewResponse.PreviousFindingStatus(1, "unresolved", "still"));
+
+    assertEquals(
+        statuses,
+        analyzer.clearNamedInConversation(
+            analyzer.parseResponse(json).findings(),
+            statuses,
+            List.of(maintainerSays("@thrillhousebot resolved null:10 — SQL injection")),
+            BOT_ID),
+        "a finding that cannot be placed in a file cannot be named by a locator");
+  }
+
+  @Test
+  void isClearDirectiveShouldRecognizeOnlyAnUnquotedResolvedInstruction() {
+    assertTrue(FollowUpAnalyzer.isClearDirective("@thrillhousebot resolved src/A.java:10 — title"));
+    assertTrue(
+        FollowUpAnalyzer.isClearDirective("thanks!\n\n@ThrillhouseBot   RESOLVED all of it"));
+    assertFalse(FollowUpAnalyzer.isClearDirective(null));
+    assertFalse(FollowUpAnalyzer.isClearDirective("@thrillhousebot why is this flagged?"));
+    assertFalse(
+        FollowUpAnalyzer.isClearDirective("@thrillhousebot resolve"),
+        "the thread-resolving command must not be read as a finding clear");
+    assertFalse(FollowUpAnalyzer.isClearDirective("> @thrillhousebot resolved"));
+    assertFalse(FollowUpAnalyzer.isClearDirective("```\n@thrillhousebot resolved\n```"));
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
@@ -620,4 +620,53 @@ class MaintainerReplyServiceTest {
         body.getValue().body().contains("partial coverage"),
         "a truncated diff must disclose the omission in the posted reply");
   }
+
+  private MaintainerReplyService.ReplyTask mentionTask(String question) {
+    return new MaintainerReplyService.ReplyTask(
+        "owner",
+        "repo",
+        42,
+        12345L,
+        "octocat",
+        "OWNER",
+        question,
+        "PR Title",
+        "PR body",
+        false,
+        null,
+        2000L,
+        true,
+        null);
+  }
+
+  @Test
+  void clearDirectiveIsAcknowledgedDeterministicallyWithoutTheAssistant() {
+    authorize();
+
+    service.handle(
+        mentionTask("@thrillhousebot resolved `src/A.java:10` — SQL injection, fixed in abc123"));
+
+    var body = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+    verify(commentClient)
+        .createComment(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), body.capture());
+    assertEquals(MaintainerReplyService.CLEAR_DIRECTIVE_ACK, body.getValue().body());
+    verifyNoInteractions(replyAssistant, prClient);
+  }
+
+  @Test
+  void anOrdinaryMentionStillGetsAnAssistantAnswer() {
+    authorize();
+    when(prClient.getPullRequestFiles(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42)))
+        .thenReturn(List.of(fileDiff("src/A.java", "@@ -1 +1 @@\n-a\n+aa", 1)));
+    when(repoSettingsResolver.resolve(eq("owner"), eq("repo"), any(), anyLong()))
+        .thenReturn(RepoSettings.EMPTY);
+    when(replyAssistant.reply(any(), any(), any(), any(), any())).thenReturn(aiOk("Answer."));
+
+    service.handle(mentionTask("@thrillhousebot did you resolve this already?"));
+
+    var body = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+    verify(commentClient)
+        .createComment(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), body.capture());
+    assertEquals("Answer.", body.getValue().body());
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
@@ -26,6 +26,7 @@ import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSessionPersistence;
 import dev.thiagogonzaga.thrillhousebot.github.*;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -963,6 +964,61 @@ class ReviewContextLoaderTest {
 
       assertFalse(loader.botSummaryCommentExists("auth", "owner", "repo", 1));
       assertTrue(loader.fetchIssueComments("auth", "owner", "repo", 1).isEmpty());
+    }
+  }
+
+  /**
+   * #548 — the conversation is where a thread-less finding is cleared, and the walk that reads it
+   * is bounded. GitHub serves issue comments oldest first with no reverse order on this endpoint,
+   * so a walk that stops at the ceiling keeps the oldest window and drops the newest — where a
+   * freshly written directive lives. The ceiling has to be recognized, not assumed away.
+   */
+  @Nested
+  class ConversationReadCeiling {
+
+    private List<GitHubCommentClient.IssueComment> comments(int count) {
+      var all = new ArrayList<GitHubCommentClient.IssueComment>(count);
+      for (var i = 0; i < count; i++) {
+        all.add(
+            new GitHubCommentClient.IssueComment(
+                "comment " + i, new GitHubReviewClient.ReviewResponse.User("maintainer")));
+      }
+      return all;
+    }
+
+    @Test
+    void shouldNameTheCeilingAsTheFullPagedWalk() {
+      assertEquals(
+          GitHubCommentClient.COMMENTS_PER_PAGE * GitHubCommentClient.MAX_COMMENT_PAGES,
+          ReviewContextLoader.MAX_CONVERSATION_COMMENTS,
+          "the documented ceiling must be the walk the client actually performs");
+    }
+
+    @Test
+    void shouldRecognizeAWalkThatStoppedAtTheCeiling() {
+      assertTrue(
+          ReviewContextLoader.conversationWalkCapped(
+              comments(ReviewContextLoader.MAX_CONVERSATION_COMMENTS)),
+          "a full window means the walk stopped at the bound, not at the end of the thread");
+    }
+
+    @Test
+    void shouldNotFlagAConversationThatFitUnderTheCeiling() {
+      assertFalse(
+          ReviewContextLoader.conversationWalkCapped(
+              comments(ReviewContextLoader.MAX_CONVERSATION_COMMENTS - 1)));
+      assertFalse(ReviewContextLoader.conversationWalkCapped(List.of()));
+    }
+
+    @Test
+    void shouldReturnEveryCommentTheWalkRead() {
+      when(commentClient.listComments(anyString(), anyString(), anyString(), anyString(), anyInt()))
+          .thenReturn(comments(ReviewContextLoader.MAX_CONVERSATION_COMMENTS));
+
+      assertEquals(
+          ReviewContextLoader.MAX_CONVERSATION_COMMENTS,
+          loader.fetchConversationComments("auth", "owner", "repo", 1).size(),
+          "disclosing the ceiling must not drop what was read");
     }
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -205,8 +205,11 @@ class ReviewOrchestratorTest {
     lenient()
         .when(
             followUpAnalyzer.unreportedUnresolvedStatusesFromParsed(
-                any(), any(), any(), any(), any(), any()))
+                any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(List.of());
+    lenient()
+        .when(followUpAnalyzer.clearNamedInConversation(any(), any(), any(), any()))
+        .thenAnswer(invocation -> invocation.getArgument(1));
     lenient()
         .when(
             followUpAnalyzer.unresolvedFindings(
@@ -4979,7 +4982,7 @@ class ReviewOrchestratorTest {
     }
 
     @Test
-    void shouldQualifyReplyGuidanceSinceABackstopFindingMayHaveNoThread() {
+    void shouldGiveAClearingPathForABackstopFindingWithNoThread() {
       delegateStatusGate();
       var result =
           buildWithBackstop(
@@ -4991,10 +4994,11 @@ class ReviewOrchestratorTest {
       verify(reviewClient)
           .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
       var body = captor.getValue().body();
-      assertTrue(body.contains("where one exists"), "the reply guidance must be qualified");
+      assertTrue(
+          body.contains("@thrillhousebot resolved"),
+          "a finding with no thread needs a path that does not depend on one (#548)");
       assertFalse(
-          body.contains("reply on their threads"),
-          "must not unconditionally promise a thread that may not exist");
+          body.contains("where one exists"), "must not merely admit that a thread may not exist");
     }
 
     @Test
@@ -5023,7 +5027,7 @@ class ReviewOrchestratorTest {
         when(aiReviewService.review(any(ReviewSession.class), any()))
             .thenReturn(new ReviewResponse(List.of(), List.of(), null));
         when(followUpAnalyzer.unreportedUnresolvedStatusesFromParsed(
-                any(), any(), any(), any(), eq(BOT_ID), any()))
+                any(), any(), any(), any(), any(), eq(BOT_ID), any()))
             .thenReturn(
                 List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still present")));
 
@@ -5215,7 +5219,7 @@ class ReviewOrchestratorTest {
       when(followUpAnalyzer.parsePreviousResponses(any()))
           .thenAnswer(invocation -> realAnalyzer.parsePreviousResponses(invocation.getArgument(0)));
       when(followUpAnalyzer.unreportedUnresolvedStatusesFromParsed(
-              any(), any(), any(), any(), eq(BOT_ID), any()))
+              any(), any(), any(), any(), any(), eq(BOT_ID), any()))
           .thenAnswer(
               invocation ->
                   realAnalyzer.unreportedUnresolvedStatusesFromParsed(
@@ -5224,7 +5228,8 @@ class ReviewOrchestratorTest {
                       invocation.getArgument(2),
                       invocation.getArgument(3),
                       invocation.getArgument(4),
-                      invocation.getArgument(5)));
+                      invocation.getArgument(5),
+                      invocation.getArgument(6)));
     }
 
     private static final String PRIOR_FINDING_JSON =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -562,8 +562,26 @@ class ReviewResultTest {
         "a human review opening with the same words carries a real finding and must be kept");
     assertFalse(
         ReviewResult.isUnresolvedPreviousMessage(
-            "Please fix them, or reply on their review thread (where one exists) with why they are"
-                + " deferred."),
+            "Please clear it by commenting `@thrillhousebot resolved path/to/File.java:42 —"
+                + " <the finding's title>` on this PR."),
         "the generated ending without the generated opening is not the sentence");
+  }
+
+  /**
+   * #548 — a finding raised below the inline-posting bar has no review thread, so guidance that
+   * points only at threads leaves it uncloseable by any maintainer action. The status line must
+   * spell out the conversation directive that reaches it.
+   */
+  @Test
+  void unresolvedPreviousMessageShouldStateHowToClearAThreadlessFinding() {
+    var message = ReviewResult.unresolvedPreviousMessage(2);
+
+    assertTrue(message.contains("2 previous finding(s) remain unresolved"), message);
+    assertTrue(message.contains("reply on their review thread"), message);
+    assertTrue(message.contains("Things to double-check"), message);
+    assertTrue(message.contains("@thrillhousebot resolved"), message);
+    assertFalse(
+        message.contains("where one exists"),
+        "the gap must be closed with a path, not admitted in a parenthetical");
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -87,6 +87,13 @@ class VerdictBuilderTest {
               return statuses == null ? List.of() : statuses;
             });
     lenient()
+        .when(followUpAnalyzer.clearNamedInConversation(any(), any(), any(), any()))
+        .thenAnswer(
+            inv -> {
+              List<?> statuses = inv.getArgument(1);
+              return statuses == null ? List.of() : statuses;
+            });
+    lenient()
         .when(summaryGenerator.generate(anyInt(), anyInt(), anyInt(), any(), any(), any()))
         .thenReturn("");
   }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

A finding raised below the inline-posting bar (`Finding#postsInline` false: low confidence under high risk) is listed only under **Things to double-check** and opens no review thread. The maintainer-reply escape hatch (#133/#142) resolves a finding's *own* thread by marker plus content, so it can never reach one — while the deterministic backstop keeps holding the finding across rounds. On #544 a LOW was fixed in code and the next review still reported it unresolved: a merge-ready PR showed an unresolved count no action could clear, and APPROVE stayed held by the unresolved-previous gate. The bot's own message admitted the gap in passing ("reply on their review thread (where one exists)").

A write-capable maintainer can now clear such a finding from the PR conversation, and the status line states that path instead of the parenthetical.

**Recognition.** A PR conversation comment clears a finding only when every leg holds; any one missing leaves it held:

- the comment is a human's, not the bot's — the bot's own summary reproduces every finding verbatim, so reading it back would clear the whole round;
- its `author_association` may hold write access (`OWNER`/`MEMBER`/`COLLABORATOR`), the same prefilter the review-thread hatch applies, so a drive-by commenter on a public repo cannot clear a hold;
- it carries `@thrillhousebot resolved` **outside quoted context** — blockquote lines and fenced code are stripped first, so GitHub's "Quote reply" of the summary names nothing. Inline code is deliberately kept, because the summary prints each locator as `` `path:line` ``;
- it names **that** finding by BOTH its printed `path:line` locator and its own content (its title, or its description when it has no title — the same content anchoring the marked-thread hatch uses).

**Over-clearing guards.** No `thrillhousebot:finding=N` marker is read at all, so a pasted marker names nothing and a clear cannot leak across rounds through marker reuse. Locators match whole only (a match followed by another digit is skipped), so a comment about `src/A.java:10` cannot clear the distinct finding at `src/A.java:1`. A finding with neither title nor description matches nothing and stays held. `@thrillhousebot resolve` (the existing thread-resolving command) is not the directive.

Both paths honour the clear: the backstop (`holdableTarget`) and the model-reported `unresolved` status (`clearNamedInConversation`, since the model never sees the conversation). The conversational-reply path answers the directive with a fixed acknowledgement rather than an assistant reply, so the bot cannot overstate what the directive does.

Plumbing outside the analyzer is minimal and additive: `IssueComment` gains `author_association` (mirroring `PullRequestComment`), and `ReviewContext` gains `conversationComments` — both with back-compat constructors, so no existing construction site changed. The conversation is fetched on the same `hasContext` gate as the inline comments, so a first review never pays for the call.

## Documentation

`README.md` documents the directive the same way the sibling behaviours are documented:

- a feature bullet next to the follow-up-tracking one, naming both ways to close a finding;
- a row in the commands table with its access level, plus a note that it is a directive rather than a slash command, is read by the next review, is not `/resolve`, and takes its access from the comment's `author_association` only (`THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` does not extend it);
- a **Clearing a finding with no thread** section after *Re-checking declines*, which until now covered only the thread case — which findings have no thread, a copyable example, and every rule a maintainer must satisfy (both the `path:line` locator **and** the finding's own content, write-capable non-bot author, quoted and fenced text ignored), stating plainly that an ambiguous naming leaves the finding held.

No `.env.example` entry: the directive introduces no configuration knob.

## Review findings fixed

Two MEDIUM findings the bot raised on this PR, both fixed in `8b73d03`.

**Using the directive vs. quoting it** (`FollowUpAnalyzer`). The token matched inside inline code, so documenting the command fired it — a comment explaining the feature (or this PR's own README example pasted into a PR) would clear the finding it names. Inline code was kept deliberately, because the summary prints each locator as `` `path:line` `` and maintainers copy the row, so the rule now separates the two texts rather than choosing between them: the **directive token** must be outside blockquotes, fences *and* inline code, while the **locator and content** are still matched with inline code intact. The inline-code pattern uses a `` `+ `` delimiter so the double-backtick documentation form is caught too.

Red proof (directive token matched against the inline-code-preserving text, i.e. the reported defect):

```
[ERROR] Failures:
[ERROR]   FollowUpAnalyzerTest.backstopShouldSeparateUsingTheDirectiveFromQuotingIt:3064 inline-code directive with the naming inside it ==> expected: <[1, 2]> but was: <[2]>
[ERROR]   FollowUpAnalyzerTest.backstopShouldSeparateUsingTheDirectiveFromQuotingIt:3064 inline-code directive with the naming outside it ==> expected: <[1, 2]> but was: <[2]>
[ERROR]   FollowUpAnalyzerTest.backstopShouldSeparateUsingTheDirectiveFromQuotingIt:3064 double-backtick directive, as docs showing a span ==> expected: <[1, 2]> but was: <[2]>
[ERROR]   FollowUpAnalyzerTest.isClearDirectiveShouldRecognizeOnlyAnUnquotedResolvedInstruction:3012 a marked-up directive is documentation, not an instruction ==> expected: <false> but was: <true>
[ERROR] Tests run: 167, Failures: 4, Errors: 0, Skipped: 0
```

The same parameterized test pins the other direction in the same run — *a real directive naming a backticked locator* and *a real directive naming a plain locator* each clear exactly their own finding and leave the other held, under both the broken and the fixed rule.

**Conversation read ceiling** (`ReviewContextLoader`). The fetch already paginates (`GitHubCommentClient.listComments`, 100/page × 10 pages), but hitting that bound was silent. GitHub serves issue comments oldest first with no reverse order on this endpoint, so a capped walk keeps the **oldest** window and drops the newest — exactly where a freshly written directive lives, so the feature would quietly do nothing on the busy PRs that need it most. The bound is now named (`MAX_CONVERSATION_COMMENTS`), recognized (`conversationWalkCapped`), logged with its cause and consequence when reached, and documented in the README. `botSummaryCommentExists` keeps the plain fetch: the summary is posted on the first round, so it lives in the window a capped walk retains.

Red proof (ceiling neither matching the real walk nor recognized):

```
[ERROR] Failures:
[ERROR]   ReviewContextLoaderTest.shouldNameTheCeilingAsTheFullPagedWalk the documented ceiling must be the walk the client actually performs ==> expected: <1000> but was: <100>
[ERROR]   ReviewContextLoaderTest.shouldRecognizeAWalkThatStoppedAtTheCeiling a full window means the walk stopped at the bound, not at the end of the thread ==> expected: <true> but was: <false>
[ERROR] Tests run: 66, Failures: 2, Errors: 0, Skipped: 0
```

## Third review round

> **Not in this merge.** #553 was merged at `a6c3f86` before these two fixes were pushed; they ship in #563 against `release/v0.6.0`. The section below is kept for the record of what was found here.


**Interrogative directive** (`FollowUpAnalyzer`, MEDIUM — fixed in `77e0cf4`). A word boundary holds before `?`, so `@thrillhousebot resolved? \`src/A.java:10\` — SQL injection` parsed as an instruction: a maintainer *asking* whether a finding was fixed quotes it well enough to name it, and the question closed the finding it was about. The token is now rejected when a `?` follows it (whitespace aside). The lookahead cannot skip past the naming, so a real directive whose sentence merely ends in a question still counts.

Red proof (lookahead removed):

```
[ERROR] Failures:
[ERROR]   FollowUpAnalyzerTest.backstopShouldNotReadAQuestionAsADirective:3098 question mark straight after the token ==> expected: <[1, 2]> but was: <[2]>
[ERROR]   FollowUpAnalyzerTest.backstopShouldNotReadAQuestionAsADirective:3098 spaced question mark ==> expected: <[1, 2]> but was: <[2]>
[ERROR] Tests run: 172, Failures: 2, Errors: 0, Skipped: 0
```

The same parameterized test pins the other direction in the same run: *plain statement still clears* and *a directive whose sentence ends in a question still clears* pass under both the broken and the fixed pattern.

**Clear-directive acknowledgement** (`MaintainerReplyService`, LOW — accepted in part, fixed in `77e0cf4`). The finding's claim that the wording was unconditional was wrong — it already said "any it does not name stays open" — but the two real defects behind it stand: the ack fired on the token alone even when the comment named nothing, and it opened with "Noted.", which reads as confirmation regardless of what follows.

Both are fixed without the reply path duplicating matching it cannot perform. It now states what the next review will *evaluate* rather than reporting an outcome, and adds one case that genuinely is decidable this early: naming a finding requires its `path:line`, so a directive carrying no `path:line`-shaped token at all provably clears nothing (`namesALocator` is a strictly *necessary* condition of the real rule), and the reply says so outright and shows the shape to use.

A locator that is present but wrong still gets the general reply, deliberately. Deciding that needs the prior round's findings, which this path does not load and which only the review can match — guessing there would be exactly the "reply path that guesses" worth avoiding.

Red proof (single unconditional ack, `Noted.` opener):

```
[ERROR] Failures:
[ERROR]   MaintainerReplyServiceTest.clearDirectiveAckNeverClaimsAClearingAlreadyHappened:686 Noted. Every previous finding your comment names by its `path:line` and title is treated as cleared from the next review onward; any it does not name stays open. ==> expected: <false> but was: <true>
[ERROR]   MaintainerReplyServiceTest.clearDirectiveNamingNoLocatorSaysNothingWillBeCleared:671 expected: <That comment names no finding, so nothing will be cleared...> but was: <Noted. Every previous finding your comment names...>
[ERROR] Tests run: 26, Failures: 2, Errors: 0, Skipped: 0
```

## Related Issues

Fixes #548

## How Has This Been Tested?

- [x] Unit tests

Both directions are covered: a comment that clears exactly one finding and nothing else, and comments that must clear nothing (no directive; directive naming nothing; a pasted marker; another round's locator; one finding's locator with another's title; a quote-reply of every summary row; a quoted or fenced directive; the `resolve` command). Ineligible authors (fork author, `CONTRIBUTOR`, absent association, the bot itself, missing author or body) are covered, as is the whole-locator guard and the title/description/neither anchor matrix.

### Red proof

With the recognition neutralized (`clearedInConversation` and `isClearDirective` returning `false`, the old message restored) and the new tests in place:

```
[ERROR] Failures:
[ERROR]   FollowUpAnalyzerTest.backstopShouldClearOnlyOnTheFindingsOwnContent:2872 title — a finding with no content of its own must stay held ==> expected: <[]> but was: <[1]>
[ERROR]   FollowUpAnalyzerTest.backstopShouldClearOnlyOnTheFindingsOwnContent:2872 description when the title is null — a finding with no content of its own must stay held ==> expected: <[]> but was: <[1]>
[ERROR]   FollowUpAnalyzerTest.backstopShouldClearOnlyOnTheFindingsOwnContent:2872 description when the title is blank — a finding with no content of its own must stay held ==> expected: <[]> but was: <[1]>
[ERROR]   FollowUpAnalyzerTest.backstopShouldClearOnlyTheThreadlessFindingTheConversationNames:2712 the named finding must be cleared and the one it does not name must stay held ==> expected: <[2]> but was: <[1, 2]>
[ERROR]   FollowUpAnalyzerTest.backstopShouldIgnoreAnAbsentConversationEntry:2829 expected: <[2]> but was: <[1, 2]>
[ERROR]   FollowUpAnalyzerTest.backstopShouldMatchWholeLocatorsOnly:2917 a later whole match still counts ==> expected: <[]> but was: <[1]>
[ERROR]   FollowUpAnalyzerTest.backstopShouldMatchWholeLocatorsOnly:2917 a match ending the comment counts ==> expected: <[]> but was: <[1]>
[ERROR]   FollowUpAnalyzerTest.backstopShouldScopeAConversationClearToTheNamedLocator:2738 expected: <[2]> but was: <[1, 2]>
[ERROR]   FollowUpAnalyzerTest.clearNamedInConversationShouldCloseOnlyTheModelReportedFindingThatWasNamed:2939 expected: <[resolved, unresolved]> but was: <[unresolved, unresolved]>
[ERROR]   FollowUpAnalyzerTest.isClearDirectiveShouldRecognizeOnlyAnUnquotedResolvedInstruction:3002 expected: <true> but was: <false>
[ERROR]   MaintainerReplyServiceTest.clearDirectiveIsAcknowledgedDeterministicallyWithoutTheAssistant:651
Wanted but not invoked:
commentClient.createComment(
    "token gh-abc",
    <any string>,
    "owner",
    "repo",
    42,
    <Capturing argument: CreateCommentRequest>
);
-> at dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyServiceTest.clearDirectiveIsAcknowledgedDeterministicallyWithoutTheAssistant(MaintainerReplyServiceTest.java:651)
Actually, there were zero interactions with this mock.

[ERROR]   ReviewResultTest.unresolvedPreviousMessageShouldStateHowToClearAThreadlessFinding:581 No new issues in this revision, but 2 previous finding(s) remain unresolved — fix them, or reply on their review thread (where one exists) with why they are deferred. ==> expected: <true> but was: <false>
[ERROR] Tests run: 215, Failures: 12, Errors: 0, Skipped: 0
```

and, in the same neutralized state:

```
[ERROR] Failures:
[ERROR]   ReviewOrchestratorTest.shouldGiveAClearingPathForABackstopFindingWithNoThread a finding with no thread needs a path that does not depend on one (#548) ==> expected: <true> but was: <false>
```

All twelve pass with the fix in place.

### Gates

- `./mvnw -B spotless:apply` then `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, `BUILD SUCCESS`
- `./mvnw -B clean test` — `Tests run: 2646, Failures: 0, Errors: 0, Skipped: 0`
- `cd website && npm ci && npm run build` — `66 page(s) built`, `All internal links are valid`
- JaCoCo ∩ `git diff -U0 abd76e5 HEAD` over changed main code — zero uncovered lines and zero uncovered branches (re-verified at each head)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

`ReviewOrchestratorTest`/`VerdictBuilderTest` needed stub updates only because `unreportedUnresolvedStatusesFromParsed` gained a parameter and `clearNamedInConversation` is new on the mocked analyzer.




