### PR TITLE
fix(improve): name the budget when it fit no part of the diff

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrImprovementService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrImprovementService.java
@@ -63,6 +63,16 @@ public class PrImprovementService extends AbstractPrSuggestionGenerator {
       "✨ ThrillhouseBot found no reviewable changes to improve in this PR.";
   static final String GENERATION_FAILED =
       "✨ ThrillhouseBot could not generate improvements for this PR. Please try `/improve` again.";
+
+  /**
+   * Posted when the token budget could fit no part of the diff: the plan is empty but the omitted
+   * list is not, so "no reviewable changes" would be false — there were changes, they could not be
+   * read. Mirrors the sibling generators, which all name the budget as the cause.
+   */
+  static final String NOT_COVERED =
+      "✨ ThrillhouseBot could not fit any part of this PR into the per-call input-token budget,"
+          + " so it has nothing to improve. Raise the input-token budget and re-run `/improve`.";
+
   static final String NOTHING_TO_IMPROVE =
       "✨ ThrillhouseBot has no improvements to suggest for the changes in this PR.";
 
@@ -153,7 +163,7 @@ public class PrImprovementService extends AbstractPrSuggestionGenerator {
               PrSuggestionPrompts.userPrompt(),
               0);
       if (plan.batches().isEmpty()) {
-        postComment(auth, task, NO_CHANGES + disclosure(plan));
+        postComment(auth, task, plan.truncated() ? NOT_COVERED + disclosure(plan) : NO_CHANGES);
         return;
       }
       var generated = generate(inputs, plan);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrImprovementServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrImprovementServiceTest.java
@@ -912,4 +912,22 @@ class PrImprovementServiceTest {
         .createPullRequestComment(any(), any(), any(), any(), anyInt(), any());
     assertTrue(postedSummary().contains("could not be pinned to the diff"), postedSummary());
   }
+
+  @Test
+  void namesTheBudgetWhenItCouldNotCoverASingleFile() {
+    // An empty plan with a non-empty omitted list is not "nothing to improve": there were
+    // changes, the budget could not read them. Saying NO_CHANGES here reports a misconfigured
+    // budget as a clean verdict, and contradicts the partial-coverage disclosure posted with it.
+    // The sibling generators all name the budget for this shape; /improve was the odd one out.
+    when(activeModel.maxInputTokens()).thenReturn(10);
+    prWithFiles(foo(), otherFile());
+
+    service.handle(task(), AUTH);
+
+    var body = postedSummary();
+    assertTrue(body.startsWith(PrImprovementService.NOT_COVERED), body);
+    assertTrue(body.contains("src/Foo.java"), body);
+    assertTrue(body.contains("partial coverage"), body);
+    verifyNoInteractions(improveAssistant);
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

When the token budget fits no part of the diff, `/improve` posted two contradicting sentences: "found no reviewable changes to improve" together with a partial-coverage disclosure naming the files it omitted. There were reviewable changes — the budget could not read them — so a misconfigured budget was reported as a clean verdict.

All four sibling generators (`PrDescriptionGenerator`, `ChangelogEntryGenerator`, `UnitTestGenerator`, `DocGenerationService`) already carry a `NOT_COVERED` branch for this exact shape, naming the budget as the cause. `/improve` was the only one missing it; this adds it with matching wording.

Found by the bot's own review of the release PR (#532).

## Related Issues

Fixes #556

## How Has This Been Tested?

- [x] Unit tests

Red, with only the branch reverted (the new constant left in place so the test still compiles):

```
[ERROR] PrImprovementServiceTest.namesTheBudgetWhenItCouldNotCoverASingleFile <<< FAILURE!
org.opentest4j.AssertionFailedError:
> ⚠️ **Large PR — partial coverage.** 2 file(s) were omitted entirely (src/Foo.java, src/Other.java) because the diff exceeded the review budget, so this covers only part of the diff. ==> expected: <true> but was: <false>
```

The failure output is the bug: the posted body carries the partial-coverage disclosure while the lead sentence claims nothing was reviewable. The new test mirrors the sibling generators' equivalent (`namesTheFilesWhenTheBudgetCouldNotCoverASingleOne`), driving the real planner with a budget the prompt overhead alone exhausts.

Green with the fix; full suite `Tests run: 2626, Failures: 0, Errors: 0`. SpotBugs `BugInstance size is 0`, spotless clean.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The plain `NO_CHANGES` path is unchanged and still covers the genuine case — a PR whose diff really has nothing to improve.