### PR TITLE
fix(review): carry a blocking lane's cut body on the truncation

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponses.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponses.java
@@ -84,6 +84,17 @@ public final class AiResponses {
    * verifier keeps its unverified findings. It is a real case, not a defensive one — a reasoning
    * model can spend its whole output budget on reasoning tokens and return an empty body with no
    * length stop to show for it.
+   *
+   * <p>The cut text travels on the failure as its {@linkplain
+   * AiResponseTruncatedException#partialBody() partial body} (#580). {@link Result#content()} holds
+   * what the model produced before the cap stopped it — output that was generated and billed, and
+   * that is well-formed up to the cut — so a caller that wants to keep the elements which closed
+   * can run it through {@link TruncatedResponseSalvager}, the same machinery the streaming review
+   * lane salvages with. Dropping it here made that impossible by construction of this helper rather
+   * than by any provider limitation: every blocking lane's cut body was discarded before its caller
+   * could see it. Handing it over decides nothing for the caller — the throw, the no-retry contract
+   * and each lane's existing error contract are unchanged, and a lane that ignores the body behaves
+   * exactly as it did.
    */
   public static String textOrThrowOnTruncation(Result<String> result, String what, ModelLane lane) {
     if (result == null) {
@@ -95,7 +106,7 @@ public final class AiResponses {
               + " stopped at the model's response-length cap (finish_reason=length), so the"
               + " response is incomplete. "
               + lane.remedy(),
-          null,
+          result.content(),
           lane == ModelLane.CONCISE);
     }
     return result.content();

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponsesTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponsesTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.thiagogonzaga.thrillhousebot.review.ai.AiResponses.ModelLane;
 import org.junit.jupiter.api.Test;
 
@@ -106,6 +107,45 @@ class AiResponsesTest {
     assertTrue(
         thrown.conciseModelImplicated(),
         "the failure must carry the concise flag so downstream copy names the same knob");
+  }
+
+  @Test
+  void carriesTheCutBodyOnTheFailureSoTheLaneCanSalvageIt() {
+    // #580: Result#content() holds what the model produced before the cap stopped it — output that
+    // was generated and billed. Dropping it here left every blocking lane with nothing to salvage
+    // from, however much of its response had completed before the cut.
+    var cut = "{\"verdicts\":[{\"id\":1,\"verdict\":\"valid\"},{\"id\":2,\"verd";
+
+    var thrown =
+        assertThrows(
+            AiResponseTruncatedException.class,
+            () ->
+                AiResponses.textOrThrowOnTruncation(
+                    aiTruncated(cut), "Finding verification", ModelLane.CONCISE));
+
+    assertEquals(cut, thrown.partialBody(), "the paid, cut body must travel with the failure");
+  }
+
+  @Test
+  void theCarriedBodyIsWhatTheSalvagerRecoversTheCompletedElementsFrom() {
+    // The point of carrying it: the body is well-formed up to the cut, so the review lane's own
+    // salvage machinery recovers the elements that closed. Pinned end to end because a body no
+    // consumer could use would be no better than the null it replaced.
+    var cut = "{\"verdicts\":[{\"id\":1,\"verdict\":\"valid\"},{\"id\":2,\"verd";
+
+    var thrown =
+        assertThrows(
+            AiResponseTruncatedException.class,
+            () ->
+                AiResponses.textOrThrowOnTruncation(
+                    aiTruncated(cut), "Finding verification", ModelLane.CONCISE));
+
+    var salvaged =
+        new TruncatedResponseSalvager(new ObjectMapper())
+            .salvageArray(thrown.partialBody(), "verdicts", VerificationResponse.Verdict.class);
+
+    assertEquals(1, salvaged.size(), "the verdict that closed before the cut is recoverable");
+    assertEquals(1, salvaged.get(0).id());
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

The single-call review lane's own salvage landed in #582. Its lane inventory named what was left of #580, and this is that residual:

> Every blocking lane goes through `AiResponses.textOrThrowOnTruncation`, which passes **`null`** as the partial body even though `result.content()` holds the cut text — so on those lanes salvage is impossible by construction of the helper, not by provider limitation.

`Result#content()` carries exactly what the model produced before the cap stopped it: output that was generated and billed, and that is well-formed up to the cut. The helper threw it away, so every blocking lane's caller was handed a truncation with nothing to salvage from, however many complete elements the response had already completed. That is a one-token gap with a lane-wide effect:

| Blocking lane | What a length stop costs it today |
|---|---|
| `FindingVerificationService#verify` | fails open and keeps the findings **unverified** — the verdicts that closed before the cut are gone, even though #546 already built the `salvageArray(body, "verdicts", …)` pass that would recover them |
| `MaintainerReplyService` | posts no reply |
| `AbstractPrSuggestionGenerator#callAssistant` (`/improve`, `/describe`, `/docs`, `/tests`) | drops the whole batch |

The cut text now travels on the failure as its `partialBody()`, the same input the streaming review lane's salvage already runs on.

**This change decides nothing for any caller.** The throw, #495's no-retry contract and each lane's own error contract are untouched, and a lane that ignores the body behaves exactly as it did — the fix is that a lane which *wants* to keep its paid output is no longer prevented from doing so by the helper. The second test pins that end to end: the carried body is run through `TruncatedResponseSalvager` and the verdict that closed before the cut comes back, because a body no consumer could use would be no better than the `null` it replaces.

## Related Issues

Fixes #580

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Red first, on unfixed main code (both new tests, `AiResponses.java` reverted to its `fda4bc7` state):

```
[ERROR] Tests run: 9, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.212 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.ai.AiResponsesTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.AiResponsesTest.carriesTheCutBodyOnTheFailureSoTheLaneCanSalvageIt -- Time elapsed: 0.008 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the paid, cut body must travel with the failure ==> expected: <{"verdicts":[{"id":1,"verdict":"valid"},{"id":2,"verd> but was: <null>
	at dev.thiagogonzaga.thrillhousebot.review.ai.AiResponsesTest.carriesTheCutBodyOnTheFailureSoTheLaneCanSalvageIt(AiResponsesTest.java:126)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.AiResponsesTest.theCarriedBodyIsWhatTheSalvagerRecoversTheCompletedElementsFrom -- Time elapsed: 0.145 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the verdict that closed before the cut is recoverable ==> expected: <1> but was: <0>
	at dev.thiagogonzaga.thrillhousebot.review.ai.AiResponsesTest.theCarriedBodyIsWhatTheSalvagerRecoversTheCompletedElementsFrom(AiResponsesTest.java:147)
```

Green with the fix, and the gates on `fda4bc7`:

| gate | result |
|---|---|
| `./mvnw -B spotless:apply` then `./mvnw -B clean compile spotbugs:check spotless:check` | `BugInstance size is 0` — BUILD SUCCESS |
| `./mvnw -B clean test` | `Tests run: 2770, Failures: 0, Errors: 0, Skipped: 0` — BUILD SUCCESS |
| jacoco ∩ `git diff -U0 fda4bc7...HEAD` | **0 uncovered lines, 0 uncovered branches** (1 executable changed main line) |

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Scope is the helper only. Teaching each blocking caller to *use* the body is per-lane work with its own error contract to respect — the verifier's is the valuable one (#546's `salvageArray` is already there, waiting for a non-null body) and is being handled in `FindingVerificationService` separately, so this PR deliberately does not touch it.

One stale phrase is left behind for that follow-up rather than edited here: `TruncatedResponseSalvager#salvage`'s javadoc still says "no body (the blocking lanes do not buffer one)", which stops being true for the length-stop path with this change.

`AiResponses.java` is also touched by the #581 fix, which rewrites the same `throw` to build its message and its concise flag from one lane source. Whichever merges second resolves by keeping both: the lane-built truncation *and* `result.content()` as the partial body.
