### PR TITLE
fix(config): create the dev-mode schema so quarkus:dev boots usable

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -282,6 +282,13 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:thrillhouse;DB_CLOSE_DELAY=-1
 %prod.quarkus.datasource.db-kind=${DATASOURCE_DB_KIND:postgresql}
 %prod.quarkus.datasource.jdbc.url=${DATABASE_URL:jdbc:postgresql://localhost:5432/thrillhouse}
 %prod.quarkus.hibernate-orm.schema-management.strategy=update
+# Dev mode points at an explicit H2 URL, so no Dev Services database is started and nothing creates
+# the schema for it; Hibernate's default strategy is `none`. Without the line below `quarkus:dev`
+# came up against an empty database — the app started and /q/health returned 200, then post-boot
+# validation logged "missing table [finding_feedback]" and every DB-backed feature failed at
+# runtime with Table "REVIEWSESSION" not found. The dev database is in-memory and discarded when
+# the JVM exits, so recreate it on each boot exactly as the test profile does.
+%dev.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 # Dashboard public base URL (session deep-links posted to GitHub) and OAuth login
 thrillhousebot.dashboard.url=${DASHBOARD_URL:http://localhost:8080}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/DevSchemaManagementTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/DevSchemaManagementTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Schema management per profile, bound straight from {@code
+ * src/main/resources/application.properties} — the dev profile is never exercised by the test suite
+ * (tests run under {@code %test}, whose own {@code src/test/resources/application.properties} sets
+ * the strategy), so nothing else here notices when the shipped file leaves {@code quarkus:dev}
+ * without one.
+ *
+ * <p>#565: the strategy was set only under {@code %prod}, and dev mode points at an explicit H2 URL
+ * so no Dev Services database creates the schema for it. Hibernate's default is {@code none}, so a
+ * fresh clone booted against an empty database — the app started and {@code /q/health} answered 200
+ * while post-boot validation logged {@code missing table [finding_feedback]} and every DB-backed
+ * request failed with {@code Table "REVIEWSESSION" not found}.
+ */
+class DevSchemaManagementTest {
+
+  private static final String STRATEGY = "quarkus.hibernate-orm.schema-management.strategy";
+  private static final String JDBC_URL = "quarkus.datasource.jdbc.url";
+
+  @Test
+  void devModeCreatesTheSchemaItStartsAgainst() throws Exception {
+    assertEquals("drop-and-create", shipped("dev").getValue(STRATEGY, String.class));
+  }
+
+  @Test
+  void devModeRecreatesOnlyAnInMemoryDatabase() throws Exception {
+    // drop-and-create is safe precisely because the dev URL is a throwaway in-memory H2 instance:
+    // if this ever becomes a file or a server URL, the strategy above has to be revisited first.
+    assertTrue(
+        shipped("dev").getValue(JDBC_URL, String.class).startsWith("jdbc:h2:mem:"),
+        "dev must stay on in-memory H2 while it recreates the schema on every boot");
+  }
+
+  @Test
+  void prodStillMigratesRatherThanRecreating() throws Exception {
+    // Guards the blast radius of the dev line: production data must never be dropped at boot.
+    assertEquals("update", shipped("prod").getValue(STRATEGY, String.class));
+  }
+
+  private static SmallRyeConfig shipped(String profile) throws Exception {
+    return new SmallRyeConfigBuilder()
+        .addDefaultInterceptors() // profile selection and ${VAR:default} expansion, as at runtime
+        .withValidateUnknown(false)
+        .withProfile(profile)
+        .withSources(
+            new PropertiesConfigSource(
+                Paths.get("src/main/resources/application.properties").toUri().toURL()))
+        .build();
+  }
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`quarkus.hibernate-orm.schema-management.strategy` was set only under `%prod`. Dev mode points at
an explicit H2 URL (`jdbc:h2:mem:thrillhouse`), so Quarkus starts no Dev Services database and
nothing creates the schema for it, and Hibernate's own default strategy is `none`. A fresh clone
running `./mvnw quarkus:dev` therefore booted against a completely empty database: the app started,
`/q/health` answered 200, and every database-backed feature failed at runtime.

This sets `%dev.quarkus.hibernate-orm.schema-management.strategy=drop-and-create`, matching what
`src/test/resources/application.properties` already does for the test profile — which is where the
test suite has been getting its schema all along, and why nothing caught this. The dev database is
in-memory and discarded when the JVM exits, so there is nothing to preserve across boots. `%prod`
is untouched and keeps `update`, so production data is never dropped.

Only `src/main/resources/application.properties` changes; no Java main code and no `pom.xml`.

## Related Issues

Fixes #565

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

### Manual: real `quarkus:dev` boot, before and after

Booted the app with `./mvnw quarkus:dev -Dquarkus.http.port=8099 -Dquarkus.observability.enabled=false`
(JDK 25, dummy GitHub App / AI credentials so `StartupConfigValidator` passes), then probed the
unauthenticated DB-backed endpoint `GET /session/{publicId}`.

**Before** — app up, health green, schema absent:

```
ERROR [io.quarkus.hibernate.orm.runtime.schema.SchemaManagementIntegrator] (Hibernate post-boot validation thread for <default>) Failed to validate Schema: Schema validation: missing table [finding_feedback]
WARN  [org.hibernate.orm.jdbc.error] (Quarkus Main Thread) Table "REVIEWSESSION" not found; SQL statement:
WARN  [dev.thiagogonzaga.thrillhousebot.dashboard.SessionCostBackfill] (Quarkus Main Thread) Session cost backfill failed; historical dashboard costs may stay at 0: org.hibernate.exception.SQLGrammarException: Could not prepare statement [Table "REVIEWSESSION" not found; SQL statement:
INFO  [io.quarkus] (Quarkus Main Thread) thrillhousebot 0.5.1-SNAPSHOT on JVM (powered by Quarkus 3.38.0) started in 4.126s. Listening on: http://localhost:8099
```

```
GET /q/health                                        -> 200
GET /session/11111111-2222-3333-4444-555555555555    -> 500
ERROR [io.quarkus.vertx.http.runtime.QuarkusErrorHandler] (executor-thread-1) HTTP Request to /session/11111111-2222-3333-4444-555555555555 failed, error id: ee3e70f7-...: org.hibernate.exception.SQLGrammarException: Could not prepare statement [Table "REVIEWSESSION" not found; SQL statement:
```

**After** — clean boot, no schema errors anywhere in the log, and the same request reaches the
database and completes (303 to the sessions page, i.e. "no such session" rather than a crash):

```
INFO  [io.quarkus] (Quarkus Main Thread) thrillhousebot 0.5.1-SNAPSHOT on JVM (powered by Quarkus 3.38.0) started in 4.155s. Listening on: http://localhost:8099

GET /q/health                                        -> 200
GET /session/11111111-2222-3333-4444-555555555555    -> 303
grep -cE 'missing table|Table "REVIEWSESSION" not found' dev-after.log  -> 0
```

### Red/green proof

`DevSchemaManagementTest` binds the shipped `src/main/resources/application.properties` under the
`dev` profile — the profile the suite otherwise never exercises. Verbatim red output on the
unfixed properties file:

```
[INFO] Running dev.thiagogonzaga.thrillhousebot.config.DevSchemaManagementTest
[ERROR] Tests run: 3, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.055 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.config.DevSchemaManagementTest
[ERROR] dev.thiagogonzaga.thrillhousebot.config.DevSchemaManagementTest.devModeCreatesTheSchemaItStartsAgainst -- Time elapsed: 0.027 s <<< ERROR!
java.util.NoSuchElementException: SRCFG00014: The config property quarkus.hibernate-orm.schema-management.strategy is required but it could not be found in any config source
	at io.smallrye.config.SmallRyeConfig.convertValue(SmallRyeConfig.java:455)
	at io.smallrye.config.SmallRyeConfig.getValue(SmallRyeConfig.java:418)
	at io.smallrye.config.SmallRyeConfig.getValue(SmallRyeConfig.java:400)
	at dev.thiagogonzaga.thrillhousebot.config.DevSchemaManagementTest.devModeCreatesTheSchemaItStartsAgainst(DevSchemaManagementTest.java:47)

[ERROR] Tests run: 3, Failures: 0, Errors: 1, Skipped: 0
```

Green with the fix: `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`.

### Gates

- `./mvnw -B spotless:apply` — clean
- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — `Tests run: 2771, Failures: 0, Errors: 0, Skipped: 0`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Patch coverage: the only changed main-code file is `application.properties`, so the changed-line ∩
JaCoCo intersection contains no Java lines or branches — nothing uncoverable and nothing gamed.

`%dev` `drop-and-create` can only ever hit the in-memory H2 instance: the non-prod datasource URL is
a fixed `jdbc:h2:mem:` literal with no env override, and the test asserts that, so the strategy
cannot silently start recreating a persistent database if the URL is ever changed.
