### PR TITLE
fix(docker): stop storing the native binary twice and drop website from the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,8 +19,11 @@ frontend/out
 frontend/coverage
 frontend/.turbo
 
-# Docs (not copied into any image)
+# Docs (not copied into any image). `website` is the Astro docs site — its sources,
+# generated output (dist/, .astro/) and local dependencies are built and published by the
+# Docs workflow, never by an image build.
 docs
+website
 
 # Secrets and local env — never ship these in a build context
 .env

--- a/src/main/docker/Dockerfile.runtime
+++ b/src/main/docker/Dockerfile.runtime
@@ -6,9 +6,12 @@ FROM quay.io/quarkus/ubi9-quarkus-micro-image@sha256:7d40f354792f52079213107a50b
 
 ARG TARGETARCH
 WORKDIR /work/
-COPY target/${TARGETARCH}/*-runner /work/application
-
-RUN chmod 555 /work/application && chown 1001:root /work /work/application
+# Set mode and ownership on the COPY itself, as Dockerfile.runtime-distroless does.
+# A follow-up RUN chmod/chown rewrites the file, so the whole native binary would be
+# stored a second time in the RUN layer, roughly doubling the image.
+# /work itself is left root-owned (0755): nothing is written to the working directory at
+# runtime, and a non-writable /work keeps uid 1001 from replacing its own executable.
+COPY --chown=1001:root --chmod=0555 target/${TARGETARCH}/*-runner /work/application
 
 EXPOSE 8080
 USER 1001


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🚀 Performance
- [x] 🔒 Security
- [x] 🏗️ CI/CD

## Description

Two Docker build-hygiene fixes, kept in one PR because both are packaging concerns on the same image build.

**#558 — the native runtime image stored the binary twice.** `Dockerfile.runtime` copied the runner and then ran `chmod`/`chown` on it in a separate layer. `chmod`/`chown` rewrites the file, so the whole native binary was written a second time into the `RUN` layer and shipped twice. Mode and ownership now ride on the `COPY`, exactly as `Dockerfile.runtime-distroless` already does.

The dropped `RUN` also chowned **`/work` itself** to `1001:root`, which `COPY --chown` does not cover. That ownership is not required, and the PR does not restore it:

- No runtime writes to the working directory: no `Files.write` / `FileOutputStream` / `createTempFile` / `FileWriter` anywhere in `src/main/java`, no `quarkus.log.file.*`, and the prod datasource is PostgreSQL (`%prod.quarkus.datasource.db-kind`), not a file-backed database.
- `Dockerfile.runtime-distroless` already ships `/work` root-owned and runs as `nonroot`, and that variant is published on every release — so a root-owned `/work` is already proven in production.
- It is also the safer state: with `/work` owned by the running uid, uid 1001 can unlink and replace `/work/application` despite the binary being `0555`. Root-owned `0755` closes that.

`/work/application` keeps its previous `1001:root` ownership and `0555` mode; only the directory ownership changes.

**#559 — `website/` was missing from `.dockerignore`.** The file's header says the build context should carry only `target/` (runtime/jvm) and `mvnw`/`.mvn`/`pom.xml`/`src` (multistage), and `docs/` is excluded on exactly that reasoning — but the Astro docs site under `website/` was not, so all of it went into every image build context while reaching no image. It is excluded next to `docs`, which covers the sources plus `dist/`, `.astro/` and any local `node_modules` in one entry (listing only the generated directories the way `frontend/` does would be a no-op on a CI checkout, where none of them exist — the 11.5MB is `website/src`).

`Dockerfile.multistage` is unaffected: the entry matches the top-level `website/` directory only, and the multistage `COPY src /code/src` copies the repo-root `src/`, which is verified below as still fully present in the context.

## Related Issues

Fixes #558
Fixes #559

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

No Java changed, so there is no behavioral test to go red; the packaging change was verified against a real image build instead. **CI does not cover this Dockerfile on a PR** — `native-build` and the `docker` job that builds `Dockerfile.runtime` are gated on `github.ref == 'refs/heads/main'`, and `docker-pr` builds `Dockerfile.jvm` only. So the verification below is the confirmation, not CI.

A faithful stand-in for the native binary (149,946,490 bytes ≈ the 143MB real runner, mode `0644`) was placed at `target/amd64/x-runner` and the same file was built with the Dockerfile before and after the change.

**Before** (`docker history`, uncompressed layer sizes):

```
150MB   RUN |1 TARGETARCH=amd64 /bin/sh -c chmod 555 /work/application && chown 1001:root /work /work/application
150MB   COPY target/amd64/*-runner /work/application
0B      WORKDIR /work/
```

`docker images` total: **326MB**

**After:**

```
150MB   COPY --chown=1001:root --chmod=0555 target/amd64/*-runner /work/application
0B      WORKDIR /work/
```

`docker images` total: **176MB** — a 150MB reduction, exactly one copy of the binary. Scaled to the real 143MB runner this takes the published native image from 311MB to roughly 168MB.

**Container still correct after the change.** The stand-in prints its own uid/gid/cwd when executed, so `docker run` exercises the real entrypoint path:

```
$ docker run --rm thb-after
uid=1001 gid=0 cwd=/work args=-Dquarkus.http.host=0.0.0.0

$ docker run --rm --entrypoint /bin/sh thb-after -c 'ls -ln /work; ls -ldn /work; [ -x /work/application ] && echo BINARY_EXECUTABLE'
-r-xr-xr-x 1 1001 0 149946490 Aug 11 21:31 application
drwxr-xr-x 1 0 0 4096 Aug 11 21:32 /work
BINARY_EXECUTABLE
```

Same on the before-image except `/work` is `1001 0` there. The binary is executed by uid 1001 with cwd `/work` and mode `0555` owned `1001:root` in both.

**Build context (#559)**, measured by copying the full context into a throwaway image and running `du -sh`:

| | context size | files |
|---|---|---|
| before | 159.5MB | 534 |
| after | 148.0MB | 397 |

(Both totals include the 143MB stand-in under `target/`.) The remaining `/ctx/src` is 4.3MB with `main` and `test` both present, and `website` is absent — so the multistage `COPY src /code/src` is unaffected.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

Gates on the branch: `./mvnw -B clean compile spotbugs:check spotless:check` → BUILD SUCCESS, `BugInstance size is 0`; `./mvnw -B clean test` → `Tests run: 2640, Failures: 0, Errors: 0, Skipped: 0`. No Java or `pom.xml` changes, so there are no changed main lines for the coverage intersection to cover.

## Additional Notes

`COPY --chmod` requires BuildKit. Both CI paths that build this file (`docker` in `ci.yml`, `docker-test-image.yml`) use `docker/build-push-action` with `setup-buildx-action`, and `Dockerfile.runtime-distroless` has been using `--chmod` all along, so no builder change is needed.
