### PR TITLE
fix(ai): give the concise lane its own reasoning effort

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,6 +174,13 @@ AI_TIMEOUT=300s
 # it. Reasoning tokens are billed as output tokens, so higher effort means higher cost and latency.
 #AI_REASONING_ENABLED=true
 #AI_REASONING_EFFORT=low
+# Effort for the fixed-shape calls on the "concise" model (final summary, finding verifier,
+# replies) — these deliberately do NOT follow AI_REASONING_EFFORT. Reasoning tokens count against
+# REVIEW_CONCISE_MAX_OUTPUT_TOKENS, so a high effort here lets the verifier spend its whole
+# allowance reasoning and return an empty response, which no larger cap reliably fixes. Unset =
+# low, lowered to AI_REASONING_EFFORT when that is set below low. Nothing is sent at all while
+# AI_REASONING_ENABLED=false.
+#AI_REASONING_EFFORT_CONCISE=low
 
 # Token pricing (USD per 1K tokens) — application.properties ships sensible defaults
 # for common OpenAI/DeepSeek/Qwen/Groq models keyed by the AI_MODEL name. Cost stays $0 if

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ will change per provider:
 | `AI_TIMEOUT` | Per-request timeout | `300s` |
 | `AI_REASONING_ENABLED` | Send a reasoning hint to reasoning-capable models; when `false` no reasoning parameter is sent and the provider default applies | `false` |
 | `AI_REASONING_EFFORT` | Effort sent while enabled: `none`/`low`/`medium`/`high`/`xhigh`/`max` (`none` explicitly asks the model not to reason; `xhigh`/`max` are the extended tiers newer reasoning models expose above `high`); reasoning tokens are billed as output tokens | `low` |
+| `AI_REASONING_EFFORT_CONCISE` | Effort for the fixed-shape calls on the `concise` model (final summary, finding verifier, replies), which do **not** follow `AI_REASONING_EFFORT`: reasoning tokens count against `REVIEW_CONCISE_MAX_OUTPUT_TOKENS`, so a high effort there lets the verifier reason its whole allowance away and return an empty response. Same accepted values; unset means `low`, lowered to `AI_REASONING_EFFORT` when that is set below `low` | `low` |
 | `GITHUB_APP_ID` | GitHub App ID | _(required)_ |
 | `GITHUB_PRIVATE_KEY` | GitHub App private key (PEM) | _(required)_ |
 | `GITHUB_WEBHOOK_SECRET` | Webhook HMAC secret | _(required)_ |
@@ -549,13 +550,21 @@ Notes:
   second model binding — the `concise` named model
   (`quarkus.langchain4j.openai.concise.*`) — that points at the same provider,
   credentials, and model through the same `AI_*` variables and follows the
-  active model's temperature/reasoning tuning, but carries its own response
-  cap, `REVIEW_CONCISE_MAX_OUTPUT_TOKENS` (default `8192`). Those responses are
+  active model's temperature tuning, but carries its own response cap,
+  `REVIEW_CONCISE_MAX_OUTPUT_TOKENS` (default `8192`), and its own reasoning
+  effort, `AI_REASONING_EFFORT_CONCISE` (default `low`). Those responses are
   fixed-shape or short, so they don't need — and shouldn't be licensed to
   spend — a cap sized for batch review output. The review itself and the
   command generators (`/describe`, `/changelog`, `/add-docs`, `/improve`,
   `/generate-tests`), whose outputs scale with the diff, stay on the default
   model and its `max-output-tokens`.
