### PR TITLE
fix(review): salvage a truncated single-call review instead of discarding it

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -173,7 +173,14 @@ public class FindingPipeline {
               .forBatch(budgetedBatch, promptInputs.baseComparison());
       quoteSource = budgetedBatch.text();
     }
-    var aiResponse = aiReviewService.review(session, singleInputs);
+    ReviewResponse aiResponse;
+    try {
+      aiResponse = aiReviewService.review(session, singleInputs);
+    } catch (AiResponseTruncatedException e) {
+      // #580: the call was made and billed, and its body is well-formed up to the cut. Losing the
+      // whole review to it would discard exactly the paid work the multi-call lane already keeps.
+      aiResponse = salvageTruncatedSingleCall(session, e, budgetedBatch, plan);
+    }
     if (budgetedBatch != null && !aiResponse.previousFindingsStatus().isEmpty()) {
       // Same scoping as the multi-call path: the single budgeted batch may carry clipped files
       // (and, at maxBatches=1, omit others entirely), so a "resolved" claim is only trusted for a
@@ -194,6 +201,87 @@ public class FindingPipeline {
         ctx.priorAiResponseJsons(),
         ctx.inlineComments(),
         lineResolver);
+  }
+
+  /**
+   * The disclose step for a single-call review the model cut at its length cap (#580): the same
+   * salvage the multi-call lane's {@link #salvageTruncatedBatch} runs, applied to the lane that had
+   * none. The complete leading findings and statuses are recovered from the buffered partial body
+   * and returned as an ordinary response, so the caller's status scoping and {@link #refine} chain
+   * treat them exactly like parsed ones — a salvaged finding faces every check a parsed finding
+   * does. The summary object rides along when it closed before the cut (it is last in the response
+   * shape, so usually it did not); {@code null} then leaves the renderer's counts-only shape, the
+   * same degradation the multi-call summary seam produces. No {@link SummaryDegradation} is
+   * recorded for it, though: that class's copy states the findings are complete, which is exactly
+   * what a salvaged review's are not — the honest disclosure here is the response-cut file class
+   * below, which says the findings up to the cut were kept.
+   *
+   * <p>A salvaged review covers the diff only up to the cut, so the files it was given are recorded
+   * as {@linkplain DiffBudgetPlanner.BudgetPlan#recordResponseCutFiles response-cut} — the existing
+   * partially-reviewed class, which holds APPROVE and makes the posted review say why. This makes
+   * no AI call of its own and never re-enters the retry lane: the truncation was already refused a
+   * retry (#495) because an identical call would cut identically.
+   *
+   * <p>When nothing salvages — the cut landed before the first element closed — the truncation is
+   * rethrown, keeping today's behaviour. Unlike a batch, whose siblings still carry the review,
+   * this lane's failed call is the whole review: there would be no finding, no status and no
+   * summary to post, so failing loudly (the orchestrator's notice names the cap and the knob to
+   * raise) beats posting an empty review whose only content is a disclosure.
+   */
+  private ReviewResponse salvageTruncatedSingleCall(
+      ReviewSession session,
+      AiResponseTruncatedException truncation,
+      DiffBudgetPlanner.DiffBatch budgetedBatch,
+      DiffBudgetPlanner.BudgetPlan plan) {
+    var salvaged = salvager.salvage(truncation.partialBody());
+    if (!salvaged.hasFindingsOrStatuses()) {
+      Log.warnf(
+          "The review call for session %d hit the model's response-length cap and nothing could be"
+              + " salvaged from the partial response; failing the review rather than posting one"
+              + " with neither findings nor coverage",
+          ledgerSessionId(session));
+      throw truncation;
+    }
+    discloseSingleCallResponseCut(session, budgetedBatch, plan, salvaged);
+    return new ReviewResponse(
+        salvaged.findings(), salvaged.previousFindingsStatus(), salvaged.summary());
+  }
+
+  /**
+   * Records what a salvaged single call could not cover. A budgeted plan's single batch is the
+   * natural unit — it is exactly the material the call was given — so its files are disclosed as
+   * partially reviewed. With no batch to name (budgeting disabled by {@code max-input-tokens <= 0},
+   * or a plan that produced none) there is no per-file unit to record and {@link VerdictBuilder}
+   * ignores the plan's file classes on that path anyway, so the cut is stated here in the log
+   * instead of being disclosed silently as nothing at all.
+   */
+  private void discloseSingleCallResponseCut(
+      ReviewSession session,
+      DiffBudgetPlanner.DiffBatch budgetedBatch,
+      DiffBudgetPlanner.BudgetPlan plan,
+      TruncatedResponseSalvager.Salvaged salvaged) {
+    if (budgetedBatch == null) {
+      Log.warnf(
+          "The review call for session %d hit the model's response-length cap; not retrying —"
+              + " salvaged %d complete finding(s) and %d status(es) from the partial response."
+              + " The plan carries no batch (budgeting disabled, or no reviewable file), so the"
+              + " covered files cannot be named and the posted review cannot mark the diff beyond"
+              + " the cut as unreviewed; enable budgeting (REVIEW_MAX_INPUT_TOKENS) for that"
+              + " disclosure",
+          ledgerSessionId(session),
+          salvaged.findings().size(),
+          salvaged.previousFindingsStatus().size());
+      return;
+    }
+    Log.warnf(
+        "The review call for session %d hit the model's response-length cap; not retrying —"
+            + " salvaged %d complete finding(s) and %d status(es) from the partial response and"
+            + " disclosing its %d file(s) as partially reviewed",
+        ledgerSessionId(session),
+        salvaged.findings().size(),
+        salvaged.previousFindingsStatus().size(),
+        budgetedBatch.files().size());
+    plan.recordResponseCutFiles(filenamesOf(budgetedBatch.files()));
   }
 
   /**

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -1001,6 +1001,126 @@ class FindingPipelineTest {
   }
 
   @Test
+  void singleCallSalvagesTheCompleteFindingsFromATruncatedReviewResponse() {
+    // #580: the single-call lane had no truncation handling at all, so the one paid call's cut
+    // body discarded the whole review. It must salvage exactly like the multi-call lane does:
+    // complete leading findings through the normal validate/verify chain, and the batch's files
+    // disclosed as PARTIALLY reviewed so approval is held and the posted review says why.
+    var session = persistedSession();
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    var plan = singleBatchPlan(batch("a.java"), List.of());
+    when(aiReviewService.review(eq(session), any()))
+        .thenThrow(
+            new AiResponseTruncatedException("finish_reason=length", partialBatchBody(), false));
+
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    // #495's no-retry stands: salvage replaces the disclose step, never re-enters the retry lane.
+    verify(aiReviewService, times(1)).review(eq(session), any());
+    // The salvaged findings face every check a parsed response's do, against the batch's own text.
+    verify(quoteValidator).validate(any(), eq("### a.java\n"));
+    verify(findingVerificationService, times(1)).verify(anyLong(), any(), any(), any(), any());
+
+    assertEquals(3, result.findings().size());
+    assertEquals("S1", result.findings().get(0).title());
+    assertEquals("S3", result.findings().get(2).title());
+    // The complete status before the cut is kept; the cut-off one is dropped.
+    assertEquals(1, result.previousFindingsStatus().size());
+    assertEquals(1, result.previousFindingsStatus().get(0).id());
+    assertNull(result.summary(), "the cut landed before the summary object, so there is none");
+    assertNotNull(session.getAiResponseJson(), "a salvaged review is persisted like any other");
+
+    // Partially reviewed — the existing response-cut class: named, holding APPROVE back, and not
+    // claimed as never-reviewed.
+    assertEquals(List.of("a.java"), plan.responseCutFiles());
+    assertTrue(plan.runtimeUncoveredFiles().isEmpty());
+    assertTrue(plan.truncated());
+    assertEquals(
+        SummaryDegradation.NONE,
+        plan.summaryDegradation(),
+        "the findings are NOT complete here, so the summary-degradation copy must not be used");
+  }
+
+  @Test
+  void singleCallSalvageKeepsASummaryObjectThatClosedBeforeTheCut() {
+    // The single call's summary rides in the same body as its findings, so a cut that lands after
+    // the summary object closed leaves usable prose — it must be kept, not thrown away with the
+    // rest of the paid response.
+    var session = persistedSession();
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    var plan = singleBatchPlan(batch("a.java"), List.of());
+    var body =
+        "{\"findings\":["
+            + bodyFinding("S1")
+            + "],\"summary\":{\"total_findings\":1,\"critical\":0,\"high\":0,\"medium\":1,"
+            + "\"low\":0,\"overall_assessment\":\"ok\",\"pr_purpose\":\"does things\"},"
+            + "\"previous_findings_status\":[{\"id\":1,\"status\":\"unres";
+    when(aiReviewService.review(eq(session), any()))
+        .thenThrow(new AiResponseTruncatedException("finish_reason=length", body, false));
+
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    assertEquals(1, result.findings().size());
+    assertNotNull(result.summary());
+    assertEquals("does things", result.summary().prPurpose());
+    assertEquals(List.of("a.java"), plan.responseCutFiles());
+  }
+
+  @Test
+  void singleCallSalvageOnTheLegacyUncappedPathKeepsTheFindingsWithoutNamingFiles() {
+    // Budgeting disabled (max-input-tokens <= 0): the plan carries no batch to name, so there is
+    // no per-file unit to disclose — the paid findings are still kept rather than the whole review
+    // discarded, and the cut is stated in the log instead.
+    var session = persistedSession();
+    var ctx = reviewContext();
+    var template =
+        new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(batch("a.java")), List.of(), List.of(), false, null, null, null, null);
+    when(aiReviewService.review(eq(session), any()))
+        .thenThrow(
+            new AiResponseTruncatedException("finish_reason=length", partialBatchBody(), false));
+
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    assertEquals(3, result.findings().size());
+    // The legacy path quote-validates against the raw diff, salvaged findings included.
+    verify(quoteValidator).validate(any(), eq("raw legacy diff"));
+    assertTrue(plan.responseCutFiles().isEmpty(), "no batch to name means no per-file disclosure");
+    assertFalse(plan.truncated());
+  }
+
+  @Test
+  void singleCallStillFailsWhenTheCutPrecedesTheFirstCompleteFinding() {
+    // A cut before the first element closed leaves nothing salvageable, and unlike a batch this
+    // lane has no sibling call carrying the review: failing loudly (the orchestrator's notice
+    // names the cap) beats posting a review whose only content is a disclosure. Green-only by
+    // necessity — this IS the pre-#580 behaviour; the guard pins that salvage never invents a
+    // "partially reviewed" claim out of an empty salvage.
+    var session = persistedSession();
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    var plan = singleBatchPlan(batch("a.java"), List.of());
+    when(aiReviewService.review(eq(session), any()))
+        .thenThrow(
+            new AiResponseTruncatedException(
+                "finish_reason=length", "{\"findings\":[{\"risk\":\"hi", false));
+
+    var resolver = new DiffLineResolver(Map.of());
+    assertThrows(
+        AiResponseTruncatedException.class,
+        () -> pipeline.run(session, template, ctx, plan, resolver));
+
+    verify(aiReviewService, times(1)).review(eq(session), any());
+    assertTrue(plan.responseCutFiles().isEmpty());
+    assertFalse(plan.truncated());
+    assertNull(session.getAiResponseJson(), "nothing salvageable persists nothing");
+  }
+
+  @Test
   void resolvedFromABatchThatNeverSawTheFileIsDemotedToUnresolved() {
     var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
     var ctx = reviewContext();


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`FindingPipeline.runWithLedger` called `aiReviewService.review(session, singleInputs)` with **no truncation handling at all** — `grep -c AiResponseTruncatedException` over that method returned 0. A single-call review whose response the model cut at its length cap was therefore discarded whole: the call had been made and billed, and the review posted nothing. Observed in production on #577 (`AI_REASONING_EFFORT=max`, review-lane cap 96000):

```
Session persisted: 129359 tokens, $0.031550
AI review attempt 1/5 for session 2412 hit the response-length cap; not retrying
Review failed for devops-thiago/ThrillhouseBot #577: AiResponseTruncatedException
```

The multi-call lane has salvaged since #500/#511. This reuses that machinery rather than writing a second salvage:

- `TruncatedResponseSalvager.salvage` recovers the complete leading `findings` and `previous_findings_status` from the buffered partial body (well-formed up to the cut; the cut-off trailing element is dropped by construction).
- They are returned as an ordinary `ReviewResponse`, so the **existing** status scoping and the **existing** `refine` chain (quote validation → framework filter → dedupe → verify → replied-duplicate drop → anchor backfill → persist) treat them exactly like parsed findings. A salvaged finding faces every check a parsed one does.
- A `summary` object that closed before the cut is kept (it is last in the response shape, so usually it did not); `null` leaves the renderer's counts-only shape.
- **No retry is added.** #495's no-retry contract stands — an identical call truncates identically — and salvage replaces the *disclose* step only. The review lane's reasoning effort and output cap are untouched (unlike the concise lane in #567, this lane genuinely benefits from reasoning; the fix is to salvage the cut, not to think less).

### Honest disclosure

A salvaged single-call review covers the diff only up to the cut, so the files it could not cover are disclosed through the **existing response-cut class** — the same treatment a salvaged batch gets:

| plan shape | what is recorded | effect on the posted review |
|---|---|---|
| budgeted, one batch (the default path) | `plan.recordResponseCutFiles(batch files)` — the batch is exactly the material the call was given | APPROVE is held (`BudgetPlan#truncated`), and the review says *"N file(s) were only partially reviewed because the model's response was cut at its length cap — findings up to the cut were kept"* |
| budgeting disabled (`max-input-tokens <= 0`), or a plan with no batch | nothing — there is no per-file unit to name, and `VerdictBuilder` ignores the plan's file classes on that path anyway | the paid findings are still kept rather than the review discarded; the cut, the salvaged counts and *why* no per-file disclosure is possible are stated in a `WARN` log naming `REVIEW_MAX_INPUT_TOKENS` |

`SummaryDegradation.RESPONSE_CUT` is deliberately **not** recorded here even though the summary is usually lost to the same cut: that class's rendered copy asserts *"the findings themselves are complete"*, which is exactly what a salvaged review's findings are not. The response-cut file class is the honest disclosure.

When **nothing** salvages (the cut landed before the first element closed), the truncation is rethrown — today's behaviour. Unlike a batch, whose siblings still carry the review, this lane's failed call *is* the whole review: there would be no finding, no status and no summary to post, so failing loudly (the orchestrator's notice names the cap and the knob to raise) beats posting a review whose only content is a disclosure.

## Lane inventory (requested by the issue)

Every code path that makes a model call, and which degradations it handles today. **Streaming?** matters structurally: only `PrReviewer.reviewStream` and `PrSummarizer.summarizeStream` buffer a body (`AiReviewService.StreamBuffer`), so only those lanes can ever carry `AiResponseTruncatedException.partialBody()`. Every blocking lane goes through `AiResponses.textOrThrowOnTruncation`, which passes **`null`** as the partial body even though `result.content()` holds the cut text — so on those lanes salvage is impossible by construction of the helper, not by provider limitation.

"Partial/cut body" below means a body cut mid-JSON with **no** `finish_reason=length` reported — the #546 failure mode.

| Lane | Model call | Streaming? | Spend ceiling | Length-cap truncation | Null/empty body | Partial/cut body |
|---|---|---|---|---|---|---|
| `FindingPipeline#runWithLedger` → `AiReviewService#review` (single-call review) | `PrReviewer`, default | yes | **NOT handled** — propagates; whole review FAILED | **handled by this PR** — salvage + response-cut disclosure | **NOT handled** — `""` → `parse` throws → classified transient → N billed retries → whole review FAILED | **NOT handled** — buffered body discarded as a parse failure; salvager never reached |
| `FindingPipeline#processBatch` / `#retryBatch` → `AiReviewService#reviewBatch` | `PrReviewer`, default | yes | handled — `recordSpendCeilingSkippedFiles`, other batches keep findings | handled — `salvageTruncatedBatch` (#500/#511) | handled (soft) — batch soft-fails, files recorded uncovered, review still posts | **NOT handled** — transient-parse path; batch discarded as uncovered, body never leaves `AiReviewService` |
| `FindingPipeline#runMultiCall` → `AiReviewService#summarize` | `PrSummarizer`, **concise** | yes | handled — `countsOnlySummary` (`SKIPPED_AT_CEILING`) | handled — `salvagedOrCountsOnlySummary` | **NOT handled** — escapes both catches → **whole multi-call review FAILED**, every paid batch finding discarded | **NOT handled** — same escape path, though `salvage` would recover the summary object |
| `FindingPipeline#summarizeWithoutReview` → `AiReviewService#summarize` | `PrSummarizer`, concise | yes | handled — `countsOnlySummary` | handled — `salvagedOrCountsOnlySummary` | **NOT handled** — whole review FAILED, losing the omission disclosures that were its only content | **NOT handled** — same |
| `FindingVerificationService#verify` (both chains) | `FindingVerifier`, concise | no | handled — skips fail-open at ceiling; usage metered directly | handled but **lossy** — keeps unverified findings; `partialBody` is `null`, so the leading verdicts are thrown away | handled — explicit null/blank guard → keeps unverified findings | **handled — best in repo** — `salvageArray(raw, "verdicts", …)` (#546); missing verdicts fail open |
| `PrDescriptionGenerator#describeEachBatch` / `#reduce` | `PrDescribeAssistant`, default | no | n/a — command lanes are outside the ledger | handled — batch counted failed, disclosed via `batchFailureNote` | handled — blank guard → same disclosure | n/a (free-text output) |
| `ChangelogEntryGenerator#draftEachBatch` / `#reduce` | `ChangelogAssistant`, default | no | n/a | handled for drafts; **a failed `merge` reduce returns `null` and `/changelog` posts nothing** despite N paid draft calls | handled (blank guard); blank merge → posts nothing | n/a (free text) |
| `PrImprovementService#generateOne` | `PrImproveAssistant`, default | no | n/a | handled coarsely — whole batch dropped, disclosed | handled — blank guard | **NOT handled** — parse failure discards the whole batch; payload is `{"improvements":[…]}`, exactly `salvageArray`'s shape |
| `UnitTestGenerator#generateOne` | `UnitTestAssistant`, default | no | n/a | handled coarsely — batch dropped, disclosed | handled — blank guard | **NOT handled** — same; `{"tests":[…]}` |
| `DocGenerationService#generateOne` | `DocGenerator`, default | no | n/a | handled coarsely — batch dropped, disclosed | handled — blank guard | **NOT handled** — same; `{"docs":[…]}` |
| `MaintainerReplyService#generateReply` | `ReplyAssistant`, **concise** | no | n/a | handled — logs the cap, posts nothing | handled — blank guard | n/a (free-text reply) |

`ConfigKeyContextResolver` and `BugFixContextResolver` make no model calls; `PrSummaryGenerator` is a renderer.

### Unhandled lanes this inventory turned up

**Not fixed here, per the issue's scope discipline — filing separately.** Ranked by cost:

1. **A summary call that returns an empty or unparseable body fails the entire multi-call review.** `runMultiCall` degrades only on `TokenSpendCeilingExceededException` and `AiResponseTruncatedException`; any other `AiReviewException` (empty body — documented as a real case in `AiResponses`, since a reasoning model can spend its whole budget on reasoning tokens and return nothing — or a cut body with no length stop, or exhausted transient retries) escapes both catches and discards every already-paid batch finding. Duplicated at `summarizeWithoutReview`. **This is the fourth recurrence, and it is the most expensive one.**
2. **`AiResponses.textOrThrowOnTruncation` passes `null` instead of `result.content()` as the partial body.** One line makes length-cap salvage impossible for every blocking lane — the verifier, `/improve`, `/generate-tests`, `/add-docs` — each of which then throws away a complete leading array it was billed for.
3. **The #546 partial/cut-body mode is unhandled on all three streaming review lanes** (single call, batch, summary). A body cut mid-JSON with no length stop is classified transient, re-billed `max-ai-retries` times, and then discarded — for a body `salvage()` would have read. The verifier was fixed for exactly this; its siblings were not.
4. **`/improve`, `/generate-tests`, `/add-docs` never call `salvageArray`** on a cut batch response, although all three payloads are single named arrays. A body cut after nine good elements loses all nine.
5. **A spend-ceiling refusal on the single-call review lane fails the review outright** instead of degrading, and lands in a failure handler that has truncation-specific copy but no ceiling-specific copy — the operator gets generic "retry `/review`" advice with no mention of `REVIEW_MAX_TOKENS_PER_REVIEW`.
6. **A failed or truncated `merge` reduce discards every paid `draft` candidate** in `ChangelogEntryGenerator`; `PrDescriptionGenerator#reduce` has the identical shape and the identical gap.
7. **The command lanes are entirely outside the token ledger** — `/describe`, `/changelog`, `/improve`, `/generate-tests`, `/add-docs` and maintainer replies are bounded only by `max-ai-calls` batch counts, so `REVIEW_MAX_TOKENS_PER_REVIEW` never constrains them.

## Related Issues

Fixes #580

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Four tests in `FindingPipelineTest`:

- `singleCallSalvagesTheCompleteFindingsFromATruncatedReviewResponse` — 3 complete findings + 1 complete status salvaged from the cut body, run through the same validate/verify chain (asserted against the batch's own text), the call made exactly once, `plan.responseCutFiles() == ["a.java"]`, `runtimeUncoveredFiles` empty, `truncated()` true, `summaryDegradation` NONE.
- `singleCallSalvageKeepsASummaryObjectThatClosedBeforeTheCut` — a summary that closed before the cut is kept, not thrown away with the rest.
- `singleCallSalvageOnTheLegacyUncappedPathKeepsTheFindingsWithoutNamingFiles` — budgeting disabled: findings kept, quote-validated against the raw diff, no per-file disclosure recorded.
- `singleCallStillFailsWhenTheCutPrecedesTheFirstCompleteFinding` — nothing salvageable still fails, and salvage never invents a "partially reviewed" claim out of an empty salvage. Green-only by necessity: this *is* the pre-fix behaviour.

### Red proof

The three behavioural tests against unfixed `FindingPipeline.java` (test file as committed, main file reverted to `806a9bd`):

```
[ERROR] Tests run: 61, Failures: 0, Errors: 3, Skipped: 0, Time elapsed: 4.857 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.singleCallSalvageKeepsASummaryObjectThatClosedBeforeTheCut -- Time elapsed: 0.056 s <<< ERROR!
[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.singleCallSalvageOnTheLegacyUncappedPathKeepsTheFindingsWithoutNamingFiles -- Time elapsed: 0.046 s <<< ERROR!
[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.singleCallSalvagesTheCompleteFindingsFromATruncatedReviewResponse -- Time elapsed: 0.046 s <<< ERROR!
[ERROR] Errors:
[ERROR]   FindingPipelineTest.singleCallSalvageKeepsASummaryObjectThatClosedBeforeTheCut:1063 » AiResponseTruncated finish_reason=length
[ERROR]   FindingPipelineTest.singleCallSalvageOnTheLegacyUncappedPathKeepsTheFindingsWithoutNamingFiles:1087 » AiResponseTruncated finish_reason=length
[ERROR]   FindingPipelineTest.singleCallSalvagesTheCompleteFindingsFromATruncatedReviewResponse:1017 » AiResponseTruncated finish_reason=length
```

The failure is exactly the claimed one: the truncation escapes the pipeline instead of being salvaged.

### Gates

| gate | result |
|---|---|
| `./mvnw -B spotless:apply` then `./mvnw -B clean compile spotbugs:check spotless:check` | `BugInstance size is 0` — BUILD SUCCESS |
| `./mvnw -B clean test` | `Tests run: 2716, Failures: 0, Errors: 0, Skipped: 0` — BUILD SUCCESS |
| jacoco ∩ `git diff -U0 806a9bd...HEAD` | **0 uncovered lines, 0 uncovered branches** in changed main code |

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Scope: `FindingPipeline` and its tests only. No changes to `PrReviewPrompts`, the GitHub clients or `ChatModelCustomizers`. No config default, reasoning-effort or output-cap change.
