### PR TITLE
fix(review): keep security severity on the defect class, not on uncertainty

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -50,6 +50,21 @@ public final class PrReviewPrompts {
                and unpinned supply-chain references. A config or hardening weakness visible in the
                diff is as much a finding as a code vulnerability — do not pass over it because it is
                declarative rather than executable.
+               Severity here is a property of the DEFECT CLASS and its blast radius, never of how
+               sure you are about code you were not shown. When the provided material shows data a
+               user can author reaching an injection sink — a framework's HTML-injection escape
+               hatch (dangerouslySetInnerHTML, bypassSecurityTrustHtml, v-html, innerHTML, any
+               raw-HTML render), string-built SQL, a shell command assembled from input, a path
+               joined from input, unsafe deserialization — and NO sanitization, encoding, escaping
+               or validation of that data is visible anywhere in the provided material, the finding
+               is at least "high"; "critical" when the material also shows the tainted value is
+               stored and rendered back to other users, or the sink is reachable without
+               authentication. That some layer you were not shown MIGHT sanitize is a statement
+               about your CONFIDENCE, not about the risk: lower the confidence, name in the
+               description the exact layer to verify, and leave the severity where the defect class
+               puts it. A sanitizer you cannot see is not a sanitizer. Rate the same class the same
+               way whatever framework or language it appears in — the escape hatch with the more
+               alarming name is not the more severe defect.
             3. REGRESSIONS: Does this change break or remove existing behavior? Compare with base commit context.
             4. COMMENT CONTRADICTS CODE: a comment that states something the code it documents does
                NOT do is a defect, not a style note, and it is demonstrable from the diff alone —
@@ -232,6 +247,16 @@ public final class PrReviewPrompts {
               (dimension 8). Each is demonstrable by quoting two lines from the provided material.
               When you have those two lines, report it — do not trade it away against the
               low-severity omission guidance above.
+            - The risk you publish must be the one your own description defends. A finding whose
+              body says the severity was capped, held back, or hedged — "deliberately capped at
+              medium" — while its risk field reads "low" contradicts itself and misplaces the
+              finding. Put the hedge in confidence and the defect class in risk; never let the two
+              disagree.
+            - Equivalent defects get equivalent severity. Before settling on a level, ask what you
+              would give the same defect class in a different framework or language. If the answer
+              differs, the difference is coming from your uncertainty rather than from the defect,
+              and it belongs in confidence — pin the risk to the class and lower the confidence
+              instead.
 
             Confidence calibration:
             - confidence "high" means another reviewer could confirm the issue using only the
@@ -355,7 +380,11 @@ public final class PrReviewPrompts {
             - Claims about the contents or behavior of artifacts not shown in the diff (base
               images, registries, installed packages, remote services) cannot be verified here:
               they are never "critical" or "high", and the description must be phrased as a
-              verification request naming the exact command or check to run.
+              verification request naming the exact command or check to run. This bullet is about
+              the ARTIFACT being unshown, not about an unshown MITIGATION for a defect that is
+              shown: when the vulnerable sink and the untrusted value reaching it are both in the
+              provided material, the possibility that some layer you were not shown neutralizes it
+              lowers confidence only — it never caps the severity (dimension 2).
             - Before claiming a name is undefined/unset or a value is missing — a variable,
               parameter, import, function, env var, or config key — check the provided material
               for its definition, and name in the description what you checked. The diff shows

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -878,6 +878,71 @@ class PrReviewPromptsContentTest {
         "a claim whose only evidence is withheld must be dropped, not contradicted (#569)");
   }
 
+  /**
+   * #570 — the round-2 corpus planted the same stored-XSS defect in Angular ({@code
+   * bypassSecurityTrustHtml}) and React ({@code dangerouslySetInnerHTML}) and got HIGH inline for
+   * one and LOW in the collapsed section for the other, on the reasoning that the backend might
+   * sanitize. Severity belongs to the defect class; "I cannot see whether something upstream
+   * mitigates this" is the confidence axis. Independent scoring measured twelve one-notch
+   * deflations and zero inflations, so the anchor below is what stops the drift.
+   */
+  @Test
+  void securitySeverityIsPinnedToTheDefectClassRatherThanToUncertainty() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "property of the DEFECT CLASS and its blast radius",
+        "the security dimension must anchor severity to the defect class (#570)");
+    assertContains(
+        sys,
+        "dangerouslySetInnerHTML, bypassSecurityTrustHtml",
+        "the equivalent framework escape hatches must be named together (#570)");
+    assertContains(
+        sys,
+        "is at least \"high\"; \"critical\" when the material also shows",
+        "an unsanitized user-authored value reaching an injection sink must floor at high (#570)");
+    assertContains(
+        sys,
+        "A sanitizer you cannot see is not a sanitizer",
+        "an unshown upstream sanitizer must not pull the severity down (#570)");
+    assertContains(
+        sys,
+        "whatever framework or language it appears in",
+        "the same defect class must score the same across frameworks (#570)");
+  }
+
+  /**
+   * The corpus's React finding published LOW while its own body said the severity was "deliberately
+   * capped at medium"; a LOW lands in the collapsed section with no inline thread, so the
+   * contradiction is what hid it. The confidence rules that produced this round's precision are
+   * untouched — the hedge moves to confidence, it does not disappear.
+   */
+  @Test
+  void publishedRiskMustMatchTheReasoningTheFindingStates() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "The risk you publish must be the one your own description defends",
+        "a finding must not publish a risk its own body argues against (#570)");
+    assertContains(
+        sys,
+        "Equivalent defects get equivalent severity",
+        "severity must be compared across frameworks before it is settled (#570)");
+    assertContains(
+        sys,
+        "it belongs in confidence — pin the risk to the class and lower the confidence",
+        "uncertainty must be routed to confidence rather than to severity (#570)");
+    // The unshown-artifact cap stays; it just cannot be stretched over a defect that IS shown.
+    assertContains(
+        sys,
+        "they are never \"critical\" or \"high\"",
+        "the unshown-artifact severity cap must survive (#570)");
+    assertContains(
+        sys,
+        "not about an unshown MITIGATION for a defect that is",
+        "the artifact cap must not apply to an unshown mitigation for a shown defect (#570)");
+  }
+
   /** The same guard on both surfaces that emit {@code description_gaps}. */
   @Test
   void bothPromptsKeepWithheldPathsOutOfDescriptionGaps() {


### PR DESCRIPTION
> **Stacked on #573** (`fix/569-570-prompt-truth`, issue #569). Both PRs touch `PrReviewPrompts`;
> this one targets that branch so the diff stays reviewable. Merge #573 first, then retarget or
> merge this.

## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔒 Security

## Description

The round-2 corpus plants the same defect in Angular and React: stored XSS through the framework's
HTML-injection escape hatch, on user-authored content, with no sanitizer anywhere in the PR.

| | Angular (`bypassSecurityTrustHtml`) | React (`dangerouslySetInnerHTML`) |
|---|---|---|
| severity | HIGH | **LOW** |
| placement | inline comment, top Key Finding | collapsed "Things to double-check" |
| framing | asserted | "confirm the backend sanitizes before storage" |

The React finding also contradicted itself — its body said the severity was *"deliberately capped at
medium"* while it published as **LOW**. Independent scoring across Java #15 and Kotlin #13 found
severity deflated by one notch in ten more instances and inflated in none.

Severity drives placement: a LOW lands in a collapsed section with no inline thread. Under-rating a
security defect does not mislabel it, it hides it — and the reasoning that produced the LOW ("the
backend might sanitize") is precisely the unverifiable external assumption the prompt's own
confidence rules already say to treat as a verification request.

### The fix

Severity is a property of the defect class and its blast radius; *confidence* is the axis for "I
cannot see whether something upstream mitigates this". The prompt separated the two, and #545
restated it for three other dimensions — the security dimension was the one still letting
uncertainty pull severity down. Three changes to `PrReviewPrompts.SYSTEM`, all prompt text:

1. **Dimension 2 gets a severity anchor.** When the provided material shows data a user can author
   reaching an injection sink — the framework HTML escape hatches named together
   (`dangerouslySetInnerHTML`, `bypassSecurityTrustHtml`, `v-html`, `innerHTML`), string-built SQL,
   a shell command or path assembled from input, unsafe deserialization — and no sanitization,
   encoding, escaping or validation is visible anywhere in the material, the finding floors at
   `high`, reaching `critical` when the material also shows the tainted value stored and rendered
   back to other users or the sink reachable unauthenticated. An unshown upstream sanitizer lowers
   *confidence* and must name the exact layer to verify. Explicitly: the same class scores the same
   whatever framework it appears in.
2. **The published risk must match the reasoning.** Added to the existing "Severity is not
   confidence" block: a body that says the severity was capped, held back or hedged cannot publish
   a lower risk field — the hedge goes to confidence, the class goes to risk.
3. **The unshown-artifact cap is scoped, not weakened.** "Claims about … artifacts not shown in the
   diff … are never critical or high" keeps its full force for unshown *artifacts*; it now says it
   does not apply to an unshown *mitigation* for a defect that is shown. That is the reading the
   React finding used to justify LOW on a sink and a tainted value both sitting in the diff.

### What is deliberately not weakened

This round's precision was 7 false positives across 88 findings with every decline trap refused, and
none of the machinery behind that is touched: the self-check list, the omit-rather-than-guess rule,
the quote-verbatim requirements, and every confidence cap keep their current wording. The change
only forbids expressing uncertainty *as a lower severity* — the uncertainty still has to be stated,
in the confidence field and in the description, which is where a reviewer can act on it. Two new
assertions pin that the unshown-artifact cap survives.

## Related Issues

Fixes #570

## How Has This Been Tested?

- [x] Unit tests

Two new `PrReviewPromptsContentTest` cases pin the security severity anchor, the cross-framework
equivalence, the published-risk/stated-reasoning agreement, and — as a regression guard against
over-correcting — that the unshown-artifact cap is still present.

Per the round's standards, a prompt-text change is exempt from red/green; the suite stays green. The
behavioral claim here is about model output, so the real evidence is the corpus: Angular #11 and
React #17 plant the same XSS class in two frameworks and should now score the same severity, which
the next scoring round can measure directly.

### Gates

| Gate | Result |
|---|---|
| `spotless:apply` + `clean compile spotbugs:check spotless:check` | BUILD SUCCESS, `BugInstance size is 0` |
| `clean test` | `Tests run: 2702, Failures: 0, Errors: 0, Skipped: 0` |
| jacoco ∩ `git diff -U0 <parent>...HEAD` (main code) | 0 uncovered lines, 0 uncovered branches |

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Prompt text only — no `README.md` or `docs/**` file is touched, so the Docs workflow is not in play.
