### PR TITLE
fix(github): back off a throttled write and log what GitHub returned

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubActionsClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubActionsClient.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 /**
@@ -34,6 +35,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
  * already declares.
  */
 @RegisterRestClient(configKey = "github-api")
+@RegisterProvider(GitHubErrorLogger.class)
 public interface GitHubActionsClient {
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * What a failed GitHub REST call actually said — the pieces of the response an operator needs to
+ * tell one 4xx from another, and the pieces {@link GitHubWriteRetry} needs to decide whether the
+ * call is worth repeating.
+ *
+ * <p>Motivated by #568: a burst of on-demand commands drew 29 × HTTP 403 on {@code
+ * GitHubCommentClient#createComment} and the logs carried nothing but the status, so a secondary
+ * rate limit and a missing App permission were indistinguishable from the instance's own output.
+ * Both defects trace back to the same missing information — the response body and the rate-limit
+ * headers — so both are read here, once, and shared by the logger and the retry.
+ *
+ * <p>The body is redacted and truncated before it is exposed: GitHub's error bodies are short JSON
+ * messages, but a body is attacker-influenced text that ends up in an operator's log, so anything
+ * shaped like a token is masked and the rest is capped at {@value #MAX_BODY_CHARS} characters.
+ */
+public final class GitHubApiError {
+
+  /** How much of a response body is kept for the log. GitHub's error bodies are far shorter. */
+  static final int MAX_BODY_CHARS = 512;
+
+  /** Replacement for anything in a response body shaped like a credential. */
+  static final String REDACTED = "***";
+
+  /**
+   * GitHub App/PAT/OAuth token prefixes and bearer/JWT shapes. GitHub does not echo credentials in
+   * an error body, but a body is untrusted text on its way to a log file, so a token-shaped run of
+   * characters is masked rather than trusted to be harmless.
+   */
+  private static final Pattern CREDENTIAL_SHAPED =
+      Pattern.compile(
+          "(?i)(gh[pousr]_[A-Za-z0-9_]{10,})"
+              + "|(github_pat_[A-Za-z0-9_]{10,})"
+              + "|(bearer\\s+[A-Za-z0-9._~+/=-]{10,})"
+              + "|(eyJ[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,})");
+
+  /**
+   * The wording GitHub uses when it is throttling rather than refusing. A secondary rate limit and
+   * a primary rate limit both arrive as 403; only the message distinguishes them from a permission
+   * refusal when the headers are absent.
+   */
+  private static final Pattern THROTTLE_WORDING =
+      Pattern.compile("(?i)secondary rate limit|abuse detection|rate limit exceeded");
+
+  /** Collapses the whitespace of a body so one failure stays on one log line. */
+  private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+
+  /** Backoff used when GitHub throttles without saying for how long. */
+  static final Duration FALLBACK_DELAY = Duration.ofSeconds(5);
+
+  private final int status;
+  private final String retryAfter;
+  private final String rateLimitRemaining;
+  private final String rateLimitReset;
+  private final String rateLimitResource;
+  private final String body;
+
+  private GitHubApiError(
+      int status,
+      String retryAfter,
+      String rateLimitRemaining,
+      String rateLimitReset,
+      String rateLimitResource,
+      String body) {
+    this.status = status;
+    this.retryAfter = retryAfter;
+    this.rateLimitRemaining = rateLimitRemaining;
+    this.rateLimitReset = rateLimitReset;
+    this.rateLimitResource = rateLimitResource;
+    this.body = body;
+  }
+
+  /** Reads the status, the throttling headers and the (redacted) body off a failed response. */
+  public static GitHubApiError from(Response response) {
+    return new GitHubApiError(
+        response.getStatus(),
+        response.getHeaderString("Retry-After"),
+        response.getHeaderString("x-ratelimit-remaining"),
+        response.getHeaderString("x-ratelimit-reset"),
+        response.getHeaderString("x-ratelimit-resource"),
+        readBody(response));
+  }
+
+  /**
+   * The same, for the exception the REST client raises. Empty when the failure carried no response
+   * at all (a connection-level failure), which is deliberately <em>not</em> treated as a throttle:
+   * see {@link GitHubWriteRetry}.
+   */
+  public static Optional<GitHubApiError> of(WebApplicationException e) {
+    return Optional.ofNullable(e.getResponse()).map(GitHubApiError::from);
+  }
+
+  /**
+   * Whether GitHub is throttling this call rather than refusing it, which is the whole difference
+   * between "post it again in a moment" and "this will never work". 429 says so outright; a 403
+   * says so only through a {@code Retry-After}, an exhausted {@code x-ratelimit-remaining}, or the
+   * rate-limit wording in the body. A permission 403 carries none of the three and so fails fast.
+   */
+  public boolean isThrottled() {
+    if (status == 429) {
+      return true;
+    }
+    if (status != 403) {
+      return false;
+    }
+    return retryAfterSeconds().isPresent()
+        || "0".equals(rateLimitRemaining)
+        || THROTTLE_WORDING.matcher(body).find();
+  }
+
+  /**
+   * Whether this failure is worth a warning in the log. Reads probe for optional files ({@code
+   * .github/instructions}, the repo settings file) and treat 404 as "absent", so a 404 is expected
+   * traffic and only clutters the log at warning level; an auth, throttle or server failure is not.
+   */
+  public boolean isSevere() {
+    return status == 401 || status == 403 || status == 429 || status >= 500;
+  }
+
+  /**
+   * How long to wait before repeating a throttled call, given the attempt just made and the current
+   * time. {@code Retry-After} wins when GitHub sent one; otherwise the reset instant of the
+   * exhausted rate-limit window is honoured; otherwise a linear backoff off {@link #FALLBACK_DELAY}
+   * so a silent throttle still slows down. Never negative — a reset already in the past means the
+   * window has reopened and the call can go straight back out.
+   */
+  public Duration retryDelay(int attempt, Instant now) {
+    var retryAfter = retryAfterSeconds();
+    if (retryAfter.isPresent()) {
+      return atLeastZero(Duration.ofSeconds(retryAfter.get()));
+    }
+    var reset = parseLong(rateLimitReset);
+    if (reset.isPresent()) {
+      return atLeastZero(Duration.between(now, Instant.ofEpochSecond(reset.get())));
+    }
+    return FALLBACK_DELAY.multipliedBy(attempt);
+  }
+
+  /**
+   * One line naming everything that separates one GitHub failure from another: the status, the
+   * throttling headers when present, and the body. This is the line that was missing in #568.
+   */
+  public String diagnostics() {
+    var text = new StringBuilder("status=").append(status);
+    append(text, "retry-after", retryAfter);
+    append(text, "x-ratelimit-remaining", rateLimitRemaining);
+    append(text, "x-ratelimit-reset", rateLimitReset);
+    append(text, "x-ratelimit-resource", rateLimitResource);
+    return text.append(" body=").append(body.isEmpty() ? "<unavailable>" : body).toString();
+  }
+
+  private static void append(StringBuilder text, String name, String value) {
+    if (value != null && !value.isBlank()) {
+      text.append(' ').append(name).append('=').append(value);
+    }
+  }
+
+  private Optional<Long> retryAfterSeconds() {
+    return parseLong(retryAfter);
+  }
+
+  private static Optional<Long> parseLong(String value) {
+    if (value == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(Long.parseLong(value.trim()));
+    } catch (NumberFormatException _) {
+      // GitHub sends whole seconds; an HTTP-date or anything else is treated as "unspecified".
+      return Optional.empty();
+    }
+  }
+
+  private static Duration atLeastZero(Duration delay) {
+    return delay.isNegative() ? Duration.ZERO : delay;
+  }
+
+  /**
+   * The response body as loggable text. An inbound response is buffered first so reading it here
+   * does not consume it for the caller that later inspects the same exception; a response built
+   * in-process holds its entity as an object instead, and one that is closed or has no readable
+   * entity yields an empty body rather than breaking the failure path it exists to explain.
+   */
+  private static String readBody(Response response) {
+    try {
+      if (response.getEntity() instanceof String text) {
+        return clean(text);
+      }
+      response.bufferEntity();
+      return clean(response.readEntity(String.class));
+    } catch (RuntimeException _) {
+      return "";
+    }
+  }
+
+  private static String clean(String raw) {
+    if (raw == null) {
+      return "";
+    }
+    var collapsed = WHITESPACE.matcher(raw.strip()).replaceAll(" ");
+    var redacted = CREDENTIAL_SHAPED.matcher(collapsed).replaceAll(REDACTED);
+    if (redacted.length() <= MAX_BODY_CHARS) {
+      return redacted;
+    }
+    // Never leave a dangling high surrogate at the cut point — that would corrupt a code point.
+    int keep =
+        Character.isHighSurrogate(redacted.charAt(MAX_BODY_CHARS - 1))
+            ? MAX_BODY_CHARS - 1
+            : MAX_BODY_CHARS;
+    return redacted.substring(0, keep) + "…";
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
@@ -22,9 +22,11 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import java.util.List;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 @RegisterRestClient(configKey = "github-api")
+@RegisterProvider(GitHubErrorLogger.class)
 public interface GitHubCheckRunClient {
 
   // GitHub serves 30 rows per page by default; 100 is the maximum.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
@@ -20,22 +20,45 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import java.util.List;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 @RegisterRestClient(configKey = "github-api")
+@RegisterProvider(GitHubErrorLogger.class)
 public interface GitHubCommentClient {
 
+  /** One HTTP attempt at creating a comment. Callers want {@link #createComment} instead. */
   @POST
   @Path("/repos/{owner}/{repo}/issues/{issueNumber}/comments")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  CommentResponse createComment(
+  CommentResponse createCommentOnce(
       @HeaderParam("Authorization") String auth,
       @HeaderParam("Accept") String accept,
       @PathParam("owner") String owner,
       @PathParam("repo") String repo,
       @PathParam("issueNumber") int issueNumber,
       CreateCommentRequest request);
+
+  /**
+   * Posts a comment, backing off and reposting while GitHub is throttling (#568). This is the last
+   * step of a command that has already run its model call to completion, so a 403 from GitHub's
+   * content-creation secondary rate limit used to discard a finished, paid-for generation outright
+   * — 7 of 56 responses in the burst that motivated this. {@link GitHubWriteRetry} repeats the post
+   * only on a positively identified throttle, never on an ambiguous failure that might already have
+   * created the comment, so no reply is ever posted twice.
+   */
+  default CommentResponse createComment(
+      String auth,
+      String accept,
+      String owner,
+      String repo,
+      int issueNumber,
+      CreateCommentRequest request) {
+    return GitHubWriteRetry.DEFAULT.call(
+        "a comment on " + owner + "/" + repo + " #" + issueNumber,
+        () -> createCommentOnce(auth, accept, owner, repo, issueNumber, request));
+  }
 
   // GitHub serves 30 issue comments per page by default; 100 is the maximum.
   int COMMENTS_PER_PAGE = 100;
@@ -85,17 +108,35 @@ public interface GitHubCommentClient {
       @PathParam("repo") String repo,
       @PathParam("issueNumber") int issueNumber);
 
+  /** One HTTP attempt at editing a comment. Callers want {@link #updateComment} instead. */
   @PATCH
   @Path("/repos/{owner}/{repo}/issues/comments/{commentId}")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  CommentResponse updateComment(
+  CommentResponse updateCommentOnce(
       @HeaderParam("Authorization") String auth,
       @HeaderParam("Accept") String accept,
       @PathParam("owner") String owner,
       @PathParam("repo") String repo,
       @PathParam("commentId") long commentId,
       CreateCommentRequest request);
+
+  /**
+   * Edits a comment, with the same throttle backoff {@link #createComment} gets. Editing the bot's
+   * existing summary in place carries the regenerated markdown of a superseded round, so losing it
+   * to a throttle leaves the PR showing a summary that describes code the diff no longer has.
+   */
+  default CommentResponse updateComment(
+      String auth,
+      String accept,
+      String owner,
+      String repo,
+      long commentId,
+      CreateCommentRequest request) {
+    return GitHubWriteRetry.DEFAULT.call(
+        "an edit of comment " + commentId + " on " + owner + "/" + repo,
+        () -> updateCommentOnce(auth, accept, owner, repo, commentId, request));
+  }
 
   record CreateCommentRequest(String body) {
     public CreateCommentRequest {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubErrorLogger.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubErrorLogger.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Writes down what a failed GitHub call actually returned, on every GitHub REST client.
+ *
+ * <p>#568: the bot logged nothing but {@code status code 403}, which is the same line for "you are
+ * creating content faster than GitHub accepts it" and for "this App has no permission to comment".
+ * The two need opposite responses — wait and repost, versus fix the App installation — and neither
+ * the maintainer nor an operator could tell which had happened from the instance's own output. The
+ * response body and the rate-limit headers say which, so they are logged.
+ *
+ * <p>Registered as a {@link ResponseExceptionMapper} rather than wired into each call site so it
+ * covers reads as well as writes and inherits any client added later. It deliberately returns
+ * {@code null}: the mapper chain then falls through to the runtime's default mapper, so callers
+ * keep the exact exception type and fail-soft handling they already have and this class changes
+ * nothing but the log. Its {@linkplain #getPriority() priority} only has to beat the default
+ * mapper's, which sits at {@link Integer#MAX_VALUE}.
+ *
+ * <p>Not every error deserves a warning: the bot probes for optional repository files ({@code
+ * .github/instructions}, the settings file, the stack manifests) and reads a 404 as "absent", so a
+ * 404 is ordinary traffic and is logged at debug. Auth, throttle and server failures are the ones
+ * that mean something went wrong.
+ */
+@Priority(Priorities.USER)
+public class GitHubErrorLogger implements ResponseExceptionMapper<Throwable> {
+
+  private static final Logger log = LoggerFactory.getLogger(GitHubErrorLogger.class);
+
+  @Override
+  public boolean handles(int status, MultivaluedMap<String, Object> headers) {
+    return status >= 400;
+  }
+
+  @Override
+  public int getPriority() {
+    return Priorities.USER;
+  }
+
+  /**
+   * Logs the failure and returns {@code null} so the runtime's default mapper still builds the
+   * exception the callers are written against.
+   */
+  @Override
+  public Throwable toThrowable(Response response) {
+    var error = GitHubApiError.from(response);
+    if (error.isSevere()) {
+      log.warn("GitHub API call failed: {}", error.diagnostics());
+    } else {
+      log.debug("GitHub API call returned an error: {}", error.diagnostics());
+    }
+    return null;
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubGraphQLClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubGraphQLClient.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import java.util.Map;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 /**
@@ -31,6 +32,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
  * threads in particular.
  */
 @RegisterRestClient(configKey = "github-api")
+@RegisterProvider(GitHubErrorLogger.class)
 public interface GitHubGraphQLClient {
 
   @POST

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubInstallationClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubInstallationClient.java
@@ -20,9 +20,11 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 @RegisterRestClient(configKey = "github-api")
+@RegisterProvider(GitHubErrorLogger.class)
 public interface GitHubInstallationClient {
 
   @GET

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLabelClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLabelClient.java
@@ -19,10 +19,12 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 /** GitHub REST endpoints for reading a repository's labels and applying them to a PR. */
 @RegisterRestClient(configKey = "github-api")
+@RegisterProvider(GitHubErrorLogger.class)
 public interface GitHubLabelClient {
 
   @GET

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubPullRequestClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubPullRequestClient.java
@@ -20,9 +20,11 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import java.util.List;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 @RegisterRestClient(configKey = "github-api")
+@RegisterProvider(GitHubErrorLogger.class)
 public interface GitHubPullRequestClient {
 
   // GitHub serves 30 PR files per page by default (100 max) and caps listings at 3000 files.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReactionClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReactionClient.java
@@ -21,6 +21,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 /**
@@ -31,6 +32,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
  * captured.
  */
 @RegisterRestClient(configKey = "github-api")
+@RegisterProvider(GitHubErrorLogger.class)
 public interface GitHubReactionClient {
 
   @POST

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -21,21 +21,42 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import java.util.List;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 @RegisterRestClient(configKey = "github-api")
+@RegisterProvider(GitHubErrorLogger.class)
 public interface GitHubReviewClient {
+
+  /** One HTTP attempt at posting a review. Callers want {@link #createReview} instead. */
   @POST
   @Path("/repos/{owner}/{repo}/pulls/{pullNumber}/reviews")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  ReviewResponse createReview(
+  ReviewResponse createReviewOnce(
       @HeaderParam("Authorization") String auth,
       @HeaderParam("Accept") String accept,
       @PathParam("owner") String owner,
       @PathParam("repo") String repo,
       @PathParam("pullNumber") int pullNumber,
       CreateReviewRequest request);
+
+  /**
+   * Posts the review, backing off and reposting while GitHub is throttling (#568). The review body
+   * and every inline finding in it are the run's model output, so a throttled 403 here discards the
+   * whole generation. See {@link GitHubWriteRetry} for why the repeat cannot post it twice.
+   */
+  default ReviewResponse createReview(
+      String auth,
+      String accept,
+      String owner,
+      String repo,
+      int pullNumber,
+      CreateReviewRequest request) {
+    return GitHubWriteRetry.DEFAULT.call(
+        "a review on " + owner + "/" + repo + " #" + pullNumber,
+        () -> createReviewOnce(auth, accept, owner, repo, pullNumber, request));
+  }
 
   // GitHub serves 30 reviews per page by default; request the 100 max and bound the page walk.
   int REVIEWS_PER_PAGE = 100;
@@ -125,11 +146,14 @@ public interface GitHubReviewClient {
     return all;
   }
 
+  /**
+   * One HTTP attempt at an inline comment. Callers want {@link #createPullRequestComment} instead.
+   */
   @POST
   @Path("/repos/{owner}/{repo}/pulls/{pullNumber}/comments")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  PullRequestCommentResponse createPullRequestComment(
+  PullRequestCommentResponse createPullRequestCommentOnce(
       @HeaderParam("Authorization") String auth,
       @HeaderParam("Accept") String accept,
       @PathParam("owner") String owner,
@@ -137,11 +161,25 @@ public interface GitHubReviewClient {
       @PathParam("pullNumber") int pullNumber,
       CreatePullRequestCommentRequest request);
 
+  /** Posts an inline comment, with the throttle backoff described on {@link GitHubWriteRetry}. */
+  default PullRequestCommentResponse createPullRequestComment(
+      String auth,
+      String accept,
+      String owner,
+      String repo,
+      int pullNumber,
+      CreatePullRequestCommentRequest request) {
+    return GitHubWriteRetry.DEFAULT.call(
+        "an inline comment on " + owner + "/" + repo + " #" + pullNumber,
+        () -> createPullRequestCommentOnce(auth, accept, owner, repo, pullNumber, request));
+  }
+
+  /** One HTTP attempt at a thread reply. Callers want {@link #replyToReviewComment} instead. */
   @POST
   @Path("/repos/{owner}/{repo}/pulls/{pullNumber}/comments/{commentId}/replies")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  PullRequestCommentResponse replyToReviewComment(
+  PullRequestCommentResponse replyToReviewCommentOnce(
       @HeaderParam("Authorization") String auth,
       @HeaderParam("Accept") String accept,
       @PathParam("owner") String owner,
@@ -149,6 +187,22 @@ public interface GitHubReviewClient {
       @PathParam("pullNumber") int pullNumber,
       @PathParam("commentId") long commentId,
       ReplyToReviewCommentRequest request);
+
+  /**
+   * Replies in a review thread, with the throttle backoff described on {@link GitHubWriteRetry}.
+   */
+  default PullRequestCommentResponse replyToReviewComment(
+      String auth,
+      String accept,
+      String owner,
+      String repo,
+      int pullNumber,
+      long commentId,
+      ReplyToReviewCommentRequest request) {
+    return GitHubWriteRetry.DEFAULT.call(
+        "a reply to comment " + commentId + " on " + owner + "/" + repo + " #" + pullNumber,
+        () -> replyToReviewCommentOnce(auth, accept, owner, repo, pullNumber, commentId, request));
+  }
 
   @DELETE
   @Path("/repos/{owner}/{repo}/pulls/{pullNumber}/reviews/{reviewId}")

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubTokenApi.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubTokenApi.java
@@ -22,9 +22,11 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 @RegisterRestClient(configKey = "github-api")
+@RegisterProvider(GitHubErrorLogger.class)
 public interface GitHubTokenApi {
 
   @POST

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetry.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetry.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import jakarta.ws.rs.WebApplicationException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Bounded backoff for the GitHub calls that publish work the bot has already paid for.
+ *
+ * <p>#568: GitHub secondary-rate-limits rapid content creation and answers a comment POST with 403
+ * and a {@code Retry-After}. Nothing honoured it, so a burst of on-demand commands lost 7 of 56
+ * responses — every one of them <em>after</em> its model call had completed. A throttled post is
+ * the cheapest failure in the run to repeat and the most expensive one to drop, so it is repeated.
+ *
+ * <h2>Why this cannot post the same comment twice</h2>
+ *
+ * A retry is attempted only when {@link GitHubApiError#isThrottled()} holds — a 429, or a 403 that
+ * carries a {@code Retry-After}, an exhausted {@code x-ratelimit-remaining}, or GitHub's rate-limit
+ * wording in the body. GitHub rejects a throttled content-creating request at the edge, before the
+ * comment exists; the response is the rejection itself, not a report about a write that happened.
+ * The ambiguous failures — a connection reset, a read timeout, a 5xx — are the ones where a write
+ * may well have landed, and those are deliberately <em>not</em> retried here: they propagate on the
+ * first attempt exactly as they did before. That is the whole duplicate-suppression argument, and
+ * it is why the throttle test is a positive signal rather than "not a success".
+ *
+ * <h2>Why this cannot stall the pipeline</h2>
+ *
+ * Reviews and commands run on a virtual-thread-per-task executor, so a waiting attempt parks its
+ * virtual thread and pins no platform thread. What a wait does hold is the per-PR serialization
+ * slot in the dispatcher, so the wait is bounded twice over: at most {@value #MAX_ATTEMPTS}
+ * attempts, and no single wait longer than {@link #MAX_DELAY_PER_ATTEMPT} however long a {@code
+ * Retry-After} asks for. One call therefore waits at most {@value #MAX_ATTEMPTS} − 1 × 30s = 60s,
+ * which is also long enough to outlast the minute-long window GitHub's content-creation secondary
+ * limit uses. Once the attempts are spent the failure propagates unchanged, and the log says the
+ * generated content was lost so an operator can see the command needs re-running.
+ */
+public final class GitHubWriteRetry {
+
+  private static final Logger log = LoggerFactory.getLogger(GitHubWriteRetry.class);
+
+  /** Total attempts, first included: one post plus at most two repeats. */
+  public static final int MAX_ATTEMPTS = 3;
+
+  /** Longest single wait honoured, however long a {@code Retry-After} asks for. */
+  public static final Duration MAX_DELAY_PER_ATTEMPT = Duration.ofSeconds(30);
+
+  /** Parks the current thread; the seam that lets the tests run the backoff without waiting. */
+  @FunctionalInterface
+  interface Sleeper {
+    void sleep(Duration delay) throws InterruptedException;
+  }
+
+  /** The instance production uses: real sleeping, real clock. */
+  static final GitHubWriteRetry DEFAULT =
+      new GitHubWriteRetry(delay -> Thread.sleep(delay.toMillis()), Instant::now);
+
+  private final Sleeper sleeper;
+  private final Supplier<Instant> clock;
+
+  GitHubWriteRetry(Sleeper sleeper, Supplier<Instant> clock) {
+    this.sleeper = sleeper;
+    this.clock = clock;
+  }
+
+  /**
+   * Runs a content-creating GitHub call, repeating it while GitHub is throttling and the budget
+   * allows. Returns the call's own result; rethrows the failure unchanged once the call is not
+   * retryable or the budget is spent, so every existing caller keeps the exception type and the
+   * fail-soft handling it already has.
+   *
+   * @param operation what is being posted, for the log — never credentials or comment text
+   */
+  public <T> T call(String operation, Supplier<T> operationCall) {
+    for (int attempt = 1; ; attempt++) {
+      try {
+        return operationCall.get();
+      } catch (WebApplicationException e) {
+        var delay = retryDelay(operation, e, attempt);
+        if (delay.isEmpty()) {
+          throw e;
+        }
+        log.warn(
+            "GitHub throttled {} — retrying in {}s (attempt {} of {})",
+            operation,
+            delay.get().toSeconds(),
+            attempt + 1,
+            MAX_ATTEMPTS);
+        try {
+          sleeper.sleep(delay.get());
+        } catch (InterruptedException _) {
+          Thread.currentThread().interrupt();
+          log.warn("Interrupted while backing off {} — the payload is lost", operation);
+          throw e;
+        }
+      }
+    }
+  }
+
+  /**
+   * How long to wait before repeating this failure, or empty when it must not be repeated — either
+   * because GitHub is refusing rather than throttling, or because the attempts are spent. The
+   * spent-attempts case is logged, because it is the one where a completed generation is discarded
+   * and the operator needs the response's own words to see why.
+   */
+  private Optional<Duration> retryDelay(
+      String operation, WebApplicationException failure, int attempt) {
+    var error = GitHubApiError.of(failure);
+    if (error.isEmpty() || !error.get().isThrottled()) {
+      return Optional.empty();
+    }
+    if (attempt >= MAX_ATTEMPTS) {
+      log.warn(
+          "GitHub still throttling {} after {} attempts — the generated content is lost and the"
+              + " command has to be re-run. {}",
+          operation,
+          MAX_ATTEMPTS,
+          error.get().diagnostics());
+      return Optional.empty();
+    }
+    return Optional.of(min(error.get().retryDelay(attempt, clock.get()), MAX_DELAY_PER_ATTEMPT));
+  }
+
+  private static Duration min(Duration left, Duration right) {
+    return left.compareTo(right) <= 0 ? left : right;
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@link GitHubApiError} — the reading of a failed GitHub response that #568 found missing:
+ * without the body and the rate-limit headers a throttle 403 and a permission 403 are the same line
+ * in the log, and the client has no basis on which to decide whether reposting is worth anything.
+ *
+ * <p>The header names, the throttle wording and the {@code 512}-character body cap are written out
+ * as literals here rather than referenced from the production constants, so the tests pin the
+ * contract with GitHub independently of the code under test.
+ */
+class GitHubApiErrorTest {
+
+  private static final String SECONDARY_LIMIT_BODY =
+      "{\"message\":\"You have exceeded a secondary rate limit. Please wait a few minutes before"
+          + " you try again.\",\"documentation_url\":\"https://docs.github.com/rest\"}";
+
+  private static final String PERMISSION_BODY =
+      "{\"message\":\"Resource not accessible by integration\",\"status\":\"403\"}";
+
+  /** An outbound response, as a test can build one: its entity is the object, not a stream. */
+  private static Response outbound(int status, String body, String... headers) {
+    var builder = Response.status(status);
+    for (int i = 0; i < headers.length; i += 2) {
+      builder.header(headers[i], headers[i + 1]);
+    }
+    return body == null ? builder.build() : builder.entity(body).build();
+  }
+
+  /** An inbound response, as the REST client hands one over: the entity is still a stream. */
+  private static Response inbound(int status, String body, String... headers) {
+    var response = mock(Response.class);
+    when(response.getStatus()).thenReturn(status);
+    when(response.getEntity())
+        .thenReturn(
+            new ByteArrayInputStream(String.valueOf(body).getBytes(StandardCharsets.UTF_8)));
+    when(response.readEntity(String.class)).thenReturn(body);
+    for (int i = 0; i < headers.length; i += 2) {
+      when(response.getHeaderString(headers[i])).thenReturn(headers[i + 1]);
+    }
+    return response;
+  }
+
+  /** The body as it reaches the log — everything {@code diagnostics} prints after {@code body=}. */
+  private static String loggedBody(Response response) {
+    return GitHubApiError.from(response).diagnostics().split(" body=", 2)[1];
+  }
+
+  @Nested
+  class ThrottleDetection {
+
+    @Test
+    void aRetryAfterOnA403IsGitHubThrottlingTheWrite() {
+      assertTrue(
+          GitHubApiError.from(outbound(403, SECONDARY_LIMIT_BODY, "Retry-After", "60"))
+              .isThrottled());
+    }
+
+    @Test
+    void anExhaustedRateLimitHeaderOnA403IsAThrottleEvenWithNoRetryAfter() {
+      assertTrue(
+          GitHubApiError.from(outbound(403, "{}", "x-ratelimit-remaining", "0")).isThrottled());
+    }
+
+    @Test
+    void theSecondaryRateLimitWordingAloneIsEnough() {
+      // The burst in #568 is the case with no headers at all — only the message says what happened.
+      assertTrue(GitHubApiError.from(outbound(403, SECONDARY_LIMIT_BODY)).isThrottled());
+    }
+
+    @Test
+    void aPermissionRefusalIsNotAThrottleAndMustNotBeRepeated() {
+      var error =
+          GitHubApiError.from(outbound(403, PERMISSION_BODY, "x-ratelimit-remaining", "42"));
+      assertFalse(error.isThrottled(), "a permission 403 will fail identically forever");
+    }
+
+    @Test
+    void a429IsAThrottleWhateverItCarries() {
+      assertTrue(GitHubApiError.from(outbound(429, "{}")).isThrottled());
+    }
+
+    @Test
+    void otherFailuresAreNotThrottles() {
+      // 5xx and connection-level failures may have written the comment already — never repeated.
+      assertFalse(GitHubApiError.from(outbound(500, "boom", "Retry-After", "5")).isThrottled());
+      assertFalse(GitHubApiError.from(outbound(404, "{}")).isThrottled());
+      assertFalse(GitHubApiError.from(outbound(422, SECONDARY_LIMIT_BODY)).isThrottled());
+    }
+
+    @Test
+    void anUnparsableRetryAfterIsIgnoredRatherThanGuessedAt() {
+      // GitHub sends whole seconds; an HTTP-date is not a number, so it cannot vouch for a
+      // throttle.
+      assertFalse(
+          GitHubApiError.from(outbound(403, PERMISSION_BODY, "Retry-After", "Wed, 21 Oct 2026 GMT"))
+              .isThrottled());
+    }
+  }
+
+  @Nested
+  class Severity {
+
+    @Test
+    void authThrottleAndServerFailuresAreWorthWarningAbout() {
+      assertTrue(GitHubApiError.from(outbound(401, "{}")).isSevere());
+      assertTrue(GitHubApiError.from(outbound(403, "{}")).isSevere());
+      assertTrue(GitHubApiError.from(outbound(429, "{}")).isSevere());
+      assertTrue(GitHubApiError.from(outbound(503, "{}")).isSevere());
+    }
+
+    @Test
+    void anAbsentOptionalFileIsOrdinaryTraffic() {
+      // The bot probes for .github/instructions and the settings file; 404 means "absent".
+      assertFalse(GitHubApiError.from(outbound(404, "{}")).isSevere());
+      assertFalse(GitHubApiError.from(outbound(422, "{}")).isSevere());
+    }
+  }
+
+  @Nested
+  class RetryDelay {
+
+    private static final Instant NOW = Instant.ofEpochSecond(1_800_000_000L);
+
+    @Test
+    void retryAfterWins() {
+      var error = GitHubApiError.from(outbound(403, "{}", "Retry-After", "47"));
+      assertEquals(Duration.ofSeconds(47), error.retryDelay(1, NOW));
+    }
+
+    @Test
+    void aRateLimitResetIsHonouredWhenNoRetryAfterIsSent() {
+      var error =
+          GitHubApiError.from(
+              outbound(
+                  403,
+                  "{}",
+                  "x-ratelimit-remaining",
+                  "0",
+                  "x-ratelimit-reset",
+                  String.valueOf(NOW.getEpochSecond() + 12)));
+      assertEquals(Duration.ofSeconds(12), error.retryDelay(1, NOW));
+    }
+
+    @Test
+    void aResetAlreadyInThePastMeansTheWindowHasReopened() {
+      var error =
+          GitHubApiError.from(
+              outbound(
+                  403,
+                  "{}",
+                  "x-ratelimit-remaining",
+                  "0",
+                  "x-ratelimit-reset",
+                  String.valueOf(NOW.getEpochSecond() - 90)));
+      assertEquals(Duration.ZERO, error.retryDelay(1, NOW));
+    }
+
+    @Test
+    void aNegativeRetryAfterIsFlooredAtZero() {
+      var error = GitHubApiError.from(outbound(403, "{}", "Retry-After", "-3"));
+      assertEquals(Duration.ZERO, error.retryDelay(1, NOW));
+    }
+
+    @Test
+    void aSilentThrottleBacksOffLinearlyByAttempt() {
+      var error = GitHubApiError.from(outbound(403, SECONDARY_LIMIT_BODY));
+      assertEquals(Duration.ofSeconds(5), error.retryDelay(1, NOW));
+      assertEquals(Duration.ofSeconds(10), error.retryDelay(2, NOW));
+    }
+  }
+
+  @Nested
+  class Diagnostics {
+
+    @Test
+    void namesTheStatusEveryThrottlingHeaderAndTheBody() {
+      var diagnostics =
+          GitHubApiError.from(
+                  outbound(
+                      403,
+                      SECONDARY_LIMIT_BODY,
+                      "Retry-After",
+                      "60",
+                      "x-ratelimit-remaining",
+                      "0",
+                      "x-ratelimit-reset",
+                      "1800000060",
+                      "x-ratelimit-resource",
+                      "core"))
+              .diagnostics();
+
+      assertEquals(
+          "status=403 retry-after=60 x-ratelimit-remaining=0 x-ratelimit-reset=1800000060"
+              + " x-ratelimit-resource=core body="
+              + SECONDARY_LIMIT_BODY,
+          diagnostics);
+    }
+
+    @Test
+    void omitsHeadersGitHubDidNotSend() {
+      var diagnostics = GitHubApiError.from(outbound(403, PERMISSION_BODY)).diagnostics();
+
+      // The line that finally separates a permission 403 from a throttle 403 in the log.
+      assertEquals("status=403 body=" + PERMISSION_BODY, diagnostics);
+    }
+
+    @Test
+    void saysSoWhenTheBodyCouldNotBeRead() {
+      assertEquals(
+          "status=403 body=<unavailable>", GitHubApiError.from(outbound(403, null)).diagnostics());
+    }
+
+    @Test
+    void omitsAHeaderThatArrivedEmpty() {
+      // A present-but-blank header states nothing; printing "retry-after=" would only mislead.
+      assertEquals(
+          "status=403 body={}",
+          GitHubApiError.from(outbound(403, "{}", "Retry-After", "  ")).diagnostics());
+    }
+  }
+
+  @Nested
+  class BodyHandling {
+
+    @Test
+    void readsAnInboundResponseWithoutConsumingItForTheCaller() {
+      var response = inbound(403, SECONDARY_LIMIT_BODY, "Retry-After", "60");
+
+      assertEquals(SECONDARY_LIMIT_BODY, loggedBody(response));
+      // Buffered first, so the exception the caller receives can still be read.
+      org.mockito.Mockito.verify(response).bufferEntity();
+    }
+
+    @Test
+    void anUnreadableResponseDegradesToAnEmptyBodyRatherThanBreakingTheFailurePath() {
+      var closed = mock(Response.class);
+      when(closed.getStatus()).thenReturn(403);
+      when(closed.getEntity()).thenThrow(new IllegalStateException("response is closed"));
+
+      assertEquals("<unavailable>", loggedBody(closed));
+    }
+
+    @Test
+    void anEmptyResponseBodyIsReportedAsUnavailableRatherThanAsBlank() {
+      assertEquals("<unavailable>", loggedBody(inbound(500, null)));
+    }
+
+    @Test
+    void collapsesWhitespaceSoOneFailureStaysOnOneLine() {
+      assertEquals("line one line two", loggedBody(outbound(500, "  line one\n\tline two  ")));
+    }
+
+    @Test
+    void masksAnythingShapedLikeACredential() {
+      var body =
+          loggedBody(
+              outbound(
+                  401,
+                  "{\"token\":\"ghs_abcdefghij0123456789\","
+                      + "\"pat\":\"github_pat_abcdefghij0123456789\","
+                      + "\"header\":\"Bearer abcdefghij0123456789\","
+                      + "\"jwt\":\"eyJhbGciOiJI.eyJpc3MiOiJ4.c2lnbmF0dXJl\"}"));
+      assertFalse(body.contains("ghs_abcdefghij0123456789"), body);
+      assertFalse(body.contains("github_pat_abcdefghij0123456789"), body);
+      assertFalse(body.contains("abcdefghij0123456789"), body);
+      assertFalse(body.contains("eyJhbGciOiJI"), body);
+      assertEquals(4, body.split("\\*\\*\\*", -1).length - 1, body);
+    }
+
+    @Test
+    void capsAnOverLongBodySoOneFailureCannotFloodTheLog() {
+      var body = loggedBody(outbound(500, "x".repeat(4_000)));
+
+      assertEquals(513, body.length());
+      assertTrue(body.endsWith("…"));
+    }
+
+    @Test
+    void neverCutsAnOverLongBodyThroughASurrogatePair() {
+      // 511 plain characters then an astral code point: the cut lands inside the pair.
+      var body = loggedBody(outbound(500, "x".repeat(511) + "𝍢".repeat(20)));
+
+      assertEquals(511, body.length() - 1);
+      assertTrue(body.endsWith("…"));
+      assertEquals(-1, body.indexOf('\uD834'), "no dangling high surrogate");
+    }
+  }
+
+  @Nested
+  class FromAnException {
+
+    @Test
+    void readsTheResponseTheRestClientAttached() {
+      var failure =
+          new WebApplicationException(outbound(403, SECONDARY_LIMIT_BODY, "Retry-After", "9"));
+
+      var error = GitHubApiError.of(failure).orElseThrow();
+
+      assertTrue(error.isThrottled());
+      assertEquals(Duration.ofSeconds(9), error.retryDelay(1, Instant.EPOCH));
+    }
+
+    @Test
+    void isEmptyWhenTheFailureCarriedNoResponseAtAll() {
+      var noResponse =
+          new WebApplicationException("connection reset") {
+            @Override
+            public Response getResponse() {
+              return null;
+            }
+          };
+
+      assertTrue(GitHubApiError.of(noResponse).isEmpty());
+    }
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClientTest.java
@@ -18,7 +18,9 @@ package dev.thiagogonzaga.thrillhousebot.github;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -26,8 +28,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient.CommentResponse;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient.CreateCommentRequest;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient.IssueComment;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
@@ -154,5 +159,47 @@ class GitHubCommentClientTest {
     var capped = new CreateCommentRequest(body).body();
 
     assertSame(body, capped, "a body within the limit is returned untouched");
+  }
+
+  /**
+   * A 403 that GitHub sends while throttling a write, carrying a {@code Retry-After} of zero so the
+   * backoff is real but instant. {@link GitHubWriteRetryTest} pins the waiting itself.
+   */
+  private static WebApplicationException throttledNow() {
+    return new WebApplicationException(
+        Response.status(403)
+            .header("Retry-After", "0")
+            .entity("{\"message\":\"You have exceeded a secondary rate limit.\"}")
+            .build());
+  }
+
+  @Test
+  void createCommentRepostsAThrottledCommentRatherThanLosingIt() {
+    var client = mock(GitHubCommentClient.class);
+    when(client.createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any()))
+        .thenCallRealMethod();
+    var request = new CreateCommentRequest("the generated reply");
+    var posted = new CommentResponse(42, "https://github.test/c/42");
+    when(client.createCommentOnce("auth", "json", "o", "r", 7, request))
+        .thenThrow(throttledNow())
+        .thenReturn(posted);
+
+    assertSame(posted, client.createComment("auth", "json", "o", "r", 7, request));
+    verify(client, times(2)).createCommentOnce("auth", "json", "o", "r", 7, request);
+  }
+
+  @Test
+  void updateCommentRepostsAThrottledEditRatherThanLeavingAStaleSummary() {
+    var client = mock(GitHubCommentClient.class);
+    when(client.updateComment(anyString(), anyString(), anyString(), anyString(), anyLong(), any()))
+        .thenCallRealMethod();
+    var request = new CreateCommentRequest("the regenerated summary");
+    var edited = new CommentResponse(99, "https://github.test/c/99");
+    when(client.updateCommentOnce("auth", "json", "o", "r", 99L, request))
+        .thenThrow(throttledNow())
+        .thenReturn(edited);
+
+    assertSame(edited, client.updateComment("auth", "json", "o", "r", 99L, request));
+    verify(client, times(2)).updateCommentOnce("auth", "json", "o", "r", 99L, request);
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentThrottleTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentThrottleTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.ws.rs.WebApplicationException;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end proof of both halves of #568, through a real REST client against a loopback GitHub.
+ *
+ * <p>The unit tests around {@link GitHubWriteRetry} and {@link GitHubErrorLogger} cover the
+ * decisions; what only a real client can show is that the pieces are wired at all — that the
+ * registered mapper is invoked and, by returning nothing, still leaves callers the exception they
+ * are written against, and that the throttled response reaches the retry with its {@code
+ * Retry-After} intact instead of being reduced to a bare status.
+ *
+ * <p>{@code Retry-After: 0} keeps the backoff instant; the wait itself is pinned by {@link
+ * GitHubWriteRetryTest}.
+ */
+@QuarkusTest
+class GitHubCommentThrottleTest {
+
+  private static final String ACCEPT = "application/vnd.github+json";
+
+  private static final String SECONDARY_LIMIT_BODY =
+      "{\"message\":\"You have exceeded a secondary rate limit. Please wait a few minutes before"
+          + " you try again.\",\"documentation_url\":\"https://docs.github.com/rest\"}";
+
+  private static final String PERMISSION_BODY =
+      "{\"message\":\"Resource not accessible by integration\"}";
+
+  private HttpServer server;
+  private final AtomicInteger attempts = new AtomicInteger();
+
+  private final List<LogRecord> logged = new CopyOnWriteArrayList<>();
+  private Logger julLogger;
+  private Handler capture;
+  private Level originalLevel;
+
+  @BeforeEach
+  void captureLogging() {
+    julLogger = Logger.getLogger(GitHubErrorLogger.class.getName());
+    originalLevel = julLogger.getLevel();
+    julLogger.setLevel(Level.ALL);
+    capture =
+        new Handler() {
+          @Override
+          public void publish(LogRecord record) {
+            logged.add(record);
+          }
+
+          @Override
+          public void flush() {
+            // Nothing is buffered.
+          }
+
+          @Override
+          public void close() {
+            // Nothing to release.
+          }
+        };
+    julLogger.addHandler(capture);
+  }
+
+  @AfterEach
+  void tearDown() {
+    julLogger.removeHandler(capture);
+    julLogger.setLevel(originalLevel);
+    if (server != null) {
+      server.stop(0);
+      server = null;
+    }
+  }
+
+  private String log() {
+    return logged.stream()
+        .map(record -> record.getMessage() + " " + Arrays.toString(record.getParameters()))
+        .reduce("", (left, right) -> left + right);
+  }
+
+  private GitHubCommentClient clientAnsweredBy(HttpHandler handler) throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/", handler);
+    server.start();
+    return QuarkusRestClientBuilder.newBuilder()
+        .baseUri(URI.create("http://127.0.0.1:" + server.getAddress().getPort()))
+        .build(GitHubCommentClient.class);
+  }
+
+  private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+    var bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().add("Content-Type", "application/json");
+    exchange.sendResponseHeaders(status, bytes.length);
+    try (var out = exchange.getResponseBody()) {
+      out.write(bytes);
+    }
+  }
+
+  @Test
+  void aThrottledCommentIsPostedOnTheRepeatInsteadOfDiscardingTheGeneration() throws IOException {
+    var client =
+        clientAnsweredBy(
+            exchange -> {
+              if (attempts.incrementAndGet() == 1) {
+                exchange.getResponseHeaders().add("Retry-After", "0");
+                exchange.getResponseHeaders().add("x-ratelimit-remaining", "0");
+                respond(exchange, 403, SECONDARY_LIMIT_BODY);
+              } else {
+                respond(exchange, 201, "{\"id\":42,\"html_url\":\"https://github.test/c/42\"}");
+              }
+            });
+
+    var posted =
+        client.createComment(
+            "Bearer token",
+            ACCEPT,
+            "owner",
+            "repo",
+            7,
+            new GitHubCommentClient.CreateCommentRequest("the generated reply"));
+
+    assertEquals(42, posted.id());
+    assertEquals(2, attempts.get(), "the throttled post is repeated, not dropped");
+    var log = log();
+    assertTrue(log.contains("secondary rate limit"), log);
+    assertTrue(log.contains("retry-after=0"), log);
+  }
+
+  @Test
+  void aPermissionRefusalStillFailsTheCallAndSaysWhyExactlyOnce() throws IOException {
+    var client =
+        clientAnsweredBy(
+            exchange -> {
+              attempts.incrementAndGet();
+              respond(exchange, 403, PERMISSION_BODY);
+            });
+
+    // The registered logger raises nothing of its own, so callers keep the exception — and the
+    // fail-soft handling built on it — that they had before #568.
+    assertThrows(
+        WebApplicationException.class,
+        () ->
+            client.createComment(
+                "Bearer token",
+                ACCEPT,
+                "owner",
+                "repo",
+                7,
+                new GitHubCommentClient.CreateCommentRequest("the generated reply")));
+
+    assertEquals(1, attempts.get(), "a refusal that will never succeed is not repeated");
+    var log = log();
+    assertTrue(log.contains("Resource not accessible by integration"), log);
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubErrorLoggerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubErrorLoggerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@link GitHubErrorLogger} — the missing half of #568. The bot logged {@code status code
+ * 403} and nothing else, so a secondary rate limit and a missing App permission read identically
+ * and neither the maintainer nor an operator could tell which had happened.
+ */
+class GitHubErrorLoggerTest {
+
+  private static final String SECONDARY_LIMIT_BODY =
+      "{\"message\":\"You have exceeded a secondary rate limit.\"}";
+
+  private final GitHubErrorLogger mapper = new GitHubErrorLogger();
+
+  private final List<LogRecord> logged = new CopyOnWriteArrayList<>();
+  private Logger julLogger;
+  private Handler capture;
+  private Level originalLevel;
+
+  @BeforeEach
+  void captureLogging() {
+    julLogger = Logger.getLogger(GitHubErrorLogger.class.getName());
+    originalLevel = julLogger.getLevel();
+    julLogger.setLevel(Level.ALL);
+    capture =
+        new Handler() {
+          @Override
+          public void publish(LogRecord record) {
+            logged.add(record);
+          }
+
+          @Override
+          public void flush() {
+            // Nothing is buffered.
+          }
+
+          @Override
+          public void close() {
+            // Nothing to release.
+          }
+        };
+    julLogger.addHandler(capture);
+  }
+
+  @AfterEach
+  void restoreLogging() {
+    julLogger.removeHandler(capture);
+    julLogger.setLevel(originalLevel);
+  }
+
+  private String warnings() {
+    return logged.stream()
+        .filter(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+        .map(record -> record.getMessage() + " " + Arrays.toString(record.getParameters()))
+        .reduce("", (left, right) -> left + right);
+  }
+
+  private static Response response(int status, String body, String... headers) {
+    var builder = Response.status(status);
+    for (int i = 0; i < headers.length; i += 2) {
+      builder.header(headers[i], headers[i + 1]);
+    }
+    return builder.entity(body).build();
+  }
+
+  @Test
+  void handlesEveryErrorStatusAndNothingBelowIt() {
+    var headers = new MultivaluedHashMap<String, Object>();
+
+    assertFalse(mapper.handles(200, headers));
+    assertFalse(mapper.handles(399, headers));
+    assertTrue(mapper.handles(400, headers));
+    assertTrue(mapper.handles(403, headers));
+    assertTrue(mapper.handles(500, headers));
+  }
+
+  @Test
+  void outranksTheRuntimeDefaultMapperSoItSeesTheResponseFirst() {
+    assertTrue(mapper.getPriority() < Integer.MAX_VALUE);
+  }
+
+  @Test
+  void raisesNoExceptionOfItsOwnSoCallersKeepTheHandlingTheyHave() {
+    // Returning null hands the response on to the default mapper, which builds the exception the
+    // fail-soft posting wrappers already catch. This class changes the log and nothing else.
+    assertNull(mapper.toThrowable(response(403, SECONDARY_LIMIT_BODY)));
+  }
+
+  @Test
+  void warnsWithTheBodyAndTheHeadersThatIdentifyAThrottle() {
+    mapper.toThrowable(
+        response(403, SECONDARY_LIMIT_BODY, "Retry-After", "60", "x-ratelimit-remaining", "0"));
+
+    var warnings = warnings();
+    assertTrue(warnings.contains("secondary rate limit"), warnings);
+    assertTrue(warnings.contains("retry-after=60"), warnings);
+    assertTrue(warnings.contains("x-ratelimit-remaining=0"), warnings);
+  }
+
+  @Test
+  void warnsWithTheBodyThatIdentifiesAPermissionRefusalInstead() {
+    mapper.toThrowable(response(403, "{\"message\":\"Resource not accessible by integration\"}"));
+
+    var warnings = warnings();
+    assertTrue(warnings.contains("Resource not accessible by integration"), warnings);
+    assertFalse(warnings.contains("retry-after"), warnings);
+  }
+
+  @Test
+  void doesNotWarnAboutAnAbsentOptionalRepositoryFile() {
+    // The bot probes for .github/instructions and the settings file and reads 404 as "absent";
+    // warning on those would bury the failures that matter under ordinary traffic.
+    assertNull(mapper.toThrowable(response(404, "{\"message\":\"Not Found\"}")));
+
+    assertEquals("", warnings());
+    assertTrue(
+        logged.stream().anyMatch(record -> record.getLevel().intValue() < Level.INFO.intValue()),
+        "still recorded, just at debug");
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClientTest.java
@@ -18,7 +18,9 @@ package dev.thiagogonzaga.thrillhousebot.github;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -29,8 +31,11 @@ import static org.mockito.Mockito.when;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.CreatePullRequestCommentRequest;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.CreateReviewRequest;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.PullRequestComment;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.PullRequestCommentResponse;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.ReplyToReviewCommentRequest;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.ReviewResponse;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
@@ -251,5 +256,66 @@ class GitHubReviewClientTest {
     var body = "a normal reply";
 
     assertSame(body, new ReplyToReviewCommentRequest(body).body());
+  }
+
+  /**
+   * A 403 that GitHub sends while throttling a write, carrying a {@code Retry-After} of zero so the
+   * backoff is real but instant. {@link GitHubWriteRetryTest} pins the waiting itself.
+   */
+  private static WebApplicationException throttledNow() {
+    return new WebApplicationException(
+        Response.status(403)
+            .header("Retry-After", "0")
+            .entity("{\"message\":\"You have exceeded a secondary rate limit.\"}")
+            .build());
+  }
+
+  @Test
+  void createReviewRepostsAThrottledReviewRatherThanLosingTheGeneration() {
+    var client = mock(GitHubReviewClient.class);
+    when(client.createReview(anyString(), anyString(), anyString(), anyString(), anyInt(), any()))
+        .thenCallRealMethod();
+    var request = new CreateReviewRequest("sha", "the generated review", "COMMENT", List.of());
+    var posted = new ReviewResponse(7, "the generated review", "COMMENTED", "sha", null);
+    when(client.createReviewOnce("auth", "json", "o", "r", 7, request))
+        .thenThrow(throttledNow())
+        .thenReturn(posted);
+
+    assertSame(posted, client.createReview("auth", "json", "o", "r", 7, request));
+    verify(client, times(2)).createReviewOnce("auth", "json", "o", "r", 7, request);
+  }
+
+  @Test
+  void createPullRequestCommentRepostsAThrottledInlineFinding() {
+    var client = mock(GitHubReviewClient.class);
+    when(client.createPullRequestComment(
+            anyString(), anyString(), anyString(), anyString(), anyInt(), any()))
+        .thenCallRealMethod();
+    var request =
+        new CreatePullRequestCommentRequest(
+            "sha", "the finding", "src/Foo.java", 12, "RIGHT", null, null);
+    var posted = new PullRequestCommentResponse(3, "the finding", "src/Foo.java", 12);
+    when(client.createPullRequestCommentOnce("auth", "json", "o", "r", 7, request))
+        .thenThrow(throttledNow())
+        .thenReturn(posted);
+
+    assertSame(posted, client.createPullRequestComment("auth", "json", "o", "r", 7, request));
+    verify(client, times(2)).createPullRequestCommentOnce("auth", "json", "o", "r", 7, request);
+  }
+
+  @Test
+  void replyToReviewCommentRepostsAThrottledReply() {
+    var client = mock(GitHubReviewClient.class);
+    when(client.replyToReviewComment(
+            anyString(), anyString(), anyString(), anyString(), anyInt(), anyLong(), any()))
+        .thenCallRealMethod();
+    var request = new ReplyToReviewCommentRequest("the generated reply");
+    var posted = new PullRequestCommentResponse(5, "the generated reply", "src/Foo.java", 12);
+    when(client.replyToReviewCommentOnce("auth", "json", "o", "r", 7, 3L, request))
+        .thenThrow(throttledNow())
+        .thenReturn(posted);
+
+    assertSame(posted, client.replyToReviewComment("auth", "json", "o", "r", 7, 3L, request));
+    verify(client, times(2)).replyToReviewCommentOnce("auth", "json", "o", "r", 7, 3L, request);
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@link GitHubWriteRetry} — the backoff #568 asked for on the calls that publish work the
+ * bot has already paid for, and, just as importantly, the failures it refuses to repeat.
+ *
+ * <p>The bounds are written out as literals (3 attempts, a 30-second ceiling on one wait) so the
+ * tests pin them rather than restate whatever the production constants happen to say.
+ */
+class GitHubWriteRetryTest {
+
+  private static final String SECONDARY_LIMIT_BODY =
+      "{\"message\":\"You have exceeded a secondary rate limit.\"}";
+
+  private final List<Duration> slept = new ArrayList<>();
+
+  /** A retry whose waiting is recorded instead of served, on a clock that never moves. */
+  private final GitHubWriteRetry retry =
+      new GitHubWriteRetry(slept::add, () -> Instant.ofEpochSecond(1_800_000_000L));
+
+  private static WebApplicationException failure(int status, String body, String... headers) {
+    var builder = Response.status(status);
+    for (int i = 0; i < headers.length; i += 2) {
+      builder.header(headers[i], headers[i + 1]);
+    }
+    return new WebApplicationException(builder.entity(body).build());
+  }
+
+  private static WebApplicationException throttled(String... headers) {
+    return failure(403, SECONDARY_LIMIT_BODY, headers);
+  }
+
+  @Test
+  void aCallThatSucceedsIsNotRepeatedAndNeverWaits() {
+    var calls = new AtomicInteger();
+
+    var result = retry.call("a comment on o/r #7", () -> "posted " + calls.incrementAndGet());
+
+    assertEquals("posted 1", result);
+    assertEquals(1, calls.get());
+    assertEquals(List.of(), slept);
+  }
+
+  @Test
+  void aThrottledPostIsRepeatedAfterTheWaitGitHubAskedFor() {
+    var calls = new AtomicInteger();
+
+    var result =
+        retry.call(
+            "a comment on o/r #7",
+            () -> {
+              if (calls.incrementAndGet() == 1) {
+                throw throttled("Retry-After", "12");
+              }
+              return "posted";
+            });
+
+    // The generation was already paid for, so the second attempt is what saves it.
+    assertEquals("posted", result);
+    assertEquals(2, calls.get());
+    assertEquals(List.of(Duration.ofSeconds(12)), slept);
+  }
+
+  @Test
+  void aPermissionRefusalFailsOnTheFirstAttemptWithoutWaiting() {
+    var calls = new AtomicInteger();
+    var refusal = failure(403, "{\"message\":\"Resource not accessible by integration\"}");
+
+    var thrown =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                retry.call(
+                    "a comment on o/r #7",
+                    () -> {
+                      calls.incrementAndGet();
+                      throw refusal;
+                    }));
+
+    // Repeating this would only burn the rate-limit budget; the caller's handling is unchanged.
+    assertSame(refusal, thrown);
+    assertEquals(1, calls.get());
+    assertEquals(List.of(), slept);
+  }
+
+  @Test
+  void aServerFailureIsNeverRepeatedBecauseTheWriteMayHaveLanded() {
+    var calls = new AtomicInteger();
+
+    assertThrows(
+        WebApplicationException.class,
+        () ->
+            retry.call(
+                "a comment on o/r #7",
+                () -> {
+                  calls.incrementAndGet();
+                  throw failure(502, "<html>bad gateway</html>", "Retry-After", "1");
+                }));
+
+    // This is the duplicate-comment case: a 502 says nothing about whether the comment exists.
+    assertEquals(1, calls.get());
+    assertEquals(List.of(), slept);
+  }
+
+  @Test
+  void aFailureWithNoResponseAtAllIsNeverRepeated() {
+    var calls = new AtomicInteger();
+    var connectionLost =
+        new WebApplicationException("connection reset") {
+          @Override
+          public Response getResponse() {
+            return null;
+          }
+        };
+
+    assertThrows(
+        WebApplicationException.class,
+        () ->
+            retry.call(
+                "a comment on o/r #7",
+                () -> {
+                  calls.incrementAndGet();
+                  throw connectionLost;
+                }));
+
+    assertEquals(1, calls.get());
+    assertEquals(List.of(), slept);
+  }
+
+  @Test
+  void aNonHttpFailurePropagatesUntouched() {
+    var boom = new IllegalStateException("serialization failed");
+
+    var thrown =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                retry.call(
+                    "a comment on o/r #7",
+                    () -> {
+                      throw boom;
+                    }));
+
+    assertSame(boom, thrown);
+    assertEquals(List.of(), slept);
+  }
+
+  @Test
+  void aPersistentThrottleGivesUpAfterThreeAttempts() {
+    var calls = new AtomicInteger();
+    var lastFailure = throttled("Retry-After", "4");
+
+    var thrown =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                retry.call(
+                    "a comment on o/r #7",
+                    () -> {
+                      calls.incrementAndGet();
+                      throw lastFailure;
+                    }));
+
+    // Bounded: one post and two repeats, so a throttled PR cannot hold its dispatcher slot forever.
+    assertSame(lastFailure, thrown);
+    assertEquals(3, calls.get());
+    assertEquals(List.of(Duration.ofSeconds(4), Duration.ofSeconds(4)), slept);
+  }
+
+  @Test
+  void aRetryAfterLongerThanTheCeilingIsClampedRatherThanObeyed() {
+    var calls = new AtomicInteger();
+
+    assertThrows(
+        WebApplicationException.class,
+        () ->
+            retry.call(
+                "a review on o/r #7",
+                () -> {
+                  calls.incrementAndGet();
+                  throw throttled("Retry-After", "3600");
+                }));
+
+    // 30s a wait, twice: the whole call waits at most a minute whatever GitHub asks for.
+    assertEquals(List.of(Duration.ofSeconds(30), Duration.ofSeconds(30)), slept);
+  }
+
+  @Test
+  void anExhaustedWindowWaitsUntilItsResetInstant() {
+    var calls = new AtomicInteger();
+
+    var result =
+        retry.call(
+            "a comment on o/r #7",
+            () -> {
+              if (calls.incrementAndGet() == 1) {
+                throw throttled("x-ratelimit-remaining", "0", "x-ratelimit-reset", "1800000021");
+              }
+              return "posted";
+            });
+
+    assertEquals("posted", result);
+    assertEquals(List.of(Duration.ofSeconds(21)), slept);
+  }
+
+  @Test
+  void anInterruptedBackoffStopsImmediatelyAndKeepsTheInterrupt() {
+    var calls = new AtomicInteger();
+    var interrupting =
+        new GitHubWriteRetry(
+            delay -> {
+              throw new InterruptedException("shutting down");
+            },
+            Instant::now);
+    var lastFailure = throttled("Retry-After", "5");
+
+    var thrown =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                interrupting.call(
+                    "a comment on o/r #7",
+                    () -> {
+                      calls.incrementAndGet();
+                      throw lastFailure;
+                    }));
+
+    assertSame(lastFailure, thrown);
+    assertEquals(1, calls.get());
+    // The flag is restored so the shutdown the interrupt announced is not swallowed here.
+    assertTrue(Thread.interrupted(), "interrupt status restored");
+    assertFalse(Thread.currentThread().isInterrupted());
+  }
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

A deliberate load burst produced **29 × HTTP 403** on `GitHubCommentClient#createComment` and lost **7 of 56 command responses**. Every loss landed *after* the model call had completed, so a finished, paid-for generation was discarded at the very last step — and the log carried nothing but the status, which reads identically for a secondary rate limit and for a missing App permission.

**1. A throttled write is now retried instead of dropped.**

`GitHubWriteRetry` repeats a content-creating call while GitHub is throttling: at most 3 attempts, honouring `Retry-After` (or the `x-ratelimit-reset` instant, or a linear fallback when GitHub says nothing) with a 30-second ceiling on any single wait, so one call waits at most a minute — long enough to outlast the minute-long window GitHub's content-creation secondary limit uses.

Applied to the calls that carry model output: `createComment`, `updateComment`, `createReview`, `createPullRequestComment`, `replyToReviewComment`. Each keeps its existing signature — the annotated method became `…Once` and the public name is now a `default` wrapper — so no caller changed.

*Not* applied to reactions, labels and check runs: they carry no generated content, and retrying them would spend the same content-creation budget the valuable posts need.

**Why this cannot post a comment twice.** A repeat happens only on a positively identified throttle — a 429, or a 403 carrying `Retry-After`, an exhausted `x-ratelimit-remaining`, or GitHub's rate-limit wording in the body. GitHub rejects a throttled content-creating request at the edge, before the comment exists; the response *is* the rejection, not a report about a write that happened. The ambiguous failures — a connection reset, a read timeout, a 5xx — are the ones where a write may well have landed, and those are deliberately **not** retried: they propagate on the first attempt exactly as before. That is why the test is a positive throttle signal rather than "not a success"; a permission 403, a 422 and a 502 all still fail immediately.

**Why this cannot stall the pipeline.** Reviews and commands run on `Executors.newVirtualThreadPerTaskExecutor()`, so a waiting attempt parks its virtual thread and pins no platform thread. What a wait does hold is the per-PR serialization slot in `ReviewDispatcher`, which is why the wait is bounded twice over (3 attempts, 30s ceiling each ⇒ ≤ 60s total) rather than obeying an arbitrarily long `Retry-After`.

**2. A failed GitHub call now says what GitHub returned.**

`GitHubErrorLogger` is registered on every GitHub REST client and logs the response body plus `Retry-After` and the `x-ratelimit-*` headers. Anything token-shaped (`ghs_…`, `github_pat_…`, `Bearer …`, JWTs) is masked, and the body is whitespace-collapsed and capped at 512 characters so one failure stays on one line and cannot flood the log.

It is a `ResponseExceptionMapper` that returns `null`, so the chain falls through to the runtime's default mapper and callers keep the exact exception type and fail-soft handling they already have — this changes the log and nothing else. A 404 is logged at debug, since the bot probes for optional repository files (`.github/instructions`, the settings file, stack manifests) and reads 404 as "absent".

Real output from the new end-to-end test:

```
WARN [GitHubErrorLogger] GitHub API call failed: status=403 retry-after=0 x-ratelimit-remaining=0 body={"message":"You have exceeded a secondary rate limit. Please wait a few minutes before you try again.","documentation_url":"https://docs.github.com/rest"}
WARN [GitHubWriteRetry] GitHub throttled a comment on owner/repo #7 — retrying in 0s (attempt 2 of 3)
```

versus the permission case, which is now distinguishable and is not retried:

```
WARN [GitHubErrorLogger] GitHub API call failed: status=403 body={"message":"Resource not accessible by integration"}
```

When the attempts are spent, the log says the content is lost and the command has to be re-run. Turning that into a *reply on the PR* needs a change in `review/` and `webhook/` (the notice would itself be a `createComment`), which is outside this PR's lane — see Additional Notes.

## Related Issues

Fixes #568

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

New tests: `GitHubApiErrorTest` (throttle vs. refusal, delay arithmetic, redaction, truncation, unreadable bodies), `GitHubWriteRetryTest` (attempt bound, ceiling, the failures never repeated, interrupt handling), `GitHubErrorLoggerTest` (severity split, raises nothing of its own), plus write-path tests on `GitHubCommentClientTest` / `GitHubReviewClientTest`. `GitHubCommentThrottleTest` is a `@QuarkusTest` driving a real REST client against a loopback GitHub — the only thing that can show the mapper is actually wired and that the throttled response reaches the retry with its `Retry-After` intact.

### Red/green proof

`GitHubCommentThrottleTest` compiles unchanged against the base commit, so it was run there with the fix removed:

```
[ERROR] Tests run: 2, Failures: 1, Errors: 1, Skipped: 0 -- in dev.thiagogonzaga.thrillhousebot.github.GitHubCommentThrottleTest
[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubCommentThrottleTest.aPermissionRefusalStillFailsTheCallAndSaysWhyExactlyOnce -- Time elapsed: 0.369 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
	at dev.thiagogonzaga.thrillhousebot.github.GitHubCommentThrottleTest.aPermissionRefusalStillFailsTheCallAndSaysWhyExactlyOnce(GitHubCommentThrottleTest.java:188)

[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubCommentThrottleTest.aThrottledCommentIsPostedOnTheRepeatInsteadOfDiscardingTheGeneration -- Time elapsed: 0.007 s <<< ERROR!
org.jboss.resteasy.reactive.ClientWebApplicationException: Received: 'Forbidden, status code 403' when invoking REST Client method: 'dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient#createComment'
	at org.jboss.resteasy.reactive.client.impl.RestClientRequestContext.unwrapException(RestClientRequestContext.java:224)
```

The error is the production symptom verbatim: the throttled post is discarded with a bare `status code 403`. The companion failure is line 188 — nothing about the permission refusal reached the log, so the two 403s were indistinguishable. Both pass with the fix.

### Gates

- `./mvnw -B spotless:apply` → BUILD SUCCESS
- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` → **Tests run: 2742, Failures: 0, Errors: 0, Skipped: 0**
- JaCoCo ∩ `git diff -U0 c9992ba...HEAD` → **0 uncovered lines, 0 uncovered branches** in the changed main code

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

See the log excerpts under Description.

## Additional Notes

Every file touched is inside `dev.thiagogonzaga.thrillhousebot.github`; no caller signature changed.

Two follow-ups the issue raises that this PR deliberately does not take:

1. **Telling the user to re-run when the budget is spent.** The exhaustion is logged, but posting that as a reply means changing the fail-soft handlers in `review/` and `webhook/` — and the notice would itself be a throttled `createComment`. Worth its own issue.
2. **Pacing concurrent commands at the client level.** Backoff is reactive; a shared content-creation limiter would stop the burst being generated at all. Also its own issue.
