### PR TITLE
feat(github): pace content-creating GitHub calls so a burst is never produced

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -73,6 +73,27 @@ public interface ThrillhouseConfig {
     @WithName("bot-logins")
     @WithDefault("thrillhousebot[bot],thrillhouse-bot[bot]")
     List<String> botLogins();
+
+    /**
+     * Spacing between two content-creating GitHub calls (comments, review comments, thread replies,
+     * reviews), shared process-wide. GitHub secondary-rate-limits rapid content creation and
+     * answers with a 403; its published guidance is no more than one such request per second. Zero
+     * disables pacing. Declared here as the namespace's schema — the limiter itself sits on the
+     * REST clients' write path, which has no CDI, and reads the key directly (see {@code
+     * GitHubWritePacer}).
+     */
+    @WithName("write-min-interval")
+    @WithDefault("1s")
+    Duration writeMinInterval();
+
+    /**
+     * Ceiling on how long one caller waits for its content-creation slot. Past it the call goes out
+     * unpaced and the bounded backoff handles a refusal, so a long queue never parks a finished
+     * command while it holds its per-PR dispatcher slot.
+     */
+    @WithName("write-max-wait")
+    @WithDefault("60s")
+    Duration writeMaxWait();
   }
 
   interface WebhookConfig {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacer.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Keeps the bot's content-creating GitHub calls inside the secondary-rate-limit envelope instead of
+ * discovering it by rejection.
+ *
+ * <p>#579: {@link GitHubWriteRetry} makes a throttled post survivable, but it is reactive — it only
+ * acts once GitHub has already refused. In the run behind #568, 56 commands across 8 PRs created
+ * content faster than GitHub would accept it and drew 29 rejections. Spacing the requests out
+ * instead is strictly better: no wasted round trip, no retry budget spent, and no dispatcher slot
+ * held while a refused call backs off.
+ *
+ * <p>The bot reaches this state without anyone doing anything unusual — a review posting many
+ * inline findings, or several PRs reviewed concurrently, both create comments in rapid succession —
+ * so the limiter is process-wide and shared by every content-creating call, not per review and not
+ * per PR. It sits on the same seam as the backoff ({@link GitHubWriteRetry#call}), which is exactly
+ * the set of calls GitHub counts as content creation: comments, review comments, thread replies and
+ * reviews.
+ *
+ * <h2>How a slot is claimed</h2>
+ *
+ * Each caller atomically claims the next free instant and advances the shared cursor by {@link
+ * #MIN_INTERVAL_KEY}, then sleeps until the instant it claimed. Claiming is a single atomic update
+ * with no lock held across the HTTP call, so a slow request never blocks the queue behind it, and
+ * callers go out in the order they arrived rather than in a thundering herd when the interval
+ * elapses. GitHub's published guidance — no more than one content-creating request per second — is
+ * the default envelope, and both numbers are knobs rather than constants:
+ *
+ * <ul>
+ *   <li>{@value #MIN_INTERVAL_KEY} (default {@code 1s}): spacing between two content-creating
+ *       requests. Zero or negative disables pacing entirely.
+ *   <li>{@value #MAX_WAIT_KEY} (default {@code 60s}): ceiling on how long one caller waits for its
+ *       slot, so a queue that has grown past the ceiling degrades to the {@link GitHubWriteRetry}
+ *       backoff — which is where the bot was before #579 — rather than parking a command for
+ *       minutes while it holds its per-PR dispatcher slot.
+ * </ul>
+ *
+ * <p>Waiting never costs the payload: a pacing wait that is interrupted proceeds with the call
+ * rather than failing it, because the content on its way out has already been paid for and the
+ * worst this limiter should ever do is let a burst through.
+ */
+public final class GitHubWritePacer {
+
+  private static final Logger log = LoggerFactory.getLogger(GitHubWritePacer.class);
+
+  /** Spacing between two content-creating requests; zero or negative disables pacing. */
+  public static final String MIN_INTERVAL_KEY = "thrillhousebot.github.write-min-interval";
+
+  /** Ceiling on a single caller's wait for its slot. */
+  public static final String MAX_WAIT_KEY = "thrillhousebot.github.write-max-wait";
+
+  /** GitHub's published guidance: no more than one content-creating request per second. */
+  static final Duration DEFAULT_MIN_INTERVAL = Duration.ofSeconds(1);
+
+  /** Matches the total {@link GitHubWriteRetry} budget: no wait here is worse than a refusal. */
+  static final Duration DEFAULT_MAX_WAIT = Duration.ofSeconds(60);
+
+  /** Parks the current thread; the seam that lets the tests run the pacing without waiting. */
+  @FunctionalInterface
+  interface Sleeper {
+    void sleep(Duration delay) throws InterruptedException;
+  }
+
+  /** Real waiting, on the current thread — a virtual one wherever the bot does its work. */
+  private static final Sleeper PARK = delay -> Thread.sleep(delay.toMillis());
+
+  /**
+   * The instance production uses. The knobs are read once, when the first GitHub write loads this
+   * class, so pacing costs one atomic update per call and no config lookup.
+   */
+  static final GitHubWritePacer DEFAULT =
+      new GitHubWritePacer(
+          configured(MIN_INTERVAL_KEY, DEFAULT_MIN_INTERVAL),
+          configured(MAX_WAIT_KEY, DEFAULT_MAX_WAIT),
+          PARK,
+          System::nanoTime);
+
+  /** No pacing at all, for the unit tests that pin the backoff rather than the spacing. */
+  static final GitHubWritePacer NONE =
+      new GitHubWritePacer(Duration.ZERO, Duration.ZERO, PARK, System::nanoTime);
+
+  private final long intervalNanos;
+  private final long maxWaitNanos;
+  private final Sleeper sleeper;
+  private final LongSupplier nanoClock;
+  private final AtomicLong nextSlot;
+
+  GitHubWritePacer(
+      Duration minInterval, Duration maxWait, Sleeper sleeper, LongSupplier nanoClock) {
+    this.intervalNanos = minInterval.toNanos();
+    this.maxWaitNanos = Math.max(0L, maxWait.toNanos());
+    this.sleeper = sleeper;
+    this.nanoClock = nanoClock;
+    this.nextSlot = new AtomicLong(nanoClock.getAsLong());
+  }
+
+  /** The configured duration for {@code key}, or {@code fallback} when the key is not set. */
+  static Duration configured(String key, Duration fallback) {
+    return ConfigProvider.getConfig().getOptionalValue(key, Duration.class).orElse(fallback);
+  }
+
+  /**
+   * Waits, if it has to, until this call's turn to create content on GitHub. Returns immediately
+   * when pacing is disabled or the queue is empty, so a lone comment on a quiet repo is not slowed
+   * down at all — the wait only appears once calls are actually arriving faster than the envelope.
+   *
+   * @param operation what is being posted, for the log — never credentials or comment text
+   */
+  public void acquire(String operation) {
+    if (intervalNanos <= 0) {
+      return;
+    }
+    long now = nanoClock.getAsLong();
+    // The claimed instant is the later of "the cursor" and "now"; the cursor then moves one
+    // interval past it, so the next caller queues behind this one instead of racing it.
+    long slot = nextSlot.accumulateAndGet(now, this::claim) - intervalNanos;
+    long waitNanos = slot - now;
+    if (waitNanos <= 0) {
+      return;
+    }
+    var wait = Duration.ofNanos(Math.min(waitNanos, maxWaitNanos));
+    log.debug("Pacing {} — waiting {}ms for a content-creation slot", operation, wait.toMillis());
+    try {
+      sleeper.sleep(wait);
+    } catch (InterruptedException _) {
+      Thread.currentThread().interrupt();
+      // Never lose the payload to the limiter: the call goes out and the backoff covers a refusal.
+      log.debug("Interrupted while pacing {} — sending it without waiting", operation);
+    }
+  }
+
+  /** Subtraction rather than {@code >} so the comparison survives a {@code nanoTime} wraparound. */
+  private long claim(long cursor, long now) {
+    return (cursor - now > 0 ? cursor : now) + intervalNanos;
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetry.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetry.java
@@ -69,16 +69,24 @@ public final class GitHubWriteRetry {
     void sleep(Duration delay) throws InterruptedException;
   }
 
-  /** The instance production uses: real sleeping, real clock. */
+  /** The instance production uses: real sleeping, real clock, the shared write pacer. */
   static final GitHubWriteRetry DEFAULT =
-      new GitHubWriteRetry(delay -> Thread.sleep(delay.toMillis()), Instant::now);
+      new GitHubWriteRetry(
+          delay -> Thread.sleep(delay.toMillis()), Instant::now, GitHubWritePacer.DEFAULT);
 
   private final Sleeper sleeper;
   private final Supplier<Instant> clock;
+  private final GitHubWritePacer pacer;
 
+  /** A retry that only backs off, for the tests that pin the backoff rather than the pacing. */
   GitHubWriteRetry(Sleeper sleeper, Supplier<Instant> clock) {
+    this(sleeper, clock, GitHubWritePacer.NONE);
+  }
+
+  GitHubWriteRetry(Sleeper sleeper, Supplier<Instant> clock, GitHubWritePacer pacer) {
     this.sleeper = sleeper;
     this.clock = clock;
+    this.pacer = pacer;
   }
 
   /**
@@ -87,11 +95,16 @@ public final class GitHubWriteRetry {
    * retryable or the budget is spent, so every existing caller keeps the exception type and the
    * fail-soft handling it already has.
    *
+   * <p>Every attempt — the first one included — waits for its slot in the shared {@link
+   * GitHubWritePacer} first, so a burst is spaced out before GitHub has to refuse it (#579) and the
+   * budget below is left for the throttling this cannot prevent.
+   *
    * @param operation what is being posted, for the log — never credentials or comment text
    */
   public <T> T call(String operation, Supplier<T> operationCall) {
     for (int attempt = 1; ; attempt++) {
       try {
+        pacer.acquire(operation);
         return operationCall.get();
       } catch (WebApplicationException e) {
         var delay = retryDelay(operation, e, attempt);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,6 +40,16 @@ thrillhousebot.github.webhook-secret=${GITHUB_WEBHOOK_SECRET:}
 # is deployed under a different slug — its bot login is <app-slug>[bot].
 thrillhousebot.github.bot-logins=${GITHUB_BOT_LOGINS:thrillhousebot[bot],thrillhouse-bot[bot]}
 
+# Pacing of content-creating GitHub calls (comments, review comments, thread replies, reviews),
+# shared process-wide. GitHub secondary-rate-limits rapid content creation and answers with a 403;
+# spacing the requests keeps the bot inside that envelope instead of discovering it by rejection.
+#   GITHUB_WRITE_MIN_INTERVAL: spacing between two content-creating requests (0 disables pacing).
+#     GitHub's published guidance is no more than one such request per second.
+#   GITHUB_WRITE_MAX_WAIT: ceiling on one caller's wait for its slot. Past it the call goes out
+#     unpaced and the bounded backoff handles a refusal, so a long queue never parks a command.
+thrillhousebot.github.write-min-interval=${GITHUB_WRITE_MIN_INTERVAL:1s}
+thrillhousebot.github.write-max-wait=${GITHUB_WRITE_MAX_WAIT:60s}
+
 # Webhook redelivery dedup — drop repeat X-GitHub-Delivery ids within the TTL so GitHub
 # redeliveries/retries do not trigger duplicate reviews (in-memory, per replica).
 thrillhousebot.webhook.dedup-ttl=${WEBHOOK_DEDUP_TTL:24h}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacerTest.java
@@ -133,6 +133,25 @@ class GitHubWritePacerTest {
         ONE_SECOND, GitHubWritePacer.configured("github-write-pacer-test.unset", ONE_SECOND));
   }
 
+  @Test
+  void theDocumentedBareZeroSurvivesTheConfigConverterAndReallyDisablesPacing() {
+    System.setProperty(PROBE_KEY, "0");
+
+    // application.properties tells operators GITHUB_WRITE_MIN_INTERVAL=0 disables pacing, and that
+    // promise runs through the config converter rather than through a Duration.ZERO handed to the
+    // constructor. Worth pinning: an unconvertible value in the mapped namespace is a validation
+    // error, so a converter that rejected a bare "0" would fail startup rather than disable
+    // anything.
+    var configured = GitHubWritePacer.configured(PROBE_KEY, ONE_SECOND);
+    assertEquals(Duration.ZERO, configured);
+
+    var pacer = new GitHubWritePacer(configured, ONE_MINUTE, waited::add, nanos::get);
+    pacer.acquire("a comment on o/r #7");
+    pacer.acquire("a comment on o/r #8");
+
+    assertEquals(List.of(), waited);
+  }
+
   @AfterEach
   void clearProbe() {
     System.clearProperty(PROBE_KEY);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@link GitHubWritePacer} — the spacing #579 asked for, so a burst of content-creating
+ * calls is never produced rather than being produced and refused.
+ *
+ * <p>The clock is driven by hand and the waiting is recorded instead of served, so what is pinned
+ * here is the arithmetic of the shared cursor: who waits, for how long, and who does not.
+ */
+class GitHubWritePacerTest {
+
+  private static final Duration ONE_SECOND = Duration.ofSeconds(1);
+  private static final Duration ONE_MINUTE = Duration.ofSeconds(60);
+
+  /** Outside the mapped {@code thrillhousebot} namespace, so it is nobody's unknown key. */
+  private static final String PROBE_KEY = "github-write-pacer-test.interval";
+
+  private final List<Duration> waited = new ArrayList<>();
+  private final AtomicLong nanos = new AtomicLong();
+
+  private GitHubWritePacer pacer(Duration interval, Duration ceiling) {
+    return new GitHubWritePacer(interval, ceiling, waited::add, nanos::get);
+  }
+
+  @Test
+  void aLoneWriteOnAQuietRepoIsNotDelayedAtAll() {
+    pacer(ONE_SECOND, ONE_MINUTE).acquire("a comment on o/r #7");
+
+    assertEquals(List.of(), waited);
+  }
+
+  @Test
+  void aBurstIsHandedOutOneIntervalApartInsteadOfAllAtOnce() {
+    var pacer = pacer(ONE_SECOND, ONE_MINUTE);
+
+    pacer.acquire("a comment on o/r #7");
+    pacer.acquire("a comment on o/r #8");
+    pacer.acquire("a review on o/r #9");
+
+    // The first goes straight out; the rest queue behind it rather than racing it to GitHub.
+    assertEquals(List.of(ONE_SECOND, Duration.ofSeconds(2)), waited);
+  }
+
+  @Test
+  void aWriteThatArrivesAfterTheQueueDrainedIsNotDelayed() {
+    var pacer = pacer(ONE_SECOND, ONE_MINUTE);
+
+    pacer.acquire("a comment on o/r #7");
+    nanos.addAndGet(Duration.ofSeconds(30).toNanos());
+    pacer.acquire("a comment on o/r #7");
+
+    // Pacing is a floor on spacing, not a queue that keeps charging a quiet repo.
+    assertEquals(List.of(), waited);
+  }
+
+  @Test
+  void aQueueLongerThanTheCeilingStopsWaitingAtTheCeiling() {
+    var pacer = pacer(ONE_SECOND, Duration.ofMillis(1500));
+
+    pacer.acquire("a comment on o/r #7");
+    pacer.acquire("a comment on o/r #8");
+    pacer.acquire("a comment on o/r #9");
+    pacer.acquire("a comment on o/r #10");
+
+    // 1s, then 2s and 3s clamped: past the ceiling the call goes out and the backoff covers it,
+    // so a long queue can never park a finished command for minutes.
+    assertEquals(List.of(ONE_SECOND, Duration.ofMillis(1500), Duration.ofMillis(1500)), waited);
+  }
+
+  @Test
+  void aZeroIntervalTurnsPacingOffEntirely() {
+    var pacer = pacer(Duration.ZERO, ONE_MINUTE);
+
+    pacer.acquire("a comment on o/r #7");
+    pacer.acquire("a comment on o/r #8");
+    pacer.acquire("a comment on o/r #9");
+
+    assertEquals(List.of(), waited);
+  }
+
+  @Test
+  void anInterruptedWaitSendsTheCallAnywayAndKeepsTheInterrupt() {
+    var interrupting =
+        new GitHubWritePacer(
+            ONE_SECOND,
+            ONE_MINUTE,
+            delay -> {
+              throw new InterruptedException("shutting down");
+            },
+            nanos::get);
+
+    interrupting.acquire("a comment on o/r #7");
+    // The second one is the one that has to wait, and the wait is what gets interrupted.
+    interrupting.acquire("a comment on o/r #7");
+
+    // The limiter never costs the payload: the write goes out unpaced rather than failing.
+    assertTrue(Thread.interrupted(), "interrupt status restored");
+    assertFalse(Thread.currentThread().isInterrupted());
+  }
+
+  @Test
+  void theEnvelopeIsAKnobAndFallsBackToTheGuidanceWhenItIsUnset() {
+    System.setProperty(PROBE_KEY, "250ms");
+
+    assertEquals(Duration.ofMillis(250), GitHubWritePacer.configured(PROBE_KEY, ONE_SECOND));
+    assertEquals(
+        ONE_SECOND, GitHubWritePacer.configured("github-write-pacer-test.unset", ONE_SECOND));
+  }
+
+  @AfterEach
+  void clearProbe() {
+    System.clearProperty(PROBE_KEY);
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacingTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacingTest.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -72,13 +73,16 @@ class GitHubWritePacingTest {
   }
 
   private GitHubCommentClient clientAnsweredBy(HttpHandler handler) throws IOException {
+    return startGitHub(handler).build(GitHubCommentClient.class);
+  }
+
+  private QuarkusRestClientBuilder startGitHub(HttpHandler handler) throws IOException {
     server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
     server.createContext("/", handler);
     server.setExecutor(Executors.newVirtualThreadPerTaskExecutor());
     server.start();
     return QuarkusRestClientBuilder.newBuilder()
-        .baseUri(URI.create("http://127.0.0.1:" + server.getAddress().getPort()))
-        .build(GitHubCommentClient.class);
+        .baseUri(URI.create("http://127.0.0.1:" + server.getAddress().getPort()));
   }
 
   private static void respond(HttpExchange exchange, int status, String body) throws IOException {
@@ -120,6 +124,82 @@ class GitHubWritePacingTest {
     }
 
     assertEquals(BURST, arrivals.size(), "every comment still posted");
+    assertSpacedOut();
+  }
+
+  @Test
+  void everyContentCreatingCallIsPacedAndNotJustTheConversationComment() throws Exception {
+    var builder =
+        startGitHub(
+            exchange -> {
+              arrivals.add(System.nanoTime());
+              respond(exchange, 201, "{\"id\":1,\"html_url\":\"https://github.test/c/1\"}");
+            });
+    var comments = builder.build(GitHubCommentClient.class);
+    var reviews = builder.build(GitHubReviewClient.class);
+
+    // All five of the calls GitHub counts as content creation, fired at once. The triggering
+    // scenarios in #579 — a review posting many inline findings, several PRs reviewed at once —
+    // run through the review client, so pacing only the conversation comment would leave the burst
+    // this PR exists to prevent fully intact.
+    List<Callable<Object>> everyWrite =
+        List.of(
+            () ->
+                comments.createComment(
+                    "Bearer token",
+                    ACCEPT,
+                    "owner",
+                    "repo",
+                    1,
+                    new GitHubCommentClient.CreateCommentRequest("a reply")),
+            () ->
+                comments.updateComment(
+                    "Bearer token",
+                    ACCEPT,
+                    "owner",
+                    "repo",
+                    99L,
+                    new GitHubCommentClient.CreateCommentRequest("an edited summary")),
+            () ->
+                reviews.createReview(
+                    "Bearer token",
+                    ACCEPT,
+                    "owner",
+                    "repo",
+                    1,
+                    new GitHubReviewClient.CreateReviewRequest("sha", "a review", "COMMENT", null)),
+            () ->
+                reviews.createPullRequestComment(
+                    "Bearer token",
+                    ACCEPT,
+                    "owner",
+                    "repo",
+                    1,
+                    new GitHubReviewClient.CreatePullRequestCommentRequest(
+                        "sha", "an inline finding", "src/Main.java", 3, "RIGHT", null, null)),
+            () ->
+                reviews.replyToReviewComment(
+                    "Bearer token",
+                    ACCEPT,
+                    "owner",
+                    "repo",
+                    1,
+                    77L,
+                    new GitHubReviewClient.ReplyToReviewCommentRequest("a thread reply")));
+
+    var posted = new ArrayList<Future<Object>>();
+    try (var burst = Executors.newVirtualThreadPerTaskExecutor()) {
+      everyWrite.forEach(write -> posted.add(burst.submit(write)));
+      for (var write : posted) {
+        write.get(2, TimeUnit.MINUTES);
+      }
+    }
+
+    assertEquals(everyWrite.size(), arrivals.size(), "every write still reached GitHub");
+    assertSpacedOut();
+  }
+
+  private void assertSpacedOut() {
     var ordered = arrivals.stream().sorted().toList();
     var gaps = new ArrayList<Long>();
     for (int i = 1; i < ordered.size(); i++) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacingTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacingTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end proof of #579, through a real REST client against a loopback GitHub.
+ *
+ * <p>{@link GitHubWritePacerTest} pins the arithmetic of the shared cursor; what only a real client
+ * can show is that the limiter is actually on the path a comment takes, and that it holds when the
+ * burst is genuinely concurrent — several PRs commanded at once, which is exactly what produced the
+ * 29 rejections behind #568. The assertion is on when the requests <em>arrive at GitHub</em>, not
+ * on anything the bot recorded about itself.
+ *
+ * <p>The threshold is deliberately below the configured one-second envelope: a loaded machine can
+ * only push the arrivals further apart, never closer together, so the test cannot flake in the
+ * direction that would matter.
+ */
+@QuarkusTest
+class GitHubWritePacingTest {
+
+  private static final String ACCEPT = "application/vnd.github+json";
+
+  /** Four concurrent posts: one more than the retry budget, so backoff cannot explain the gaps. */
+  private static final int BURST = 4;
+
+  /** Floor on the spacing GitHub must see, in milliseconds, against a 1s configured interval. */
+  private static final long MIN_GAP_MS = 800;
+
+  private HttpServer server;
+  private final List<Long> arrivals = new CopyOnWriteArrayList<>();
+
+  @AfterEach
+  void stopServer() {
+    if (server != null) {
+      server.stop(0);
+      server = null;
+    }
+  }
+
+  private GitHubCommentClient clientAnsweredBy(HttpHandler handler) throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/", handler);
+    server.setExecutor(Executors.newVirtualThreadPerTaskExecutor());
+    server.start();
+    return QuarkusRestClientBuilder.newBuilder()
+        .baseUri(URI.create("http://127.0.0.1:" + server.getAddress().getPort()))
+        .build(GitHubCommentClient.class);
+  }
+
+  private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+    var bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().add("Content-Type", "application/json");
+    exchange.sendResponseHeaders(status, bytes.length);
+    try (var out = exchange.getResponseBody()) {
+      out.write(bytes);
+    }
+  }
+
+  @Test
+  void aConcurrentBurstOfCommentsReachesGitHubSpacedOutRatherThanAllAtOnce() throws Exception {
+    var client =
+        clientAnsweredBy(
+            exchange -> {
+              arrivals.add(System.nanoTime());
+              respond(exchange, 201, "{\"id\":1,\"html_url\":\"https://github.test/c/1\"}");
+            });
+
+    var posted = new ArrayList<Future<GitHubCommentClient.CommentResponse>>();
+    try (var burst = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (int pr = 1; pr <= BURST; pr++) {
+        int number = pr;
+        posted.add(
+            burst.submit(
+                () ->
+                    client.createComment(
+                        "Bearer token",
+                        ACCEPT,
+                        "owner",
+                        "repo",
+                        number,
+                        new GitHubCommentClient.CreateCommentRequest("the generated reply"))));
+      }
+      for (var reply : posted) {
+        reply.get(2, TimeUnit.MINUTES);
+      }
+    }
+
+    assertEquals(BURST, arrivals.size(), "every comment still posted");
+    var ordered = arrivals.stream().sorted().toList();
+    var gaps = new ArrayList<Long>();
+    for (int i = 1; i < ordered.size(); i++) {
+      gaps.add(TimeUnit.NANOSECONDS.toMillis(ordered.get(i) - ordered.get(i - 1)));
+    }
+    assertTrue(
+        gaps.stream().allMatch(gap -> gap >= MIN_GAP_MS),
+        () ->
+            "content-creating calls reached GitHub "
+                + gaps
+                + "ms apart; its envelope is one per second, and a burst tighter than that is"
+                + " exactly what it answers with 403");
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
@@ -234,6 +234,32 @@ class GitHubWriteRetryTest {
   }
 
   @Test
+  void everyAttemptWaitsForItsPacingSlotIncludingTheRepeats() {
+    var paced = new ArrayList<Duration>();
+    var calls = new AtomicInteger();
+    var pacedRetry =
+        new GitHubWriteRetry(
+            slept::add,
+            () -> Instant.ofEpochSecond(1_800_000_000L),
+            new GitHubWritePacer(
+                Duration.ofSeconds(1), Duration.ofSeconds(60), paced::add, () -> 0L));
+
+    var result =
+        pacedRetry.call(
+            "a comment on o/r #7",
+            () -> {
+              if (calls.incrementAndGet() < 3) {
+                throw throttled("Retry-After", "1");
+              }
+              return "posted";
+            });
+
+    // A repeat is a content-creating call too, so it queues rather than jumping the limiter.
+    assertEquals("posted", result);
+    assertEquals(List.of(Duration.ofSeconds(1), Duration.ofSeconds(2)), paced);
+  }
+
+  @Test
   void anInterruptedBackoffStopsImmediatelyAndKeepsTheInterrupt() {
     var calls = new AtomicInteger();
     var interrupting =


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature

## Description

#568 made a throttled post survivable; it does not stop the burst being produced. In the run behind
it, 56 commands across 8 PRs created content faster than GitHub would accept it and drew **29
rejections** — every one a wasted round trip, a spent retry attempt, and a dispatcher slot held
while a doomed call backed off.

`GitHubWritePacer` spaces content-creating calls out instead, so the bot stays inside GitHub's
secondary-rate-limit envelope rather than discovering it by rejection.

**Where it sits.** On the same seam as the backoff — `GitHubWriteRetry#call` — which is exactly the
set GitHub counts as content creation: `createComment`, `updateComment`, `createReview`,
`createPullRequestComment`, `replyToReviewComment`. It is therefore process-wide and shared across
reviews and commands rather than per review, which is what the issue asks for: the bot produces a
burst without anyone doing anything unusual. `ReviewPublisher#tryPostInlineComment` issues one
content-creating call per inline finding, and several PRs are reviewed concurrently.

**How a slot is claimed.** Each caller atomically claims the next free instant and advances a shared
cursor by one interval, then waits until the instant it claimed. Claiming is a single atomic update
with no lock held across the HTTP call, so a slow request never blocks the queue behind it, and
callers go out in the order they arrived instead of in a thundering herd when the interval elapses.

**Both numbers are knobs rather than constants**, as the issue asks:

| key | env | default | meaning |
| --- | --- | --- | --- |
| `thrillhousebot.github.write-min-interval` | `GITHUB_WRITE_MIN_INTERVAL` | `1s` | spacing between two content-creating requests; `0` disables pacing entirely |
| `thrillhousebot.github.write-max-wait` | `GITHUB_WRITE_MAX_WAIT` | `60s` | ceiling on how long one caller waits for its slot |

The default is GitHub's published guidance: no more than one content-creating request per second.

**Why there is a ceiling.** A wait holds the per-PR serialization slot in the dispatcher — the same
reason #568's backoff is bounded twice over. Past the ceiling the call goes out unpaced and the
bounded backoff handles a refusal, which is exactly where the bot is today, rather than parking a
finished command for minutes.

**Why pacing can never cost a payload.** A pacing wait that is interrupted proceeds with the call
rather than failing it. The content on its way out has already been paid for, so the worst this
limiter is ever allowed to do is let a burst through.

**How this composes with #568 and #578.** The pacer is the preventative form: it keeps the burst
from being produced. The backoff remains the fallback for throttling pacing cannot prevent — another
instance of the App, or a repo busy for reasons the bot did not cause — and #578's dropped-post
notice is the last resort when even that runs out. Every attempt is paced, repeats included, so a
repeat queues rather than jumping the limiter.

## Related Issues

Fixes #579

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

`GitHubWritePacerTest` drives the clock by hand and records the waiting instead of serving it, so
what is pinned is the arithmetic of the shared cursor: the lone write that is not delayed at all, a
burst handed out one interval apart, a queue that drained charging nothing, the ceiling clamping a
long queue, `0` disabling pacing, an interrupted wait sending the call anyway, and the knob falling
back to the guidance when unset. `GitHubWriteRetryTest` gains a case showing a throttle repeat is
paced too.

`GitHubWritePacingTest` is a `@QuarkusTest` driving a real REST client against a loopback GitHub —
the only thing that can show the limiter is on the path a comment actually takes, and that it holds
when the burst is genuinely concurrent. It asserts on when the requests *arrive at GitHub*, not on
anything the bot recorded about itself.

### Red/green proof

`GitHubWritePacingTest` compiles unchanged against the base commit, so it was run there:

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3.075 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.github.GitHubWritePacingTest
[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubWritePacingTest.aConcurrentBurstOfCommentsReachesGitHubSpacedOutRatherThanAllAtOnce -- Time elapsed: 0.586 s <<< FAILURE!
org.opentest4j.AssertionFailedError: content-creating calls reached GitHub [0, 0, 0]ms apart; its envelope is one per second, and a burst tighter than that is exactly what it answers with 403 ==> expected: <true> but was: <false>
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:199)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubWritePacingTest.aConcurrentBurstOfCommentsReachesGitHubSpacedOutRatherThanAllAtOnce(GitHubWritePacingTest.java:128)
```

`[0, 0, 0]ms apart` is the defect verbatim: four concurrent posts all reach GitHub inside the same
millisecond, which is the burst it answers with 403. With the fix they arrive a second apart.

### Gates

- `./mvnw -B spotless:apply` → BUILD SUCCESS
- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` → **Tests run: 2779, Failures: 0, Errors: 0, Skipped: 0**
- JaCoCo ∩ `git diff -U0 fda4bc7...HEAD` → **0 uncovered lines, 0 uncovered branches** across the 38 trackable changed main-code lines (`GitHubWritePacer` 32, `GitHubWriteRetry` 6)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

The limiter is quiet by design — it logs at debug, because a slot wait is normal operation rather
than an incident:

```
DEBUG [GitHubWritePacer] Pacing a comment on owner/repo #3 — waiting 1000ms for a content-creation slot
```

The line that used to appear instead is the 403 the wait prevents.

## Additional Notes

`ThrillhouseConfig.GitHubConfig` gains the two knobs. That is not optional: `@ConfigMapping(prefix =
"thrillhousebot")` validates its whole namespace, so an undeclared `thrillhousebot.github.*` key
fails startup outright —

```
io.smallrye.config.ConfigValidationException: Configuration validation failed:
	SRCFG00050: thrillhousebot.github.write-min-interval ... does not map to any root
```

— and the declaration is the namespace's schema. The limiter itself reads the key directly, because
it lives on the REST clients' `default`-method write path where there is no CDI.

The follow-up for #578 (announcing a dropped post on the PR) touches a disjoint set of files —
`GitHubCommentClient`, `GitHubReviewClient` and a new class — so the two merge cleanly in either
order.


## Review follow-up

Both of the review's lower-confidence findings were checked against the code rather than argued
with. Both turned out to be right about the *evidence* being thin and wrong about there being a
defect, so **nothing under `src/main` changed** and two tests were added instead.

**"Verify all five content-creating methods dispatch through `GitHubWriteRetry.call`."** They do —
all five, and nothing else does:

```
$ grep -n "GitHubWriteRetry.DEFAULT.call" src/main/java/dev/thiagogonzaga/thrillhousebot/github/*.java
GitHubCommentClient.java:58    createComment
GitHubCommentClient.java:136   updateComment
GitHubReviewClient.java:56     createReview
GitHubReviewClient.java:172    createPullRequestComment
GitHubReviewClient.java:202    replyToReviewComment
```

Five hits, five methods, no other call sites — and `call` paces unconditionally, so reaching it *is*
being paced. The finding is right that only one of the five was demonstrated end to end, and that is
worth closing because it is this PR's central claim. `GitHubWritePacingTest.everyContentCreatingCallIsPacedAndNotJustTheConversationComment`
now fires all five at once against the loopback GitHub and asserts every arrival is spaced. On the
base commit it fails exactly as the finding predicts an unpaced path would:

```
org.opentest4j.AssertionFailedError: content-creating calls reached GitHub [1, 2, 0, 0]ms apart; its envelope is one per second, and a burst tighter than that is exactly what it answers with 403 ==> expected: <true> but was: <false>
	at dev.thiagogonzaga.thrillhousebot.github.GitHubWritePacingTest.everyContentCreatingCallIsPacedAndNotJustTheConversationComment(GitHubWritePacingTest.java:199)
```

**"Documented '0 disables pacing' value never exercised through the config converter."** It survives
it. Measured against the real SmallRye converter rather than reasoned about:

```
PROBE raw=0    -> PT0S
PROBE raw=0s   -> PT0S
PROBE raw=0S   -> PT0S
PROBE raw=PT0S -> PT0S
```

So a bare `0` converts to `Duration.ZERO`, the documentation is accurate, and the startup-validation
failure the finding feared does not occur — no wording changed. The gap it identifies is real
though: that promise runs through the converter, while the only zero-interval test handed
`Duration.ZERO` straight to the constructor. `GitHubWritePacerTest.theDocumentedBareZeroSurvivesTheConfigConverterAndReallyDisablesPacing`
now sets the property, converts it, and paces a burst with the result, because the failure mode
would otherwise stay invisible until an operator reached for the knob during an incident.
