### PR TITLE
fix(review): keep the verdicts a cut verifier body already carried

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -55,23 +55,29 @@ public class FindingVerificationService {
   private final ThrillhouseConfig config;
   private final ObjectMapper mapper;
   private final ReviewTokenLedger tokenLedger;
+  private final TruncatedResponseSalvager salvager;
 
   @Inject
   public FindingVerificationService(
       FindingVerifier verifier,
       ThrillhouseConfig config,
       ObjectMapper mapper,
-      ReviewTokenLedger tokenLedger) {
+      ReviewTokenLedger tokenLedger,
+      TruncatedResponseSalvager salvager) {
     this.verifier = verifier;
     this.config = config;
     this.mapper = mapper;
     this.tokenLedger = tokenLedger;
+    this.salvager = salvager;
   }
 
   private static final Pattern HEDGING =
       Pattern.compile("\\b(may|might|could|potentially|possibly)\\b", Pattern.CASE_INSENSITIVE);
 
   private static final String MEDIUM_LABEL = "medium";
+
+  /** The verifier response's only field, and the array salvage keys on when the body is cut. */
+  private static final String VERDICTS = "verdicts";
 
   /**
    * Audits the response's findings; {@code diff}, {@code projectStack} and {@code previousFindings}
@@ -127,16 +133,53 @@ public class FindingVerificationService {
             screened.findings().size());
         return screened;
       }
-      var verdicts =
-          mapper.readValue(ReviewResponseParser.extractJson(raw), VerificationResponse.class);
-      return apply(screened, verdicts);
+      return apply(screened, parseOrSalvage(raw, screened.findings().size()));
     } catch (AiResponseTruncatedException e) {
       // The verifier fails open by design; say why so a cap is not mistaken for a provider fault.
       Log.warnf("Finding verification — keeping unverified findings. %s", e.getMessage());
       return screened;
     } catch (IOException | RuntimeException e) {
-      Log.warn("Finding verification failed — keeping unverified findings", e);
+      Log.warnf(
+          e,
+          "Finding verification failed — keeping the %d unverified finding(s)",
+          screened.findings().size());
       return screened;
+    }
+  }
+
+  /**
+   * Parses the verifier body, salvaging the verdicts that completed when it arrives cut mid-JSON
+   * (#546). Production has seen the body cut with no {@code finish_reason=length} reported, so it
+   * never reaches the truncation lane above: it landed in the generic catch and every verdict was
+   * thrown away, leaving a response that carried nine complete verdicts and a tenth cut off
+   * contributing nothing. The cut body is well-formed up to the cut, so {@link
+   * TruncatedResponseSalvager} recovers the verdicts that closed — the same machinery the review
+   * lane already uses, not a second parser.
+   *
+   * <p>Salvage is strictly additive to the fail-open contract: a candidate whose verdict fell on
+   * the far side of the cut simply has no verdict, and {@link #apply} keeps such a finding exactly
+   * as it stands — a missing verdict never rejects or downgrades anything. When nothing at all is
+   * recoverable the parse failure is rethrown, so the caller logs and fails open as before.
+   */
+  private VerificationResponse parseOrSalvage(String raw, int candidates) throws IOException {
+    try {
+      return mapper.readValue(ReviewResponseParser.extractJson(raw), VerificationResponse.class);
+    } catch (IOException | RuntimeException e) {
+      var salvaged = salvager.salvageArray(raw, VERDICTS, VerificationResponse.Verdict.class);
+      if (salvaged.isEmpty()) {
+        throw e;
+      }
+      var verified =
+          salvaged.stream()
+              .mapToInt(VerificationResponse.Verdict::id)
+              .filter(id -> id >= 1 && id <= candidates)
+              .distinct()
+              .count();
+      Log.warnf(
+          "Finding verification response was cut mid-JSON (%s); salvaged %d verdict(s) covering %d"
+              + " of %d candidate finding(s) — the remaining %d stay unverified",
+          e.getMessage(), salvaged.size(), verified, candidates, candidates - verified);
+      return new VerificationResponse(salvaged);
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvager.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvager.java
@@ -28,11 +28,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Salvages the complete leading JSON elements out of a response the model cut at its length cap
- * ({@link AiResponseTruncatedException#partialBody()}). The body is well-formed up to the cut, so
- * every {@code findings} / {@code previous_findings_status} array element that closed before it —
- * and a {@code summary} object that did — is recoverable as-is; the trailing cut-off value is
- * dropped by construction.
+ * Salvages the complete leading JSON elements out of a response the model cut mid-JSON — at its
+ * length cap ({@link AiResponseTruncatedException#partialBody()}), or with no {@code
+ * finish_reason=length} reported at all (#546). The body is well-formed up to the cut, so every
+ * {@code findings} / {@code previous_findings_status} array element that closed before it — and a
+ * {@code summary} object that did — is recoverable as-is; the trailing cut-off value is dropped by
+ * construction. {@link #salvageArray} exposes the same pass for the other review-path responses
+ * whose payload is a single named array, such as the finding verifier's {@code verdicts}.
  *
  * <p>Deliberately a separate class from {@link ReviewResponseParser}: the parser's contract is
  * all-or-nothing on a complete body, while salvage is best-effort on a known-cut one, and the two
@@ -83,8 +85,6 @@ public class TruncatedResponseSalvager {
       previousFindingsStatus = List.copyOf(previousFindingsStatus);
     }
 
-    static final Salvaged NOTHING = new Salvaged(List.of(), List.of(), null);
-
     /** Whether anything a batch disclosure could honestly call "partially reviewed" came back. */
     public boolean hasFindingsOrStatuses() {
       return !findings.isEmpty() || !previousFindingsStatus.isEmpty();
@@ -92,40 +92,85 @@ public class TruncatedResponseSalvager {
   }
 
   /**
-   * Salvages the complete elements of {@code partialBody}. Returns {@link Salvaged#NOTHING} when
-   * there is nothing to work with — no body (the blocking lanes do not buffer one), a body that
-   * does not open a JSON object, or a cut that landed before the first element closed.
+   * Salvages the complete elements of {@code partialBody}. Everything comes back empty when there
+   * is nothing to work with — no body (the blocking lanes do not buffer one), a body that does not
+   * open a JSON object, or a cut that landed before the first element closed.
    */
   public Salvaged salvage(String partialBody) {
+    var findings = new ArrayList<ReviewResponse.Finding>();
+    var statuses = new ArrayList<ReviewResponse.PreviousFindingStatus>();
+    // One-element holder: the summary is the pass's only scalar result, and the field handler
+    // below is a lambda, which cannot assign a local.
+    var summary = new ReviewResponse.Summary[1];
+    scan(
+        partialBody,
+        (parser, field, value) -> {
+          switch (field) {
+            case "findings" ->
+                salvageArrayElements(parser, value, ReviewResponse.Finding.class, findings);
+            case "previous_findings_status" ->
+                salvageArrayElements(
+                    parser, value, ReviewResponse.PreviousFindingStatus.class, statuses);
+            case "summary" ->
+                summary[0] = objectOrNull(parser, value, ReviewResponse.Summary.class);
+            default -> parser.skipChildren();
+          }
+        });
+    return new Salvaged(findings, statuses, summary[0]);
+  }
+
+  /**
+   * Salvages the complete leading elements of a single named top-level array — the shape of a
+   * response whose whole payload is one array of records, such as the finding verifier's {@code
+   * {"verdicts": [...]}} (#546). Same bounded, never-throwing pass as {@link #salvage}: the
+   * elements that closed before the cut come back mapped onto {@code type}, the cut-off trailing
+   * element is dropped, and an empty list means there was nothing recoverable — no body, no such
+   * field, a non-array value, or a cut before the first element closed.
+   */
+  public <T> List<T> salvageArray(String partialBody, String field, Class<T> type) {
+    var elements = new ArrayList<T>();
+    scan(
+        partialBody,
+        (parser, name, value) -> {
+          if (field.equals(name)) {
+            salvageArrayElements(parser, value, type, elements);
+          } else {
+            parser.skipChildren();
+          }
+        });
+    return List.copyOf(elements);
+  }
+
+  /** How a scan pass consumes one top-level field, positioned on its value token. */
+  @FunctionalInterface
+  private interface FieldHandler {
+    void handle(JsonParser parser, String field, JsonToken value) throws IOException;
+  }
+
+  /**
+   * The single bounded forward pass every salvage shares: hand each top-level field of the cut body
+   * to {@code handler}, and end quietly at the cut. Does nothing when there is nothing to work with
+   * — no body, an oversized one, or one that does not open a JSON object.
+   */
+  private void scan(String partialBody, FieldHandler handler) {
     if (partialBody == null
         || partialBody.isBlank()
         || partialBody.length() > MAX_SALVAGED_BODY_CHARS) {
-      return Salvaged.NOTHING;
+      return;
     }
     var json = ReviewResponseParser.extractJson(partialBody);
-    var findings = new ArrayList<ReviewResponse.Finding>();
-    var statuses = new ArrayList<ReviewResponse.PreviousFindingStatus>();
-    ReviewResponse.Summary summary = null;
     JsonParser parser = null;
     try {
       parser = mapper.createParser(json);
       if (parser.nextToken() != JsonToken.START_OBJECT) {
-        return Salvaged.NOTHING;
+        return;
       }
       while (parser.nextToken() == JsonToken.FIELD_NAME) {
         var field = parser.currentName();
         // Never null: inside the root object, Jackson raises JsonEOFException at the cut instead
         // of returning null, and the catch below ends the pass.
         var value = parser.nextToken();
-        switch (field) {
-          case "findings" ->
-              salvageArrayElements(parser, value, ReviewResponse.Finding.class, findings);
-          case "previous_findings_status" ->
-              salvageArrayElements(
-                  parser, value, ReviewResponse.PreviousFindingStatus.class, statuses);
-          case "summary" -> summary = objectOrNull(parser, value, ReviewResponse.Summary.class);
-          default -> parser.skipChildren();
-        }
+        handler.handle(parser, field, value);
       }
     } catch (IOException e) {
       // The cut point (or trailing garbage): everything that closed before it is already
@@ -135,7 +180,6 @@ public class TruncatedResponseSalvager {
     } finally {
       closeQuietly(parser);
     }
-    return new Salvaged(findings, statuses, summary);
   }
 
   /**

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -1463,7 +1463,12 @@ class FindingPipelineTest {
     var findingVerifier = mock(dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerifier.class);
     var realVerificationService =
         new FindingVerificationService(
-            findingVerifier, thrillhouseConfig, new ObjectMapper(), tokenLedger);
+            findingVerifier,
+            thrillhouseConfig,
+            new ObjectMapper(),
+            tokenLedger,
+            new dev.thiagogonzaga.thrillhousebot.review.ai.TruncatedResponseSalvager(
+                new ObjectMapper()));
     var p =
         new FindingPipeline(
             aiReviewService,

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -54,7 +54,7 @@ class FindingVerificationServiceTest {
     MockitoAnnotations.openMocks(this);
     when(config.review()).thenReturn(reviewConfig);
     when(reviewConfig.verifierEnabled()).thenReturn(true);
-    service = new FindingVerificationService(verifier, config, new ObjectMapper(), tokenLedger);
+    service = serviceWith(tokenLedger);
   }
 
   /** Swaps in a real, opened ledger so a test can observe the spend the service records. */
@@ -62,8 +62,14 @@ class FindingVerificationServiceTest {
     when(reviewConfig.maxTokensPerReview()).thenReturn(ceiling);
     var ledger = new ReviewTokenLedger(config);
     ledger.open(SESSION);
-    service = new FindingVerificationService(verifier, config, new ObjectMapper(), ledger);
+    service = serviceWith(ledger);
     return ledger;
+  }
+
+  private FindingVerificationService serviceWith(ReviewTokenLedger ledger) {
+    var mapper = new ObjectMapper();
+    return new FindingVerificationService(
+        verifier, config, mapper, ledger, new TruncatedResponseSalvager(mapper));
   }
 
   private static Result<String> aiOkWithUsage(String text, int inputTokens, int outputTokens) {
@@ -393,6 +399,80 @@ class FindingVerificationServiceTest {
       assertEquals("high", result.findings().get(0).risk());
       parser.verify(() -> ReviewResponseParser.extractJson(any()), never());
     }
+  }
+
+  @Test
+  void appliesTheVerdictsThatCompletedWhenTheBodyIsCutMidJson() {
+    // #546: production has seen the verifier body arrive cut mid-JSON with no finish_reason=length
+    // (STOP, as built here), so it never reaches the truncation lane — before the salvage, the
+    // whole pass was discarded and every complete verdict thrown away. The three verdicts that
+    // closed must be applied; the candidate whose verdict was on the far side of the cut stays
+    // unverified, never rejected.
+    ReviewResponse original =
+        response(
+            finding("critical", "high", "Hallucinated API claim"),
+            finding("high", "high", "Speculative"),
+            finding("critical", "high", "Real injection"),
+            finding("high", "high", "Verdict cut off"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiOk(
+                """
+            {"verdicts": [
+              {"id": 1, "verdict": "rejected", "reason": "framework idiom"},
+              {"id": 2, "verdict": "downgraded", "risk": "low", "confidence": "low", "reason": "r"},
+              {"id": 3, "verdict": "confirmed", "risk": "critical", "confidence": "high", "reason": "ok"},
+              {"id": 4, "verdict": "reje"""));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals(3, result.findings().size());
+    assertEquals("Speculative", result.findings().get(0).title());
+    assertEquals("low", result.findings().get(0).risk());
+    assertEquals("low", result.findings().get(0).confidence());
+    assertEquals("Real injection", result.findings().get(1).title());
+    // The unverified candidate survives untouched — a missing verdict never rejects or downgrades.
+    var unverified = result.findings().get(2);
+    assertEquals("Verdict cut off", unverified.title());
+    assertEquals("high", unverified.risk());
+    assertEquals("high", unverified.confidence());
+    assertEquals(3, result.summary().totalFindings());
+  }
+
+  @Test
+  void keepsEveryFindingWhenTheCutLeavesNoCompleteVerdict() {
+    // Nothing recoverable: the salvage adds nothing, and the service fails open exactly as it did
+    // before — the parse failure is rethrown into the fail-open catch.
+    ReviewResponse original =
+        response(finding("critical", "high", "Bug"), finding("low", "high", "Nit"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(aiOk("{\"verdicts\": [{\"id\": 1, \"verdict\": \"reje"));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+  }
+
+  @Test
+  void ignoresSalvagedVerdictsWhoseIdMatchesNoCandidate() {
+    // Salvage is best-effort over model output, so a verdict can carry an id outside the candidate
+    // range. It must not reject anything, while the in-range verdict beside it still applies.
+    ReviewResponse original = response(finding("critical", "high", "Bug"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiOk(
+                """
+            {"verdicts": [
+              {"id": 0, "verdict": "rejected", "reason": "no such candidate"},
+              {"id": 9, "verdict": "rejected", "reason": "no such candidate either"},
+              {"id": 1, "verdict": "downgraded", "risk": "low", "confidence": "low", "reason": "r"},
+              {"id": 2, "verdict": "conf"""));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals(1, result.findings().size());
+    assertEquals("low", result.findings().get(0).risk());
+    assertEquals("low", result.findings().get(0).confidence());
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvagerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvagerTest.java
@@ -282,6 +282,38 @@ class TruncatedResponseSalvagerTest {
   }
 
   @Test
+  void salvagesTheCompleteElementsOfANamedArray() {
+    // #546: the verifier's response is one named array, and its body arrives cut mid-JSON too. The
+    // same pass serves it — the verdicts that closed come back, the cut one is dropped, and the
+    // fields around it are skipped whole.
+    var body =
+        """
+        {"note":"thinking out loud",
+         "verdicts":[{"id":1,"verdict":"rejected","risk":null,"confidence":null,"reason":"fp"},
+                     {"id":2,"verdict":"confirmed","risk":"high","confidence":"high","reason":"ok"},
+                     {"id":3,"verdict":"downgr""";
+
+    var verdicts = salvager.salvageArray(body, "verdicts", VerificationResponse.Verdict.class);
+
+    assertEquals(2, verdicts.size());
+    assertEquals(1, verdicts.get(0).id());
+    assertEquals("rejected", verdicts.get(0).verdict());
+    assertEquals("confirmed", verdicts.get(1).verdict());
+  }
+
+  @Test
+  void namedArraySalvageComesBackEmptyWhenThereIsNothingToRecover() {
+    var type = VerificationResponse.Verdict.class;
+    // No body at all, and a body whose cut precedes the first complete element.
+    assertTrue(salvager.salvageArray(null, "verdicts", type).isEmpty());
+    assertTrue(
+        salvager.salvageArray("{\"verdicts\":[{\"id\":1,\"verd", "verdicts", type).isEmpty());
+    // A complete body that simply has no such field, and one where the field is not an array.
+    assertTrue(salvager.salvageArray("{\"other\":[{\"id\":1}]}", "verdicts", type).isEmpty());
+    assertTrue(salvager.salvageArray("{\"verdicts\":{\"id\":1}}", "verdicts", type).isEmpty());
+  }
+
+  @Test
   void closeQuietlyToleratesANullParser() {
     // Reached only if createParser itself threw; the guard is contract, tested directly.
     assertDoesNotThrow(() -> TruncatedResponseSalvager.closeQuietly(null));


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Seen twice in production on the 170-file PR #532:

```
WARN [FindingVerificationService] Finding verification failed — keeping unverified findings:
com.fasterxml.jackson.core.io.JsonEOFException: Unexpected end-of-input: expected close marker for Object
```

The verifier's body arrives cut mid-JSON **without** `finish_reason=length`, so it never reaches the truncation lane that names the cap — it lands in the generic `IOException | RuntimeException` catch and every verdict is thrown away, including the ones that parsed completely. A response carrying nine complete verdicts and a tenth cut off contributed nothing.

The review lane already solves this exact shape with `TruncatedResponseSalvager` (#500/#511), so this reuses that machinery rather than writing a second parser:

- `TruncatedResponseSalvager` keeps one bounded, never-throwing forward pass, now extracted into a private `scan` helper. `salvage` (findings / previous_findings_status / summary) and the new `salvageArray` both run on it, so the fence stripping, control-character escaping, element caps, body-size bound and end-at-the-cut handling stay in exactly one place.
- `salvageArray(body, field, type)` recovers the complete leading elements of a single named top-level array — the shape of the verifier's `{"verdicts": […]}`.
- `FindingVerificationService` parses as before, and only on a parse failure salvages the verdicts that closed before the cut and applies them. When nothing is recoverable the original failure is rethrown, so the caller logs and fails open exactly as it did.

Design constraints held:

- **Fail-open is unchanged and salvage is strictly additive to it.** A candidate whose verdict fell on the far side of the cut simply has no verdict, and `apply` already keeps such a finding as it stands — a missing verdict never rejects or downgrades anything.
- **The `finish_reason=length` lane is untouched**; a reported truncation still warns with the cap it names and keeps the unverified findings.
- **The log answers the next occurrence**, with counts on both sides:

```
WARN  [FindingVerificationService] Finding verification response was cut mid-JSON (Unexpected
end-of-input: was expecting closing quote for a string value … (through reference chain:
VerificationResponse["verdicts"]->java.util.ArrayList[3]->Verdict["verdict"])); salvaged 3
verdict(s) covering 3 of 4 candidate finding(s) — the remaining 1 stay unverified
INFO  [FindingVerificationService] Verifier rejected finding 'Hallucinated API claim' (src/Main.java:10): framework idiom
INFO  [FindingVerificationService] Finding verification: 2 kept, 1 downgraded, 1 rejected
```

The unrecoverable path's warning now also carries the count it keeps (`keeping the N unverified finding(s)`), so both outcomes are countable from the log. `Salvaged.NOTHING` went away with the early returns it served.

## Related Issues

Fixes #546

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**Red/green proof.** With the salvage lookup stubbed out to an empty list (the pre-fix behaviour: parse failure → discard everything) and nothing else changed, the two behavioural tests fail exactly as claimed:

```
[ERROR] Tests run: 3, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 1.147 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.ignoresSalvagedVerdictsWhoseIdMatchesNoCandidate -- Time elapsed: 0.015 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <low> but was: <critical>
	at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.ignoresSalvagedVerdictsWhoseIdMatchesNoCandidate(FindingVerificationServiceTest.java:474)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.appliesTheVerdictsThatCompletedWhenTheBodyIsCutMidJson -- Time elapsed: 0.008 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <3> but was: <4>
	at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.appliesTheVerdictsThatCompletedWhenTheBodyIsCutMidJson(FindingVerificationServiceTest.java:429)
```

`expected: <3> but was: <4>` is the bug verbatim: four candidates, three complete verdicts (one of them a rejection), and the pre-fix code keeps all four because it discarded the pass. The third new service test, `keepsEveryFindingWhenTheCutLeavesNoCompleteVerdict`, passes both before and after by design — it pins the unchanged fail-open path.

With the fix in place: `FindingVerificationServiceTest` 34 tests green, `TruncatedResponseSalvagerTest` 21 green (2 new: named-array salvage, and the nothing-to-recover shapes).

**Gates** (Java 25):

- `./mvnw -B spotless:apply` — BUILD SUCCESS
- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — `Tests run: 2630, Failures: 0, Errors: 0, Skipped: 0`, BUILD SUCCESS

**Coverage** — jacoco ∩ `git diff -U0` over changed main code: 40 instrumented changed lines, **0 uncovered lines and 0 uncovered branches**.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Covered above.

## Additional Notes

`FindingVerificationService`'s constructor gains the salvager, so the one other test that builds it directly (`FindingPipelineTest`) was updated. `TruncatedResponseSalvager`'s existing `salvage` behaviour is unchanged — all of its prior tests pass untouched.
