### PR TITLE
fix(review): publish one observation on one surface of the summary comment

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -143,8 +143,15 @@ public class PrSummaryGenerator {
     var sb = new StringBuilder();
     sb.append(SUMMARY_HEADING).append("\n\n");
 
+    // One observation must be published once. The findings are the most specific surface, so a
+    // description-gap bullet — or a walkthrough clause appended after the row's file summary —
+    // that only restates one of them is collapsed away before anything is rendered (#588).
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            descriptionGaps(aiSummary), summariesByPath(aiSummary), result.findings());
+
     appendPrPurpose(sb, aiSummary);
-    appendDescriptionGaps(sb, aiSummary);
+    appendDescriptionGaps(sb, surfaces.descriptionGaps());
     appendWalkthroughDiagram(sb, aiSummary);
 
     sb.append("### Changes Overview\n");
@@ -152,7 +159,7 @@ public class PrSummaryGenerator {
     sb.append("- **Lines added:** ").append(signed('+', additions)).append("\n");
     sb.append("- **Lines removed:** ").append(signed('-', deletions)).append("\n\n");
 
-    appendChangedFiles(sb, filesChanged, changedFiles, aiSummary);
+    appendChangedFiles(sb, filesChanged, changedFiles, surfaces.fileSummaries());
 
     sb.append("### Risk Assessment\n");
     sb.append("| Risk | Count |\n");
@@ -384,12 +391,16 @@ public class PrSummaryGenerator {
     sb.append(aiSummary.prPurpose().strip()).append("\n\n");
   }
 
-  private static void appendDescriptionGaps(StringBuilder sb, ReviewResponse.Summary aiSummary) {
+  /** The model's non-blank description gaps; empty when there is no summary to read them from. */
+  private static List<String> descriptionGaps(ReviewResponse.Summary aiSummary) {
     if (aiSummary == null) {
-      return;
+      return List.of();
     }
     // List.copyOf in the Summary constructor guarantees no null elements
-    List<String> gaps = aiSummary.descriptionGaps().stream().filter(g -> !g.isBlank()).toList();
+    return aiSummary.descriptionGaps().stream().filter(g -> !g.isBlank()).toList();
+  }
+
+  private static void appendDescriptionGaps(StringBuilder sb, List<String> gaps) {
     if (gaps.isEmpty()) {
       return;
     }
@@ -416,12 +427,10 @@ public class PrSummaryGenerator {
       StringBuilder sb,
       int totalFilesChanged,
       List<ChangedFile> changedFiles,
-      ReviewResponse.Summary aiSummary) {
+      Map<String, String> summaryByPath) {
     if (changedFiles == null || changedFiles.isEmpty()) {
       return;
     }
-    Map<String, String> summaryByPath = summariesByPath(aiSummary);
-
     sb.append("### Changed Files\n");
     sb.append("| File | Change | Summary |\n");
     sb.append("|------|--------|---------|\n");

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
@@ -243,10 +243,17 @@ final class SummarySurfaceDeduplicator {
   }
 
   /**
-   * Strips trailing inflection letters down to a shared stem. Deliberately cruder than a real
-   * stemmer: it only has to make the plural, past and third-person forms of one word collide
-   * ("failure"/"failures", "hardcoded"/"hardcodes", "return"/"returned"/"returns"), and a stem
-   * shorter than four characters is left alone so short words are not flattened together.
+   * Strips trailing {@code s}, {@code e} and {@code d} until a three-character floor stops the
+   * erosion, so a word of three characters or fewer is never touched. Deliberately cruder than a
+   * real stemmer: it collides the {@code -s}, {@code -es} and {@code -ed} forms of one word along
+   * with the silent {@code -e} they leave behind — "failure"/"failures", "hardcoded"/"hardcodes",
+   * "return"/"returned"/"returns".
+   *
+   * <p>Inflections that rewrite the stem itself are not caught. The y→i of "verify"/"verifies"
+   * strips to "verify" and "verifi", which read as two unrelated words, and the same goes for
+   * "modifies", "identifies" and "applies". That costs a collapse those texts might otherwise have
+   * earned, which is the direction this class prefers: a surviving duplicate is the behaviour being
+   * improved on, while a wider stem would merge more words and risk deleting a claim.
    */
   private static String stem(String word) {
     int end = word.length();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Collapses one observation published on several surfaces of the same summary comment down to its
+ * most specific surface. A model routinely raises the same claim as an inline finding, again as a
+ * "Description vs. Implementation" bullet, and again inside a Changed Files walkthrough row; a
+ * reader infers severity from that repetition, so a low-value note ends up outranking the severest
+ * finding in the same comment.
+ *
+ * <p>Precedence is inline finding &gt; description-gap bullet &gt; walkthrough row, so:
+ *
+ * <ul>
+ *   <li>a description gap that restates a finding (or an earlier gap) is dropped;
+ *   <li>a walkthrough row keeps its <em>first</em> clause always — a row summarising a file that
+ *       also carries an inline finding is normal and useful — and drops only the clauses appended
+ *       after it that restate an already-published claim.
+ * </ul>
+ *
+ * <p>Two texts state the same claim when they share a contiguous run of {@value #PHRASE_TOKENS}
+ * content words, or when their content words overlap by {@value #OVERLAP_THRESHOLD} of the shorter
+ * side. The overlap arm needs {@value #MIN_OVERLAP_TOKENS} content words on the shorter side: below
+ * that the coefficient is noise, and keeping both copies is the safe direction.
+ */
+final class SummarySurfaceDeduplicator {
+
+  private SummarySurfaceDeduplicator() {}
+
+  /** Fraction of the shorter side's content words that must be shared to call it a restatement. */
+  static final double OVERLAP_THRESHOLD = 0.5;
+
+  /** Content words the shorter side needs before the overlap coefficient means anything. */
+  static final int MIN_OVERLAP_TOKENS = 5;
+
+  /** Length of the contiguous content-word run that on its own proves a shared claim. */
+  static final int PHRASE_TOKENS = 3;
+
+  /**
+   * Function words carrying no claim content. Dropping them keeps "the PR says X" from looking like
+   * "the docs say Y", and keeps the phrase runs aligned across two paraphrases of one claim.
+   */
+  private static final Set<String> STOPWORDS =
+      Set.of(
+          "all", "also", "an", "and", "any", "are", "as", "at", "be", "been", "but", "by", "can",
+          "do", "does", "each", "for", "from", "has", "have", "if", "in", "into", "is", "it", "its",
+          "just", "more", "no", "not", "of", "on", "only", "or", "other", "per", "so", "still",
+          "than", "that", "the", "their", "them", "then", "there", "these", "this", "to", "was",
+          "were", "when", "which", "while", "with", "would");
+
+  /** The description-gap bullets and per-path walkthrough notes left after collapsing. */
+  record Surfaces(List<String> descriptionGaps, Map<String, String> fileSummaries) {}
+
+  /**
+   * Collapses {@code descriptionGaps} and {@code fileSummaries} against the findings already
+   * published as their own items, and against each other in precedence order.
+   */
+  static Surfaces collapse(
+      List<String> descriptionGaps, Map<String, String> fileSummaries, List<Finding> findings) {
+    var claims = new ArrayList<List<String>>(findings.size() + descriptionGaps.size());
+    for (Finding finding : findings) {
+      claims.add(contentTokens(finding.title()));
+    }
+    var keptGaps = new ArrayList<String>(descriptionGaps.size());
+    for (String gap : descriptionGaps) {
+      var tokens = contentTokens(gap);
+      if (!restates(tokens, claims)) {
+        keptGaps.add(gap);
+        claims.add(tokens);
+      }
+    }
+    var trimmed = new HashMap<String, String>(fileSummaries.size());
+    for (var entry : fileSummaries.entrySet()) {
+      trimmed.put(entry.getKey(), trimRestatedClauses(entry.getValue(), claims));
+    }
+    return new Surfaces(keptGaps, trimmed);
+  }
+
+  /**
+   * The walkthrough note with every restating clause after the first removed. The first clause is
+   * the row's file summary and is never touched, so a row always keeps a real description of the
+   * file even when everything appended to it was already published elsewhere.
+   */
+  static String trimRestatedClauses(String summary, List<List<String>> claims) {
+    int firstBreak = summary.indexOf(';');
+    if (firstBreak < 0) {
+      return summary;
+    }
+    var kept = new StringBuilder(summary.substring(0, firstBreak).strip());
+    var dropped = false;
+    for (String clause : clauses(summary.substring(firstBreak + 1))) {
+      if (restates(contentTokens(clause), claims)) {
+        dropped = true;
+      } else {
+        kept.append("; ").append(clause);
+      }
+    }
+    return dropped ? kept.toString() : summary;
+  }
+
+  private static List<String> clauses(String tail) {
+    return Arrays.stream(tail.split(";")).map(String::strip).filter(c -> !c.isEmpty()).toList();
+  }
+
+  /**
+   * True when {@code candidate} states a claim one of {@code claims} already states. The
+   * candidate's phrase and word sets are derived once and reused across every claim.
+   */
+  private static boolean restates(List<String> candidate, List<List<String>> claims) {
+    Set<String> candidatePhrases = phrases(candidate);
+    Set<String> candidateWords = new HashSet<>(candidate);
+    for (List<String> claim : claims) {
+      if (sharesPhrase(candidatePhrases, claim) || overlaps(candidateWords, claim)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** True when the claim contains one of the candidate's {@value #PHRASE_TOKENS}-word runs. */
+  private static boolean sharesPhrase(Set<String> candidatePhrases, List<String> claim) {
+    return phrases(claim).stream().anyMatch(candidatePhrases::contains);
+  }
+
+  private static Set<String> phrases(List<String> tokens) {
+    var phrases = new HashSet<String>();
+    for (int i = 0; i + PHRASE_TOKENS <= tokens.size(); i++) {
+      phrases.add(String.join(" ", tokens.subList(i, i + PHRASE_TOKENS)));
+    }
+    return phrases;
+  }
+
+  /** Overlap coefficient — shared content words over the shorter side — against the threshold. */
+  private static boolean overlaps(Set<String> candidateWords, List<String> claim) {
+    var claimWords = new HashSet<>(claim);
+    int shorter = Math.min(candidateWords.size(), claimWords.size());
+    if (shorter < MIN_OVERLAP_TOKENS) {
+      return false;
+    }
+    claimWords.retainAll(candidateWords);
+    return (double) claimWords.size() / shorter >= OVERLAP_THRESHOLD;
+  }
+
+  /**
+   * The claim-bearing words of {@code text}, in order: lowercased alphanumeric runs minus stop
+   * words, numbers and single characters (line numbers and list markers match everything), each
+   * reduced to a crude stem so "hardcodes" and "hardcoded" are one word.
+   */
+  static List<String> contentTokens(String text) {
+    if (text == null) {
+      return List.of();
+    }
+    var tokens = new ArrayList<String>();
+    for (String word : text.toLowerCase(Locale.ROOT).split("[^a-z0-9]+")) {
+      if (word.length() > 1 && !STOPWORDS.contains(word) && !Character.isDigit(word.charAt(0))) {
+        tokens.add(stem(word));
+      }
+    }
+    return tokens;
+  }
+
+  /**
+   * Strips trailing inflection letters down to a shared stem. Deliberately cruder than a real
+   * stemmer: it only has to make the plural, past and third-person forms of one word collide
+   * ("failure"/"failures", "hardcoded"/"hardcodes", "return"/"returned"/"returns"), and a stem
+   * shorter than four characters is left alone so short words are not flattened together.
+   */
+  private static String stem(String word) {
+    int end = word.length();
+    while (end > 3 && "sed".indexOf(word.charAt(end - 1)) >= 0) {
+      end--;
+    }
+    return word.substring(0, end);
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Collapses one observation published on several surfaces of the same summary comment down to its
@@ -42,9 +43,12 @@ import java.util.Set;
  *
  * <p>Two texts state the same claim when they share a contiguous run of {@value #PHRASE_TOKENS}
  * content words, or when their content words overlap by {@value #OVERLAP_THRESHOLD} of the shorter
- * side — and only when they agree on polarity. The overlap arm needs {@value #MIN_OVERLAP_TOKENS}
- * content words on the shorter side: below that the coefficient is noise, and keeping both copies
- * is the safe direction.
+ * side. Polarity does not gate that test in general: it holds a pair back only when the two say the
+ * same things with opposite polarity — one negates and neither names anything the other leaves out
+ * — because such a pair scores as a perfect match while asserting opposite things. Two texts that
+ * disagree on polarity and also differ in substance are still judged on their content. The overlap
+ * arm needs {@value #MIN_OVERLAP_TOKENS} content words on the shorter side: below that the
+ * coefficient is noise, and keeping both copies is the safe direction.
  */
 final class SummarySurfaceDeduplicator {
 
@@ -66,10 +70,10 @@ final class SummarySurfaceDeduplicator {
   private static final Set<String> STOPWORDS =
       Set.of(
           "all", "also", "an", "and", "any", "are", "as", "at", "be", "been", "but", "by", "can",
-          "do", "does", "each", "for", "from", "has", "have", "if", "in", "into", "is", "it", "its",
-          "just", "more", "of", "on", "only", "or", "other", "per", "so", "still", "than", "that",
-          "the", "their", "them", "then", "there", "these", "this", "to", "was", "were", "when",
-          "which", "while", "with", "would");
+          "could", "did", "do", "does", "each", "for", "from", "has", "have", "if", "in", "into",
+          "is", "it", "its", "just", "more", "of", "on", "only", "or", "other", "per", "should",
+          "so", "still", "than", "that", "the", "their", "them", "then", "there", "these", "this",
+          "to", "was", "were", "when", "which", "while", "with", "would");
 
   /**
    * Syntactic negators. A negator flips what a sentence asserts while contributing a single token,
@@ -79,6 +83,17 @@ final class SummarySurfaceDeduplicator {
    */
   private static final Set<String> NEGATIONS =
       Set.of("cannot", "neither", "never", "no", "non", "none", "nor", "not", "nothing", "without");
+
+  /**
+   * A negation contracted onto its auxiliary, with the irregular stems of "can't", "won't",
+   * "shan't" and "ain't" folded in. Content words are split on non-alphanumeric runs, which would
+   * tear "isn't" into "isn" and "t" — neither a negator — leaving a negated sentence reading as
+   * affirmative and its opposite deletable as a duplicate. Rewriting the contraction to a bare
+   * "not" before the split restores the polarity, and swallowing the irregular stems keeps "wo" and
+   * "ca" from becoming content words of their own.
+   */
+  private static final Pattern CONTRACTED_NEGATION =
+      Pattern.compile("(?:ca|wo|sha|ai)?n['\u2019]t\\b");
 
   /** One text reduced to what it asserts: its content words in order, and whether it negates. */
   record Claim(List<String> words, boolean negated) {}
@@ -209,7 +224,8 @@ final class SummarySurfaceDeduplicator {
     }
     var words = new ArrayList<String>();
     var negated = false;
-    for (String word : text.toLowerCase(Locale.ROOT).split("[^a-z0-9]+")) {
+    var expanded = CONTRACTED_NEGATION.matcher(text.toLowerCase(Locale.ROOT)).replaceAll(" not ");
+    for (String word : expanded.split("[^a-z0-9]+")) {
       if (NEGATIONS.contains(word)) {
         negated = true;
       } else if (word.length() > 1

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
@@ -42,8 +42,9 @@ import java.util.Set;
  *
  * <p>Two texts state the same claim when they share a contiguous run of {@value #PHRASE_TOKENS}
  * content words, or when their content words overlap by {@value #OVERLAP_THRESHOLD} of the shorter
- * side. The overlap arm needs {@value #MIN_OVERLAP_TOKENS} content words on the shorter side: below
- * that the coefficient is noise, and keeping both copies is the safe direction.
+ * side — and only when they agree on polarity. The overlap arm needs {@value #MIN_OVERLAP_TOKENS}
+ * content words on the shorter side: below that the coefficient is noise, and keeping both copies
+ * is the safe direction.
  */
 final class SummarySurfaceDeduplicator {
 
@@ -66,9 +67,21 @@ final class SummarySurfaceDeduplicator {
       Set.of(
           "all", "also", "an", "and", "any", "are", "as", "at", "be", "been", "but", "by", "can",
           "do", "does", "each", "for", "from", "has", "have", "if", "in", "into", "is", "it", "its",
-          "just", "more", "no", "not", "of", "on", "only", "or", "other", "per", "so", "still",
-          "than", "that", "the", "their", "them", "then", "there", "these", "this", "to", "was",
-          "were", "when", "which", "while", "with", "would");
+          "just", "more", "of", "on", "only", "or", "other", "per", "so", "still", "than", "that",
+          "the", "their", "them", "then", "there", "these", "this", "to", "was", "were", "when",
+          "which", "while", "with", "would");
+
+  /**
+   * Syntactic negators. A negator flips what a sentence asserts while contributing a single token,
+   * so no similarity score can separate "the value is sanitized" from "the value is not sanitized"
+   * — several of these read as function words and would otherwise be dropped, leaving the two
+   * tokenized identically. They are kept out of the content words and tracked as polarity instead.
+   */
+  private static final Set<String> NEGATIONS =
+      Set.of("cannot", "neither", "never", "no", "non", "none", "nor", "not", "nothing", "without");
+
+  /** One text reduced to what it asserts: its content words in order, and whether it negates. */
+  record Claim(List<String> words, boolean negated) {}
 
   /** The description-gap bullets and per-path walkthrough notes left after collapsing. */
   record Surfaces(List<String> descriptionGaps, Map<String, String> fileSummaries) {}
@@ -79,16 +92,16 @@ final class SummarySurfaceDeduplicator {
    */
   static Surfaces collapse(
       List<String> descriptionGaps, Map<String, String> fileSummaries, List<Finding> findings) {
-    var claims = new ArrayList<List<String>>(findings.size() + descriptionGaps.size());
+    var claims = new ArrayList<Claim>(findings.size() + descriptionGaps.size());
     for (Finding finding : findings) {
-      claims.add(contentTokens(finding.title()));
+      claims.add(claim(finding.title()));
     }
     var keptGaps = new ArrayList<String>(descriptionGaps.size());
     for (String gap : descriptionGaps) {
-      var tokens = contentTokens(gap);
-      if (!restates(tokens, claims)) {
+      var candidate = claim(gap);
+      if (!restates(candidate, claims)) {
         keptGaps.add(gap);
-        claims.add(tokens);
+        claims.add(candidate);
       }
     }
     var trimmed = new HashMap<String, String>(fileSummaries.size());
@@ -103,7 +116,7 @@ final class SummarySurfaceDeduplicator {
    * the row's file summary and is never touched, so a row always keeps a real description of the
    * file even when everything appended to it was already published elsewhere.
    */
-  static String trimRestatedClauses(String summary, List<List<String>> claims) {
+  static String trimRestatedClauses(String summary, List<Claim> claims) {
     int firstBreak = summary.indexOf(';');
     if (firstBreak < 0) {
       return summary;
@@ -111,7 +124,7 @@ final class SummarySurfaceDeduplicator {
     var kept = new StringBuilder(summary.substring(0, firstBreak).strip());
     var dropped = false;
     for (String clause : clauses(summary.substring(firstBreak + 1))) {
-      if (restates(contentTokens(clause), claims)) {
+      if (restates(claim(clause), claims)) {
         dropped = true;
       } else {
         kept.append("; ").append(clause);
@@ -128,15 +141,36 @@ final class SummarySurfaceDeduplicator {
    * True when {@code candidate} states a claim one of {@code claims} already states. The
    * candidate's phrase and word sets are derived once and reused across every claim.
    */
-  private static boolean restates(List<String> candidate, List<List<String>> claims) {
-    Set<String> candidatePhrases = phrases(candidate);
-    Set<String> candidateWords = new HashSet<>(candidate);
-    for (List<String> claim : claims) {
-      if (sharesPhrase(candidatePhrases, claim) || overlaps(candidateWords, claim)) {
+  private static boolean restates(Claim candidate, List<Claim> claims) {
+    Set<String> candidatePhrases = phrases(candidate.words());
+    Set<String> candidateWords = new HashSet<>(candidate.words());
+    for (Claim claim : claims) {
+      if (contradicts(candidate, candidateWords, claim)) {
+        continue;
+      }
+      if (sharesPhrase(candidatePhrases, claim.words())
+          || overlaps(candidateWords, claim.words())) {
         return true;
       }
     }
     return false;
+  }
+
+  /**
+   * True when the two make the same statement with opposite polarity: one negates and the other
+   * does not, and neither names anything the other leaves out. Such a pair scores as a perfect
+   * match on every similarity arm — the negator is not a content word, so it cannot move the score
+   * — while asserting the opposite of each other, which is a contradiction to surface, never a
+   * duplicate to delete. Polarity is only decisive here: two texts that also differ in substance
+   * are still judged on their content, so "the PR claims X, but the code cannot X" continues to
+   * collapse onto the finding that reports X missing.
+   */
+  private static boolean contradicts(Claim candidate, Set<String> candidateWords, Claim claim) {
+    if (candidate.negated() == claim.negated()) {
+      return false;
+    }
+    var claimWords = new HashSet<>(claim.words());
+    return candidateWords.containsAll(claimWords) || claimWords.containsAll(candidateWords);
   }
 
   /** True when the claim contains one of the candidate's {@value #PHRASE_TOKENS}-word runs. */
@@ -164,21 +198,27 @@ final class SummarySurfaceDeduplicator {
   }
 
   /**
-   * The claim-bearing words of {@code text}, in order: lowercased alphanumeric runs minus stop
-   * words, numbers and single characters (line numbers and list markers match everything), each
-   * reduced to a crude stem so "hardcodes" and "hardcoded" are one word.
+   * What {@code text} asserts. The content words are its lowercased alphanumeric runs minus stop
+   * words, negators, numbers and single characters (line numbers and list markers match
+   * everything), each reduced to a crude stem so "hardcodes" and "hardcoded" are one word; the
+   * negators it dropped set the polarity instead of vanishing.
    */
-  static List<String> contentTokens(String text) {
+  static Claim claim(String text) {
     if (text == null) {
-      return List.of();
+      return new Claim(List.of(), false);
     }
-    var tokens = new ArrayList<String>();
+    var words = new ArrayList<String>();
+    var negated = false;
     for (String word : text.toLowerCase(Locale.ROOT).split("[^a-z0-9]+")) {
-      if (word.length() > 1 && !STOPWORDS.contains(word) && !Character.isDigit(word.charAt(0))) {
-        tokens.add(stem(word));
+      if (NEGATIONS.contains(word)) {
+        negated = true;
+      } else if (word.length() > 1
+          && !STOPWORDS.contains(word)
+          && !Character.isDigit(word.charAt(0))) {
+        words.add(stem(word));
       }
     }
-    return tokens;
+    return new Claim(words, negated);
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
@@ -44,11 +44,12 @@ import java.util.regex.Pattern;
  * <p>Two texts state the same claim when they share a contiguous run of {@value #PHRASE_TOKENS}
  * content words, or when their content words overlap by {@value #OVERLAP_THRESHOLD} of the shorter
  * side. Polarity does not gate that test in general: it holds a pair back only when the two say the
- * same things with opposite polarity — one negates and neither names anything the other leaves out
- * — because such a pair scores as a perfect match while asserting opposite things. Two texts that
- * disagree on polarity and also differ in substance are still judged on their content. The overlap
- * arm needs {@value #MIN_OVERLAP_TOKENS} content words on the shorter side: below that the
- * coefficient is noise, and keeping both copies is the safe direction.
+ * same things with opposite polarity — one negates, and every content word of one side is present
+ * in the other, containment in either direction — because such a pair scores as a perfect match
+ * while asserting opposite things. Two texts that disagree on polarity but each name something the
+ * other leaves out are still judged on their content. The overlap arm needs {@value
+ * #MIN_OVERLAP_TOKENS} content words on the shorter side: below that the coefficient is noise, and
+ * keeping both copies is the safe direction.
  */
 final class SummarySurfaceDeduplicator {
 
@@ -173,12 +174,16 @@ final class SummarySurfaceDeduplicator {
 
   /**
    * True when the two make the same statement with opposite polarity: one negates and the other
-   * does not, and neither names anything the other leaves out. Such a pair scores as a perfect
-   * match on every similarity arm — the negator is not a content word, so it cannot move the score
-   * — while asserting the opposite of each other, which is a contradiction to surface, never a
-   * duplicate to delete. Polarity is only decisive here: two texts that also differ in substance
-   * are still judged on their content, so "the PR claims X, but the code cannot X" continues to
-   * collapse onto the finding that reports X missing.
+   * does not, and every content word of one side is present in the other. Containment in either
+   * direction counts, so a short negated claim lying wholly inside a longer affirmative one — "user
+   * input is not sanitized" against "user input is sanitized before it reaches the SQL query" — is
+   * caught as well; requiring the two word sets to match exactly would let that pair through and
+   * delete the shorter copy. Such a pair scores as a perfect match on every similarity arm — the
+   * negator is not a content word, so it cannot move the score — while asserting the opposite of
+   * each other, which is a contradiction to surface, never a duplicate to delete. Polarity is only
+   * decisive here: two texts that each name something the other leaves out are still judged on
+   * their content, so "the PR claims X, but the code cannot X" continues to collapse onto the
+   * finding that reports X missing.
    */
   private static boolean contradicts(Claim candidate, Set<String> candidateWords, Claim claim) {
     if (candidate.negated() == claim.negated()) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -1184,4 +1184,251 @@ class PrSummaryGeneratorTest {
     }
     return count;
   }
+
+  // ---------------------------------------------------------------------------------------------
+  // #588 — one observation, one surface. The corpus below is the verbatim text ThrillhouseBot
+  // published on devops-thiago/ThrillhouseBot-test #23 (Java) and #22 (C), where the same claim was
+  // asserted as an inline finding, again as a description-gap bullet, and again as its own clause
+  // in a Changed Files walkthrough row.
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void restatedDescriptionGapAndWalkthroughClauseCollapseToTheInlineFinding() {
+    var findings =
+        List.of(
+            new Finding(
+                RiskLevel.HIGH,
+                "src/main/java/com/thrillhouse/scheduler/Main.java",
+                22,
+                "Main passes a hardcoded empty task list, so nothing is ever dispatched",
+                "desc",
+                null,
+                null));
+    var aiSummary =
+        new ReviewResponse.Summary(
+            1,
+            0,
+            1,
+            0,
+            0,
+            "ok",
+            null,
+            List.of(
+                "The runnable entry point passes a hardcoded empty task list to `dispatchDueTasks`,"
+                    + " so the shipped service cannot actually dispatch any task.",
+                "PR says TaskRunRepository persists run history, but the added class only contains"
+                    + " searchRunsByTaskName; no insert/update/upsert write path is present in the"
+                    + " diff."),
+            List.of(),
+            List.of(
+                new ReviewResponse.FileSummary(
+                    "src/main/java/com/thrillhouse/scheduler/Main.java",
+                    "Added one-shot entry point; hardcodes an empty task list and reads only"
+                        + " registry URL env var")),
+            null);
+    var result =
+        new ReviewResult(
+            findings,
+            0,
+            1,
+            0,
+            0,
+            RiskLevel.HIGH,
+            ReviewState.REQUEST_CHANGES,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
+
+    var summary =
+        generator.generate(
+            1,
+            30,
+            0,
+            List.of(
+                new PrSummaryGenerator.ChangedFile(
+                    "src/main/java/com/thrillhouse/scheduler/Main.java", "added")),
+            aiSummary,
+            result);
+
+    // The claim keeps its most specific surface: the inline finding.
+    assertTrue(
+        summary.contains(
+            "**HIGH:** Main passes a hardcoded empty task list, so nothing is ever dispatched"),
+        summary);
+    // ...and is gone from the other two.
+    assertFalse(summary.contains("the shipped service cannot actually dispatch any task"), summary);
+    assertFalse(summary.contains("hardcodes an empty task list"), summary);
+    // The walkthrough row survives, still summarising the file (the deliberate nuance in #588).
+    assertTrue(
+        summary.contains(
+            "| `src/main/java/com/thrillhouse/scheduler/Main.java` | Added | Added one-shot entry"
+                + " point |"),
+        summary);
+    // A gap that states something no finding states is untouched.
+    assertTrue(summary.contains("no insert/update/upsert write path"), summary);
+    assertTrue(summary.contains("### ⚠️ Description vs. Implementation"), summary);
+  }
+
+  @Test
+  void restatedGapCollapsesEvenWhenTheFindingIsNotAKeyFinding() {
+    // ThrillhouseBot-test #22: the dead-config claim was 8th by severity, so it never reached the
+    // Key Findings list — the dedupe still has to see it as published.
+    var findings = new java.util.ArrayList<Finding>();
+    for (int i = 0; i < 5; i++) {
+      findings.add(
+          new Finding(
+              RiskLevel.CRITICAL, "src/other" + i + ".c", i, "Unrelated " + i, "d", null, null));
+    }
+    findings.add(
+        new Finding(
+            RiskLevel.MEDIUM,
+            "src/main.c",
+            45,
+            "LOGD_BAN_REFRESH_INTERVAL is dead config; banlist is never refreshed",
+            "desc",
+            null,
+            null));
+    var aiSummary =
+        new ReviewResponse.Summary(
+            6,
+            5,
+            0,
+            1,
+            0,
+            "ok",
+            null,
+            List.of(
+                "Periodic banned-IP refresh claimed in the PR is not implemented: banlist_fetch is"
+                    + " called only once at startup (src/main.c:45) and LOGD_BAN_REFRESH_INTERVAL"
+                    + " is read into cfg.ban_refresh_interval (src/config.c:46) but never used.",
+                "Duplicate skipping is claimed to last 'within a connection's lifetime', but dedup"
+                    + " state is process-global in rotator.c (already_seen/remember), so identical"
+                    + " messages from different clients/connections are also dropped."),
+            List.of(),
+            List.of(),
+            null);
+    var result =
+        new ReviewResult(
+            findings,
+            5,
+            0,
+            1,
+            0,
+            RiskLevel.CRITICAL,
+            ReviewState.REQUEST_CHANGES,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
+
+    var summary = generator.generate(2, 60, 0, List.of(), aiSummary, result);
+
+    assertFalse(summary.contains("Periodic banned-IP refresh claimed in the PR"), summary);
+    assertTrue(summary.contains("dedup state is process-global in rotator.c"), summary);
+  }
+
+  @Test
+  void descriptionGapsSectionDisappearsWhenEveryBulletRestatesAFinding() {
+    var findings =
+        List.of(
+            new Finding(
+                RiskLevel.HIGH,
+                "src/rotator.c",
+                45,
+                "LOGD_MAX_FILE_SIZE never enforced; no rotation despite docs",
+                "desc",
+                null,
+                null));
+    var aiSummary =
+        new ReviewResponse.Summary(
+            1,
+            0,
+            1,
+            0,
+            0,
+            "ok",
+            null,
+            List.of(
+                "Per-source 'rotated' log files and LOGD_MAX_FILE_SIZE rollover claimed in the PR"
+                    + " and docs: rotator_write always appends to <source>.log and never reads"
+                    + " r->max_file_size (src/rotator.c:13,45); no rotation logic exists."),
+            List.of(),
+            List.of(),
+            null);
+    var result =
+        new ReviewResult(
+            findings,
+            0,
+            1,
+            0,
+            0,
+            RiskLevel.HIGH,
+            ReviewState.REQUEST_CHANGES,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
+
+    var summary = generator.generate(1, 10, 0, List.of(), aiSummary, result);
+
+    assertFalse(summary.contains("### ⚠️ Description vs. Implementation"), summary);
+  }
+
+  @Test
+  void walkthroughRowThatOnlySummarisesItsFileIsNeverTrimmed() {
+    var findings =
+        List.of(
+            new Finding(
+                RiskLevel.CRITICAL,
+                "src/rotator.c",
+                43,
+                "Path traversal: unvalidated client source reaches fopen path",
+                "desc",
+                null,
+                null));
+    var aiSummary =
+        summaryWithFiles(
+            new ReviewResponse.FileSummary(
+                "src/rotator.c",
+                "Dedup + append to <source>.log using an unvalidated client source path"),
+            new ReviewResponse.FileSummary("src/banlist.h", "Declares banlist API"));
+    var result =
+        new ReviewResult(
+            findings,
+            1,
+            0,
+            0,
+            0,
+            RiskLevel.CRITICAL,
+            ReviewState.REQUEST_CHANGES,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
+
+    var summary =
+        generator.generate(
+            2,
+            20,
+            0,
+            List.of(
+                new PrSummaryGenerator.ChangedFile("src/rotator.c", "added"),
+                new PrSummaryGenerator.ChangedFile("src/banlist.h", "added")),
+            aiSummary,
+            result);
+
+    // A single-clause row is the file's summary, not a re-assertion — it stays verbatim even
+    // though it overlaps the inline finding heavily.
+    assertTrue(
+        summary.contains(
+            "| `src/rotator.c` | Added | Dedup + append to <source>.log using an unvalidated"
+                + " client source path |"),
+        summary);
+    assertTrue(summary.contains("| `src/banlist.h` | Added | Declares banlist API |"), summary);
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicatorTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SummarySurfaceDeduplicatorTest {
+
+  private static Finding finding(String title) {
+    return new Finding(RiskLevel.HIGH, "src/A.java", 1, title, "desc", null, null);
+  }
+
+  @Test
+  void keepsAGapThatStatesSomethingNoFindingStates() {
+    var gaps =
+        List.of("The PR promises a health check before dispatch, but no health field is present.");
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            gaps,
+            Map.of(),
+            List.of(finding("Worker registry pagination not followed; only first page returned")));
+
+    assertEquals(gaps, surfaces.descriptionGaps());
+  }
+
+  @Test
+  void dropsASecondGapThatOnlyRephrasesTheFirst() {
+    // No finding at all: the gaps are collapsed against each other, first bullet wins.
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            List.of(
+                "RunSummary.degraded is computed from every result rather than only failures, so a"
+                    + " successful tick is reported degraded.",
+                "The degraded flag is computed from all results and not just failures, which"
+                    + " reports a successful tick as degraded."),
+            Map.of(),
+            List.of());
+
+    assertEquals(1, surfaces.descriptionGaps().size());
+    assertTrue(surfaces.descriptionGaps().get(0).startsWith("RunSummary.degraded"));
+  }
+
+  @Test
+  void aFindingWithNoTitleMatchesNothing() {
+    var gaps = List.of("The PR description omits the new retry budget entirely.");
+
+    var surfaces = SummarySurfaceDeduplicator.collapse(gaps, Map.of(), List.of(finding(null)));
+
+    assertEquals(gaps, surfaces.descriptionGaps());
+  }
+
+  @Test
+  void aClaimTooShortToScoreLeavesBothCopiesStanding() {
+    // Four content words on the shorter side: below MIN_OVERLAP_TOKENS, and no shared 3-word run.
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            List.of(),
+            Map.of("src/A.java", "Adds the repository; query is vulnerable to SQL injection"),
+            List.of(finding("SQL injection in task-name search query")));
+
+    assertEquals(
+        "Adds the repository; query is vulnerable to SQL injection",
+        surfaces.fileSummaries().get("src/A.java"));
+  }
+
+  @Test
+  void singleClauseWalkthroughNoteIsReturnedUntouched() {
+    var note = "Added round-robin dispatch and the degraded flag computed from all results";
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            List.of(),
+            Map.of("src/A.java", note),
+            List.of(finding("degraded flag computed from all results, not just failures")));
+
+    // Identity, not just equality: a note with no clause break never goes through the rebuild.
+    assertSame(note, surfaces.fileSummaries().get("src/A.java"));
+  }
+
+  @Test
+  void keepsANonRestatingClauseAndTheOriginalWhenNothingIsDropped() {
+    var note = "Added HTTP client for the registry; linear membership lookup";
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            List.of(), Map.of("src/A.java", note), List.of(finding("Unrelated parser off-by-one")));
+
+    assertSame(note, surfaces.fileSummaries().get("src/A.java"));
+  }
+
+  @Test
+  void dropsOnlyTheRestatingClauseAndKeepsTheRest() {
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            List.of(),
+            Map.of(
+                "src/A.java",
+                "Added HTTP client for worker registry; returns only the first page of workers"
+                    + " (pagination not walked); also adds a retry budget"),
+            List.of(finding("Worker registry pagination not followed; only first page returned")));
+
+    assertEquals(
+        "Added HTTP client for worker registry; also adds a retry budget",
+        surfaces.fileSummaries().get("src/A.java"));
+  }
+
+  @Test
+  void emptyClausesAroundASemicolonAreNotTreatedAsContent() {
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            List.of(),
+            Map.of(
+                "src/A.java",
+                "Added HTTP client for worker registry; returns only the first page of workers"
+                    + " (pagination not walked);  ;"),
+            List.of(finding("Worker registry pagination not followed; only first page returned")));
+
+    assertEquals(
+        "Added HTTP client for worker registry", surfaces.fileSummaries().get("src/A.java"));
+  }
+
+  @Test
+  void tokenizerDropsStopWordsNumbersAndSingleCharacters() {
+    // "is"/"at" are stop words, "c" is a single character and "45" a line number: none of them
+    // says anything about the claim, and all three match nearly every other text.
+    assertEquals(
+        List.of("banlist", "rea", "src", "main"),
+        SummarySurfaceDeduplicator.contentTokens("banlist is read at src/main.c:45"));
+  }
+
+  @Test
+  void inflectedFormsOfOneWordCollideAndShortWordsAreLeftAlone() {
+    assertEquals(
+        SummarySurfaceDeduplicator.contentTokens("hardcoded failures return"),
+        SummarySurfaceDeduplicator.contentTokens("hardcodes failure returned"));
+    assertEquals(List.of("use", "log"), SummarySurfaceDeduplicator.contentTokens("use logs"));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicatorTest.java
@@ -16,6 +16,7 @@
 package dev.thiagogonzaga.thrillhousebot.review;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -137,19 +138,74 @@ class SummarySurfaceDeduplicatorTest {
   }
 
   @Test
+  void aNegatedParaphraseContradictsTheFindingInsteadOfRestatingIt() {
+    // Identical but for the negation: "does"/"not" used to be stop words, so both sides tokenized
+    // the same and the gap was deleted as a duplicate of the claim it contradicts.
+    var gaps = List.of("Path traversal: unvalidated client source does not reach fopen path");
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            gaps,
+            Map.of(),
+            List.of(finding("Path traversal: unvalidated client source reaches fopen path")));
+
+    assertEquals(gaps, surfaces.descriptionGaps());
+  }
+
+  @Test
+  void aWalkthroughClauseIsKeptWhenItAssertsTheOppositeOfTheFinding() {
+    // The clause names strictly less than the finding does, so containment runs the other way.
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            List.of(),
+            Map.of(
+                "src/A.java",
+                "Adds the repository; user input is sanitized before it reaches the query"),
+            List.of(finding("User input is not sanitized before it reaches the SQL query")));
+
+    assertEquals(
+        "Adds the repository; user input is sanitized before it reaches the query",
+        surfaces.fileSummaries().get("src/A.java"));
+  }
+
+  @Test
+  void oppositePolarityStillCollapsesWhenTheTwoAlsoDifferInSubstance() {
+    // A description gap normally quotes the PR's affirmative promise while the finding reports the
+    // absence, so differing polarity alone must not keep a genuine duplicate alive.
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            List.of(
+                "The PR says the worker registry is walked page by page, but the client stops"
+                    + " after the first page of workers it receives."),
+            Map.of(),
+            List.of(finding("Worker registry pagination not followed; only first page returned")));
+
+    assertEquals(List.of(), surfaces.descriptionGaps());
+  }
+
+  @Test
+  void negatorsSetPolarityInsteadOfBecomingContentWords() {
+    var negated = SummarySurfaceDeduplicator.claim("the banlist is never refreshed");
+    var plain = SummarySurfaceDeduplicator.claim("the banlist is refreshed");
+
+    assertEquals(plain.words(), negated.words());
+    assertTrue(negated.negated());
+    assertFalse(plain.negated());
+  }
+
+  @Test
   void tokenizerDropsStopWordsNumbersAndSingleCharacters() {
     // "is"/"at" are stop words, "c" is a single character and "45" a line number: none of them
     // says anything about the claim, and all three match nearly every other text.
     assertEquals(
         List.of("banlist", "rea", "src", "main"),
-        SummarySurfaceDeduplicator.contentTokens("banlist is read at src/main.c:45"));
+        SummarySurfaceDeduplicator.claim("banlist is read at src/main.c:45").words());
   }
 
   @Test
   void inflectedFormsOfOneWordCollideAndShortWordsAreLeftAlone() {
     assertEquals(
-        SummarySurfaceDeduplicator.contentTokens("hardcoded failures return"),
-        SummarySurfaceDeduplicator.contentTokens("hardcodes failure returned"));
-    assertEquals(List.of("use", "log"), SummarySurfaceDeduplicator.contentTokens("use logs"));
+        SummarySurfaceDeduplicator.claim("hardcoded failures return").words(),
+        SummarySurfaceDeduplicator.claim("hardcodes failure returned").words());
+    assertEquals(List.of("use", "log"), SummarySurfaceDeduplicator.claim("use logs").words());
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicatorTest.java
@@ -183,6 +183,57 @@ class SummarySurfaceDeduplicatorTest {
   }
 
   @Test
+  void aContractedNegationIsDetectedSoItsOppositeSurvives() {
+    // Splitting on non-alphanumeric runs tears "doesn't" into "doesn" and "t", so without the
+    // contraction rewrite both gaps read as affirmative, score 1.0 on the shorter side, and the
+    // negative conclusion is deleted as a restatement of the affirmative one.
+    var gaps =
+        List.of(
+            "The registry URL is validated before use.",
+            "The client doesn't validate the registry URL before use.");
+
+    var surfaces = SummarySurfaceDeduplicator.collapse(gaps, Map.of(), List.of());
+
+    assertEquals(gaps, surfaces.descriptionGaps());
+  }
+
+  @Test
+  void aContractedNegationInTheFindingKeepsTheOpposingWalkthroughClause() {
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            List.of(),
+            Map.of(
+                "src/A.java",
+                "Adds the repository; user input is sanitized before it reaches the SQL query"),
+            List.of(finding("User input isn't sanitized before it reaches the SQL query")));
+
+    assertEquals(
+        "Adds the repository; user input is sanitized before it reaches the SQL query",
+        surfaces.fileSummaries().get("src/A.java"));
+  }
+
+  @Test
+  void everyContractedNegatorFormSetsPolarityAndLeavesNoStrayWord() {
+    var plain = SummarySurfaceDeduplicator.claim("the value is sanitized");
+
+    for (String contracted :
+        List.of(
+            "the value isn't sanitized",
+            "the value isn’t sanitized",
+            "the value wasn't sanitized",
+            "the value won't be sanitized",
+            "the value can't be sanitized",
+            "the value couldn't be sanitized",
+            "the value shouldn't be sanitized",
+            "the value didn't sanitize")) {
+      var claim = SummarySurfaceDeduplicator.claim(contracted);
+
+      assertTrue(claim.negated(), contracted);
+      assertEquals(plain.words(), claim.words(), contracted);
+    }
+  }
+
+  @Test
   void negatorsSetPolarityInsteadOfBecomingContentWords() {
     var negated = SummarySurfaceDeduplicator.claim("the banlist is never refreshed");
     var plain = SummarySurfaceDeduplicator.claim("the banlist is refreshed");


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

One observation was being published on up to three surfaces of the same summary comment — as an
inline finding, again as a "Description vs. Implementation" bullet, and again as its own clause in a
Changed Files walkthrough row — with nothing tying the copies together. Readers infer severity from
repetition, so a low-value note raised three times outranked the severest finding in the same
comment (on ThrillhouseBot-test #23 it outranked a SQL injection), and the duplicate emissions
inflated the apparent finding count.

The renderer already holds the full set it is about to publish across all three surfaces, so it now
collapses each claim to its most specific surface before rendering anything:

- **inline finding > description-gap bullet > walkthrough row.** A description gap that restates a
  finding is dropped; so is a second gap that only rephrases an earlier one. All findings are
  considered, not just the five that reach "Key Findings" — on ThrillhouseBot-test #22 the duplicated
  claim was 8th by severity and never appeared in that list.
- **Walkthrough rows are preserved.** A row summarising a file that also carries an inline finding is
  normal and useful, so the row's *first* clause is never touched; only the clauses appended after it
  that restate an already-published claim are removed. A row therefore always keeps a real
  description of its file, and a single-clause note is returned untouched.

Two texts state the same claim when they share a contiguous run of three content words, or when
their content words overlap by half of the shorter side. Polarity does not gate that test in
general — it holds a pair back only when the two say the same things with opposite polarity, one
negating and every content word of one side present in the other (containment in either direction).
Such a pair scores as a perfect match while asserting opposite things, because a negator contributes
a single token and no similarity score can separate "the value is sanitized" from "the value is not
sanitized"; that is a contradiction to surface, never a duplicate to delete. Two texts that disagree
on polarity but each name something the other leaves out are still judged on their content, so a gap
quoting the PR's affirmative promise still collapses onto the finding reporting the absence.
Contracted negations ("isn't", "won't") are rewritten before tokenizing, since content words are
split on non-alphanumeric runs and would otherwise tear "isn't" into "isn" and "t". The overlap arm
requires five content words on the shorter side — below that the coefficient is noise, and keeping
both copies is the safe direction.

Under-firing is deliberately the safe direction throughout: a missed duplicate is the status quo,
while a false collapse silently deletes a claim the model made.

The regression material is the corpus itself — the fixtures in the new tests are the verbatim text
ThrillhouseBot published on devops-thiago/ThrillhouseBot-test #23 (Java) and #22 (C).

## Related Issues

Fixes #588

## How Has This Been Tested?

- [x] Unit tests

Red/green proof. With the renderer change reverted (`SummarySurfaceDeduplicator` removed,
`PrSummaryGenerator` restored), the new tests fail exactly as claimed — the flagship case shows the
same claim on all three surfaces at once:

```
[ERROR] Tests run: 60, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 1.261 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.PrSummaryGeneratorTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.PrSummaryGeneratorTest.restatedDescriptionGapAndWalkthroughClauseCollapseToTheInlineFinding -- Time elapsed: 0 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
## 🤖 ThrillhouseBot PR Summary

### ⚠️ Description vs. Implementation
The PR description does not fully match the change:
- The runnable entry point passes a hardcoded empty task list to `dispatchDueTasks`, so the shipped service cannot actually dispatch any task.
- PR says TaskRunRepository persists run history, but the added class only contains searchRunsByTaskName; no insert/update/upsert write path is present in the diff.

### Changes Overview
- **Files changed:** 1
- **Lines added:** +30
- **Lines removed:** 0

### Changed Files
| File | Change | Summary |
|------|--------|---------|
| `src/main/java/com/thrillhouse/scheduler/Main.java` | Added | Added one-shot entry point; hardcodes an empty task list and reads only registry URL env var |

### Risk Assessment
| Risk | Count |
|------|-------|
| 🔴 Critical | 0 |
| 🟠 High | 1 |
| 🟡 Medium | 0 |
| 🔵 Low | 0 |

### Key Findings
- **HIGH:** Main passes a hardcoded empty task list, so nothing is ever dispatched (`src/main/java/com/thrillhouse/scheduler/Main.java:22`)

---
*Automated review by ThrillhouseBot. Reply with `/review` to re-run.*
 ==> expected: <false> but was: <true>
	at org.junit.jupiter.api.Assertions.assertFalse(Assertions.java:266)
	at dev.thiagogonzaga.thrillhousebot.review.PrSummaryGeneratorTest.restatedDescriptionGapAndWalkthroughClauseCollapseToTheInlineFinding(PrSummaryGeneratorTest.java:1261)

[ERROR] PrSummaryGeneratorTest.restatedGapCollapsesEvenWhenTheFindingIsNotAKeyFinding:1329 ==> expected: <false> but was: <true>
[ERROR] PrSummaryGeneratorTest.descriptionGapsSectionDisappearsWhenEveryBulletRestatesAFinding:1378 ==> expected: <false> but was: <true>
```

With the fix in place all three pass, and the full suite is green.

Gates:

- `./mvnw -B spotless:apply` then `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, BUILD SUCCESS.
- `./mvnw -B clean test` — BUILD SUCCESS, no failures, no errors.
- Coverage: jacoco ∩ `git diff -U0 fda4bc7...HEAD` shows zero uncovered lines and zero uncovered
  branches across the changed main code.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The dedupe pass is deliberately conservative. Two known duplicates in the corpus survive it: a
walkthrough clause of only four content words ("query is vulnerable to SQL injection" against the
finding "SQL injection in task-name search query") falls under the minimum-token guard, and a
clause phrased entirely differently from its finding ("degraded flag is true whenever any dispatch
was attempted") scores below the overlap threshold. Both are the tolerable failure direction:
publishing a claim twice is the current behaviour, while a wrong collapse would delete it.

Review follow-up (da65366): the bot's own review of this PR caught a false-collapse route through
the stop list — "no"/"not"/"does" were dropped as function words, so a negated paraphrase tokenized
identically to the finding it contradicts and was deleted. Fixed by tracking polarity separately,
with three regression tests; see the resolved thread for the red output and why removing the
negators from the stop list alone would not have been sufficient.

Review follow-up (fdd9602): the re-review found the same false-collapse still reachable through
contracted negations — content words split on non-alphanumeric runs, so "doesn't" tore into "doesn"
and "t" and the sentence read as affirmative. Contractions are now rewritten to a bare "not" before
the split, irregular stems included, so no stray content word is left behind. The same review caught
the class javadoc overclaiming that collapsing requires polarity agreement; the behaviour is
deliberate and test-pinned, so the documentation was corrected rather than the code.

Review follow-up (this round): a third review pass found both javadocs still describing the polarity
override as mutual containment ("neither names anything the other leaves out") while the code fires
on containment in either direction. The one-directional behaviour is correct — a short negated claim
lying wholly inside a longer affirmative one is exactly the contradiction that must be surfaced, and
tightening to mutual containment would reintroduce the silent deletion — so both javadocs were
corrected to state the condition the code implements, documentation only.

Review follow-up (6bcb075): a fourth pass found the `stem()` javadoc claiming it makes "the plural,
past and third-person forms of one word collide", which overstates it — stripping trailing s/e/d
leaves "verifies" as "verifi" while "verify" keeps its y, so y→i inflections never meet. The
stemmer is unchanged: missing a y→i collapse lets a duplicate survive, the under-firing direction
this class prefers, while widening it would merge more words and risk deleting a claim. The comment
now states the rule it implements and names the uncaught case, documentation only.
