### PR TITLE
build(deps): keep the H2 driver out of the runtime image

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ will change per provider:
 | `REVIEW_LABELS_MAX` | Maximum labels applied or suggested per PR | `3` |
 | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | OAuth credentials for dashboard login | _(required for dashboard)_ |
 | `DASHBOARD_URL` | Public dashboard URL (OAuth callback base) | `http://localhost:8080` |
-| `DATASOURCE_DB_KIND` | `h2` or `postgresql` | `h2` (dev), `postgresql` (`%prod`) |
+| `DATASOURCE_DB_KIND` | `h2` or `postgresql`. Quarkus fixes the datasource kind at build time, so this picks the driver when the app is built, not when a prebuilt image starts — released images are built for PostgreSQL and ignore an `h2` value | `h2` (dev), `postgresql` (`%prod`) |
 | `HTTP_CONNECT_TIMEOUT` | Outbound HTTP connect timeout (GitHub API, OAuth) | `10s` |
 | `HTTP_REQUEST_TIMEOUT` | Outbound HTTP request timeout (GitHub API, OAuth) | `10s` |
 | `WEBSOCKET_KEEPALIVE_MS` | Dashboard WebSocket keepalive interval in ms; `0` or negative disables it (and stale replay-buffer eviction) | `25000` |
@@ -737,7 +737,8 @@ This is still an early-stage project; the current constraints are:
   If the app owner cannot be resolved from GitHub, the dashboard fails closed (denies all access) until
   `thrillhousebot.dashboard.github.account-owner` is set.
 - **Production database** — container and native production builds use PostgreSQL
-  (`%prod`). H2 is for local `quarkus:dev` only.
+  (`%prod`). H2 is for local `quarkus:dev` and the test suite only; its driver is a
+  `provided` dependency and is not packaged into the runtime image.
 - **OpenAI-compatible APIs only** — endpoints must implement the chat-completions
   API shape LangChain4j expects.
 - **Cost tracking** — needs a `thrillhousebot.ai.pricing.<model>.*` entry per model.

--- a/pom.xml
+++ b/pom.xml
@@ -157,14 +157,21 @@
             <artifactId>quarkus-websockets</artifactId>
         </dependency>
 
-        <!-- Database: H2 (dev) + Panache -->
+        <!-- Database: PostgreSQL (prod) / H2 (dev + test) + Panache -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-panache</artifactId>
         </dependency>
+        <!-- H2 backs `quarkus:dev` and the test suite only; %prod is PostgreSQL, so the driver
+             (and its transitive org.locationtech.jts geospatial jar) has no business in the
+             runtime image. `provided` keeps it on the dev-mode and test classpaths while
+             quarkus:build leaves it out of quarkus-app/lib/main. `test` scope would drop it from
+             dev mode too, and dev mode then fails to boot: "Unable to find a JDBC driver
+             corresponding to the database kind 'h2'". -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-h2</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -264,7 +264,10 @@ thrillhousebot.review.large-pr-nudge.enabled=${REVIEW_LARGE_PR_NUDGE_ENABLED:fal
 thrillhousebot.review.large-pr-nudge.min-files=${REVIEW_LARGE_PR_NUDGE_MIN_FILES:20}
 thrillhousebot.review.large-pr-nudge.min-changed-lines=${REVIEW_LARGE_PR_NUDGE_MIN_CHANGED_LINES:1000}
 
-# Database (H2 for dev, PostgreSQL for prod)
+# Database (H2 for dev, PostgreSQL for prod). db-kind is fixed at build time, and the H2 driver is
+# a `provided` dependency (see pom.xml), so it is on the dev-mode and test classpaths but not in
+# the packaged runtime: a production build is PostgreSQL and DATASOURCE_DB_KIND cannot change that
+# after the fact. To build for H2, build under a non-prod profile.
 quarkus.datasource.db-kind=${DATASOURCE_DB_KIND:h2}
 quarkus.datasource.jdbc.url=jdbc:h2:mem:thrillhouse;DB_CLOSE_DELAY=-1
 %prod.quarkus.datasource.db-kind=${DATASOURCE_DB_KIND:postgresql}


