### PR TITLE
fix(ai): skip an empty SSE frame instead of failing it on the event loop

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/EmptyAiStreamFrameInterceptor.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/EmptyAiStreamFrameInterceptor.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.config;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.ConstrainedTo;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.RuntimeType;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.ReaderInterceptor;
+import jakarta.ws.rs.ext.ReaderInterceptorContext;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Drops a payload-less server-sent event from the AI provider's streaming response instead of
+ * letting it reach the JSON mapper.
+ *
+ * <p>During long reasoning pauses (high/xhigh/max effort) providers emit filler frames — a
+ * keep-alive comment ({@code : ping}), a bare {@code data:} with nothing after it, or a stray blank
+ * line. RESTEasy Reactive's {@code SseParser} dispatches those as an {@code InboundSseEvent} whose
+ * data is the empty string, and quarkus-langchain4j's {@code @SseEventFilter(DoneFilter)} only
+ * drops the terminal {@code [DONE]} sentinel, so the empty frame goes on to {@code
+ * InboundSseEventImpl.readData(ChatCompletionResponse.class)} and Jackson fails it with {@code
+ * MismatchedInputException: No content to map due to end-of-input}. That throw happens inside the
+ * SSE event handler on a Vert.x event-loop thread, outside every retry and truncation guard the
+ * review pipeline has, so it surfaces only as {@code VertxCoreRecorder: Uncaught exception received
+ * by Vert.x} at ERROR — the exact log line an operator scans for when a review really did fail
+ * (#552). Nothing is actually lost: the frame carried no payload and the stream survives.
+ *
+ * <p>Neither throwing layer is ours: the interceptor lives in quarkus-langchain4j's {@code
+ * OpenAiRestApi} and the parser in RESTEasy Reactive, and the SSE event filter that could have
+ * dropped the frame is fixed by annotation on that third-party interface. What is reachable is the
+ * reader-interceptor chain: {@code InboundSseEventImpl} builds it from the REST client's
+ * configuration, and Quarkus auto-registers every {@code @Provider} as a global REST client
+ * provider, so this interceptor is inserted into the AI client's chain. Its priority puts it ahead
+ * of {@code OpenAiRestApi.OpenAiRestApiReaderInterceptor} ({@link Priorities#USER}), so it sees the
+ * frame first. Returning {@code null} rather than calling {@code proceed()} skips the frame the way
+ * {@code MultiInvoker} already expects — it emits an item only when the read returns non-null — so
+ * the stream continues untouched.
+ *
+ * <p>The guard is deliberately narrow, because the point of #552 is to stop masking real failures,
+ * not to add masking of our own. All three conditions must hold:
+ *
+ * <ul>
+ *   <li>the target type is one of the OpenAI wire types ({@value #OPENAI_WIRE_TYPE_PACKAGE}), so
+ *       reads for the GitHub REST clients and every other client are untouched;
+ *   <li>the reader context carries no headers, which is only true of the per-event SSE read path
+ *       ({@code InboundSseEventImpl} passes an empty map, while a whole-response read always passes
+ *       the response headers) — an empty body on a non-streaming AI call therefore still fails
+ *       loudly instead of turning into a silent null;
+ *   <li>the frame body is blank. A frame with any JSON in it is handed on unread-from, and a
+ *       malformed non-blank frame still raises the mapping error it should.
+ * </ul>
+ */
+@Provider
+@ConstrainedTo(RuntimeType.CLIENT)
+@Priority(EmptyAiStreamFrameInterceptor.PRIORITY)
+public class EmptyAiStreamFrameInterceptor implements ReaderInterceptor {
+
+  /**
+   * Ahead of {@code OpenAiRestApi.OpenAiRestApiReaderInterceptor}, which is registered without a
+   * {@link Priority} and so sorts at {@link Priorities#USER}; the chain runs in ascending priority.
+   */
+  static final int PRIORITY = Priorities.USER - 100;
+
+  /**
+   * Package holding the OpenAI-compatible response types the AI client deserializes frames into.
+   */
+  static final String OPENAI_WIRE_TYPE_PACKAGE = "dev.langchain4j.model.openai.internal.";
+
+  @Override
+  public Object aroundReadFrom(ReaderInterceptorContext context) throws IOException {
+    if (!isAiStreamFrame(context)) {
+      return context.proceed();
+    }
+    byte[] frame = context.getInputStream().readAllBytes();
+    if (new String(frame, StandardCharsets.UTF_8).isBlank()) {
+      return null;
+    }
+    context.setInputStream(new ByteArrayInputStream(frame));
+    return context.proceed();
+  }
+
+  /** True only for a single server-sent event read into an AI response type. */
+  private static boolean isAiStreamFrame(ReaderInterceptorContext context) {
+    Class<?> type = context.getType();
+    return type != null
+        && type.getName().startsWith(OPENAI_WIRE_TYPE_PACKAGE)
+        && context.getHeaders().isEmpty();
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/EmptyAiStreamFrameInterceptorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/EmptyAiStreamFrameInterceptorTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
+import io.quarkiverse.langchain4j.openai.common.OpenAiRestApi;
+import io.quarkus.arc.Arc;
+import io.quarkus.rest.client.reactive.runtime.AnnotationRegisteredProviders;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.ws.rs.RuntimeType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.ReaderInterceptorContext;
+import java.io.IOException;
+import org.jboss.resteasy.reactive.client.impl.ClientSerialisers;
+import org.jboss.resteasy.reactive.client.impl.InboundSseEventImpl;
+import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
+import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drives the real read path of #552: an {@link InboundSseEventImpl} carrying an empty {@code data:}
+ * payload, read through the same reader-interceptor chain the AI client uses ({@code
+ * OpenAiRestApi.OpenAiRestApiReaderInterceptor} over {@code
+ * OpenAiRestApi.OpenAiRestApiJacksonReader}). Without {@link EmptyAiStreamFrameInterceptor} in that
+ * chain the read fails with {@code MismatchedInputException: No content to map due to end-of-input}
+ * — and in production that throw happens on a Vert.x event loop, where it can only surface as an
+ * uncaught ERROR.
+ */
+@QuarkusTest
+class EmptyAiStreamFrameInterceptorTest {
+
+  /** A frame body that maps cleanly; {@code id} is what the AI client's own validation requires. */
+  private static final String REAL_FRAME = "{\"id\":\"chatcmpl-552\"}";
+
+  /** Sentinel returned by a mocked {@code proceed()}, so "passed through" is observable. */
+  private static final Object PROCEEDED = new Object();
+
+  @Test
+  void anEmptyFrameIsSkippedInsteadOfFailingTheRead() {
+    assertNull(readFrame("", true));
+  }
+
+  @Test
+  void aWhitespaceOnlyFrameIsSkippedToo() {
+    assertNull(readFrame("   ", true));
+  }
+
+  @Test
+  void withoutTheInterceptorTheSameFrameFailsToMap() {
+    var failure = assertThrows(RuntimeException.class, () -> readFrame("", false));
+
+    var cause = rootCause(failure);
+    assertInstanceOf(MismatchedInputException.class, cause, failure.toString());
+    assertTrue(cause.getMessage().contains("No content to map"), cause.getMessage());
+  }
+
+  @Test
+  void aFrameCarryingContentIsStillDeserialized() {
+    var response = readFrame(REAL_FRAME, true);
+
+    assertNotNull(response);
+    assertEquals("chatcmpl-552", response.id());
+  }
+
+  @Test
+  void aMalformedNonBlankFrameStillFailsLoudly() {
+    assertThrows(RuntimeException.class, () -> readFrame("{", true));
+  }
+
+  @Test
+  void aReadForAnotherClientsTypeIsLeftAlone() throws IOException {
+    var context = contextFor(String.class, new CaseInsensitiveMap<>());
+
+    assertSame(PROCEEDED, new EmptyAiStreamFrameInterceptor().aroundReadFrom(context));
+    verify(context, never()).getInputStream();
+  }
+
+  @Test
+  void aReadWithoutAKnownTypeIsLeftAlone() throws IOException {
+    var context = contextFor(null, new CaseInsensitiveMap<>());
+
+    assertSame(PROCEEDED, new EmptyAiStreamFrameInterceptor().aroundReadFrom(context));
+    verify(context, never()).getInputStream();
+  }
+
+  @Test
+  void aWholeResponseReadWithHeadersIsLeftAlone() throws IOException {
+    var headers = new CaseInsensitiveMap<String>();
+    headers.putSingle("content-type", MediaType.APPLICATION_JSON);
+    var context = contextFor(ChatCompletionResponse.class, headers);
+
+    assertSame(PROCEEDED, new EmptyAiStreamFrameInterceptor().aroundReadFrom(context));
+    verify(context, never()).getInputStream();
+  }
+
+  @Test
+  void theInterceptorIsRegisteredOnTheAiRestClient() {
+    var providers =
+        Arc.container()
+            .instance(AnnotationRegisteredProviders.class)
+            .get()
+            .getProviders(OpenAiRestApi.class);
+
+    assertEquals(
+        EmptyAiStreamFrameInterceptor.PRIORITY,
+        providers.get(EmptyAiStreamFrameInterceptor.class),
+        () -> "not registered on the AI client: " + providers.keySet());
+  }
+
+  private static ReaderInterceptorContext contextFor(
+      Class<?> type, CaseInsensitiveMap<String> headers) throws IOException {
+    var context = mock(ReaderInterceptorContext.class);
+    doReturn(type).when(context).getType();
+    when(context.getHeaders()).thenReturn(headers);
+    when(context.proceed()).thenReturn(PROCEEDED);
+    return context;
+  }
+
+  private static ChatCompletionResponse readFrame(String data, boolean withInterceptor) {
+    return sseFrame(data, withInterceptor).readData(ChatCompletionResponse.class);
+  }
+
+  /**
+   * The AI client's reader chain as {@code QuarkusOpenAiClient} builds it, reproduced around a
+   * single dispatched server-sent event.
+   */
+  private static InboundSseEventImpl sseFrame(String data, boolean withInterceptor) {
+    var configuration = new ConfigurationImpl(RuntimeType.CLIENT);
+    configuration.register(new OpenAiRestApi.OpenAiRestApiJacksonReader());
+    configuration.register(new OpenAiRestApi.OpenAiRestApiReaderInterceptor());
+    if (withInterceptor) {
+      configuration.register(new EmptyAiStreamFrameInterceptor());
+    }
+    var event = new InboundSseEventImpl(configuration, new ClientSerialisers());
+    event.setData(data);
+    event.setMediaType(MediaType.APPLICATION_JSON_TYPE);
+    return event;
+  }
+
+  private static Throwable rootCause(Throwable throwable) {
+    var cause = throwable;
+    while (cause.getCause() != null) {
+      cause = cause.getCause();
+    }
+    return cause;
+  }
+}


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

An SSE frame with an empty `data:` payload — a keep-alive comment (`: ping`), a bare `data:` with nothing after it, or a stray blank line — raises an uncaught `ProcessingException` on a Vert.x event loop during long reasoning. Benign in outcome (nothing is lost, the stream survives and the review completes), but logged at ERROR as *uncaught* once every few reviews, which is precisely the signature an operator scans for when a review really does fail.

### What was diagnosed first

The throw is entirely in third-party code, so the first job was establishing what we can actually influence:

1. **`SseParser` dispatches the frame at all.** `SseParser.dispatchEvent` does `event.setData(dataBuffer.length() == 0 ? "" : ...)`, so a payload-less frame becomes an `InboundSseEvent` with data `""` rather than being dropped. Not configurable.
2. **The event filter that could drop it is fixed by annotation.** `MultiInvoker.createEventPredicate` reads `@SseEventFilter` off the invoked method, and quarkus-langchain4j declares `@SseEventFilter(DoneFilter.class)` on `OpenAiRestApi.streamingChatCompletion`. `DoneFilter` is `!"[DONE]".equals(event.data())` — the empty frame is kept. We cannot supply a different filter without patching that interface.
3. **The client cannot be told to skip empty frames.** `QuarkusOpenAiClient` builds the REST client itself; the builder exposes timeouts, logging, proxy, headers and TLS — no frame filtering. Nothing in `quarkus.langchain4j.openai.*` touches SSE frame handling.
4. **The reader-interceptor chain *is* reachable.** `InboundSseEventImpl` builds its interceptor array from `configuration.getReaderInterceptors()` (the REST client's own configuration), and Quarkus's `RestClientReactiveProcessor.registerProvidersFromAnnotations` adds every `@Provider` class as a *global* rest-client provider, merged into each client's provider map by `AnnotationRegisteredProviders.addProviders`. So a `@Provider` `ReaderInterceptor` of ours lands in the AI client's chain.

Ranked, that makes an interceptor the narrowest real lever — it pre-empts the deserialization at the exact frame that would fail, rather than reacting to the log line afterwards. **Log suppression was not needed and is not used here**: no Vert.x uncaught-exception handler, no log filter, no blanket `ProcessingException` handling. The ERROR line stays fully intact for every failure that is not this shape.

### The fix

`EmptyAiStreamFrameInterceptor` — a `@Provider @ConstrainedTo(CLIENT) ReaderInterceptor` at `Priorities.USER - 100`, which puts it ahead of `OpenAiRestApi.OpenAiRestApiReaderInterceptor` (registered without a priority, so it sorts at `Priorities.USER`). For a blank frame it returns `null` instead of calling `proceed()`. `MultiInvoker` already handles that: `R item = event.readData(responseType); if (item != null) { multiRequest.emit(item); }` — the frame is skipped and the stream continues untouched.

### Trade-off, and how the guard is kept narrow

Returning `null` where the stack used to throw is a form of swallowing, and #552 is explicitly about *not* masking real failures. So all three conditions must hold before the interceptor does anything:

| Condition | What it rules out |
| --- | --- |
| target type is in `dev.langchain4j.model.openai.internal.` | every other REST client (GitHub API clients, dashboard) reads unchanged |
| the reader context carries **no headers** | only true of the per-event SSE read (`InboundSseEventImpl` passes an empty map; a whole-response read always passes the response headers). An empty body on a *non-streaming* AI call therefore still fails loudly instead of turning into a silent `null` |
| the frame body is blank | a malformed non-blank frame still raises the mapping error it should; a frame carrying JSON is handed on with its stream restored |

Residual trade-off worth naming: if a provider ever regressed into sending an empty frame *instead of* real content, that would now be silent rather than loud. That failure mode is already covered elsewhere — an empty stream produces an empty response, which the review pipeline's own truncation/empty-response handling catches on the app side, where it can be reported with context, rather than as an uncaught event-loop ERROR that no handler sees.

The type match is by package name rather than a hard class reference, so no new dependency is declared on langchain4j's `internal` package. If that package is ever renamed the guard stops matching and the old ERROR comes back — visible, not silent. `theInterceptorIsRegisteredOnTheAiRestClient` guards the registration half of that.

## Related Issues

Fixes #552

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

No live API calls were made. The reproduction is synthetic: an `InboundSseEventImpl` with empty `data`, read through the same chain the AI client uses (`OpenAiRestApi.OpenAiRestApiReaderInterceptor` over `OpenAiRestApi.OpenAiRestApiJacksonReader`, both the real third-party classes).

### Red — verbatim, with the interceptor body reduced to a pass-through `return context.proceed();`

```
[ERROR] Tests run: 9, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 2.633 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.config.EmptyAiStreamFrameInterceptorTest
[ERROR] dev.thiagogonzaga.thrillhousebot.config.EmptyAiStreamFrameInterceptorTest.anEmptyFrameIsSkippedInsteadOfFailingTheRead -- Time elapsed: 0.005 s <<< ERROR!
[ERROR] dev.thiagogonzaga.thrillhousebot.config.EmptyAiStreamFrameInterceptorTest.aWhitespaceOnlyFrameIsSkippedToo -- Time elapsed: 0.001 s <<< ERROR!
[ERROR] Errors:
[ERROR]   EmptyAiStreamFrameInterceptorTest.aWhitespaceOnlyFrameIsSkippedToo:72->readFrame:147 » Processing com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
[ERROR]   EmptyAiStreamFrameInterceptorTest.anEmptyFrameIsSkippedInsteadOfFailingTheRead:67->readFrame:147 » Processing com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
```

The red stack lands on the same third-party frames as the production report, at the same line numbers:

```
jakarta.ws.rs.ProcessingException:
com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
	at org.jboss.resteasy.reactive.client.impl.ClientReaderInterceptorContextImpl.proceed(ClientReaderInterceptorContextImpl.java:90)
	at io.quarkiverse.langchain4j.openai.common.OpenAiRestApi$OpenAiRestApiReaderInterceptor.aroundReadFrom(OpenAiRestApi.java:309)
	at org.jboss.resteasy.reactive.client.impl.ClientReaderInterceptorContextImpl.proceed(ClientReaderInterceptorContextImpl.java:135)
	at dev.thiagogonzaga.thrillhousebot.config.EmptyAiStreamFrameInterceptor.aroundReadFrom(EmptyAiStreamFrameInterceptor.java:88)
	at org.jboss.resteasy.reactive.client.impl.ClientReaderInterceptorContextImpl.proceed(ClientReaderInterceptorContextImpl.java:135)
	at org.jboss.resteasy.reactive.client.impl.ClientSerialisers.invokeClientReader(ClientSerialisers.java:157)
	at org.jboss.resteasy.reactive.client.impl.InboundSseEventImpl.readData(InboundSseEventImpl.java:130)
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
	at io.quarkiverse.langchain4j.openai.common.OpenAiRestApi$OpenAiRestApiJacksonReader.readFrom(OpenAiRestApi.java:292)
```

`OpenAiRestApi.java:309` and `InboundSseEventImpl.java:130` are the exact frames quoted in #552.

### Green

```
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.711 s -- in dev.thiagogonzaga.thrillhousebot.config.EmptyAiStreamFrameInterceptorTest
```

Nine tests: empty frame skipped, whitespace-only frame skipped, the same frame failing to map without the interceptor, a real frame still deserialized (`chatcmpl-552`), a malformed non-blank frame still failing loudly, and the three narrowing conditions each proven to pass the read straight through (another client's type, an unknown type, a whole-response read with headers). The ninth boots the app and asserts `AnnotationRegisteredProviders.getProviders(OpenAiRestApi.class)` really contains the interceptor at its declared priority — that is what proves the registration mechanism, not just the logic.

### Gates

| Gate | Result |
| --- | --- |
| `./mvnw -B spotless:apply` | clean |
| `./mvnw -B clean compile spotbugs:check spotless:check` | `BugInstance size is 0`, BUILD SUCCESS |
| `./mvnw -B clean test` | `Tests run: 2634, Failures: 0, Errors: 0, Skipped: 0` |
| jacoco ∩ diff | `EmptyAiStreamFrameInterceptor.java`: LINE missed 0 / covered 12, BRANCH missed 0 / covered 10 |

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Production signature this removes:

```
ERROR [io.quarkus.vertx.core.runtime.VertxCoreRecorder] (vert.x-eventloop-thread-N)
Uncaught exception received by Vert.x: jakarta.ws.rs.ProcessingException:
com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
```

## Additional Notes

- No behaviour change for any non-AI client, and none for non-streaming AI calls.
- No `application.properties` change — nothing needed one; the fix is entirely in the client provider chain.
- Nothing in the review pipeline was touched.
