### PR TITLE
fix(ai): disable chat memory on every AI service

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChangelogAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChangelogAssistant.java
@@ -26,7 +26,8 @@ import io.quarkiverse.langchain4j.RegisterAiService;
  * (Added/Changed/Fixed/Security…). Returns the entry as plain Markdown — like the describe and
  * reply assistants, there is no JSON schema to parse.
  */
-@RegisterAiService
+@RegisterAiService(
+    chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
 public interface ChangelogAssistant {
 
   // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/DocGenerator.java
@@ -27,7 +27,8 @@ import io.quarkiverse.langchain4j.RegisterAiService;
  * DocGenerationParser}) rather than the streaming, schema-rich response the full review uses — this
  * is a focused, single-shot blocking call like {@link ReplyAssistant}.
  */
-@RegisterAiService
+@RegisterAiService(
+    chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
 public interface DocGenerator {
 
   // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifier.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifier.java
@@ -24,13 +24,15 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * Second-pass AI call that audits candidate findings; returns raw JSON parsed by the caller.
- * Application-scoped (no chat memory) so parallel map-reduce batch threads can invoke it. Bound to
- * the {@code concise} named model: the response is one verdict per finding, so it carries the
- * concise response cap ({@code REVIEW_CONCISE_MAX_OUTPUT_TOKENS}) instead of the batch review's
- * allowance.
+ * Application-scoped so parallel map-reduce batch threads can invoke it, with chat memory disabled
+ * explicitly for the reason documented on {@link PrReviewer}. Bound to the {@code concise} named
+ * model: the response is one verdict per finding, so it carries the concise response cap ({@code
+ * REVIEW_CONCISE_MAX_OUTPUT_TOKENS}) instead of the batch review's allowance.
  */
 @ApplicationScoped
-@RegisterAiService(modelName = "concise")
+@RegisterAiService(
+    modelName = "concise",
+    chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
 public interface FindingVerifier {
 
   // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrDescribeAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrDescribeAssistant.java
@@ -25,7 +25,8 @@ import io.quarkiverse.langchain4j.RegisterAiService;
  * Suggests an improved PR title and description generated from the diff. Returns the suggestion as
  * plain Markdown — like the reply assistant, there is no JSON schema to parse.
  */
-@RegisterAiService
+@RegisterAiService(
+    chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
 public interface PrDescribeAssistant {
 
   // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrImproveAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrImproveAssistant.java
@@ -27,7 +27,8 @@ import io.quarkiverse.langchain4j.RegisterAiService;
  * returns JSON (parsed by {@link ImprovementParser}) so each improvement can be posted as a
  * committable suggestion anchored to the diff.
  */
-@RegisterAiService
+@RegisterAiService(
+    chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
 public interface PrImproveAssistant {
 
   // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewer.java
@@ -26,12 +26,20 @@ import jakarta.enterprise.context.ApplicationScoped;
  * Stateless streaming AI service for the PR review call, whose response scales with finding count
  * and therefore carries the default model's response cap. The final summary call lives on {@link
  * PrSummarizer}, bound to the {@code concise} named model, so its fixed-shape response gets a
- * tighter cap. Application-scoped because there is no chat memory / {@code @MemoryId} — request
- * scope would break parallel map-reduce batches that run on virtual threads without an inherited
- * CDI request context.
+ * tighter cap. Application-scoped because request scope would break parallel map-reduce batches
+ * that run on virtual threads without an inherited CDI request context.
+ *
+ * <p>Chat memory is disabled explicitly. Omitting {@code chatMemoryProviderSupplier} does not make
+ * a service stateless: the annotation defaults to {@code BeanChatMemoryProviderSupplier}, so the
+ * extension's default {@code MessageWindowChatMemory} applies, and with no {@code @MemoryId}
+ * parameter every call shares one default memory id — which made each review resend the previous
+ * reviews' prompts and answers (#584). State for a review is carried by the previous-findings
+ * context, the code check for whether a finding was fixed, and user comments, never by conversation
+ * history.
  */
 @ApplicationScoped
-@RegisterAiService
+@RegisterAiService(
+    chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
 public interface PrReviewer {
 
   // {{repoInstructions}} carries the pre-rendered trailing guidance: available repository labels

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrSummarizer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrSummarizer.java
@@ -29,11 +29,14 @@ import jakarta.enterprise.context.ApplicationScoped;
  * count, while the summary returns one fixed-shape object plus {@code previous_findings_status}, so
  * it binds to the {@code concise} named model whose {@code max-tokens} is sized for fixed-shape
  * output ({@code REVIEW_CONCISE_MAX_OUTPUT_TOKENS}). Application-scoped for the same reason as
- * {@link PrReviewer}: there is no chat memory / {@code @MemoryId}, and request scope would break
- * callers on virtual threads without an inherited CDI request context.
+ * {@link PrReviewer}: request scope would break callers on virtual threads without an inherited CDI
+ * request context. Chat memory is disabled explicitly, for the reason documented on {@link
+ * PrReviewer}.
  */
 @ApplicationScoped
-@RegisterAiService(modelName = "concise")
+@RegisterAiService(
+    modelName = "concise",
+    chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
 public interface PrSummarizer {
 
   // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReplyAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReplyAssistant.java
@@ -27,7 +27,9 @@ import io.quarkiverse.langchain4j.RegisterAiService;
  * concise} named model: a reply is short prose, so it carries the concise response cap ({@code
  * REVIEW_CONCISE_MAX_OUTPUT_TOKENS}) instead of the batch review's allowance.
  */
-@RegisterAiService(modelName = "concise")
+@RegisterAiService(
+    modelName = "concise",
+    chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
 public interface ReplyAssistant {
 
   // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/UnitTestAssistant.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/UnitTestAssistant.java
@@ -27,7 +27,8 @@ import io.quarkiverse.langchain4j.RegisterAiService;
  * free Markdown, so the bot — not the model — owns how each test file is fenced and labelled in the
  * posted comment. A focused, single-shot blocking call like {@link DocGenerator}.
  */
-@RegisterAiService
+@RegisterAiService(
+    chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
 public interface UnitTestAssistant {
 
   // @UserMessage MUST stay on the method: on a parameter, quarkus-langchain4j sends only that

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelWiringTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ChatModelWiringTest.java
@@ -16,17 +16,34 @@
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
 import io.quarkiverse.langchain4j.ModelName;
+import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -62,6 +79,8 @@ class ChatModelWiringTest {
   @Inject
   @ModelName("concise")
   StreamingChatModel conciseStreamingChatModel;
+
+  @Inject PrReviewer prReviewer;
 
   @Test
   void blockingModelCarriesConfiguredTuning() {
@@ -118,6 +137,93 @@ class ChatModelWiringTest {
         "the concise lane sends its own effort, not the active model's 'Medium'");
     assertEquals(0.3, params.temperature());
     assertEquals(0.95, params.topP());
+  }
+
+  /**
+   * Review calls are stateless by design — state is carried by the previous-findings context, the
+   * code check for whether a finding was fixed, and user comments, never by conversation history.
+   * Without an explicit opt-out every {@code @RegisterAiService} interface gets the extension's
+   * default {@code MessageWindowChatMemory}, and because none of them declare {@code @MemoryId}
+   * every call shares one memory id: the second review would resend the first review's prompt and
+   * answer (#584).
+   *
+   * <p>The two reviews run on a plain virtual-thread executor, the shape {@code
+   * ReviewExecutorProducer} gives the real review path, so no CDI request context is active — the
+   * only default memory-id provider the extension ships resolves the request-context state and
+   * returns {@code null} there, leaving the constant fallback id shared by every PR the process
+   * ever reviews. Distinct diffs make that concrete: neither request may carry the other's.
+   */
+  @Test
+  void reviewRequestsCarryOnlyTheCurrentUserMessage() throws Exception {
+    var requests = new CopyOnWriteArrayList<List<ChatMessage>>();
+    QuarkusMock.installMockForType(
+        new CapturingStreamingChatModel(requests), StreamingChatModel.class);
+
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      executor.submit(() -> streamOneReview("diff-of-the-first-pr")).get(30, TimeUnit.SECONDS);
+      executor.submit(() -> streamOneReview("diff-of-the-second-pr")).get(30, TimeUnit.SECONDS);
+    }
+
+    assertEquals(2, requests.size(), "both review calls must reach the model");
+    var second = requests.get(1);
+    assertEquals(
+        0,
+        second.stream().filter(AiMessage.class::isInstance).count(),
+        "a review request must carry no assistant messages — chat memory is replaying prior"
+            + " answers: "
+            + describe(second));
+    assertEquals(
+        1,
+        second.stream().filter(dev.langchain4j.data.message.UserMessage.class::isInstance).count(),
+        "a review request must carry exactly one user message — chat memory is replaying prior"
+            + " prompts: "
+            + describe(second));
+    assertFalse(
+        second.stream().anyMatch(message -> message.toString().contains("diff-of-the-first-pr")),
+        "a review request must not carry another review's diff");
+  }
+
+  private Void streamOneReview(String diff) {
+    var done = new CompletableFuture<Void>();
+    prReviewer
+        .reviewStream(diff, "prContext", "baseComparison", "stack", "tests", "previous", "instr")
+        .onPartialResponse(token -> {})
+        .onCompleteResponse(response -> done.complete(null))
+        .onError(done::completeExceptionally)
+        .start();
+    try {
+      done.get(30, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(e);
+    } catch (ExecutionException | TimeoutException e) {
+      throw new IllegalStateException(e);
+    }
+    return null;
+  }
+
+  private static String describe(List<ChatMessage> messages) {
+    return messages.stream().map(m -> m.type().toString()).toList().toString();
+  }
+
+  /** Records the messages of every request instead of calling a provider. */
+  private record CapturingStreamingChatModel(List<List<ChatMessage>> requests)
+      implements StreamingChatModel {
+
+    @Override
+    public void doChat(ChatRequest request, StreamingChatResponseHandler handler) {
+      requests.add(List.copyOf(request.messages()));
+      handler.onPartialResponse("{}");
+      handler.onCompleteResponse(
+          ChatResponse.builder()
+              .aiMessage(AiMessage.from("{}"))
+              .metadata(
+                  ChatResponseMetadata.builder()
+                      .finishReason(FinishReason.STOP)
+                      .tokenUsage(new TokenUsage(1, 1))
+                      .build())
+              .build());
+    }
   }
 
   public static class TuningEnabled implements QuarkusTestProfile {


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Every `@RegisterAiService` interface omitted `chatMemoryProviderSupplier`. That attribute is not
optional-by-absence: verified against quarkus-langchain4j 1.12.2 on the classpath, its annotation
default is `RegisterAiService.BeanChatMemoryProviderSupplier`, so with no
`quarkus.langchain4j.chat-memory` configuration and no `ChatMemoryProvider` bean the extension's
default `MessageWindowChatMemory` applied to all nine services. None of them declare `@MemoryId`,
so every call shared one memory id and each review resent the previous reviews' prompts and
answers, up to the ten-message window — the measured 9,273,595-character / ~2.29M-token request
against a ~360k budget.

These calls are stateless by design: state is carried by the previous-findings context, the code
check for whether a finding was fixed, and user comments, never by conversation history.

Changes:

- `chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class` on all nine
  AI services: `ChangelogAssistant`, `DocGenerator`, `FindingVerifier`, `PrDescribeAssistant`,
  `PrImproveAssistant`, `PrReviewer`, `PrSummarizer`, `ReplyAssistant`, `UnitTestAssistant`.
- Corrected the javadoc on `PrReviewer`, `PrSummarizer` and `FindingVerifier`, which asserted there
  was no chat memory. That claim is what hid the bug, so `PrReviewer` now spells out why the
  attribute is required.

### Cross-PR / cross-repo leakage: confirmed, and closed by this PR

The mechanism is real, not just possible. The only `DefaultMemoryIdProvider` the extension ships
is `RequestScopeStateDefaultMemoryIdProvider`, which returns the CDI request-context state and
`null` when no request context is active. `ReviewExecutorProducer` hands the review path a plain
`Executors.newVirtualThreadPerTaskExecutor()`, so no request context is active there and
`AiServiceMethodImplementationSupport.memoryId` falls through to its constant `"default"` id —
one id shared by every PR and every repository the process ever reviews.

Demonstrated on unfixed code: two independent `reviewStream` calls with distinct diffs, submitted
to a virtual-thread executor, produced a second request that literally contained the first call's
diff.

```
LEAKDEMO types=[SYSTEM, USER, AI, USER]
LEAKDEMO secondRequestContainsFirstPrDiff=true
```

The regression test below runs the same two-task shape, so it pins that property too.

## Related Issues

Fixes #584

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

`ChatModelWiringTest.reviewRequestsCarryOnlyTheCurrentUserMessage` boots the real
quarkus-langchain4j wiring, swaps the `StreamingChatModel` bean for a capturing one, and runs two
reviews on a plain virtual-thread executor (the production executor shape, so no CDI request
context). It asserts the second request carries exactly one user message, no assistant messages,
and none of the first review's diff.

**Red on unfixed code** (`chatMemoryProviderSupplier` removed from `PrReviewer` only, everything
else as in this PR):

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.136 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.ai.ChatModelWiringTest
org.opentest4j.AssertionFailedError: a review request must carry no assistant messages — chat memory is replaying prior answers: [SYSTEM, USER, AI, USER] ==> expected: <0> but was: <1>
	at dev.thiagogonzaga.thrillhousebot.review.ai.ChatModelWiringTest.reviewRequestsCarryOnlyTheCurrentUserMessage(ChatModelWiringTest.java:169)
```

`[SYSTEM, USER, AI, USER]` is the window in miniature: the first review's prompt and answer riding
along with the second.

**Green with the fix**: `Tests run: 2715, Failures: 0, Errors: 0, Skipped: 0`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Gates on `2c56f88`:

- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, Spotless clean.
- `./mvnw -B clean test` — `Tests run: 2715, Failures: 0, Errors: 0, Skipped: 0`.
- JaCoCo ∩ `git diff -U0 c37a80e...HEAD -- src/main` — 0 coverable changed lines, therefore 0
  uncovered lines and 0 uncovered branches. Every changed main line is an annotation attribute or
  javadoc; the behavior they control is covered by the test above.

## Additional Notes

The change is annotation-only in main code. `#583`'s previous-findings mechanism and `#562`'s
estimate-versus-actual gap should be re-measured after this lands — the planner estimates one
prompt, and one prompt is now what gets sent.