### PR DESCRIPTION
## What type of PR is this?

- [x] 📦 Dependency update
- [x] 🔒 Security
- [x] 📝 Documentation

## Description

`quarkus-jdbc-h2` was declared at **compile** scope under a comment saying it is for dev, so the
published JVM image carried a JDBC driver the deployment can never use, plus its transitive
geospatial dependency.

Changing it to **`provided`** scope keeps H2 on the dev-mode and test classpaths — `quarkus:dev`
and the test suite behave exactly as before — while `quarkus:build` leaves it out of
`quarkus-app/lib/main`.

### The trade-off, resolved on measurement

**1. What actually depends on H2 today.** `application.properties` sets
`quarkus.datasource.db-kind=${DATASOURCE_DB_KIND:h2}` as the profile-less default with
`%prod` overriding to `postgresql`, so **dev and test both run on H2** and prod runs on PostgreSQL.
The test suite uses it through `quarkus-test-h2` (already `test` scope) plus this driver.
Baseline `./mvnw quarkus:dev` does start today and reports `jdbc-h2` in its installed features, so
dev mode genuinely depends on this dependency being visible outside `test` scope.

**2. Is the JTS saving real?** Yes — `dependency:tree` shows `org.locationtech.jts:jts-core` has
exactly one path into the build, through H2:

```
+- io.quarkus:quarkus-jdbc-h2:jar:3.38.0:compile
|  +- com.h2database:h2:jar:2.4.240:compile
|  \- org.locationtech.jts:jts-core:jar:1.19.0:compile
```

(The similarly named `org.jboss.narayana.jts:narayana-jts-integration` is Java Transaction Service,
unrelated, and stays.)

**3. Which option preserves the dev workflow.** Three were tried; only one costs nothing.

| Option | Image | `quarkus:dev` | Verdict |
|---|---|---|---|
| `test` scope | H2 gone | **Fails to boot** | Rejected |
| Dev Services (containerized PostgreSQL) | H2 gone | Works, needs Docker | Rejected |
| **`provided` scope** | **H2 gone** | **Unchanged** | **Chosen** |

- **`test` scope — rejected, measured.** Quarkus dev mode does not see test-scoped dependencies.
  With H2 at `test` scope, `./mvnw quarkus:dev` fails at augmentation:

  ```
  [error]: Build step io.quarkus.agroal.deployment.AgroalProcessor#build threw an exception:
  io.quarkus.runtime.configuration.ConfigurationException: Unable to find a JDBC driver
  corresponding to the database kind 'h2' for the default datasource (available: 'postgresql').
  ```

  `curl localhost:8080/q/health` returned `500` instead of `200`. That is a real regression for
  every contributor, for 3.6MB.

- **Dev Services for PostgreSQL — rejected on cost, not on merit.** It would give dev/prod parity,
  but it makes `quarkus:dev` require a container runtime, and README **Development** states "For
  local development without Docker, you'll need Java 25+, Node.js 22+". Trading a documented
  Docker-free dev path for 3.6MB of image is not a call this PR should make unilaterally; it is a
  separate conversation with the team.

- **A Maven profile — rejected.** A profile active by default still ships H2 in a plain
  `./mvnw package`; one that is not active by default means every contributor must remember
  `-P<dev>` on `quarkus:dev`. `provided` gets the same result with no flag to remember.

- **`provided` scope — chosen.** Maven keeps `provided` on the compile *and test* classpaths, and
  Quarkus dev mode picks it up, so nothing about the developer workflow changes; Quarkus's fast-jar
  packaging excludes it from the runtime.

### `DATASOURCE_DB_KIND` documentation fix

