### PR TITLE
fix(review): reject the interrogative clear directive, and say when one named nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,15 @@ the repository (or to be named in
 AI budget.
 
 **`@thrillhousebot resolved`** — a directive, not a slash command: it has no `/resolved`
-form, and it is read by the *next* review rather than acted on immediately (the bot replies
-with a short acknowledgement when it sees one). Do not confuse it with `/resolve`, which
-resolves GitHub review threads and does nothing to a finding that never opened one. Its
-access check is the commenter's GitHub `author_association` on that comment — `OWNER`,
-`MEMBER` or `COLLABORATOR` — and `THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` does
-*not* extend it.
+form, and it is read by the *next* review rather than acted on immediately. The bot replies
+straight away to say what that review will evaluate — and, when the comment names no
+`path:line` at all, to say plainly that nothing will be cleared, so a mistyped locator shows
+up immediately instead of as a review that changes nothing. It is a statement, never a
+question: `@thrillhousebot resolved?` is asking, not deciding, and clears nothing. Do not
+confuse it with `/resolve`, which resolves GitHub review threads and does nothing to a
+finding that never opened one. Its access check is the commenter's GitHub
+`author_association` on that comment — `OWNER`, `MEMBER` or `COLLABORATOR` — and
+`THRILLHOUSEBOT_REVIEW_MANUAL_TRIGGER_ALLOWED_LOGINS` does *not* extend it.
 
 **Pause** — while a PR is paused, ThrillhouseBot skips automatic reviews on new commits,
 ignores `/review`, `/summary`, `/describe`, `/changelog`, `/add-docs`, `/improve` and
@@ -403,9 +406,12 @@ Closing a finding wrongly is worse than leaving it open, so the match is strict
 and **when the naming is ambiguous the finding stays held**. All of the
 following must hold:
 
-- **The comment carries `@thrillhousebot resolved`.** `resolve` (the thread
+- **The comment states `@thrillhousebot resolved`.** `resolve` (the thread
   command) is not it, and a mention alone is not it — an ordinary question about
-  a finding is engagement, not a decision.
+  a finding is engagement, not a decision. Nor is the interrogative:
+  `@thrillhousebot resolved?` *asks* whether a finding was fixed, so it clears
+  nothing even when the rest of the comment names one. A question mark anywhere
+  later is fine — only one straight after the directive words makes it a question.
 - **You name the finding by *both* its `path:line` locator and its own content**
   — its title, or its description when it has no title. Each **Things to
   double-check** row already prints both, the title first and then the locator in
@@ -431,8 +437,15 @@ One comment may name several findings; each is matched independently, and one it
 does not name stays open. A finding with neither a title nor a description can
 never be named this way, so it stays held — fix it, or reply on its thread if it
 has one. The clearing is applied by the next review, which records the finding
-**resolved**; the bot posts a short acknowledgement when it sees the directive so
-you know it was read.
+**resolved**.
+
+The bot answers the directive as soon as it sees it, but only with what is
+knowable that early: it has no review loaded and no findings to match against, so
+it says what the next review will evaluate rather than reporting an outcome. The
+one exception is a directive naming no `path:line` at all — that provably clears
+nothing, so the reply says so outright and shows the shape to use. A locator that
+is present but wrong still gets the general reply, and the review is what reports
+the finding still unresolved.
 
 **Conversation read ceiling.** A review reads the PR conversation in pages of
 100, up to 10 pages — 1000 comments — so one review can never turn a runaway

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -737,9 +737,17 @@ public class FollowUpAnalyzer {
    * it is not the existing {@code /resolve} command (which resolves GitHub review threads) under a
    * second name — {@code TriggerDetector}'s {@code resolve} pattern ends in a word boundary and
    * therefore does not fire on {@code resolved}.
+   *
+   * <p>The trailing lookahead rejects the interrogative: a word boundary holds before {@code ?}, so
+   * "@thrillhousebot resolved? `src/A.java:10` — SQL injection" — a maintainer <em>asking</em>
+   * whether a finding was fixed, while quoting it well enough to name it — otherwise parses as an
+   * instruction and closes the very finding the question is about. Asking is not deciding, and this
+   * is the over-clear direction, so a token immediately followed by a question mark (whitespace
+   * aside) is not a directive. The lookahead cannot skip past the naming, so a genuine directive
+   * that happens to end in a question ("…— fixed in abc123, ok?") still counts.
    */
   private static final Pattern CLEAR_DIRECTIVE =
-      Pattern.compile("@thrillhousebot\\s+resolved\\b", Pattern.CASE_INSENSITIVE);
+      Pattern.compile("@thrillhousebot\\s+resolved\\b(?!\\s*\\?)", Pattern.CASE_INSENSITIVE);
 
   /** Fenced code blocks, dropped before a conversation comment is read as a directive. */
   private static final Pattern FENCED_CODE = Pattern.compile("(?s)```.*?```|~~~.*?~~~");
@@ -771,6 +779,30 @@ public class FollowUpAnalyzer {
    */
   static boolean isClearDirective(String body) {
     return body != null && CLEAR_DIRECTIVE.matcher(directiveText(body)).find();
+  }
+
+  /**
+   * The shape every locator has — a path, a colon, a line number. Only ever used to prove a
+   * <em>negative</em>; see {@link #namesALocator}.
+   */
+  private static final Pattern LOCATOR_SHAPE = Pattern.compile("\\S+:\\d+");
+
+  /**
+   * Whether {@code body} names anything locator-shaped at all. This is a <em>necessary</em>
+   * condition of {@link #clearedInConversation}, never a sufficient one: clearing a finding
+   * requires its exact {@code path:line}, so a comment carrying no {@code path:line} token
+   * whatsoever provably clears nothing, while one that carries such a token may still match no
+   * finding.
+   *
+   * <p>That asymmetry is the whole point. {@link MaintainerReplyService} answers a directive before
+   * any review has run, with no prior round loaded and no findings to match against — it cannot
+   * decide whether a clear will happen, and guessing would be worse than silence. It can, however,
+   * state the one thing derivable from the comment alone: that a directive naming no locator will
+   * clear nothing, so a maintainer who wrote the directive but forgot (or mistyped away) the
+   * locator is told immediately rather than after the next review quietly changes nothing.
+   */
+  static boolean namesALocator(String body) {
+    return body != null && LOCATOR_SHAPE.matcher(namingText(body)).find();
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
@@ -191,28 +191,46 @@ public class MaintainerReplyService {
   }
 
   /**
-   * Acknowledgement posted for an {@code @thrillhousebot resolved} comment. Deliberately
-   * deterministic prose rather than an assistant answer: the directive is an instruction the review
-   * path acts on, not a question, and a generated reply could contradict or overstate what it does.
-   * The wording is conditional because the clearing decision is made by the next review, which
-   * matches each named finding against its own {@code path:line} and title (#548).
+   * Acknowledgement posted for an {@code @thrillhousebot resolved} comment that names at least one
+   * locator. Deliberately deterministic prose rather than an assistant answer: the directive is an
+   * instruction the review path acts on, not a question, and a generated reply could contradict or
+   * overstate what it does.
+   *
+   * <p>It states what will be <em>evaluated</em>, never that a clear happened. This reply is
+   * written before any review has run — no prior round is loaded here and no findings exist to
+   * match against — so whether a given locator names a real finding is not knowable at this point
+   * and is left to the review that decides it (#548). Hence no "done", and no count.
    */
   static final String CLEAR_DIRECTIVE_ACK =
-      "Noted. Every previous finding your comment names by its `path:line` and title is treated as"
-          + " cleared from the next review onward; any it does not name stays open.";
+      "The next review will close every previous finding this comment names by its `path:line` and"
+          + " title; anything it does not name stays open.";
+
+  /**
+   * Acknowledgement for a directive that names no {@code path:line} at all. Unlike the general
+   * case, this outcome <em>is</em> knowable from the comment alone — naming a finding requires its
+   * locator ({@link FollowUpAnalyzer#namesALocator}) — so the reply says plainly that nothing will
+   * be cleared rather than leaving a maintainer who mistyped or omitted the locator to discover it
+   * from a review that changes nothing.
+   */
+  static final String CLEAR_DIRECTIVE_NO_LOCATOR_ACK =
+      "That comment names no finding, so nothing will be cleared. Name each one by its `path:line`"
+          + " and title exactly as the summary prints it — for example `@thrillhousebot resolved"
+          + " src/main/java/com/example/Widget.java:42 — Missing null check`.";
 
   private void handleMention(String auth, ReplyTask task) {
     if (FollowUpAnalyzer.isClearDirective(task.question())) {
+      boolean named = FollowUpAnalyzer.namesALocator(task.question());
       commentClient.createComment(
           auth,
           ACCEPT,
           task.owner(),
           task.repo(),
           task.prNumber(),
-          new GitHubCommentClient.CreateCommentRequest(CLEAR_DIRECTIVE_ACK));
+          new GitHubCommentClient.CreateCommentRequest(
+              named ? CLEAR_DIRECTIVE_ACK : CLEAR_DIRECTIVE_NO_LOCATOR_ACK));
       Log.infof(
-          "Acknowledged a maintainer clear directive on %s/%s #%d",
-          task.owner(), task.repo(), task.prNumber());
+          "Acknowledged a maintainer clear directive on %s/%s #%d (names a locator: %b)",
+          task.owner(), task.repo(), task.prNumber(), named);
       return;
     }
     var diff = fetchDiff(auth, task);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -3066,4 +3066,53 @@ class FollowUpAnalyzerTest {
         heldIds(backstopWith(List.of(maintainerSays(body)))),
         name);
   }
+
+  /**
+   * Asking whether a finding was fixed is not deciding that it was. A word boundary holds before
+   * {@code ?}, so the interrogative form quotes the finding well enough to name it and would
+   * otherwise close the very finding the question is about — the over-clear direction.
+   */
+  static Stream<Arguments> interrogativeDirectiveCases() {
+    return Stream.of(
+        arguments(
+            "question mark straight after the token",
+            "@thrillhousebot resolved? `src/A.java:10` — SQL injection",
+            false),
+        arguments(
+            "spaced question mark",
+            "@thrillhousebot resolved ? `src/A.java:10` — SQL injection",
+            false),
+        arguments(
+            "plain statement still clears",
+            "@thrillhousebot resolved `src/A.java:10` — SQL injection",
+            true),
+        arguments(
+            "a directive whose sentence ends in a question still clears",
+            "@thrillhousebot resolved `src/A.java:10` — SQL injection, fixed in abc123, ok?",
+            true));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("interrogativeDirectiveCases")
+  void backstopShouldNotReadAQuestionAsADirective(String name, String body, boolean clears) {
+    assertEquals(
+        clears ? List.of(2) : List.of(1, 2),
+        heldIds(backstopWith(List.of(maintainerSays(body)))),
+        name);
+  }
+
+  @Test
+  void namesALocatorShouldProveOnlyThatNothingWasNamed() {
+    assertTrue(FollowUpAnalyzer.namesALocator("@thrillhousebot resolved src/A.java:10 — title"));
+    assertTrue(
+        FollowUpAnalyzer.namesALocator("@thrillhousebot resolved `src/A.java:10` — title"),
+        "the summary prints the locator in backticks, which is what maintainers copy");
+    assertFalse(FollowUpAnalyzer.namesALocator(null));
+    assertFalse(
+        FollowUpAnalyzer.namesALocator("@thrillhousebot resolved the null check thing"),
+        "no path:line means no finding can be named, whatever the round holds");
+    assertFalse(
+        FollowUpAnalyzer.namesALocator("> @thrillhousebot resolved src/A.java:10 — title"),
+        "a quoted locator names nothing, matching where the clear actually looks");
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
@@ -653,6 +653,42 @@ class MaintainerReplyServiceTest {
     verifyNoInteractions(replyAssistant, prClient);
   }
 
+  /**
+   * The reply runs before any review, with no prior round loaded, so it cannot know whether a
+   * locator matches a real finding — but a directive carrying no locator at all provably clears
+   * nothing, and saying so beats leaving a maintainer who mistyped it to infer the failure from a
+   * review that changes nothing.
+   */
+  @Test
+  void clearDirectiveNamingNoLocatorSaysNothingWillBeCleared() {
+    authorize();
+
+    service.handle(mentionTask("@thrillhousebot resolved the null check thing, it's fine now"));
+
+    var body = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+    verify(commentClient)
+        .createComment(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), body.capture());
+    assertEquals(MaintainerReplyService.CLEAR_DIRECTIVE_NO_LOCATOR_ACK, body.getValue().body());
+    assertTrue(
+        body.getValue().body().contains("nothing will be cleared"),
+        "the maintainer must not read this as a confirmation");
+    verifyNoInteractions(replyAssistant, prClient);
+  }
+
+  @Test
+  void clearDirectiveAckNeverClaimsAClearingAlreadyHappened() {
+    // The ack states what the next review will evaluate; it must not report an outcome it cannot
+    // know, and must not open with a bare confirmation.
+    for (var ack :
+        List.of(
+            MaintainerReplyService.CLEAR_DIRECTIVE_ACK,
+            MaintainerReplyService.CLEAR_DIRECTIVE_NO_LOCATOR_ACK)) {
+      assertFalse(ack.startsWith("Noted"), ack);
+      assertFalse(ack.contains("has been cleared"), ack);
+      assertFalse(ack.contains("is cleared"), ack);
+    }
+  }
+
   @Test
   void anOrdinaryMentionStillGetsAnAssistantAnswer() {
     authorize();


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Follow-up to #553, which merged before these two review findings were fixed. Both are on the escape hatch that PR added, and the first is a live over-clear in `release/v0.6.0`.

**The interrogative parsed as an instruction.** `CLEAR_DIRECTIVE` was `@thrillhousebot\s+resolved\b`, and a word boundary holds before `?`. So `@thrillhousebot resolved? \`src/A.java:10\` — SQL injection` — a maintainer *asking* whether a finding was fixed, quoting it closely enough to name it — read as a directive and closed the very finding the question was about. Asking is not deciding, and this is the over-clear direction, so the token is now rejected when a `?` follows it (whitespace aside). The lookahead cannot skip past the naming, so a genuine directive whose sentence merely ends in a question (`…— fixed in abc123, ok?`) still counts.

**The acknowledgement read as confirmation.** The clear-directive reply fired on the token alone — even when the comment named nothing at all — and opened with "Noted.", which reads as "done" whatever follows it. A maintainer who mistyped the locator got "Noted." and no clearing.

The reply now states what the next review will *evaluate* rather than reporting an outcome, and adds the one case that genuinely is decidable this early: naming a finding requires its `path:line`, so a directive carrying no `path:line`-shaped token at all provably clears nothing. `namesALocator` is a strictly *necessary* condition of the real rule, never a sufficient one, so it can only ever prove the negative — it never claims a clearing will happen.

A locator that is present but wrong still gets the general reply, deliberately: deciding that needs the prior round's findings, which this path does not load and which only the review can match. Guessing there would be worse than saying less.

## Related Issues

Refs #548. Follows up #553.

## How Has This Been Tested?

- [x] Unit tests

The interrogative is covered in both directions (question mark straight after the token, spaced question mark, plain statement, and a directive whose sentence ends in a question), as is the acknowledgement (names a locator, names none, and a guard that neither ack opens with a bare confirmation or claims a clearing already happened).

### Red proof — interrogative

With the lookahead removed:

```
[ERROR] Failures:
[ERROR]   FollowUpAnalyzerTest.backstopShouldNotReadAQuestionAsADirective:3098 question mark straight after the token ==> expected: <[1, 2]> but was: <[2]>
[ERROR]   FollowUpAnalyzerTest.backstopShouldNotReadAQuestionAsADirective:3098 spaced question mark ==> expected: <[1, 2]> but was: <[2]>
[ERROR] Tests run: 172, Failures: 2, Errors: 0, Skipped: 0
```

The same parameterized test pins the other direction in that run: *plain statement still clears* and *a directive whose sentence ends in a question still clears* pass under both the broken and the fixed pattern, so the guard is not buying safety by breaking the normal path.

### Red proof — acknowledgement

With a single unconditional ack and the `Noted.` opener restored:

```
[ERROR] Failures:
[ERROR]   MaintainerReplyServiceTest.clearDirectiveAckNeverClaimsAClearingAlreadyHappened:686 Noted. Every previous finding your comment names by its `path:line` and title is treated as cleared from the next review onward; any it does not name stays open. ==> expected: <false> but was: <true>
[ERROR]   MaintainerReplyServiceTest.clearDirectiveNamingNoLocatorSaysNothingWillBeCleared:671 expected: <That comment names no finding, so nothing will be cleared...> but was: <Noted. Every previous finding your comment names...>
[ERROR] Tests run: 26, Failures: 2, Errors: 0, Skipped: 0
```

### Gates

- `./mvnw -B spotless:apply` then `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, `BUILD SUCCESS`
- `./mvnw -B clean test` — `Tests run: 2692, Failures: 0, Errors: 0, Skipped: 0`
- JaCoCo ∩ `git diff -U0 b036719 HEAD` over changed main code — zero uncovered lines and zero uncovered branches
- `cd website && npm ci && npm run build` — `66 page(s) built`, `All internal links are valid`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

README updated for both rules: the directive is a statement and never a question, and the bot's immediate reply says what the next review will evaluate — saying outright that nothing will be cleared when the comment names no `path:line`.
