### PR TITLE
fix(review): floor unmitigated-injection-sink findings at high risk

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -74,6 +74,63 @@ public class FindingVerificationService {
   private static final Pattern HEDGING =
       Pattern.compile("\\b(may|might|could|potentially|possibly)\\b", Pattern.CASE_INSENSITIVE);
 
+  /**
+   * Sentence/clause boundaries the hedging scan splits on, so a hedge is judged against the clause
+   * it actually qualifies rather than against the whole finding body.
+   */
+  private static final Pattern CLAUSE_BOUNDARY = Pattern.compile("(?<=[.;!?])\\s+|\\R");
+
+  /**
+   * A clause that asks the reader to check something rather than hedging the defect itself. The
+   * review prompt REQUIRES this clause on a finding whose sink and tainted value are both in the
+   * diff but whose mitigation might live in a layer that was not shown: "lower the confidence, name
+   * in the description the exact layer to verify". Counting the hedge word inside that mandated
+   * clause as a hedge of the claim charges the same uncertainty twice, on a security class where
+   * the prompt guarantees the clause is present.
+   */
+  private static final Pattern VERIFICATION_CUE =
+      Pattern.compile(
+          "\\b(verify|verifying|verification|confirm\\w*|unverifiable|not shown|not visible"
+              + "|outside the diff|not in the diff)\\b",
+          Pattern.CASE_INSENSITIVE);
+
+  /**
+   * Injection sinks and vulnerability classes named explicitly, per the review prompt's dimension-2
+   * list. Matching one of these is only the first half of the floor's test.
+   */
+  private static final Pattern INJECTION_SINK =
+      Pattern.compile(
+          "\\b(xss|cross[- ]site scripting|sql injection|command injection|shell injection"
+              + "|path traversal|directory traversal|(unsafe|insecure) deserializ\\w*"
+              + "|dangerouslysetinnerhtml|bypasssecuritytrusthtml|v-html|inner_?html|outerhtml"
+              + "|insertadjacenthtml|document\\.write)\\b",
+          Pattern.CASE_INSENSITIVE);
+
+  /** String-built SQL, which findings usually name by its shape rather than as "SQL injection". */
+  private static final Pattern SQL = Pattern.compile("\\bsql\\b", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern STRING_BUILT =
+      Pattern.compile(
+          "\\b(concatenat\\w*|interpolat\\w*|string[- ]?built|built from)\\b",
+          Pattern.CASE_INSENSITIVE);
+
+  /**
+   * The finding's own statement that nothing neutralizes the tainted value. Deliberately keyed on
+   * an ABSENCE claim: it is what turns "this code uses innerHTML" into "user data reaches an
+   * injection sink unmitigated", which is the class the prompt floors at "high".
+   */
+  private static final Pattern NO_MITIGATION =
+      Pattern.compile(
+          "\\b(unsanitiz\\w*|unescaped|unvalidated|unparameteriz\\w*|non-parameteriz\\w*"
+              + "|(no|not|without|missing|never|lacks?|absent)\\s+(\\w+[\\s-]+){0,3}"
+              + "(sanitiz|escap|validat|parameteriz|encod)\\w*)",
+          Pattern.CASE_INSENSITIVE);
+
+  /** The floor an unmitigated-injection-sink finding may never publish below (#570). */
+  private static final RiskLevel INJECTION_SINK_FLOOR = RiskLevel.HIGH;
+
+  private static final String HIGH_LABEL = "high";
+
   private static final String MEDIUM_LABEL = "medium";
 
   /** The verifier response's only field, and the array salvage keys on when the body is cut. */
@@ -88,6 +145,17 @@ public class FindingVerificationService {
    * spend ceiling is reached the call is skipped fail-open, keeping the unverified findings.
    */
   public ReviewResponse verify(
+      long ledgerSessionId,
+      ReviewResponse response,
+      String diff,
+      String projectStack,
+      String previousFindings) {
+    return floorInjectionSinkRisk(
+        audit(ledgerSessionId, response, diff, projectStack, previousFindings));
+  }
+
+  /** The audit itself; {@link #verify} applies the deterministic severity floor to its result. */
+  private ReviewResponse audit(
       long ledgerSessionId,
       ReviewResponse response,
       String diff,
@@ -203,6 +271,12 @@ public class FindingVerificationService {
    * blocking-eligible finding whose own wording hedges ("may", "might", "could"...) is by
    * definition not a demonstrated failure, so its confidence drops to medium — it still posts, but
    * can no longer request changes on its own.
+   *
+   * <p>The hedge is read clause by clause: a hedge word inside a clause that names something to
+   * verify is the verification request the prompt mandates next to a demonstrated defect, not a
+   * hedge of the defect. Scanning the whole body made that mandated clause self-defeating on the
+   * security class it was written for — a demonstrated injection whose description named the
+   * unshown sanitizing layer lost its blocking confidence for saying so (#570).
    */
   static ReviewResponse demoteHedgedBlockingFindings(ReviewResponse response) {
     if (response.findings().isEmpty()) {
@@ -236,6 +310,79 @@ public class FindingVerificationService {
     return new ReviewResponse(adjusted, response.previousFindingsStatus(), response.summary());
   }
 
+  /**
+   * Deterministic severity floor for the one class the review prompt already pins (#570): a finding
+   * that names an injection sink AND states that nothing sanitizes, escapes, validates, encodes or
+   * parameterizes the value reaching it publishes at no less than "high" risk.
+   *
+   * <p>Applied to the audit's OUTPUT, so it holds however the level was arrived at — the review
+   * call rating the class low in one framework and high in another, or the verifier taking it down
+   * because a rendering or query-dialect semantic "is not verifiable here". Both were observed on
+   * the same planted defect in two frameworks, published as CRITICAL inline against MEDIUM
+   * collapsed; the prompt-side floor alone did not hold, because nothing downstream enforced it.
+   *
+   * <p>Only risk moves, and only upward: severity is a property of the defect class and its blast
+   * radius, while "some layer I was not shown might neutralize this" is a statement about
+   * confidence. Confidence is therefore left exactly where the model or the verifier put it — the
+   * hedge survives, the misclassification does not. Placement follows: {@code Finding.postsInline}
+   * keeps a high-risk finding on an inline thread however low its confidence, so the same defect
+   * class stops landing in the collapsed "Things to double-check" block in one framework and on the
+   * diff in another.
+   *
+   * <p>The trigger needs BOTH halves stated in the finding's own words, so it never fires on a
+   * mention of a sink in passing (a sink rendering a literal template) or on an unrelated finding
+   * that happens to say "unvalidated". A critical keeps its level: the floor lifts, never lowers.
+   */
+  static ReviewResponse floorInjectionSinkRisk(ReviewResponse response) {
+    if (response.findings().isEmpty()) {
+      return response;
+    }
+    var adjusted = new ArrayList<ReviewResponse.Finding>(response.findings().size());
+    var changed = false;
+    for (ReviewResponse.Finding finding : response.findings()) {
+      if (!belowInjectionSinkFloor(finding)) {
+        adjusted.add(finding);
+        continue;
+      }
+      Log.infof(
+          "Raising unmitigated-injection-sink finding '%s' from %s to %s risk; confidence stays %s",
+          finding.title(), finding.risk(), HIGH_LABEL, finding.confidence());
+      adjusted.add(
+          new ReviewResponse.Finding(
+              HIGH_LABEL,
+              finding.confidence(),
+              finding.file(),
+              finding.line(),
+              finding.title(),
+              finding.description(),
+              finding.suggestionOld(),
+              finding.suggestionNew()));
+      changed = true;
+    }
+    if (!changed) {
+      return response;
+    }
+    return new ReviewResponse(
+        adjusted, response.previousFindingsStatus(), recount(response.summary(), adjusted));
+  }
+
+  private static boolean belowInjectionSinkFloor(ReviewResponse.Finding finding) {
+    // Both enums declare constants most- to least-severe, so a higher ordinal is a lower rating.
+    if (RiskLevel.fromString(finding.risk()).ordinal() <= INJECTION_SINK_FLOOR.ordinal()) {
+      return false;
+    }
+    String text =
+        (finding.title() == null ? "" : finding.title())
+            + "\n"
+            + (finding.description() == null ? "" : finding.description());
+    return namesInjectionSink(text) && NO_MITIGATION.matcher(text).find();
+  }
+
+  private static boolean namesInjectionSink(String text) {
+    return INJECTION_SINK.matcher(text).find()
+        || (SQL.matcher(text).find() && STRING_BUILT.matcher(text).find());
+  }
+
   private static boolean isBlockingEligible(ReviewResponse.Finding finding) {
     RiskLevel risk = RiskLevel.fromString(finding.risk());
     return (risk == RiskLevel.CRITICAL || risk == RiskLevel.HIGH)
@@ -243,8 +390,25 @@ public class FindingVerificationService {
   }
 
   private static boolean containsHedging(ReviewResponse.Finding finding) {
-    return (finding.title() != null && HEDGING.matcher(finding.title()).find())
-        || (finding.description() != null && HEDGING.matcher(finding.description()).find());
+    return hedgesTheClaim(finding.title()) || hedgesTheClaim(finding.description());
+  }
+
+  /**
+   * Whether the finding's own wording hedges the DEFECT, judged clause by clause. A hedge word
+   * inside a clause that names something to verify does not hedge the claim — it is the
+   * verification request the prompt asks for alongside a defect the material demonstrates, so on
+   * its own it must not cost the finding its blocking confidence (#570).
+   */
+  private static boolean hedgesTheClaim(String text) {
+    if (text == null) {
+      return false;
+    }
+    for (String clause : CLAUSE_BOUNDARY.split(text)) {
+      if (HEDGING.matcher(clause).find() && !VERIFICATION_CUE.matcher(clause).find()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** The shape each candidate is presented in; ids are 1-based positions in the findings list. */
@@ -360,7 +524,7 @@ public class FindingVerificationService {
     }
     return switch (value.strip().toLowerCase(Locale.ROOT)) {
       case "critical" -> RiskLevel.CRITICAL;
-      case "high" -> RiskLevel.HIGH;
+      case HIGH_LABEL -> RiskLevel.HIGH;
       case MEDIUM_LABEL -> RiskLevel.MEDIUM;
       case "low" -> RiskLevel.LOW;
       default -> null;
@@ -372,7 +536,7 @@ public class FindingVerificationService {
       return null;
     }
     return switch (value.strip().toLowerCase(Locale.ROOT)) {
-      case "high" -> Confidence.HIGH;
+      case HIGH_LABEL -> Confidence.HIGH;
       case MEDIUM_LABEL -> Confidence.MEDIUM;
       case "low" -> Confidence.LOW;
       default -> null;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -126,6 +126,35 @@ public class FindingVerificationService {
               + "(sanitiz|escap|validat|parameteriz|encod)\\w*)",
           Pattern.CASE_INSENSITIVE);
 
+  /**
+   * A finding that RULES THE SINK OUT rather than reporting it ("so there is no SQL injection",
+   * "not vulnerable to XSS"). Both floor signals are token matches, so such a sentence satisfies
+   * them out of its own negation — the sink name sits inside the denial, and a phrase like "not
+   * concatenated but parameterized" matches the absence group on the very mitigation it asserts.
+   * The gap is one word, so an assertion of the defect that merely contains a negation ("no
+   * protection against SQL injection") is not mistaken for a denial.
+   */
+  private static final Pattern SINK_DENIED =
+      Pattern.compile(
+          "\\b(no|not|never)\\s+(\\w+[\\s-]+){0,1}"
+              + "(xss|cross[- ]site scripting|sql injection|command injection|shell injection"
+              + "|path traversal|directory traversal|vulnerab\\w*|exploitab\\w*)\\b",
+          Pattern.CASE_INSENSITIVE);
+
+  /**
+   * A finding that states the mitigation IS present ("it is escaped on render", "React escapes
+   * them"). An absence claim about one layer must not floor the class when the same text says
+   * another layer neutralizes the value. Negated forms are excluded, so "is not escaped" and "was
+   * never sanitized" stay absence claims instead of defeating themselves.
+   */
+  private static final Pattern MITIGATION_ASSERTED =
+      Pattern.compile(
+          "\\b(is|are|was|were|gets|been|already)\\s+(?!(no|not|never)\\b)(\\w+[\\s-]+){0,1}"
+              + "(sanitiz|escap|validat|parameteriz|encod)(ed|es|ing)\\b"
+              + "|\\b(?!(no|not|never|nothing)\\b)\\w+\\s+"
+              + "(sanitizes|escapes|validates|parameterizes|encodes)\\b",
+          Pattern.CASE_INSENSITIVE);
+
   /** The floor an unmitigated-injection-sink finding may never publish below (#570). */
   private static final RiskLevel INJECTION_SINK_FLOOR = RiskLevel.HIGH;
 
@@ -329,9 +358,13 @@ public class FindingVerificationService {
    * class stops landing in the collapsed "Things to double-check" block in one framework and on the
    * diff in another.
    *
-   * <p>The trigger needs BOTH halves stated in the finding's own words, so it never fires on a
+   * <p>The trigger needs BOTH halves stated in the finding's own words, so it does not fire on a
    * mention of a sink in passing (a sink rendering a literal template) or on an unrelated finding
-   * that happens to say "unvalidated". A critical keeps its level: the floor lifts, never lowers.
+   * that happens to say "unvalidated". Both halves are token matches, though, so a sentence that
+   * RULES THE SINK OUT can satisfy them out of its own negation ("not concatenated but
+   * parameterized, so no SQL injection is possible"); two defeaters — a denied sink, and a
+   * mitigation the finding says IS present — suppress the floor for exactly those. A critical keeps
+   * its level: the floor lifts, never lowers.
    */
   static ReviewResponse floorInjectionSinkRisk(ReviewResponse response) {
     if (response.findings().isEmpty()) {
@@ -375,7 +408,13 @@ public class FindingVerificationService {
         (finding.title() == null ? "" : finding.title())
             + "\n"
             + (finding.description() == null ? "" : finding.description());
-    return namesInjectionSink(text) && NO_MITIGATION.matcher(text).find();
+    return namesInjectionSink(text)
+        && NO_MITIGATION.matcher(text).find()
+        // Either defeater anywhere in the finding suppresses the floor. Under-firing costs a
+        // finding the lift it should have had, which is where this class already stood; over-firing
+        // escalates a non-defect and, at high confidence, blocks the merge on it.
+        && !SINK_DENIED.matcher(text).find()
+        && !MITIGATION_ASSERTED.matcher(text).find();
   }
 
   private static boolean namesInjectionSink(String text) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -27,6 +27,7 @@ import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.service.Result;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import dev.thiagogonzaga.thrillhousebot.review.Finding;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -718,5 +719,203 @@ class FindingVerificationServiceTest {
     service.verify(SESSION, original, "the-diff", "the-stack", null);
 
     verify(verifier).verify(anyString(), eq("the-diff"), eq("the-stack"), eq(""));
+  }
+
+  /**
+   * #570's controlled pair, as the dogfood corpus plants it: the same stored-XSS class behind two
+   * frameworks' HTML-injection escape hatches, each finding stating that no sanitizer is present.
+   */
+  private static ReviewResponse.Finding angularXss(String risk, String confidence) {
+    return new ReviewResponse.Finding(
+        risk,
+        confidence,
+        "src/app/incident-timeline/event-item/event-item.component.ts",
+        16,
+        "Stored XSS: responder note rendered via bypassSecurityTrustHtml without sanitization",
+        "The responder note is user-authored and reaches the sink with no sanitizer in the diff.",
+        null,
+        null);
+  }
+
+  private static ReviewResponse.Finding reactXss(String risk, String confidence) {
+    return new ReviewResponse.Finding(
+        risk,
+        confidence,
+        "src/components/ResultItem.tsx",
+        23,
+        "Unsanitized API-supplied snippetHtml injected via dangerouslySetInnerHTML (XSS)",
+        "snippetHtml comes straight from the API response and is rendered as raw HTML.",
+        null,
+        null);
+  }
+
+  @Test
+  void floorsAnUnsanitizedInjectionSinkFindingTheModelRatedBelowHigh() {
+    // #570: the React half of the planted pair published MEDIUM while the Angular half published
+    // CRITICAL. Severity is a property of the defect class, so the class floors at high; the
+    // model's uncertainty stays where it belongs — on confidence.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original = response(reactXss("medium", "low"));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("high", result.findings().get(0).risk());
+    assertEquals("low", result.findings().get(0).confidence());
+    assertEquals(1, result.summary().high());
+    assertEquals(0, result.summary().medium());
+  }
+
+  @Test
+  void floorsStringBuiltSqlNamedByItsShapeRatherThanTheWordsSqlInjection() {
+    // #570's second round-3 instance: the C# tenant filter. Its title never says "SQL injection",
+    // it says the value is concatenated into SQL with no parameterization — the same class.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "medium",
+                "low",
+                "src/InvoiceExporter/Data/InvoiceRepository.cs",
+                27,
+                "Tenant filter is concatenated into SQL with no parameterization",
+                "The account code is interpolated into the command text.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("high", result.findings().get(0).risk());
+    assertEquals("low", result.findings().get(0).confidence());
+  }
+
+  @Test
+  void keepsAnInjectionSinkFindingAtHighRiskWhenTheVerifierDowngradesIt() {
+    // #570: the verifier's "remembered framework / rendering semantics" ground caps such a claim at
+    // medium risk with low confidence, which is what routed a demonstrated XSS into the collapsed
+    // block. The verifier may still take the confidence down; it may not take the class below high.
+    ReviewResponse original = response(reactXss("high", "high"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiOk(
+                """
+            {"verdicts": [{"id": 1, "verdict": "downgraded", "risk": "medium",
+            "confidence": "low", "reason": "rendering semantics are not verifiable here"}]}
+            """));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("high", result.findings().get(0).risk());
+    assertEquals("low", result.findings().get(0).confidence());
+    assertEquals(1, result.summary().high());
+    assertEquals(0, result.summary().medium());
+  }
+
+  @Test
+  void ratesBothHalvesOfThePlantedXssPairTheSameAndKeepsBothInline() {
+    // The regression test #570 asks for: the same class in two frameworks must publish at the same
+    // severity AND the same placement. Placement follows from severity — a high finding opens an
+    // inline thread however low its confidence is.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original = response(angularXss("high", "high"), reactXss("medium", "low"));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals(result.findings().get(0).risk(), result.findings().get(1).risk());
+    assertTrue(Finding.fromAiResponse(result.findings().get(0)).postsInline());
+    assertTrue(Finding.fromAiResponse(result.findings().get(1)).postsInline());
+  }
+
+  @Test
+  void keepsBlockingConfidenceWhenTheOnlyHedgeSitsInAVerificationRequest() {
+    // #570: the review prompt REQUIRES a demonstrated-sink finding to name the unshown layer to
+    // verify, which puts a hedge word into the description of every such finding by construction.
+    // Reading that mandated clause as a hedge of the claim strips the finding's blocking
+    // confidence (BlockingStrictness.BALANCED needs high) and stamps a "verify before acting"
+    // disclaimer on a defect the diff demonstrates.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "high",
+                "high",
+                "src/main/java/Repo.java",
+                27,
+                "SQL injection in findPendingByChannel via unsanitized channel",
+                "The channel value is concatenated into the query text. Verify whether a layer"
+                    + " above this method might sanitize it; that layer is not shown here.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    assertEquals("high", result.findings().get(0).confidence());
+  }
+
+  @Test
+  void stillDemotesWhenAHedgeSitsOutsideTheVerificationRequest() {
+    // The narrowing is clause-scoped, not a blanket exemption: a finding that hedges the claim
+    // itself still loses its blocking confidence even when it also asks for a verification.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "high",
+                "high",
+                "f",
+                1,
+                "Query build",
+                "This could fail under load. Verify whether the pool size might be the cause.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("medium", result.findings().get(0).confidence());
+  }
+
+  @Test
+  void leavesCriticalInjectionFindingsAndUnrelatedRatingsAlone() {
+    // The floor only lifts, so a critical keeps its level; and it never fires unless the finding
+    // states both halves — a named sink AND the absence of any sanitization.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            angularXss("critical", "high"),
+            new ReviewResponse.Finding(
+                "low",
+                "high",
+                "src/components/ResultItem.tsx",
+                23,
+                "dangerouslySetInnerHTML renders a constant template",
+                "The markup is a literal in this file, so nothing user-authored reaches it.",
+                null,
+                null),
+            new ReviewResponse.Finding(
+                "medium",
+                "high",
+                "docs/config.md",
+                4,
+                "Documented key omits its separator semantics with no validation of the list form",
+                "The table shows one value and never says the binding is comma-separated.",
+                null,
+                null),
+            // Names SQL, but as a query whose RESULT is unsanitized on the way out — nothing here
+            // builds the statement from a value, so this is not the string-built-SQL shape.
+            new ReviewResponse.Finding(
+                "low",
+                "high",
+                "src/Report.java",
+                8,
+                "Unsanitized SQL row count is written straight into the report header",
+                null,
+                null,
+                null),
+            new ReviewResponse.Finding(
+                "low", "high", "src/Report.java", 12, null, "Totals are unvalidated.", null, null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -875,6 +875,58 @@ class FindingVerificationServiceTest {
   }
 
   @Test
+  void doesNotFloorAFindingThatDeniesTheSinkItNames() {
+    // The floor's two signals were matched independently anywhere in the text, so a finding that
+    // RULED OUT the sink still satisfied both: "sql injection" inside "no SQL injection", and the
+    // no-mitigation group inside "not concatenated but parameterized" — the very mitigation the
+    // sentence asserts. Raising such a finding to high is this floor's own failure mode pointed
+    // the other way, and at high confidence it would go on to block the merge.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "low",
+                "high",
+                "src/InvoiceExporter/Data/InvoiceRepository.cs",
+                27,
+                "Tenant filter reads awkwardly",
+                "The user input is not concatenated but parameterized, so no SQL injection is"
+                    + " possible; the naming is just hard to follow.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    assertEquals("low", result.findings().get(0).risk());
+  }
+
+  @Test
+  void doesNotFloorAFindingThatDescribesTheMitigationAsPresent() {
+    // The other half of the same defect: no negated sink here, but the finding affirmatively
+    // states the value IS escaped. An absence claim about one layer ("unvalidated" at storage)
+    // must not floor the class when the text also says another layer neutralizes it.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "low",
+                "high",
+                "src/components/Profile.tsx",
+                12,
+                "Profile names are unvalidated before storage",
+                "React escapes them at render, so the XSS exposure is limited to the stored value"
+                    + " itself.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    assertEquals("low", result.findings().get(0).risk());
+  }
+
+  @Test
   void leavesCriticalInjectionFindingsAndUnrelatedRatingsAlone() {
     // The floor only lifts, so a critical keeps its level; and it never fires unless the finding
     // states both halves — a named sink AND the absence of any sanitization.


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔒 Security

## Description

Round 3 reproduced #570's controlled pair with brand new code: the same planted
stored-XSS defect published as **CRITICAL, inline, top Key Finding** behind
Angular's `bypassSecurityTrustHtml` and as **MEDIUM, collapsed, low confidence**
behind React's `dangerouslySetInnerHTML`. A string-concatenated SQL tenant
filter published the same way — asserted as fact in the walkthrough row,
hedged at MEDIUM/low-confidence in the finding for the same line.

#575 addressed this in `PrReviewPrompts.SYSTEM` alone. The floor it added is
prose, and nothing downstream enforced it, so two separate mechanisms could
still undo it:

1. **The verifier's severity cap.** `FindingVerificationService.downgrade`
   applies whatever risk the verifier proposes, in the lowering direction,
   with no floor. The verifier's own rejection grounds name "routing and
   rendering semantics" as remembered framework behavior capped at
   `"medium"` risk with `"low"` confidence — which is precisely how a
   demonstrated `dangerouslySetInnerHTML` sink is described. That produces
   exactly the observed `MEDIUM` + low-confidence pair, and explains why the
   walkthrough (never verified) asserts what the finding (verified) hedges.
2. **The hedging demotion reading the wrong text.** `demoteHedgedBlockingFindings`
   scans the whole title and description for `may|might|could|potentially|possibly`.
   #575's own instruction — "lower the confidence, name in the description the
   exact layer to verify" — puts one of those words into the description of
   every demonstrated-sink finding *by construction*. The guard then read that
   mandated clause as a hedge of the claim and took the finding's confidence
   from `high` to `medium`, which costs it its blocking eligibility
   (`BlockingStrictness.BALANCED` requires `Confidence.HIGH`) and stamps a
   "verify before acting" disclaimer on a defect the diff demonstrates.
   Production logs from the round-3 corpus show it firing on
   `SQL injection in findPendingByChannel via unsanitized channel`.

### What changed

**A deterministic severity floor, applied to the audit's output.** A finding
that names an injection sink *and* states that nothing sanitizes, escapes,
validates, encodes or parameterizes the value reaching it publishes at no less
than `high` risk. It is applied in `verify`, wrapping every path — the model's
own rating, a verifier downgrade, and every fail-open return — and the summary
counts are recomputed when it fires.

Only risk moves, and only upward. Confidence is left exactly where the model or
the verifier put it, which is the separation #570 asks for: severity is a
property of the defect class and its blast radius, while "some layer I was not
shown might neutralize this" is a statement about confidence. **Placement
follows severity**: `Finding.postsInline` keeps a `high` finding on an inline
thread however low its confidence, so the same defect class stops landing in
the collapsed "Things to double-check" block in one framework and on the diff
in another.

The trigger requires both halves stated in the finding's own words, so it does
not fire on a sink mentioned in passing (an escape hatch rendering a literal
template) or on an unrelated finding that happens to say "unvalidated". A
`critical` keeps its level — the floor lifts, never lowers.

Both halves are token matches, though, so a sentence that *rules the sink out*
could satisfy them out of its own negation — "sql injection" matches inside "so
no SQL injection is possible", and the absence group matches "not concatenated
but parameterized", the very mitigation that sentence asserts. Two defeaters,
either of which suppresses the floor anywhere in the text, close that: a
**denied sink** ("no XSS", "not vulnerable to SQL injection") and a
**mitigation the finding says IS present** ("it is escaped on render", "React
escapes them"). Negated forms are excluded from the second, so "is not escaped"
stays an absence claim rather than defeating itself, and the denial gap is one
word so "no protection against SQL injection" still reads as an assertion of
the defect. Under-firing leaves a finding where this class already stood;
over-firing escalates a non-defect and, at high confidence, would block the
merge on it — the defeaters take the safe direction.

**The hedging demotion now reads clause by clause.** A hedge word inside a
clause that names something to verify is the verification request the prompt
mandates next to a demonstrated defect, not a hedge of the defect. A hedge
anywhere else still demotes, so the guard's intent — a claim that hedges itself
cannot request changes on its own — is untouched.

### Note on the collapsed-block routing

Routing was investigated and is **not** itself broken.
`Finding.postsInline()` keys on `Confidence.LOW` only, so `medium` confidence
still posts inline; a `critical`/`high` finding posts inline at any confidence.
The collapsed block therefore requires **both** a below-high risk **and** low
confidence, which is why the severity floor — not a routing change — is the
fix. No renderer file is touched by this PR.

## Related Issues

Fixes #570

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Eight new tests in `FindingVerificationServiceTest`, including the regression
test #570 asks for (the same class in two frameworks must publish the same
severity *and* the same placement).

### Red output on unfixed code

```
[ERROR] Tests run: 41, Failures: 5, Errors: 0, Skipped: 0
[ERROR]   FindingVerificationServiceTest.floorsAnUnsanitizedInjectionSinkFindingTheModelRatedBelowHigh:762 expected: <high> but was: <medium>
[ERROR]   FindingVerificationServiceTest.floorsStringBuiltSqlNamedByItsShapeRatherThanTheWordsSqlInjection:787 expected: <high> but was: <medium>
[ERROR]   FindingVerificationServiceTest.keepsAnInjectionSinkFindingAtHighRiskWhenTheVerifierDowngradesIt:807 expected: <high> but was: <medium>
[ERROR]   FindingVerificationServiceTest.ratesBothHalvesOfThePlantedXssPairTheSameAndKeepsBothInline:823 expected: <high> but was: <medium>
[ERROR]   FindingVerificationServiceTest.keepsBlockingConfidenceWhenTheOnlyHedgeSitsInAVerificationRequest:851 expected: <ReviewResponse[findings=[Finding[risk=high, confidence=high, ... title=SQL injection in findPendingByChannel via unsanitized channel, ...]]]> but was: <ReviewResponse[findings=[Finding[risk=high, confidence=medium, ... title=SQL injection in findPendingByChannel via unsanitized channel, ...]]]>
```

`leavesCriticalInjectionFindingsAndUnrelatedRatingsAlone` passes before and
after — it pins what the floor must *not* do.

### Red output for the two defeaters

Both defeater tests fail on the floor as first written, each raising a finding
that rules the sink out to `high` (note `confidence=high` on the first: it
would have become blocking-eligible):

```
[ERROR] Tests run: 43, Failures: 2, Errors: 0, Skipped: 0
[ERROR]   FindingVerificationServiceTest.doesNotFloorAFindingThatDeniesTheSinkItNames:900
  expected: <...Finding[risk=low, confidence=high, ... description=The user input is not
  concatenated but parameterized, so no SQL injection is possible; ...]...>
  but was: <...Finding[risk=high, confidence=high, ...]... summary=Summary[..., high=1, ...]>
[ERROR]   FindingVerificationServiceTest.doesNotFloorAFindingThatDescribesTheMitigationAsPresent:925
  expected: <...Finding[risk=low, confidence=high, ... description=React escapes them at
  render, so the XSS exposure is limited to the stored value itself.]...>
  but was: <...Finding[risk=high, confidence=high, ...]... summary=Summary[..., high=1, ...]>
```

### Gates

```
./mvnw -B spotless:apply                                    OK
./mvnw -B clean compile spotbugs:check spotless:check       BugInstance size is 0 / BUILD SUCCESS
./mvnw -B clean test                                        Tests run: 2777, Failures: 0, Errors: 0, Skipped: 0
```

Coverage — jacoco ∩ `git diff -U0 fda4bc7...HEAD` on changed main code: 60
instrumented changed lines, **zero uncovered lines and zero uncovered
branches**.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The verifier's own prompt (`FindingVerifierPrompts.SYSTEM`) still lists
"routing and rendering semantics" as a downgrade ground with no carve-out for a
sink whose tainted value is visible in the diff, the way it already carves out
config/IaC, mock-fidelity, heuristic and producer→consumer findings. That file
is outside this change's scope; the deterministic floor makes the outcome
correct regardless of what the verifier proposes, but a matching carve-out
there would stop the verifier spending a downgrade on it in the first place.
