### PR TITLE
fix(review): name the withheld paths in the review call's own material

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -60,10 +60,29 @@ public class FindingPipeline {
   /** Directory rows listed in the scope header before the remainder is rolled up by count. */
   private static final int MAX_SCOPE_DIRECTORIES = 10;
 
+  /** Withheld paths named in the review call's notice before the rest is rolled up by count. */
+  private static final int MAX_WITHHELD_PATHS = 20;
+
   private record BatchOutcome(
       int index,
       List<ReviewResponse.Finding> findings,
       List<ReviewResponse.PreviousFindingStatus> statuses) {}
+
+  /**
+   * The shared prompt template for a review call plus the PR-level {@linkplain
+   * #withheldMaterialNotice withheld-material notice}, so every call this class assembles material
+   * for carries the same disclosure and the prefixing lives in one place. The notice rides inside
+   * the diff slot's untrusted fence — the paths in it come from the pull request — while the rule
+   * that acts on it is in the trusted system prompt.
+   */
+  private record BatchPrompts(AiReviewService.PromptInputs template, String withheldNotice) {
+
+    AiReviewService.PromptInputs forBatch(
+        DiffBudgetPlanner.DiffBatch batch, String baseComparison) {
+      return withDiff(
+          template, PromptTemplateEscaper.fence(withheldNotice + batch.text()), baseComparison);
+    }
+  }
 
   private final AiReviewService aiReviewService;
   private final FindingQuoteValidator quoteValidator;
@@ -150,10 +169,8 @@ public class FindingPipeline {
       budgetedBatch = plan.batches().get(0);
       // The base comparison stays: the planner counted it in the shared overhead.
       singleInputs =
-          withDiff(
-              promptInputs,
-              PromptTemplateEscaper.fence(budgetedBatch.text()),
-              promptInputs.baseComparison());
+          new BatchPrompts(promptInputs, withheldMaterialNotice(ctx, plan))
+              .forBatch(budgetedBatch, promptInputs.baseComparison());
       quoteSource = budgetedBatch.text();
     }
     var aiResponse = aiReviewService.review(session, singleInputs);
@@ -205,6 +222,7 @@ public class FindingPipeline {
     // findings; a batch may only close a prior finding whose file its own diff slice contained.
     var previousFilesById = followUpAnalyzer.previousFindingFilesById(ctx.previousFindingsList());
 
+    var batchPrompts = new BatchPrompts(promptInputs, withheldMaterialNotice(ctx, plan));
     var outcomesByIndex = new BatchOutcome[batches.size()];
     var failedIndices = new ArrayList<Integer>();
     try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
@@ -215,13 +233,13 @@ public class FindingPipeline {
                       CompletableFuture.supplyAsync(
                           () ->
                               processBatch(
-                                  i, batches, session, promptInputs, plan, previousFilesById),
+                                  i, batches, session, batchPrompts, plan, previousFilesById),
                           executor))
               .toList();
       joinBatchOutcomes(
           futures,
           batches,
-          promptInputs,
+          batchPrompts,
           plan,
           session,
           previousFilesById,
@@ -243,7 +261,7 @@ public class FindingPipeline {
         plan.recordSpendCeilingSkippedFiles(filenamesOf(batches.get(index).files()));
         continue;
       }
-      retryBatch(index, batches, session, promptInputs, plan, previousFilesById, outcomesByIndex);
+      retryBatch(index, batches, session, batchPrompts, plan, previousFilesById, outcomesByIndex);
     }
 
     var outcomes =
@@ -388,13 +406,13 @@ public class FindingPipeline {
       int index,
       List<DiffBudgetPlanner.DiffBatch> batches,
       ReviewSession session,
-      AiReviewService.PromptInputs promptInputs,
+      BatchPrompts prompts,
       DiffBudgetPlanner.BudgetPlan plan,
       Map<Integer, String> previousFilesById,
       BatchOutcome[] outcomesByIndex) {
     try {
       outcomesByIndex[index] =
-          processBatch(index, batches, session, promptInputs, plan, previousFilesById);
+          processBatch(index, batches, session, prompts, plan, previousFilesById);
       Log.infof("Batch %d/%d succeeded on retry", index + 1, batches.size());
     } catch (TokenSpendCeilingExceededException e) {
       // The gate above passed but a concurrent late callback (e.g. a timed-out attempt's usage)
@@ -411,7 +429,7 @@ public class FindingPipeline {
         // salvage-or-disclose step as a parallel-pass truncation, and no further retry (#495).
         outcomesByIndex[index] =
             salvageTruncatedBatch(
-                session, index, batches, promptInputs, plan, previousFilesById, truncation.get());
+                session, index, batches, prompts, plan, previousFilesById, truncation.get());
         return;
       }
       // Soft-fail like the on-request generators (DocGenerationService / PrImprovementService):
@@ -440,7 +458,7 @@ public class FindingPipeline {
   private void joinBatchOutcomes(
       List<CompletableFuture<BatchOutcome>> futures,
       List<DiffBudgetPlanner.DiffBatch> batches,
-      AiReviewService.PromptInputs promptInputs,
+      BatchPrompts prompts,
       DiffBudgetPlanner.BudgetPlan plan,
       ReviewSession session,
       Map<Integer, String> previousFilesById,
@@ -457,7 +475,7 @@ public class FindingPipeline {
           // the complete leading findings out of the buffered partial body first (#500).
           outcomesByIndex[i] =
               salvageTruncatedBatch(
-                  session, i, batches, promptInputs, plan, previousFilesById, truncation.get());
+                  session, i, batches, prompts, plan, previousFilesById, truncation.get());
         } else if (isSpendCeilingBlocked(e)) {
           // Deterministic like a truncation: the ledger is monotonic within a review, so a retry
           // would be refused identically. Degrade like the budgeter — disclose, with the ceiling
@@ -486,11 +504,11 @@ public class FindingPipeline {
       int index,
       List<DiffBudgetPlanner.DiffBatch> batches,
       ReviewSession session,
-      AiReviewService.PromptInputs promptInputs,
+      BatchPrompts prompts,
       DiffBudgetPlanner.BudgetPlan plan,
       Map<Integer, String> previousFilesById) {
     var batch = batches.get(index);
-    var batchInputs = withDiff(promptInputs, PromptTemplateEscaper.fence(batch.text()), "");
+    var batchInputs = prompts.forBatch(batch, "");
     var batchResponse =
         aiReviewService.reviewBatch(session, batchInputs, index + 1, batches.size());
     return refineBatchOutcome(
@@ -543,7 +561,7 @@ public class FindingPipeline {
       ReviewSession session,
       int index,
       List<DiffBudgetPlanner.DiffBatch> batches,
-      AiReviewService.PromptInputs promptInputs,
+      BatchPrompts prompts,
       DiffBudgetPlanner.BudgetPlan plan,
       Map<Integer, String> previousFilesById,
       AiResponseTruncatedException truncation) {
@@ -566,7 +584,7 @@ public class FindingPipeline {
         salvaged.findings().size(),
         salvaged.previousFindingsStatus().size());
     plan.recordResponseCutFiles(filenamesOf(batch.files()));
-    var batchInputs = withDiff(promptInputs, PromptTemplateEscaper.fence(batch.text()), "");
+    var batchInputs = prompts.forBatch(batch, "");
     var partialResponse =
         new ReviewResponse(salvaged.findings(), salvaged.previousFindingsStatus(), null);
     return refineBatchOutcome(
@@ -853,6 +871,72 @@ public class FindingPipeline {
       case "justified" -> 1;
       default -> 0;
     };
+  }
+
+  /**
+   * The review call's disclosure of what this pull request changes that its diff deliberately does
+   * NOT show: pure renames (excluded by #386), paths the ignore list took out of review scope, and
+   * files the token budget could not fit. Without it the model reads absence from its material as
+   * absence from the pull request and reports finished work as missing — the walkthrough lists the
+   * renamed file while {@code description_gaps} claims the rename the PR body describes is not in
+   * the diff (#569).
+   *
+   * <p>The budgeted path is where this bites, and it is why the disclosure has to be rebuilt here:
+   * a batch's text is file sections only, so the rollup {@link
+   * ReviewDiffFormatter#buildDiffStringWithStats} puts in the legacy raw diff's header never
+   * reaches the call — and budgeting is on by default, so in practice no review call ever saw it.
+   * The wording deliberately matches that rollup's ("omitted from AI review"), so the system
+   * prompt's rule recognizes either form.
+   *
+   * <p>Returns empty when nothing was withheld, leaving an ordinary PR's prompt byte-identical.
+   * Uses {@code ctx.files()} minus {@code ctx.reviewableFiles()}, which is exactly the material the
+   * review call cannot see, so a path withheld for any reason is named rather than only the classes
+   * enumerated here.
+   */
+  private static String withheldMaterialNotice(
+      ReviewContextLoader.ReviewContext ctx, DiffBudgetPlanner.BudgetPlan plan) {
+    var reviewable = ReviewDiffFormatter.namesOf(ctx.reviewableFiles());
+    var rows = new ArrayList<String>();
+    for (var file : ctx.files()) {
+      if (reviewable.contains(file.filename())) {
+        continue;
+      }
+      rows.add(
+          ReviewDiffFormatter.isPureRename(file)
+              ? renamePath(file) + " (pure rename — no content change)"
+              : file.filename() + " (excluded from review scope by the ignore list)");
+    }
+    // Planned omissions are reviewable files that did not fit any batch: withheld for a third
+    // reason, and just as invisible to this call as the two above.
+    for (var name : plan.omittedFiles()) {
+      rows.add(name + " (exceeded the review call budget)");
+    }
+    if (rows.isEmpty()) {
+      return "";
+    }
+    var sb =
+        new StringBuilder(
+            "## Changed files omitted from AI review\n"
+                + "Each path below IS changed by this pull request. Its content was withheld from"
+                + " the diff below, so nothing about it can appear in the material you were"
+                + " given.\n");
+    for (var row : rows.subList(0, Math.min(rows.size(), MAX_WITHHELD_PATHS))) {
+      sb.append("- ").append(row).append('\n');
+    }
+    if (rows.size() > MAX_WITHHELD_PATHS) {
+      sb.append("- (+")
+          .append(rows.size() - MAX_WITHHELD_PATHS)
+          .append(" more changed files omitted from AI review)\n");
+    }
+    return sb.append('\n').toString();
+  }
+
+  /** "old → new" for a rename that carries its previous path, else the current path alone. */
+  private static String renamePath(GitHubPullRequestClient.FileDiff file) {
+    var previous = file.previousFilename();
+    return previous == null || previous.isBlank()
+        ? file.filename()
+        : previous + " → " + file.filename();
   }
 
   /** Copies the shared prompt context, swapping the diff and base-comparison slots. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -363,6 +363,17 @@ public final class PrReviewPrompts {
               file just outside the visible hunk: its absence from the hunk is not proof the
               name is undefined. When you cannot see the definition, do not assert the name is
               undefined.
+            - Material WITHHELD from your input is not material ABSENT from the pull request. The
+              provided material names what was withheld: a "Changed files omitted from AI review"
+              block, a "N pure renames omitted from AI review (old → new)" rollup, a path marked
+              omitted, not reviewed, or excluded by the ignore list. Every path named that way IS
+              changed by this pull request and its content was deliberately not sent to you, so its
+              absence from the diff is not evidence of anything. Never report a change carried by
+              such a path as missing, unimplemented, not done, or contradicting the description —
+              not as a finding, and not in summary.description_gaps. When the PR description claims
+              work whose only evidence would live in a withheld path, the claim is unverifiable
+              here, not false: say nothing about it. A rename the description states and the
+              withheld list confirms is DONE, not missing.
             - A suggestion must not contradict a convention visible in the provided material —
               for example, suggesting an unpinned reference when every similar reference nearby
               is pinned. When the obvious fix conflicts with such a convention, describe the
@@ -426,7 +437,11 @@ public final class PrReviewPrompts {
               mismatches between what the author claims and what the code does (claimed changes
               that are missing, significant changes the description never mentions, and a
               producer→consumer trace whose end-to-end behavior is the inverse of the stated
-              intent — dimension 9). Empty array when there is no description or no mismatch.
+              intent — dimension 9). Empty array when there is no description or no mismatch. A
+              claimed change counts as missing ONLY when the file that would carry it is in your
+              material and does not carry it; never enter one here because you could not find it in
+              a path the material lists as omitted from AI review, and never contradict a
+              disclosure the same material already makes.
             - file_summaries: an array of { path, summary } objects, one per changed file, that gives
               reviewers a file-by-file walkthrough. The object keys must be spelled exactly "path"
               and "summary" — not "file", "filename" or "description" — and the field itself
@@ -559,7 +574,10 @@ public final class PrReviewPrompts {
             - description_gaps: when a PR description is provided, an array of concrete mismatches
               between what the author claims and what the change does — including a description
               whose scope is narrower than the change itself (it covers one component, or far fewer
-              files than the PR scope totals report). Empty array otherwise.
+              files than the PR scope totals report). Empty array otherwise. A path the changed-file
+              list marks as a pure rename, omitted from AI review, or not reviewed IS part of this
+              change and was withheld from review on purpose: never report the work it carries as
+              missing or unimplemented, and never contradict a disclosure that list already makes.
             - file_summaries: REQUIRED, and the field this call most often gets wrong. It is an
               array of { path, summary } objects that fills the rendered file-by-file walkthrough
               table; omitting it, or emitting [], leaves every row of that table blank, which is

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -827,6 +827,153 @@ class FindingPipelineTest {
     verify(quoteValidator).validate(any(), eq("raw legacy diff"));
   }
 
+  /** Runs the budgeted single-batch path over {@code ctx}/{@code plan}, returning the diff sent. */
+  private String captureBudgetedReviewDiff(
+      ReviewSession session,
+      ReviewContextLoader.ReviewContext ctx,
+      DiffBudgetPlanner.BudgetPlan plan) {
+    var template =
+        new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
+    var captor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
+    when(aiReviewService.review(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    return captor.getValue().diff();
+  }
+
+  private static DiffBudgetPlanner.BudgetPlan singleBatchPlan(
+      DiffBudgetPlanner.DiffBatch batch, List<String> omittedByName) {
+    return new DiffBudgetPlanner.BudgetPlan(
+        List.of(batch), omittedByName, List.of(), true, null, null, null, null);
+  }
+
+  /**
+   * #569 — the pure rename is excluded from the model's input by design (#386), and the budgeted
+   * path's batch text is file sections only, so before this the review call had no way to know the
+   * rename existed and reported the PR's own described work as missing in description_gaps.
+   */
+  @Test
+  void budgetedReviewCallIsToldWhichPureRenameWasWithheldFromIt() {
+    var session = ReviewSession.create("owner/repo", 1, "Move the README", "sha");
+    var app = new FileDiff("src/App.java", "modified", 3, 0, 3, "@@ -1 +1 @@\n+x\n");
+    var ctx =
+        reviewContext(
+            List.of(new FileDiff("docs/JAVA.md", "renamed", 0, 0, 0, null, "README.md"), app),
+            List.of(app),
+            null);
+
+    var diff =
+        captureBudgetedReviewDiff(session, ctx, singleBatchPlan(batch("src/App.java"), List.of()));
+
+    assertTrue(diff.contains("## Changed files omitted from AI review"), diff);
+    assertTrue(diff.contains("README.md → docs/JAVA.md (pure rename — no content change)"), diff);
+    assertTrue(diff.contains("### src/App.java"), diff);
+    // The notice rides inside the diff slot's untrusted fence, and quote validation still runs
+    // against the batch's own text — the disclosure must never become quotable "diff" content.
+    verify(quoteValidator).validate(any(), eq("### src/App.java\n"));
+  }
+
+  /** The same mechanism names every class of withheld path, not only the pure renames. */
+  @Test
+  void withheldNoticeAlsoNamesIgnoreListedAndOverBudgetPaths() {
+    var session = ReviewSession.create("owner/repo", 1, "Bump a dependency", "sha");
+    var app = new FileDiff("src/App.java", "modified", 3, 0, 3, "@@ -1 +1 @@\n+x\n");
+    var ctx =
+        reviewContext(
+            List.of(new FileDiff("pom.xml", "modified", 8, 1, 9, "@@ -1 +1 @@\n+dep\n"), app),
+            List.of(app),
+            null);
+
+    var diff =
+        captureBudgetedReviewDiff(
+            session, ctx, singleBatchPlan(batch("src/App.java"), List.of("vendor/bundle.js")));
+
+    assertTrue(diff.contains("- pom.xml (excluded from review scope by the ignore list)"), diff);
+    assertTrue(diff.contains("- vendor/bundle.js (exceeded the review call budget)"), diff);
+  }
+
+  /** A rename GitHub reported without a previous path degrades to its current path alone. */
+  @Test
+  void withheldNoticeFallsBackToTheCurrentPathWhenNoPreviousOneIsReported() {
+    var session = ReviewSession.create("owner/repo", 1, "Move files", "sha");
+    var ctx =
+        reviewContext(
+            List.of(
+                new FileDiff("docs/A.md", "renamed", 0, 0, 0, null, null),
+                new FileDiff("docs/B.md", "renamed", 0, 0, 0, null, "  ")),
+            List.of(),
+            null);
+
+    var diff = captureBudgetedReviewDiff(session, ctx, singleBatchPlan(batch("a.java"), List.of()));
+
+    assertTrue(diff.contains("- docs/A.md (pure rename — no content change)"), diff);
+    assertTrue(diff.contains("- docs/B.md (pure rename — no content change)"), diff);
+  }
+
+  /** A bulk move must not crowd the diff out of the call: the tail is rolled up by count. */
+  @Test
+  void withheldNoticeRollsUpThePathsBeyondTheCap() {
+    var session = ReviewSession.create("owner/repo", 1, "Move a package", "sha");
+    var files = new ArrayList<FileDiff>();
+    for (var i = 0; i < 23; i++) {
+      files.add(
+          new FileDiff(
+              "pkg/new/File" + i + ".java",
+              "renamed",
+              0,
+              0,
+              0,
+              null,
+              "pkg/old/File" + i + ".java"));
+    }
+    var ctx = reviewContext(files, List.of(), null);
+
+    var diff = captureBudgetedReviewDiff(session, ctx, singleBatchPlan(batch("a.java"), List.of()));
+
+    assertTrue(diff.contains("pkg/old/File0.java → pkg/new/File0.java"), diff);
+    assertFalse(diff.contains("pkg/old/File22.java"), diff);
+    assertTrue(diff.contains("- (+3 more changed files omitted from AI review)"), diff);
+  }
+
+  /** Nothing withheld: the prompt the model receives is exactly the planned batch text. */
+  @Test
+  void nothingWithheldLeavesTheBudgetedPromptUnchanged() {
+    var session = ReviewSession.create("owner/repo", 1, "Ordinary PR", "sha");
+    var app = new FileDiff("src/App.java", "modified", 3, 0, 3, "@@ -1 +1 @@\n+x\n");
+    var ctx = reviewContext(List.of(app), List.of(app), null);
+
+    var diff =
+        captureBudgetedReviewDiff(session, ctx, singleBatchPlan(batch("src/App.java"), List.of()));
+
+    assertFalse(diff.contains("omitted from AI review"), diff);
+  }
+
+  /** Every batch of a multi-call review carries the same PR-level disclosure. */
+  @Test
+  void everyBatchOfAMultiCallReviewIsToldWhatWasWithheld() {
+    var session = ReviewSession.create("owner/repo", 1, "Big PR with a move", "sha");
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    var ctx =
+        reviewContext(
+            List.of(new FileDiff("docs/JAVA.md", "renamed", 0, 0, 0, null, "README.md")),
+            List.of(),
+            null);
+    var captor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
+    when(aiReviewService.reviewBatch(eq(session), captor.capture(), anyInt(), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+    when(aiReviewService.summarize(eq(session), any()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+
+    assertEquals(2, captor.getAllValues().size());
+    for (var inputs : captor.getAllValues()) {
+      assertTrue(inputs.diff().contains("README.md → docs/JAVA.md"), inputs.diff());
+    }
+  }
+
   @Test
   void singleCallCeilingRefusalPropagatesForTheOrchestratorToFailSoft() {
     // Characterization of the single-call contract: a mid-retry ceiling refusal has no paid batch

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -850,4 +850,44 @@ class PrReviewPromptsContentTest {
         "neither drops nor loses confidence on this ground",
         "an uncovered-line finding must survive the self-check at its own confidence (#115)");
   }
+
+  /**
+   * #569 — the review's own material discloses what was withheld from it (a pure rename, an
+   * ignore-listed or over-budget path), and the model reported that withheld work as missing in
+   * description_gaps: one posted comment named the rename and then told the maintainer to go and do
+   * it. The rule that reads the disclosure has to survive any rewording of these prompts.
+   */
+  @Test
+  void withheldMaterialIsNeverReportedAsMissingWork() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "Material WITHHELD from your input is not material ABSENT from the pull request",
+        "the prompt must separate absence from the material from absence from the PR (#569)");
+    assertContains(
+        sys,
+        "Changed files omitted from AI review",
+        "the rule must name the disclosure block the review call is given (#569)");
+    assertContains(
+        sys,
+        "missing, unimplemented, not done, or contradicting the description",
+        "a withheld path's work must not be reportable as missing (#569)");
+    assertContains(
+        sys,
+        "the claim is unverifiable",
+        "a claim whose only evidence is withheld must be dropped, not contradicted (#569)");
+  }
+
+  /** The same guard on both surfaces that emit {@code description_gaps}. */
+  @Test
+  void bothPromptsKeepWithheldPathsOutOfDescriptionGaps() {
+    assertContains(
+        PrReviewPrompts.SYSTEM,
+        "a path the material lists as omitted from AI review",
+        "the review call's description_gaps must exclude withheld paths (#569)");
+    assertContains(
+        PrReviewPrompts.SUMMARY_SYSTEM,
+        "pure rename, omitted from AI review, or not reviewed IS part of this",
+        "the summary call's description_gaps must exclude withheld paths (#569)");
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

A pure rename is excluded from the model's input by design (#386). The review call was never told
that happened, so it read absence from its material as absence from the pull request. On 8 of 8
round-2 corpus PRs one posted comment carried all three of:

1. the banner — *"1 pure rename omitted from AI review (README.md → docs/JAVA.md)"*
2. a walkthrough row — `docs/JAVA.md | Renamed | Pure rename — content unchanged`
3. a `description_gaps` entry claiming the rename the PR body describes is **not in the diff**

The third one sends a maintainer to redo work the PR already contains.

### Why the existing disclosure never arrived

`ReviewDiffFormatter.buildDiffStringWithStats` does prepend the pure-rename rollup — to the raw
diff's header. But token budgeting is on by default (`thrillhousebot.review.max-input-tokens=48000`),
and on that path `ReviewContextLoader` leaves `ctx.diff()` empty while `FindingPipeline` sends
`DiffBudgetPlanner`'s batch text instead — which `toBatch` builds from file sections only, with no
header. `FindingPipeline.changedFilesOverview` prepends the rollup for the **summary** call only.
So in production no review call has ever seen the disclosure, which is why the model reports the
withholding as a defect.

### The fix

Two halves, general rather than rename-specific:

- **Material.** `FindingPipeline` rebuilds the disclosure where it assembles each review call's diff
  slot (`BatchPrompts`), so the single budgeted call and every batch of a multi-call review carry
  the same block. It names each path this pull request changes that the call cannot see, derived as
  `ctx.files()` minus `ctx.reviewableFiles()` plus the plan's omissions — pure renames, ignore-listed
  paths, and files that exceeded the call budget — capped at 20 with the tail rolled up by count.
  It rides **inside** the diff slot's untrusted fence, because the paths come from the pull request;
  the rule that acts on it is in the trusted system prompt. Empty when nothing was withheld, so an
  ordinary PR's prompt is byte-identical to before.
- **Rule.** `PrReviewPrompts.SYSTEM` gains a self-check bullet: material withheld from the input is
  not material absent from the pull request, and a claimed change whose only evidence would live in
  a withheld path is unverifiable here, not false — say nothing about it rather than reporting it as
  missing. The `description_gaps` spec of both the review prompt and `SUMMARY_SYSTEM` gets the same
  guard, since both surfaces emit that field.

The notice deliberately reuses the existing rollup's wording ("omitted from AI review"), so the one
rule recognizes either form — including the rollup the legacy uncapped path still carries in its
diff header and the one the summary call already receives in its changed-files overview.

### Does this cover #566?

**Yes, mechanically, for the review call — but #566 is not claimed fixed here and stays open.**

The withheld set is computed as "everything this PR changes that this call was not given", so an
ignore-listed path such as `pom.xml` is named in the notice with its reason, and the new system-prompt
rule applies to it verbatim. That is #566's first bullet ("tell the model which paths were withheld
by the ignore filter"). What this PR does **not** do is #566's second bullet — no self-check
specifically invalidates a "the claimed change is missing" finding by matching it against a filtered
file — and it does not touch the ignore list itself, the summary call's changed-files overview (which
still lists only reviewable files, pure renames and budget omissions), or the question of whether a
docs-only-after-filtering PR should be reviewed at all. Verifying #566 against a real PR is left to
its own issue.

### Not covered

`/describe` reproduces the same false claim on its own prompt surface. That generator is outside this
PR's lane and is not touched here.

## Related Issues

Fixes #569

## How Has This Been Tested?

- [x] Unit tests

Six new `FindingPipelineTest` cases (the withheld rename, the ignore-listed and over-budget classes,
the no-previous-path fallback, the >20 rollup, the nothing-withheld control, and every batch of a
multi-call review), plus two new `PrReviewPromptsContentTest` pins for the prompt rule.

### Red proof

The five positive assertions fail on unfixed `FindingPipeline` (the negative control passes, as it
must). Verbatim, with the main-code change stashed:

```
[ERROR] Tests run: 6, Failures: 5, Errors: 0, Skipped: 0, Time elapsed: 1.714 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest

dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.budgetedReviewCallIsToldWhichPureRenameWasWithheldFromIt -- Time elapsed: 0.115 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
[[THRILLHOUSEBOT-UNTRUSTED-DATA-08c3ecc7c84c1657b756d723be4dd779]]
### src/App.java

[[THRILLHOUSEBOT-UNTRUSTED-DATA-08c3ecc7c84c1657b756d723be4dd779]] ==> expected: <true> but was: <false>
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.budgetedReviewCallIsToldWhichPureRenameWasWithheldFromIt(FindingPipelineTest.java:870)

dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.everyBatchOfAMultiCallReviewIsToldWhatWasWithheld -- Time elapsed: 0.104 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
[[THRILLHOUSEBOT-UNTRUSTED-DATA-8538070bed5f3f863b15cade0f639e9d]]
### b.java

[[THRILLHOUSEBOT-UNTRUSTED-DATA-8538070bed5f3f863b15cade0f639e9d]] ==> expected: <true> but was: <false>
```

The failure output is the whole prompt the model would receive: the fence, the batch's file sections,
and nothing else — the rename is nowhere in it.

### Gates

| Gate | Result |
|---|---|
| `spotless:apply` + `clean compile spotbugs:check spotless:check` | BUILD SUCCESS, `BugInstance size is 0` |
| `clean test` | `Tests run: 2700, Failures: 0, Errors: 0, Skipped: 0` |
| jacoco ∩ `git diff -U0 c9992ba...HEAD` (main code) | 0 uncovered lines, 0 uncovered branches |

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The prompt-text half of this change is exempt from red/green by the round's standards; the
`FindingPipeline` half is not, and its red output is quoted above. No `README.md` or `docs/**` file
is touched, so the Docs workflow is not in play.