`quarkus.datasource.db-kind` is fixed at build time (the driver is resolved by a deployment build
step, as the error above shows), so a prebuilt image could never have been switched to H2 at
runtime — the shipped driver was dead weight in the strictest sense. The README env-var table
implied otherwise; it and the Limitations entry are corrected, and the reasoning is left as a
comment in both `pom.xml` and `application.properties` so the scope does not silently regress.

## Related Issues

Fixes #560

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

**Full suite:** `./mvnw -B clean test` → `Tests run: 2640, Failures: 0, Errors: 0, Skipped: 0`,
BUILD SUCCESS. H2 still backs the tests through `provided` + `quarkus-test-h2`.

**`quarkus:dev` still starts** — unchanged from baseline, no new developer steps:

```
INFO [io.quarkus] thrillhousebot 0.5.1-SNAPSHOT on JVM (powered by Quarkus 3.38.0)
     started in 4.552s. Listening on: http://localhost:8080
INFO [io.quarkus] Installed features: [agroal, cdi, ..., jdbc-h2, jdbc-postgresql, ...]
$ curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/q/health
200
```

**Packaged output, before → after** (`./mvnw clean package`, `target/quarkus-app/lib/main/`):

| | jars | bytes |
|---|---|---|
| before | 235 | 67,131,674 |
| after | 232 | 63,329,544 |
| **delta** | **-3** | **-3,802,130 (-3.63 MiB)** |

The three jars that left, and nothing else:

```
com.h2database.h2-2.4.240.jar            2,682,809
org.locationtech.jts.jts-core-1.19.0.jar 1,103,721
io.quarkus.quarkus-jdbc-h2-3.38.0.jar       15,600
```

**The packaged app still runs on PostgreSQL.** Started `quarkus-run.jar` (prod profile) against a
real PostgreSQL 16 container, deliberately with `DATASOURCE_DB_KIND=h2` set to prove the build-time
claim:

```
INFO [io.quarkus] thrillhousebot 0.5.1-SNAPSHOT on JVM started in 2.201s. Listening on: http://0.0.0.0:8099
INFO [io.quarkus] Installed features: [agroal, cdi, hibernate-orm, hibernate-orm-panache,
     jdbc-postgresql, ...]
$ curl -s localhost:8099/q/health
{"status": "UP", "checks": [{"name": "Database connections health check", "status": "UP",
 "data": {"<default>": "UP"}}]}
```

`jdbc-h2` is absent from the installed features, the runtime env var is ignored as documented,
schema management ran, and no `NoClassDefFoundError` appears anywhere in the log.

**Docs site** (README changed): `cd website && npm ci && npm run build` → 66 pages built,
"All internal links are valid."

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

Note on the tests checkbox: this change lives entirely in the build's dependency graph, where no
unit test can observe it. The evidence is the before/after jar inventory and byte counts above,
plus the packaged app running green against real PostgreSQL. A `maven-enforcer-plugin`
`bannedDependencies` rule pinning `com.h2database:h2` out of compile/runtime scope would make the
guarantee permanent; that means adding a new build plugin, so it is offered as a follow-up rather
than folded in here.

## Screenshots / Logs

Gates: `./mvnw -B spotless:apply`; `./mvnw -B clean compile spotbugs:check spotless:check` →
`BugInstance size is 0`, `Error size is 0`, BUILD SUCCESS; `./mvnw -B clean test` → 2640 passed.

## Additional Notes

- **No production behaviour changes.** Prod was already PostgreSQL-only and could not have selected
  H2 after the build; this only stops shipping the driver.
- **Native builds** resolve the same application model, so H2 is excluded there too. A native build
  was not run locally (it needs a container build); CI's native job covers it.
- **Out of scope, found while measuring:** dev mode boots but its H2 database has **no schema** —
  only `%prod` sets `quarkus.hibernate-orm.schema-management.strategy`, so `quarkus:dev` logs
  `Schema validation: missing table [finding_feedback]` and
  `Table "REVIEWSESSION" not found`, and every DB-backed dev feature fails at runtime. That is a
  pre-existing bug unrelated to dependency scope and is left for a separate issue rather than
  smuggled in here.