+- **Reasoning effort is per lane.** Reasoning tokens are billed as output and
+  count against the response cap, so on the `concise` model a high effort can
+  consume the whole allowance and leave no content — the verifier then reports
+  that it kept its findings unverified. That tail is variable-length, not a
+  size threshold, so raising `REVIEW_CONCISE_MAX_OUTPUT_TOKENS` only shifts the
+  odds. Keep `AI_REASONING_EFFORT_CONCISE` low (the default) and spend the
+  effort budget on `AI_REASONING_EFFORT`, which drives the review itself.
 - **`max-output-tokens` vs `output-buffer-tokens`**: `max-output-tokens` is the
   hard response-length cap sent to the provider; `output-buffer-tokens` only
   reserves input-budget headroom for the map-reduce budgeter. On a shared-window

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -322,7 +322,8 @@ public class StartupConfigValidator {
   /**
    * Validated even while reasoning is disabled: an operator who sets an invalid effort value has
    * expressed clear intent, and rejecting the typo at boot beats discovering it when the flag is
-   * later flipped on.
+   * later flipped on. The concise lane's own effort ({@code AI_REASONING_EFFORT_CONCISE}, #567) is
+   * held to the same list, and only when set — unset resolves to a valid value by construction.
    */
   private static void validateReasoningEffort(
       List<String> problems, ThrillhouseConfig.AiPricingConfig.ReasoningConfig reasoning) {
@@ -335,6 +336,19 @@ public class StartupConfigValidator {
               + " (thrillhousebot.ai.reasoning.effort): "
               + reasoning.effort());
     }
+    reasoning
+        .conciseEffort()
+        .filter(
+            effort ->
+                !allowed.contains(
+                    ThrillhouseConfig.AiPricingConfig.ReasoningConfig.normalize(effort)))
+        .ifPresent(
+            effort ->
+                problems.add(
+                    "AI_REASONING_EFFORT_CONCISE must be one of "
+                        + String.join(", ", allowed)
+                        + " (thrillhousebot.ai.reasoning.concise-effort): "
+                        + effort));
   }
 
   /**
@@ -477,16 +491,35 @@ public class StartupConfigValidator {
 
   /**
    * Mirrors {@link #logActiveModelStatus}'s per-model line for the {@code concise} named model, so
-   * the boot log states which response cap the summary/verifier/reply calls run under — including
-   * the shipped 8192 default, which applies without any operator action.
+   * the boot log states which response cap and reasoning effort the summary/verifier/reply calls
+   * run under — including the shipped defaults, which apply without any operator action. The effort
+   * is on this line because it is the one generation parameter that no longer follows the active
+   * model (#567), so an operator reading the banner would otherwise draw the wrong conclusion about
+   * where the verifier's output allowance goes.
    */
   private void logConciseModelStatus() {
     log.info(
         "Concise model active for summary/verifier/reply calls: max-output-tokens={}"
-            + " (REVIEW_CONCISE_MAX_OUTPUT_TOKENS); other generation parameters follow the active"
-            + " model '{}'.",
+            + " (REVIEW_CONCISE_MAX_OUTPUT_TOKENS), reasoning_effort={}; other generation"
+            + " parameters follow the active model '{}'.",
         orProviderDefault(conciseMaxOutputTokens),
+        conciseReasoningEffortBanner(),
         activeModel.modelName());
+  }
+
+  /**
+   * The concise lane's {@code reasoning_effort} as the banner states it: the resolved wire value
+   * and the knob that sets it while reasoning is on, and otherwise a note that nothing is sent —
+   * the same "no parameter, so the provider default applies" contract {@code
+   * AI_REASONING_ENABLED=false} carries everywhere else. Package-private so the operator-facing
+   * wording is asserted without a log appender.
+   */
+  String conciseReasoningEffortBanner() {
+    var reasoning = config.ai().reasoning();
+    return reasoning.enabled()
+        ? ThrillhouseConfig.AiPricingConfig.ReasoningConfig.resolveConciseEffort(reasoning)
+            + " (AI_REASONING_EFFORT_CONCISE)"
+        : "not sent (AI_REASONING_ENABLED=false)";
   }
 
   /** Env-var prefix every per-model setting shares. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -554,10 +554,22 @@ public interface ThrillhouseConfig {
      * the configured {@link #effort()} is sent as the OpenAI-compatible {@code reasoning_effort} on
      * every chat call, which providers map to their thinking budgets. Reasoning tokens are billed
      * as output tokens, so this is the operator's cost/quality dial.
+     *
+     * <p>The concise lane (summary, verifier, replies) has its own {@link #conciseEffort()} rather
+     * than following {@link #effort()} — see that method for why.
      */
     interface ReasoningConfig {
       /** Effort values accepted by {@link #effort()}, in ascending cost/quality order. */
       List<String> ALLOWED_EFFORTS = List.of("none", "low", "medium", "high", "xhigh", "max");
+
+      /**
+       * Ceiling applied to the concise lane when {@link #conciseEffort()} is unset. {@code low} and
+       * not {@code none}: {@code none} is not a tier every provider recognizes (an unknown tier is
+       * rejected outright, not downgraded), whereas {@code low} is the value this project already
+       * ships as the {@link #effort()} default, so it is the lowest tier known to be valid wherever
+       * reasoning is enabled at all.
+       */
+      String DEFAULT_CONCISE_EFFORT = "low";
 
       /** Master switch — no reasoning parameter is sent unless this is {@code true}. */
       @WithDefault("false")
@@ -575,9 +587,45 @@ public interface ThrillhouseConfig {
       @WithDefault("low")
       String effort();
 
+      /**
+       * Effort sent on the {@code concise} named model's calls while {@link #enabled()} — the
+       * multi-call review's final summary, the finding verifier, and maintainer replies. Same
+       * accepted values as {@link #effort()}; unset resolves through {@link #resolveConciseEffort}.
+       *
+       * <p>This lane exists as a separate knob because it must NOT follow {@link #effort()} (#567).
+       * Reasoning tokens are billed as output and count against the response cap, so at a high
+       * effort the verifier can spend its whole allowance reasoning and return no content at all —
+       * observed intermittently at {@code max} for the same finding count that succeeded on another
+       * run, which makes it a variable-length reasoning tail rather than a size threshold that a
+       * bigger {@code REVIEW_CONCISE_MAX_OUTPUT_TOKENS} could clear. The lane's calls are
+       * fixed-shape mechanical work — one verdict per finding, a summary object, a status list — so
+       * capping their effort costs nothing the review itself needs.
+       */
+      @WithName("concise-effort")
+      Optional<String> conciseEffort();
+
       /** An {@link #effort()} value normalized to the lowercase wire value providers expect. */
       static String normalize(String effort) {
         return effort.strip().toLowerCase(java.util.Locale.ROOT);
+      }
+
+      /**
+       * The wire value the concise lane sends while {@link #enabled()}: {@link #conciseEffort()}
+       * verbatim when the operator set one, otherwise {@link #DEFAULT_CONCISE_EFFORT} — lowered to
+       * {@link #effort()} when the active lane is configured below that ceiling, so an operator who
+       * asked for {@code none} everywhere never gets more reasoning on the concise lane than on the
+       * main one. An unrecognized {@link #effort()} is left alone here; {@link
+       * StartupConfigValidator} refuses the boot over it.
+       */
+      static String resolveConciseEffort(ReasoningConfig reasoning) {
+        var explicit = reasoning.conciseEffort().map(ReasoningConfig::normalize);
+        if (explicit.isPresent()) {
+          return explicit.get();
+        }
+        var active = ALLOWED_EFFORTS.indexOf(normalize(reasoning.effort()));
+        return active >= 0 && active < ALLOWED_EFFORTS.indexOf(DEFAULT_CONCISE_EFFORT)
+            ? ALLOWED_EFFORTS.get(active)
+            : DEFAULT_CONCISE_EFFORT;
       }
     }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelCustomizers.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelCustomizers.java
@@ -48,30 +48,40 @@ import java.util.function.BiConsumer;
  * ones it would have its response cap ({@code
  * quarkus.langchain4j.openai.concise.chat-model.max-tokens}, aliased to {@code
  * REVIEW_CONCISE_MAX_OUTPUT_TOKENS}) stomped by the active model's {@code max-output-tokens}. The
- * concise pair therefore applies every shared parameter except the response cap.
+ * concise pair therefore applies every shared parameter except the response cap, and sends the
+ * concise lane's own reasoning effort ({@code thrillhousebot.ai.reasoning.concise-effort}) rather
+ * than the active model's — reasoning tokens are billed against that same response cap, so a high
+ * active-lane effort would otherwise let the verifier reason its whole allowance away and return no
+ * content (#567).
  */
 public final class ChatModelCustomizers {
 
   private ChatModelCustomizers() {}
 
   /**
-   * The {@code reasoning_effort} wire value to send, or empty when the feature is disabled and the
-   * provider default should apply.
+   * The {@code reasoning_effort} wire value one lane sends, or empty when the feature is disabled
+   * and the provider default should apply. The concise lane resolves its own effort instead of
+   * following the active model's (#567) — see {@link
+   * ThrillhouseConfig.AiPricingConfig.ReasoningConfig#resolveConciseEffort}.
    */
-  static Optional<String> reasoningEffort(ThrillhouseConfig config) {
+  static Optional<String> reasoningEffort(ThrillhouseConfig config, boolean concise) {
     var reasoning = config.ai().reasoning();
-    return reasoning.enabled()
-        ? Optional.of(
-            ThrillhouseConfig.AiPricingConfig.ReasoningConfig.normalize(reasoning.effort()))
-        : Optional.empty();
+    if (!reasoning.enabled()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        concise
+            ? ThrillhouseConfig.AiPricingConfig.ReasoningConfig.resolveConciseEffort(reasoning)
+            : ThrillhouseConfig.AiPricingConfig.ReasoningConfig.normalize(reasoning.effort()));
   }
 
   /**
    * The shared customizer body, applied through one builder flavour's setter references — the
    * blocking and streaming builders share no supertype, so the four customizers adapt via {@link
    * #BLOCKING_TUNING}/{@link #STREAMING_TUNING} instead of each repeating the knob list. {@code
-   * applyResponseCap} is false for the concise pair, which must never see the active model's {@code
-   * max-output-tokens} (it would stomp the named config block's cap).
+   * concise} selects the two ways that lane differs: it sends its own reasoning effort, and it
+   * never sees the active model's {@code max-output-tokens} (which would stomp the named config
+   * block's cap).
    */
   private record SharedTuning<B>(
       BiConsumer<B, String> reasoningEffort,
@@ -83,15 +93,12 @@ public final class ChatModelCustomizers {
       BiConsumer<B, Integer> seed) {
 
     void apply(
-        ThrillhouseConfig config,
-        ActiveModelSettings activeModel,
-        B builder,
-        boolean applyResponseCap) {
-      ChatModelCustomizers.reasoningEffort(config)
+        ThrillhouseConfig config, ActiveModelSettings activeModel, B builder, boolean concise) {
+      ChatModelCustomizers.reasoningEffort(config, concise)
           .ifPresent(v -> reasoningEffort.accept(builder, v));
       activeModel.temperature().ifPresent(v -> temperature.accept(builder, v));
       activeModel.topP().ifPresent(v -> topP.accept(builder, v));
-      if (applyResponseCap) {
+      if (!concise) {
         activeModel.maxOutputTokens().ifPresent(v -> maxTokens.accept(builder, v));
       }
       activeModel.frequencyPenalty().ifPresent(v -> frequencyPenalty.accept(builder, v));
@@ -136,7 +143,7 @@ public final class ChatModelCustomizers {
 
     @Override
     public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
-      BLOCKING_TUNING.apply(config, activeModel, builder, true);
+      BLOCKING_TUNING.apply(config, activeModel, builder, false);
     }
   }
 
@@ -155,16 +162,16 @@ public final class ChatModelCustomizers {
 
     @Override
     public void customize(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder builder) {
-      STREAMING_TUNING.apply(config, activeModel, builder, true);
+      STREAMING_TUNING.apply(config, activeModel, builder, false);
     }
   }
 
   /**
    * Tuning for the concise named model's blocking bean (verifier, replies). Applies the same
-   * reasoning and generation parameters as the default model's customizer, but never {@code
-   * maxTokens}: the concise response cap comes from the named config block and applying the active
-   * model's {@code max-output-tokens} here would overwrite it — customizers run after config
-   * properties.
+   * generation parameters as the default model's customizer, but never {@code maxTokens}: the
+   * concise response cap comes from the named config block and applying the active model's {@code
+   * max-output-tokens} here would overwrite it — customizers run after config properties. The
+   * reasoning effort is the concise lane's own, not the active model's (#567).
    */
   @ApplicationScoped
   @ModelName("concise")
@@ -181,7 +188,7 @@ public final class ChatModelCustomizers {
 
     @Override
     public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
-      BLOCKING_TUNING.apply(config, activeModel, builder, false);
+      BLOCKING_TUNING.apply(config, activeModel, builder, true);
     }
   }
 
@@ -204,7 +211,7 @@ public final class ChatModelCustomizers {
 
     @Override
     public void customize(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder builder) {
-      STREAMING_TUNING.apply(config, activeModel, builder, false);
+      STREAMING_TUNING.apply(config, activeModel, builder, true);
     }
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -78,6 +78,15 @@ thrillhousebot.ai.provider-name=${AI_PROVIDER:}
 # so enabling this raises cost and latency.
 thrillhousebot.ai.reasoning.enabled=${AI_REASONING_ENABLED:false}
 thrillhousebot.ai.reasoning.effort=${AI_REASONING_EFFORT:low}
+# Effort for the "concise" model below (summary, finding verifier, replies) — deliberately NOT the
+# active model's (#567). Reasoning tokens are billed as output and count against that model's
+# response cap, so at a high effort the verifier can spend its whole allowance reasoning and return
+# an empty body; it recurred at max for a finding count that had succeeded on an earlier run, so it
+# is a variable-length reasoning tail that a bigger cap cannot close. These calls are fixed-shape
+# mechanical work (one verdict per finding, a summary object, a status list), so capping the effort
+# costs nothing. Unset = low, lowered to AI_REASONING_EFFORT when that is set below low, so
+# 'none' everywhere stays 'none' here. Nothing is sent at all while AI_REASONING_ENABLED=false.
+thrillhousebot.ai.reasoning.concise-effort=${AI_REASONING_EFFORT_CONCISE:}
 # Per-model AI settings keyed by the model name (the AI_MODEL value), mirroring the pricing map's
 # key scheme (#50). Only the active model's entry is read, so entries for several models can be
 # kept and AI_MODEL switched freely. max-input-tokens is the model's input hard cap (its context

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -84,6 +84,7 @@ class StartupConfigValidatorTest {
     private String ciGating = "strict";
     private boolean reasoningEnabled = false;
     private String reasoningEffort = "low";
+    private Optional<String> conciseReasoningEffort = Optional.empty();
     private String blockingStrictness = "balanced";
     private String modelName = "deepseek-chat";
     private Optional<Integer> conciseMaxOutputTokens = Optional.of(8192);
@@ -160,6 +161,11 @@ class StartupConfigValidatorTest {
       return this;
     }
 
+    ConfigBuilder conciseReasoningEffort(Optional<String> v) {
+      this.conciseReasoningEffort = v;
+      return this;
+    }
+
     ConfigBuilder blockingStrictness(String v) {
       this.blockingStrictness = v;
       return this;
@@ -194,6 +200,7 @@ class StartupConfigValidatorTest {
       lenient().when(ai.reasoning()).thenReturn(reasoning);
       lenient().when(reasoning.enabled()).thenReturn(reasoningEnabled);
       lenient().when(reasoning.effort()).thenReturn(reasoningEffort);
+      lenient().when(reasoning.conciseEffort()).thenReturn(conciseReasoningEffort);
       lenient().when(github.appId()).thenReturn(appId);
       lenient().when(github.privateKey()).thenReturn(privateKey);
       lenient().when(github.webhookSecret()).thenReturn(webhookSecret);
@@ -776,6 +783,76 @@ class StartupConfigValidatorTest {
   }
 
   @Test
+  void failsFastWhenTheConciseReasoningEffortIsInvalid() {
+    // The concise lane's own effort (#567) rides the same wire as AI_REASONING_EFFORT, so a typo
+    // must be refused at boot rather than rejected by the provider mid-review.
+    var ex =
+        assertFailsValidation(
+            new ConfigBuilder().conciseReasoningEffort(Optional.of("minimal")).build());
+    assertTrue(
+        ex.getMessage()
+            .contains(
+                "AI_REASONING_EFFORT_CONCISE must be one of none, low, medium, high, xhigh, max"),
+        ex.getMessage());
+    assertTrue(
+        ex.getMessage().contains("(thrillhousebot.ai.reasoning.concise-effort): minimal"),
+        ex.getMessage());
+  }
+
+  @Test
+  void acceptsEveryConciseReasoningEffortCaseInsensitivelyWithWhitespace() {
+    for (var effort : new String[] {"none", "LOW", " Medium ", "high", "XHigh", " max "}) {
+      new ConfigBuilder()
+          .reasoningEnabled(true)
+          .conciseReasoningEffort(Optional.of(effort))
+          .build()
+          .validate();
+    }
+  }
+
+  @Test
+  void bannerNamesTheConciseLanesResolvedEffortAndItsKnob() {
+    // The concise cap is already named in the boot banner; the effort has to be too, since it is
+    // the one generation parameter that no longer follows the active model (#567).
+    assertEquals(
+        "low (AI_REASONING_EFFORT_CONCISE)",
+        new ConfigBuilder()
+            .reasoningEnabled(true)
+            .reasoningEffort("max")
+            .build()
+            .conciseReasoningEffortBanner());
+    assertEquals(
+        "high (AI_REASONING_EFFORT_CONCISE)",
+        new ConfigBuilder()
+            .reasoningEnabled(true)
+            .conciseReasoningEffort(Optional.of("HIGH"))
+            .build()
+            .conciseReasoningEffortBanner());
+  }
+
+  @Test
+  void bannerSaysNoEffortIsSentWhileReasoningIsDisabled() {
+    assertEquals(
+        "not sent (AI_REASONING_ENABLED=false)",
+        new ConfigBuilder()
+            .reasoningEnabled(false)
+            .conciseReasoningEffort(Optional.of("high"))
+            .build()
+            .conciseReasoningEffortBanner());
+  }
+
+  @Test
+  void bootsWhenTheConciseReasoningEffortIsUnset() {
+    // Unset is the shipped state: the lane resolves its own default, so there is nothing to reject.
+    new ConfigBuilder()
+        .reasoningEnabled(true)
+        .reasoningEffort("max")
+        .conciseReasoningEffort(Optional.empty())
+        .build()
+        .validate();
+  }
+
+  @Test
   void classifiesDashboardOauthStatusForEveryCombination() {
     assertEquals(
         StartupConfigValidator.DashboardOauthStatus.ENABLED,
@@ -816,6 +893,25 @@ class StartupConfigValidatorTest {
         @WithName("separate-output-budget")
         Optional<Boolean> separateOutputBudget();
       }
+    }
+
+    @Test
+    void theShippedConciseEffortResolvesToUnset() throws Exception {
+      // The shipped line is
+      // thrillhousebot.ai.reasoning.concise-effort=${AI_REASONING_EFFORT_CONCISE:}
+      // — an empty default, so with no env var set the lane must see "unset" (and resolve its own
+      // default) rather than an empty string the provider would reject as a reasoning tier.
+      var shipped =
+          new SmallRyeConfigBuilder()
+              .addDefaultInterceptors()
+              .withValidateUnknown(false)
+              .withSources(
+                  new PropertiesConfigSource(
+                      Paths.get("src/main/resources/application.properties").toUri().toURL()))
+              .build();
+      assertEquals(
+          Optional.empty(),
+          shipped.getOptionalValue("thrillhousebot.ai.reasoning.concise-effort", String.class));
     }
 
     @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelCustomizersTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelCustomizersTest.java
@@ -37,6 +37,14 @@ class ChatModelCustomizersTest {
       boolean reasoningEnabled,
       String effort,
       Map<String, ThrillhouseConfig.AiPricingConfig.ModelSettings> models) {
+    return config(reasoningEnabled, effort, Optional.empty(), models);
+  }
+
+  private static ThrillhouseConfig config(
+      boolean reasoningEnabled,
+      String effort,
+      Optional<String> conciseEffort,
+      Map<String, ThrillhouseConfig.AiPricingConfig.ModelSettings> models) {
     var config = mock(ThrillhouseConfig.class);
     var ai = mock(ThrillhouseConfig.AiPricingConfig.class);
     var reasoning = mock(ThrillhouseConfig.AiPricingConfig.ReasoningConfig.class);
@@ -45,6 +53,7 @@ class ChatModelCustomizersTest {
     lenient().when(ai.models()).thenReturn(models);
     lenient().when(reasoning.enabled()).thenReturn(reasoningEnabled);
     lenient().when(reasoning.effort()).thenReturn(effort);
+    lenient().when(reasoning.conciseEffort()).thenReturn(conciseEffort);
     return config;
   }
 
@@ -187,6 +196,7 @@ class ChatModelCustomizersTest {
     // The concise model's cap comes from its named config block
     // (quarkus.langchain4j.openai.concise.chat-model.max-tokens); customizers run after config
     // properties, so a maxTokens call here would stomp the cap the named model exists to carry.
+    // The reasoning effort is the lane's own default, not the active model's "Medium" (#567).
     var builder = mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
     var config =
         config(
@@ -197,7 +207,7 @@ class ChatModelCustomizersTest {
     new ChatModelCustomizers.ConciseChatModelCustomizer(config, activeModel(config))
         .customize(builder);
 
-    verify(builder).reasoningEffort("medium");
+    verify(builder).reasoningEffort("low");
     verify(builder).temperature(0.2);
     verify(builder).topP(0.95);
     verifyNoMoreInteractions(builder);
@@ -215,10 +225,101 @@ class ChatModelCustomizersTest {
     new ChatModelCustomizers.ConciseStreamingChatModelCustomizer(config, activeModel(config))
         .customize(builder);
 
-    verify(builder).reasoningEffort("medium");
+    verify(builder).reasoningEffort("low");
     verify(builder).temperature(0.2);
     verify(builder).topP(0.95);
     verifyNoMoreInteractions(builder);
+  }
+
+  @Test
+  void conciseModelsDoNotInheritTheActiveModelsMaxEffort() {
+    // #567: reasoning tokens are billed as output and count against the concise response cap, so a
+    // max-effort active model could leave the verifier with no allowance left for content and no
+    // body at all. The lane caps its own effort instead.
+    var blocking = mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+    var streaming = mock(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder.class);
+    var config = config(true, "max", Map.of());
+
+    new ChatModelCustomizers.ConciseChatModelCustomizer(config, activeModel(config))
+        .customize(blocking);
+    new ChatModelCustomizers.ConciseStreamingChatModelCustomizer(config, activeModel(config))
+        .customize(streaming);
+
+    verify(blocking).reasoningEffort("low");
+    verify(streaming).reasoningEffort("low");
+    verifyNoMoreInteractions(blocking, streaming);
+  }
+
+  @Test
+  void theActiveLaneKeepsMaxEffortWhileTheConciseLaneIsCapped() {
+    // The dial the operator set still drives the review itself — only the fixed-shape calls change.
+    var blocking = mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+    var streaming = mock(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder.class);
+    var config = config(true, "max", Map.of());
+
+    new ChatModelCustomizers.ChatModelCustomizer(config, activeModel(config)).customize(blocking);
+    new ChatModelCustomizers.StreamingChatModelCustomizer(config, activeModel(config))
+        .customize(streaming);
+
+    verify(blocking).reasoningEffort("max");
+    verify(streaming).reasoningEffort("max");
+    verifyNoMoreInteractions(blocking, streaming);
+  }
+
+  @Test
+  void anExplicitConciseEffortWinsOverTheLanesDefault() {
+    var builder = mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+    var config = config(true, "max", Optional.of(" High "), Map.of());
+
+    new ChatModelCustomizers.ConciseChatModelCustomizer(config, activeModel(config))
+        .customize(builder);
+
+    verify(builder).reasoningEffort("high");
+    verifyNoMoreInteractions(builder);
+  }
+
+  @Test
+  void theConciseLaneNeverReasonsMoreThanTheActiveLane() {
+    // An operator who asked for 'none' everywhere must not get 'low' on the concise calls just
+    // because that is this lane's ceiling.
+    var builder = mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+    var config = config(true, "None", Map.of());
+
+    new ChatModelCustomizers.ConciseChatModelCustomizer(config, activeModel(config))
+        .customize(builder);
+
+    verify(builder).reasoningEffort("none");
+    verifyNoMoreInteractions(builder);
+  }
+
+  @Test
+  void anUnrecognizedActiveEffortLeavesTheConciseLaneAtItsDefault() {
+    // Boot fails over the typo (StartupConfigValidator); the lane must still resolve to a value it
+    // can send rather than propagating the unknown tier.
+    var builder = mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+    var config = config(true, "maximum", Map.of());
+
+    new ChatModelCustomizers.ConciseChatModelCustomizer(config, activeModel(config))
+        .customize(builder);
+
+    verify(builder).reasoningEffort("low");
+    verifyNoMoreInteractions(builder);
+  }
+
+  @Test
+  void conciseModelsSendNoEffortWhileReasoningIsDisabled() {
+    // Disabled still means no reasoning parameter at all on either lane — the concise default must
+    // not smuggle one onto a non-reasoning model.
+    var blocking = mock(OpenAiChatModel.OpenAiChatModelBuilder.class);
+    var streaming = mock(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder.class);
+    var config = config(false, "max", Optional.of("high"), Map.of());
+
+    new ChatModelCustomizers.ConciseChatModelCustomizer(config, activeModel(config))
+        .customize(blocking);
+    new ChatModelCustomizers.ConciseStreamingChatModelCustomizer(config, activeModel(config))
+        .customize(streaming);
+
+    verifyNoInteractions(blocking, streaming);
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelWiringTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelWiringTest.java
@@ -44,8 +44,9 @@ import org.junit.jupiter.api.Test;
  * customizers bind by CDI qualifier ({@code applyCustomizers} selects {@code @Default} beans for
  * the default model and {@code @ModelName}-qualified beans for a named one), so these assertions
  * prove the named model carries its own response cap ({@code REVIEW_CONCISE_MAX_OUTPUT_TOKENS}
- * default 8192) instead of the active model's {@code max-output-tokens}, while still receiving the
- * shared reasoning/temperature tuning — and that the batch-review models keep theirs.
+ * default 8192) instead of the active model's {@code max-output-tokens}, and its own {@code
+ * reasoning_effort} instead of the active model's (#567), while still receiving the shared
+ * temperature tuning — and that the batch-review models keep theirs.
  */
 @QuarkusTest
 @TestProfile(ChatModelWiringTest.TuningEnabled.class)
@@ -93,9 +94,9 @@ class ChatModelWiringTest {
         params.maxOutputTokens(),
         "the concise response cap must apply, not the active model's max-output-tokens");
     assertEquals(
-        "medium",
+        "low",
         params.reasoningEffort(),
-        "the concise model must not silently lose the reasoning setting");
+        "the concise lane sends its own effort, not the active model's 'Medium'");
     assertEquals(0.3, params.temperature());
     assertEquals(0.95, params.topP());
   }
@@ -112,9 +113,9 @@ class ChatModelWiringTest {
         params.maxOutputTokens(),
         "the concise response cap must apply, not the active model's max-output-tokens");
     assertEquals(
-        "medium",
+        "low",
         params.reasoningEffort(),
-        "the concise model must not silently lose the reasoning setting");
+        "the concise lane sends its own effort, not the active model's 'Medium'");
     assertEquals(0.3, params.temperature());
     assertEquals(0.95, params.topP());
   }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [x] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

The `concise` named model — the multi-call review's final summary, the finding verifier, and maintainer replies — inherited `reasoning_effort` from the active model. Reasoning tokens are billed as output and count against that model's response cap, so at `AI_REASONING_EFFORT=max` the verifier could spend its whole allowance reasoning and return no content at all. The production measurements make the shape clear: finding-sets of 8, 9, 10, 12 and 14 verified, while 11 and 12 returned no body — **12 lands on both sides**, so this is a variable-length reasoning tail, not a size threshold. Raising `REVIEW_CONCISE_MAX_OUTPUT_TOKENS` again can only shift the odds; it cannot close a tail.

The lane now carries its own effort:

- New knob `thrillhousebot.ai.reasoning.concise-effort`, aliased to `AI_REASONING_EFFORT_CONCISE`, read by the two `@ModelName("concise")` customizers in `ChatModelCustomizers` (the seam where `AI_REASONING_EFFORT` reaches the builders). The active model's own lane is unchanged, so `/review`, `/describe`, `/changelog` etc. still get the effort the operator asked for.
- **Default `low`, not `none`.** This is the conservative choice the brief asks for. The repo's own contract is that the effort value "rides the wire verbatim, so a provider that does not recognize a tier rejects the call rather than silently downgrading it", and nothing in the code or configuration establishes which tiers any given OpenAI-compatible endpoint accepts — there is no provider capability table, and `none` is not a tier every provider knows. `low` is the value the project already ships as the `AI_REASONING_EFFORT` default, so it is the lowest tier demonstrably valid wherever reasoning is enabled at all. An operator who knows their provider accepts `none` can set it explicitly.
- **Never above the active lane.** When the knob is unset the resolved value is lowered to `AI_REASONING_EFFORT` if that sits below `low` (using `ALLOWED_EFFORTS`' documented ascending order), so an operator who asked for `none` everywhere does not get `low` here. An explicitly set `AI_REASONING_EFFORT_CONCISE` always wins verbatim.
- **`AI_REASONING_ENABLED=false` still sends nothing on either lane**, so non-reasoning models never see a parameter they might reject — the concise default cannot smuggle one in.
- Invalid values are refused at boot like the active lane's, and the resolved effort is now named on the concise startup banner line alongside the cap:

  `Concise model active for summary/verifier/reply calls: max-output-tokens=8192 (REVIEW_CONCISE_MAX_OUTPUT_TOKENS), reasoning_effort=low (AI_REASONING_EFFORT_CONCISE); other generation parameters follow the active model 'deepseek-v4-flash'.`

Docs updated: `.env.example`, the README env table, and the README bullet that previously claimed the concise model "follows the active model's temperature/reasoning tuning" (now temperature only, plus a bullet explaining why the effort is per lane).

## Related Issues

Fixes #567

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

**Red proof.** The behavioural change is that the concise customizers stop inheriting the active effort. Restoring exactly that line (`reasoningEffort(config, false)` in `SharedTuning.apply`) puts the pre-fix behaviour back, and the new/updated tests fail on it:

```
[ERROR] Tests run: 19, Failures: 5, Errors: 0, Skipped: 0, Time elapsed: 0.965 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.ai.ChatModelCustomizersTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.ChatModelCustomizersTest.conciseModelsDoNotInheritTheActiveModelsMaxEffort -- Time elapsed: 0.002 s <<< FAILURE!
Argument(s) are different! Wanted:
openAiChatModelBuilder.reasoningEffort(
    "low"
);
-> at dev.langchain4j.model.openai.OpenAiChatModel$OpenAiChatModelBuilder.reasoningEffort(OpenAiChatModel.java:410)
Actual invocations have different arguments:
openAiChatModelBuilder.reasoningEffort(
    "max"
);
-> at dev.thiagogonzaga.thrillhousebot.review.ai.ChatModelCustomizers$SharedTuning.lambda$apply$0(ChatModelCustomizers.java:98)
```

The unfixed code also fails the real wiring test that boots quarkus-langchain4j and reads the built beans' default request parameters, which is the end-to-end statement of the bug:

```
[ERROR]   ChatModelWiringTest.conciseBlockingModelCarriesTheConciseCapAndTheSharedTuning:95 the concise model must not silently lose the reasoning setting ==> expected: <medium> but was: <low>
[ERROR]   ChatModelWiringTest.conciseStreamingModelCarriesTheConciseCapAndTheSharedTuning:114 the concise model must not silently lose the reasoning setting ==> expected: <medium> but was: <low>
```

And for the boot-time refusal, dropping the new validation block:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest.failsFastWhenTheConciseReasoningEffortIsInvalid -- Time elapsed: 0.768 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Expected dev.thiagogonzaga.thrillhousebot.config.ConfigValidationException to be thrown, but nothing was thrown.
```

**Green.** New/updated coverage: the concise lane caps `max` to `low` on both builder flavours while the active lane still gets `max`; an explicit override wins (case/whitespace-insensitive); `none` everywhere stays `none`; an unrecognized active effort leaves the lane at its default; disabled reasoning still sends nothing on the concise lane; the boot refusal names `AI_REASONING_EFFORT_CONCISE` and the property; the banner string is asserted in both the enabled and disabled states; and the shipped `application.properties` line is bound through SmallRye to prove the empty default resolves to "unset" rather than an empty-string tier.

Gates (Java 25, `/Library/Java/JavaVirtualMachines/jdk-25.jdk`):

- `./mvnw -B spotless:apply` then `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` → `Tests run: 2704, Failures: 0, Errors: 0, Skipped: 0`
- jacoco ∩ `git diff -U0 c9992ba...HEAD` over changed main code → zero uncovered lines and zero uncovered branches
- `cd website && npm ci && npm run build` (README touched) → `All internal links are valid.`, 66 pages built

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

No behaviour change for deployments that leave reasoning off (the shipped default) — nothing is sent on either lane. Deployments running with reasoning on will see the summary/verifier/reply calls drop to `low` effort; that is the point of the fix, and `AI_REASONING_EFFORT_CONCISE` restores the old behaviour explicitly if anyone wants it.
