### PR TITLE
fix(review): build a streaming truncation's remedy from its own lane

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponses.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponses.java
@@ -68,6 +68,20 @@ public final class AiResponses {
     String remedy() {
       return remedy;
     }
+
+    /**
+     * The truncation to raise for a call on this lane: {@code detail} states what was cut and this
+     * lane appends the remedy and sets the {@linkplain
+     * AiResponseTruncatedException#conciseModelImplicated() concise flag}. Both come from this one
+     * source so they cannot disagree (#581) — a caller that wrote its own remedy text and then
+     * patched the flag afterwards produced an exception telling the operator to raise a knob that
+     * its own flag says does not cap the call. {@code partialBody} is the text the call had
+     * produced before the cut — {@link Result#content()} on the blocking path, the buffered stream
+     * on the streaming one (#580) — and stays {@code null} only for a caller that holds none.
+     */
+    AiResponseTruncatedException truncation(String detail, String partialBody) {
+      return new AiResponseTruncatedException(detail + " " + remedy, partialBody, this == CONCISE);
+    }
   }
 
   /**
@@ -101,13 +115,11 @@ public final class AiResponses {
       return null;
     }
     if (result.finishReason() == FinishReason.LENGTH) {
-      throw new AiResponseTruncatedException(
+      throw lane.truncation(
           what
               + " stopped at the model's response-length cap (finish_reason=length), so the"
-              + " response is incomplete. "
-              + lane.remedy(),
-          result.content(),
-          lane == ModelLane.CONCISE);
+              + " response is incomplete.",
+          result.content());
     }
     return result.content();
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewService.java
@@ -22,6 +22,7 @@ import dev.langchain4j.service.TokenStream;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
 import dev.thiagogonzaga.thrillhousebot.dashboard.SessionEventBroadcaster;
+import dev.thiagogonzaga.thrillhousebot.review.ai.AiResponses.ModelLane;
 import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusAiServiceTokenStream;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -74,7 +75,7 @@ public class AiReviewService {
 
   /** Single-call review (normal-size PRs): streams tokens to the dashboard as they arrive. */
   public ReviewResponse review(ReviewSession session, PromptInputs inputs) {
-    return runWithRetries(session, () -> reviewStream(inputs), true);
+    return runWithRetries(session, () -> reviewStream(inputs), true, ModelLane.ACTIVE);
   }
 
   /**
@@ -88,7 +89,7 @@ public class AiReviewService {
       ReviewSession session, PromptInputs inputs, int batchIndex, int batchCount) {
     broadcaster.broadcast(
         SessionEventBroadcaster.SessionEvent.batch(session, batchIndex, batchCount));
-    return runWithRetries(session, () -> reviewStream(inputs), false);
+    return runWithRetries(session, () -> reviewStream(inputs), false, ModelLane.ACTIVE);
   }
 
   /**
@@ -96,27 +97,23 @@ public class AiReviewService {
    * PR-level summary object + previous_findings_status. Blocking, no token stream; the returned
    * response carries the summary and previous-findings status (its findings list is empty). Runs on
    * the {@code concise} named model — the response is one fixed-shape object, so it carries the
-   * concise cap rather than the batch review's response allowance.
+   * concise cap rather than the batch review's response allowance. That binding is declared here as
+   * the call's {@link ModelLane} and travels to the truncation site, so a cut summary states {@code
+   * REVIEW_CONCISE_MAX_OUTPUT_TOKENS} from the outset instead of being raised with the active
+   * model's wording and re-marked afterwards (#581).
    */
   public ReviewResponse summarize(ReviewSession session, SummaryInputs inputs) {
-    try {
-      return runWithRetries(
-          session,
-          () ->
-              prSummarizer.summarizeStream(
-                  inputs.prContext(),
-                  inputs.findings(),
-                  inputs.changedFiles(),
-                  inputs.previousFindings(),
-                  inputs.repoInstructions()),
-          false);
-    } catch (AiResponseTruncatedException e) {
-      // This call runs on the concise named model, so the cap that cut it is
-      // REVIEW_CONCISE_MAX_OUTPUT_TOKENS — mark the failure so downstream copy names that knob
-      // instead of only the active model's max-output-tokens. Rethrown outside the retry loop,
-      // which already declined to retry, so the no-retry contract is untouched.
-      throw e.implicatingConciseModel();
-    }
+    return runWithRetries(
+        session,
+        () ->
+            prSummarizer.summarizeStream(
+                inputs.prContext(),
+                inputs.findings(),
+                inputs.changedFiles(),
+                inputs.previousFindings(),
+                inputs.repoInstructions()),
+        false,
+        ModelLane.CONCISE);
   }
 
   private TokenStream reviewStream(PromptInputs inputs) {
@@ -131,7 +128,10 @@ public class AiReviewService {
   }
 
   private ReviewResponse runWithRetries(
-      ReviewSession session, Supplier<TokenStream> streamFactory, boolean broadcastTokens) {
+      ReviewSession session,
+      Supplier<TokenStream> streamFactory,
+      boolean broadcastTokens,
+      ModelLane lane) {
     var maxAttempts = config.review().maxAiRetries();
     RuntimeException lastFailure = null;
 
@@ -150,7 +150,7 @@ public class AiReviewService {
       }
 
       try {
-        return streamOnce(session, streamFactory, attempt, broadcastTokens);
+        return streamOnce(session, streamFactory, attempt, broadcastTokens, lane);
       } catch (AiResponseTruncatedException e) {
         // Deterministic: the next attempt sends the identical prompt against the identical cap and
         // is cut at the identical point. Retrying only bills the same failure again.
@@ -201,7 +201,8 @@ public class AiReviewService {
       ReviewSession session,
       Supplier<TokenStream> streamFactory,
       int attempt,
-      boolean broadcastTokens) {
+      boolean broadcastTokens,
+      ModelLane lane) {
     var result = new CompletableFuture<ReviewResponse>();
     var buffer = new StreamBuffer();
     var chunkCount = new AtomicInteger();
@@ -223,7 +224,8 @@ public class AiReviewService {
           .onPartialResponse(
               token -> handlePartialToken(token, buffer, flushStream, cancelled, lastFlushNanos))
           .onCompleteResponse(
-              response -> handleCompleteResponse(response, result, buffer, flushStream, cancelled))
+              response ->
+                  handleCompleteResponse(response, result, buffer, flushStream, cancelled, lane))
           // langchain4j requires exactly one of onError/ignoreErrors; start() rejects both.
           .onError(error -> handleStreamError(error, result, flushStream, cancelled))
           .start();
@@ -276,7 +278,8 @@ public class AiReviewService {
       CompletableFuture<ReviewResponse> result,
       StreamBuffer buffer,
       Runnable flushStream,
-      AtomicBoolean cancelled) {
+      AtomicBoolean cancelled,
+      ModelLane lane) {
     if (cancelled.get()) {
       return;
     }
@@ -290,15 +293,16 @@ public class AiReviewService {
       if (response.finishReason() == FinishReason.LENGTH) {
         // The buffered partial text travels with the exception: it is well-formed up to the cut,
         // and the disclose step can salvage its complete leading elements (#500) instead of
-        // discarding output that was already paid for.
+        // discarding output that was already paid for. The remedy wording and the concise flag
+        // both come from the call's lane (#581) — this site used to state the active model's knob
+        // unconditionally and let the summary lane re-mark the flag afterwards, which left a
+        // concise-model truncation naming a cap that does not bound it.
         result.completeExceptionally(
-            new AiResponseTruncatedException(
+            lane.truncation(
                 "Model stopped at its response-length cap (finish_reason=length) after "
                     + text.length()
-                    + " characters, so the response is incomplete. Raise the active model's"
-                    + " max-output-tokens, or leave it unset to use the provider default.",
-                text,
-                false));
+                    + " characters, so the response is incomplete.",
+                text));
         return;
       }
       result.complete(parser.parse(text));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewServiceTest.java
@@ -1180,6 +1180,60 @@ class AiReviewServiceTest {
     assertEquals(partial, thrown.partialBody(), "the marked copy must keep the salvage input");
   }
 
+  @Test
+  void aTruncatedSummarysMessageNamesTheSameCapItsConciseFlagDoes() {
+    // #581: the message and the concise flag are two halves of one statement about which cap cut
+    // the call. Built apart — active-model wording at the stream site, the flag patched on after
+    // the throw — they drifted: a summary truncation carried conciseModelImplicated=true next to
+    // a message telling the operator to raise a knob that, per that very flag, does not cap it.
+    var starts = new java.util.concurrent.atomic.AtomicInteger();
+    ReviewSession session = reviewSession();
+    when(prSummarizer.summarizeStream(
+            anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenAnswer(
+            invocation -> new TruncatedTokenStream("{\"summary\":{\"total_findings\":2", starts));
+
+    var inputs = new AiReviewService.SummaryInputs("ctx", "[]", "files", "", "");
+    var thrown =
+        assertThrows(AiResponseTruncatedException.class, () -> service.summarize(session, inputs));
+
+    assertTrue(thrown.conciseModelImplicated(), "the summary call runs on the concise named model");
+    assertTrue(
+        thrown.getMessage().contains("raise REVIEW_CONCISE_MAX_OUTPUT_TOKENS"),
+        "the message must name the cap its own flag points at: " + thrown.getMessage());
+    assertFalse(
+        thrown.getMessage().contains("Raise the active model's max-output-tokens"),
+        "the active model's cap does not bound the concise binding: " + thrown.getMessage());
+  }
+
+  @Test
+  void aTruncatedReviewKeepsTheActiveModelsRemedy() {
+    // The other half of the same guarantee: the review lane is bound to the active model, so its
+    // truncation must keep naming max-output-tokens — the lane decides the wording, not a default.
+    var starts = new java.util.concurrent.atomic.AtomicInteger();
+    ReviewSession session = reviewSession();
+    when(prReviewer.reviewStream(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString()))
+        .thenAnswer(invocation -> new TruncatedTokenStream("{\"findings\":[", starts));
+
+    var thrown =
+        assertThrows(
+            AiResponseTruncatedException.class, () -> service.review(session, PROMPT_INPUTS));
+
+    assertFalse(thrown.conciseModelImplicated());
+    assertTrue(
+        thrown.getMessage().contains("Raise the active model's max-output-tokens"),
+        thrown.getMessage());
+    assertFalse(
+        thrown.getMessage().contains("REVIEW_CONCISE_MAX_OUTPUT_TOKENS"), thrown.getMessage());
+  }
+
   private static ReviewSession reviewSession() {
     var session = new ReviewSession();
     session.id = 42L;


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`AiReviewService`'s streaming completion handler built its truncation with the **active** model's remedy and `conciseModelImplicated = false`, and `summarize()` — whose call runs on the `concise` named model — re-marked the flag after the throw:

```java
throw e.implicatingConciseModel();   // "same message, same partial body"
```

So a cut summary carried `conciseModelImplicated = true` alongside a message telling the operator to raise `max-output-tokens`, the very knob that flag exists to say does **not** cap this call. On that lane the two never agreed — the red output below is the exception stating both at once.

#542 gave the blocking path one source for both: `AiResponses.ModelLane` carries the remedy text *and* decides the flag. The streaming path now uses the same source:

- each entry point declares the binding its call runs on — `review` and `reviewBatch` → `ACTIVE`, `summarize` → `CONCISE`;
- the lane travels through `runWithRetries` → `streamOnce` → the completion handler, which asks it for the truncation (`lane.truncation(detail, partialBody)`) instead of writing remedy text of its own;
- `ModelLane#truncation` appends the remedy and sets the flag together, so no caller can supply one without the other. `textOrThrowOnTruncation` goes through it too, which is why the blocking lanes' message text is byte-for-byte what it was.

`summarize()`'s after-the-fact re-marking is deleted. Nothing patches the flag any more, so nothing can patch it out of step with the words — which is the actual fix; the wrong remedy string was only the symptom.

**Behaviour that does not change:** #495's no-retry contract (the truncation is still raised at the same point and still refused a retry), the buffered `partialBody` that #500's salvage runs on, `conciseModelImplicated` as seen by every consumer that branches on it (`ReviewOrchestrator#truncationCheckSummary`, `ReviewPublisher`), and every blocking lane's message.

## Related Issues

Fixes #581

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Red first, on unfixed main code (`AiResponses.java` and `AiReviewService.java` reverted to their `fda4bc7` state). The failure message is the defect itself — the flag assertion above it passes, then the message contradicts it:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewServiceTest.aTruncatedSummarysMessageNamesTheSameCapItsConciseFlagDoes -- Time elapsed: 0.012 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the message must name the cap its own flag points at: Model stopped at its response-length cap (finish_reason=length) after 30 characters, so the response is incomplete. Raise the active model's max-output-tokens, or leave it unset to use the provider default. ==> expected: <true> but was: <false>
	at dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewServiceTest.aTruncatedSummarysMessageNamesTheSameCapItsConciseFlagDoes(AiReviewServiceTest.java:1201)
```

The sibling test `aTruncatedReviewKeepsTheActiveModelsRemedy` passes before and after by design: it pins the half that was already right, so the fix cannot be "make everything say concise".

Green with the fix, and the gates re-run after the rebase onto `1a2f22b`:

| gate | result |
|---|---|
| `./mvnw -B spotless:apply` then `./mvnw -B clean compile spotbugs:check spotless:check` | `BugInstance size is 0` — BUILD SUCCESS |
| `./mvnw -B clean test` | `Tests run: 2795, Failures: 0, Errors: 0, Skipped: 0` — BUILD SUCCESS |
| jacoco ∩ `git diff -U0 1a2f22b...HEAD` | **0 uncovered lines, 0 uncovered branches** (15 trackable changed main lines; both `ModelLane` arms exercised) |

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

`AiResponseTruncatedException#implicatingConciseModel()` is left in place: with `summarize()` no longer calling it, it has no production caller and cannot produce a contradiction, but removing it (or making it rewrite the remedy, the issue's other option) means editing `AiResponseTruncatedException.java` and the two tests that still build a concise truncation through it — outside this change's file scope, so it is flagged rather than done here.

Rebased onto `1a2f22b` after #592 merged. The predicted conflict was the one `throw` in `textOrThrowOnTruncation` and nothing else, resolved as this body said it should be — the lane-built truncation **and** `result.content()` as the partial body:

```java
throw lane.truncation(
    what + " stopped at the model's response-length cap (finish_reason=length), so the response is incomplete.",
    result.content());
```

Verified by mutation rather than by reading the diff, since a resolution that silently drops the #580 side would still compile and still pass everything that predates #592. Putting `null` back in the resolved code turns #592's own tests red:

```
[ERROR] AiResponsesTest.carriesTheCutBodyOnTheFailureSoTheLaneCanSalvageIt <<< FAILURE!
org.opentest4j.AssertionFailedError: the paid, cut body must travel with the failure ==> expected: <{"verdicts":[{"id":1,"verdict":"valid"},{"id":2,"verd> but was: <null>
[ERROR] AiResponsesTest.theCarriedBodyIsWhatTheSalvagerRecoversTheCompletedElementsFrom <<< FAILURE!
org.opentest4j.AssertionFailedError: the verdict that closed before the cut is recoverable ==> expected: <1> but was: <0>
```

`ModelLane#truncation`'s javadoc picked up the merged reality in the same resolution: the partial body is now the cut text on *both* paths — `Result#content()` blocking, the buffered stream streaming — rather than "null when the lane does not buffer one".
