### PR TITLE
feat(github): tell the pull request when a throttled reply was dropped

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
@@ -47,6 +47,11 @@ public interface GitHubCommentClient {
    * — 7 of 56 responses in the burst that motivated this. {@link GitHubWriteRetry} repeats the post
    * only on a positively identified throttle, never on an ambiguous failure that might already have
    * created the comment, so no reply is ever posted twice.
+   *
+   * <p>This is also the surface that tells the user when a post was lost anyway (#578): a comment
+   * dropped once the budget is spent leaves a notice behind, and the next comment to land on the
+   * same pull request carries it up front. See {@link GitHubLostWrites} for why the notice travels
+   * with a comment rather than being posted as one.
    */
   default CommentResponse createComment(
       String auth,
@@ -55,9 +60,20 @@ public interface GitHubCommentClient {
       String repo,
       int issueNumber,
       CreateCommentRequest request) {
-    return GitHubWriteRetry.DEFAULT.call(
-        "a comment on " + owner + "/" + repo + " #" + issueNumber,
-        () -> createCommentOnce(auth, accept, owner, repo, issueNumber, request));
+    return GitHubLostWrites.SHARED.carrying(
+        new GitHubLostWrites.Target(owner, repo, issueNumber),
+        notice ->
+            GitHubWriteRetry.DEFAULT.call(
+                "a comment on " + owner + "/" + repo + " #" + issueNumber,
+                () ->
+                    createCommentOnce(
+                        auth,
+                        accept,
+                        owner,
+                        repo,
+                        issueNumber,
+                        new CreateCommentRequest(
+                            GitHubLostWrites.prepend(notice, request.body())))));
   }
 
   // GitHub serves 30 issue comments per page by default; 100 is the maximum.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWrites.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWrites.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -57,7 +58,9 @@ public final class GitHubLostWrites {
   private static final Logger log = LoggerFactory.getLogger(GitHubLostWrites.class);
 
   /**
-   * How many pull requests may hold a pending notice at once, so the map cannot grow without end.
+   * How many pull requests may hold an outstanding notice at once, so the map cannot grow without
+   * end. An entry is dropped as soon as its notice has been delivered, so a slot is only held while
+   * a pull request is genuinely still owed one.
    */
   static final int DEFAULT_MAX_TARGETS = 200;
 
@@ -73,30 +76,41 @@ public final class GitHubLostWrites {
   }
 
   /**
-   * What this pull request has lost, as two running totals and the time of the last loss.
+   * What this pull request has lost, as two running totals and the time of the last loss, under an
+   * id identifying this run of losses.
    *
-   * <p>They are watermarks rather than a single "outstanding" count on purpose. Two posts on the
-   * same pull request can be in flight at once, each having read the same pending total, and a
+   * <p>The totals are watermarks rather than a single "outstanding" count on purpose. Two posts on
+   * the same pull request can be in flight at once, each having read the same pending total, and a
    * fresh loss can land between their reads and their completions. Subtracting each carrier's
    * snapshot from a shared counter double-counts that overlap and can retire a loss neither post
    * actually announced — the user then never hears about it, which is the failure #578 exists to
    * remove. Advancing {@code announced} monotonically towards {@code lost} instead can only ever
    * repeat a notice, never drop one, and repeating is the harmless direction.
+   *
+   * <p>{@code id} exists because a fully announced entry is dropped rather than kept at zero. Both
+   * totals restart from scratch when a later loss recreates the entry, so a carrier still in flight
+   * from the previous run holds a snapshot whose {@code lost} may equal the new run's — and would
+   * retire it. Comparing the id makes that stale carrier a no-op, which is what lets the entry be
+   * dropped at all.
    */
-  private record Loss(long lost, long announced, Instant at) {
+  private record Loss(long id, long lost, long announced, Instant at) {
     int pending() {
       return (int) (lost - announced);
     }
   }
 
-  /** Stands in for a pull request with nothing pending, so no code path handles a null loss. */
-  private static final Loss NOTHING = new Loss(0, 0, Instant.EPOCH);
+  /**
+   * Stands in for a pull request with nothing pending, so no code path handles a null loss. Its id
+   * matches no real entry — {@link #ids} only ever hands out positive ones.
+   */
+  private static final Loss NOTHING = new Loss(0, 0, 0, Instant.EPOCH);
 
   /** The process-wide registry: a loss recorded on one code path is announced by any other. */
   static final GitHubLostWrites SHARED =
       new GitHubLostWrites(Instant::now, DEFAULT_MAX_TARGETS, DEFAULT_TTL);
 
   private final Map<Target, Loss> pending = new ConcurrentHashMap<>();
+  private final AtomicLong ids = new AtomicLong();
   private final Supplier<Instant> clock;
   private final int maxTargets;
   private final Duration ttl;
@@ -173,9 +187,15 @@ public final class GitHubLostWrites {
   }
 
   /**
-   * Marks everything the delivered post carried as announced. The watermark only moves forward, so
-   * a second carrier that read the same snapshot cannot retire a loss recorded after it — the entry
-   * is left in place with the newer loss still pending rather than being cleared.
+   * Marks everything the delivered post carried as announced, and drops the entry once nothing is
+   * left pending on it so its slot goes back to the registry immediately rather than sitting
+   * settled until the TTL sweeps it.
+   *
+   * <p>Two guards decide whether this delivery counts. The id must still match, or this carrier is
+   * stale — the entry it read was already announced and dropped, and what sits here now is a later,
+   * unrelated run of losses it never carried. The watermark must still be behind, or a second
+   * carrier that read the same snapshot would retire a loss recorded after it. Failing either one
+   * leaves the entry exactly as found.
    */
   private void announce(Target target, Loss carried) {
     if (carried.pending() == 0) {
@@ -183,10 +203,13 @@ public final class GitHubLostWrites {
     }
     pending.computeIfPresent(
         target,
-        (key, loss) ->
-            loss.announced() >= carried.lost()
-                ? loss
-                : new Loss(loss.lost(), carried.lost(), loss.at()));
+        (key, loss) -> {
+          if (loss.id() != carried.id() || loss.announced() >= carried.lost()) {
+            return loss;
+          }
+          var settled = new Loss(loss.id(), loss.lost(), carried.lost(), loss.at());
+          return settled.pending() == 0 ? null : settled;
+        });
   }
 
   private void remember(Target target) {
@@ -204,8 +227,8 @@ public final class GitHubLostWrites {
     var total =
         pending.merge(
             target,
-            new Loss(1, 0, now),
-            (old, one) -> new Loss(old.lost() + 1, old.announced(), now));
+            new Loss(ids.incrementAndGet(), 1, 0, now),
+            (old, one) -> new Loss(old.id(), old.lost() + 1, old.announced(), now));
     log.warn(
         "Lost a throttled post on {} — the next comment the bot lands there will say so ({} now"
             + " pending)",

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWrites.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWrites.java
@@ -72,8 +72,25 @@ public final class GitHubLostWrites {
     }
   }
 
-  /** How many posts this pull request has lost, and when the last one went. */
-  private record Loss(int count, Instant at) {}
+  /**
+   * What this pull request has lost, as two running totals and the time of the last loss.
+   *
+   * <p>They are watermarks rather than a single "outstanding" count on purpose. Two posts on the
+   * same pull request can be in flight at once, each having read the same pending total, and a
+   * fresh loss can land between their reads and their completions. Subtracting each carrier's
+   * snapshot from a shared counter double-counts that overlap and can retire a loss neither post
+   * actually announced — the user then never hears about it, which is the failure #578 exists to
+   * remove. Advancing {@code announced} monotonically towards {@code lost} instead can only ever
+   * repeat a notice, never drop one, and repeating is the harmless direction.
+   */
+  private record Loss(long lost, long announced, Instant at) {
+    int pending() {
+      return (int) (lost - announced);
+    }
+  }
+
+  /** Stands in for a pull request with nothing pending, so no code path handles a null loss. */
+  private static final Loss NOTHING = new Loss(0, 0, Instant.EPOCH);
 
   /** The process-wide registry: a loss recorded on one code path is announced by any other. */
   static final GitHubLostWrites SHARED =
@@ -93,13 +110,14 @@ public final class GitHubLostWrites {
   /**
    * Runs a content-creating call whose body lands in the pull request's conversation, handing it
    * the pending notice to carry (or an empty string when there is nothing to say). The notice is
-   * only cleared once the call has actually succeeded, so a post that is itself dropped does not
-   * take the notice with it.
+   * only marked announced once the call has actually succeeded, so a post that is itself dropped
+   * does not take the notice with it, and a loss that lands while this post is in flight is still
+   * waiting for the next one.
    */
   public <T> T carrying(Target target, Function<String, T> send) {
-    int carried = pendingCount(target);
-    var result = recording(target, () -> send.apply(notice(carried)));
-    settle(target, carried);
+    var carried = snapshot(target);
+    var result = recording(target, () -> send.apply(notice(carried.pending())));
+    announce(target, carried);
     return result;
   }
 
@@ -141,26 +159,34 @@ public final class GitHubLostWrites {
     return body == null || body.isBlank() ? notice : notice + "\n\n" + body;
   }
 
-  private int pendingCount(Target target) {
+  /** What this pull request has pending right now, or {@link #NOTHING} when it has nothing. */
+  private Loss snapshot(Target target) {
     var loss = pending.get(target);
     if (loss == null) {
-      return 0;
+      return NOTHING;
     }
     if (expired(loss, clock.get())) {
       pending.remove(target, loss);
-      return 0;
+      return NOTHING;
     }
-    return loss.count();
+    return loss;
   }
 
-  /** Drops what was just announced, keeping anything lost while this post was in flight. */
-  private void settle(Target target, int carried) {
-    if (carried == 0) {
+  /**
+   * Marks everything the delivered post carried as announced. The watermark only moves forward, so
+   * a second carrier that read the same snapshot cannot retire a loss recorded after it — the entry
+   * is left in place with the newer loss still pending rather than being cleared.
+   */
+  private void announce(Target target, Loss carried) {
+    if (carried.pending() == 0) {
       return;
     }
     pending.computeIfPresent(
         target,
-        (key, loss) -> loss.count() > carried ? new Loss(loss.count() - carried, loss.at()) : null);
+        (key, loss) ->
+            loss.announced() >= carried.lost()
+                ? loss
+                : new Loss(loss.lost(), carried.lost(), loss.at()));
   }
 
   private void remember(Target target) {
@@ -176,12 +202,15 @@ public final class GitHubLostWrites {
       return;
     }
     var total =
-        pending.merge(target, new Loss(1, now), (old, one) -> new Loss(old.count() + 1, now));
+        pending.merge(
+            target,
+            new Loss(1, 0, now),
+            (old, one) -> new Loss(old.lost() + 1, old.announced(), now));
     log.warn(
         "Lost a throttled post on {} — the next comment the bot lands there will say so ({} now"
             + " pending)",
         target,
-        total.count());
+        total.pending());
   }
 
   private boolean expired(Loss loss, Instant now) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWrites.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWrites.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import jakarta.ws.rs.WebApplicationException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Makes a post that GitHub threw away visible on the pull request, instead of only in the bot's
+ * log.
+ *
+ * <p>#578: {@link GitHubWriteRetry} bounds its budget, so a persistently throttled reply is still
+ * dropped once the attempts are spent. Today that is logged and nothing else — from the PR the
+ * command simply never answered, which is indistinguishable from the bot ignoring the user, and the
+ * user has no way to know the right move is to run it again.
+ *
+ * <h2>Why the notice rides along instead of being posted</h2>
+ *
+ * The obvious remedy — reply "this was throttled, please re-run" — is itself a {@code
+ * createComment}: the exact call that is being throttled, sent at the exact moment GitHub is
+ * refusing it. So the notice is not posted on its own. It is held, and the <em>next</em> content
+ * the bot successfully lands on that pull request carries it. That costs no additional
+ * content-creating request (which is the whole point of #579), cannot be throttled separately from
+ * the post it travels with, and appears on the PR the loss happened on rather than in a log the
+ * user cannot read.
+ *
+ * <p>What it cannot do is promise delivery on a PR the bot never writes to again; that case is no
+ * worse than today's log-only behaviour. A notice is also forgotten after {@link #DEFAULT_TTL},
+ * because "a reply was dropped" glued onto a comment days later is noise rather than a signal.
+ *
+ * <p>The wording deliberately does not name the command. This layer sees a comment on a pull
+ * request, not the {@code /describe} or {@code /improve} that produced it, and an honest "if you
+ * were waiting on an answer, re-run it" is more useful than a guess.
+ */
+public final class GitHubLostWrites {
+
+  private static final Logger log = LoggerFactory.getLogger(GitHubLostWrites.class);
+
+  /**
+   * How many pull requests may hold a pending notice at once, so the map cannot grow without end.
+   */
+  static final int DEFAULT_MAX_TARGETS = 200;
+
+  /** How long a pending notice stays worth announcing. */
+  static final Duration DEFAULT_TTL = Duration.ofHours(6);
+
+  /** The pull request a content-creating call was aimed at. */
+  public record Target(String owner, String repo, int number) {
+    @Override
+    public String toString() {
+      return owner + "/" + repo + " #" + number;
+    }
+  }
+
+  /** How many posts this pull request has lost, and when the last one went. */
+  private record Loss(int count, Instant at) {}
+
+  /** The process-wide registry: a loss recorded on one code path is announced by any other. */
+  static final GitHubLostWrites SHARED =
+      new GitHubLostWrites(Instant::now, DEFAULT_MAX_TARGETS, DEFAULT_TTL);
+
+  private final Map<Target, Loss> pending = new ConcurrentHashMap<>();
+  private final Supplier<Instant> clock;
+  private final int maxTargets;
+  private final Duration ttl;
+
+  GitHubLostWrites(Supplier<Instant> clock, int maxTargets, Duration ttl) {
+    this.clock = clock;
+    this.maxTargets = maxTargets;
+    this.ttl = ttl;
+  }
+
+  /**
+   * Runs a content-creating call whose body lands in the pull request's conversation, handing it
+   * the pending notice to carry (or an empty string when there is nothing to say). The notice is
+   * only cleared once the call has actually succeeded, so a post that is itself dropped does not
+   * take the notice with it.
+   */
+  public <T> T carrying(Target target, Function<String, T> send) {
+    int carried = pendingCount(target);
+    var result = recording(target, () -> send.apply(notice(carried)));
+    settle(target, carried);
+    return result;
+  }
+
+  /**
+   * Runs a content-creating call that cannot carry a notice — an inline comment or a thread reply —
+   * but can still leave one behind when GitHub throttles it away.
+   */
+  public <T> T recording(Target target, Supplier<T> send) {
+    try {
+      return send.get();
+    } catch (WebApplicationException e) {
+      // Only a throttle: a permission refusal or a 422 is a defect to fix, not a post to re-run,
+      // and announcing it on the PR would be noise on every single comment.
+      if (GitHubApiError.of(e).filter(GitHubApiError::isThrottled).isPresent()) {
+        remember(target);
+      }
+      throw e;
+    }
+  }
+
+  /** The notice text for {@code lost} dropped posts, or empty when there is nothing pending. */
+  static String notice(int lost) {
+    if (lost <= 0) {
+      return "";
+    }
+    return "> [!WARNING]\n> "
+        + (lost == 1
+            ? "**An earlier reply on this pull request was never posted.**"
+            : "**" + lost + " earlier replies on this pull request were never posted.**")
+        + " GitHub was rate-limiting the bot and the retries ran out, so work it had already"
+        + " finished was thrown away. If you were waiting on an answer, run the command again.";
+  }
+
+  /** Puts {@code notice} above {@code body}, leaving the body untouched when there is no notice. */
+  static String prepend(String notice, String body) {
+    if (notice.isEmpty()) {
+      return body;
+    }
+    return body == null || body.isBlank() ? notice : notice + "\n\n" + body;
+  }
+
+  private int pendingCount(Target target) {
+    var loss = pending.get(target);
+    if (loss == null) {
+      return 0;
+    }
+    if (expired(loss, clock.get())) {
+      pending.remove(target, loss);
+      return 0;
+    }
+    return loss.count();
+  }
+
+  /** Drops what was just announced, keeping anything lost while this post was in flight. */
+  private void settle(Target target, int carried) {
+    if (carried == 0) {
+      return;
+    }
+    pending.computeIfPresent(
+        target,
+        (key, loss) -> loss.count() > carried ? new Loss(loss.count() - carried, loss.at()) : null);
+  }
+
+  private void remember(Target target) {
+    var now = clock.get();
+    pending.values().removeIf(loss -> expired(loss, now));
+    if (pending.size() >= maxTargets && !pending.containsKey(target)) {
+      // Nothing left to do but say so in the log, which is exactly where #578 started.
+      log.warn(
+          "Lost a throttled post on {} and {} pull requests already hold a pending notice, so this"
+              + " one is only recorded here",
+          target,
+          pending.size());
+      return;
+    }
+    var total =
+        pending.merge(target, new Loss(1, now), (old, one) -> new Loss(old.count() + 1, now));
+    log.warn(
+        "Lost a throttled post on {} — the next comment the bot lands there will say so ({} now"
+            + " pending)",
+        target,
+        total.count());
+  }
+
+  private boolean expired(Loss loss, Instant now) {
+    return Duration.between(loss.at(), now).compareTo(ttl) > 0;
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -45,6 +45,10 @@ public interface GitHubReviewClient {
    * Posts the review, backing off and reposting while GitHub is throttling (#568). The review body
    * and every inline finding in it are the run's model output, so a throttled 403 here discards the
    * whole generation. See {@link GitHubWriteRetry} for why the repeat cannot post it twice.
+   *
+   * <p>The review body is the second surface that can carry a dropped-post notice (#578): it lands
+   * in the pull request's conversation, so a reply GitHub threw away earlier is announced here when
+   * a review is what comes next.
    */
   default ReviewResponse createReview(
       String auth,
@@ -53,9 +57,23 @@ public interface GitHubReviewClient {
       String repo,
       int pullNumber,
       CreateReviewRequest request) {
-    return GitHubWriteRetry.DEFAULT.call(
-        "a review on " + owner + "/" + repo + " #" + pullNumber,
-        () -> createReviewOnce(auth, accept, owner, repo, pullNumber, request));
+    return GitHubLostWrites.SHARED.carrying(
+        new GitHubLostWrites.Target(owner, repo, pullNumber),
+        notice ->
+            GitHubWriteRetry.DEFAULT.call(
+                "a review on " + owner + "/" + repo + " #" + pullNumber,
+                () ->
+                    createReviewOnce(
+                        auth,
+                        accept,
+                        owner,
+                        repo,
+                        pullNumber,
+                        new CreateReviewRequest(
+                            request.commitId(),
+                            GitHubLostWrites.prepend(notice, request.body()),
+                            request.event(),
+                            request.comments()))));
   }
 
   // GitHub serves 30 reviews per page by default; request the 100 max and bound the page walk.
@@ -161,7 +179,12 @@ public interface GitHubReviewClient {
       @PathParam("pullNumber") int pullNumber,
       CreatePullRequestCommentRequest request);
 
-  /** Posts an inline comment, with the throttle backoff described on {@link GitHubWriteRetry}. */
+  /**
+   * Posts an inline comment, with the throttle backoff described on {@link GitHubWriteRetry}. An
+   * inline comment is anchored to a diff line, so it is a poor place to announce an unrelated
+   * dropped post and does not carry a notice — but losing one is still a loss the pull request
+   * should hear about, so it leaves a notice for the next comment to carry (#578).
+   */
   default PullRequestCommentResponse createPullRequestComment(
       String auth,
       String accept,
@@ -169,9 +192,13 @@ public interface GitHubReviewClient {
       String repo,
       int pullNumber,
       CreatePullRequestCommentRequest request) {
-    return GitHubWriteRetry.DEFAULT.call(
-        "an inline comment on " + owner + "/" + repo + " #" + pullNumber,
-        () -> createPullRequestCommentOnce(auth, accept, owner, repo, pullNumber, request));
+    return GitHubLostWrites.SHARED.recording(
+        new GitHubLostWrites.Target(owner, repo, pullNumber),
+        () ->
+            GitHubWriteRetry.DEFAULT.call(
+                "an inline comment on " + owner + "/" + repo + " #" + pullNumber,
+                () ->
+                    createPullRequestCommentOnce(auth, accept, owner, repo, pullNumber, request)));
   }
 
   /** One HTTP attempt at a thread reply. Callers want {@link #replyToReviewComment} instead. */
@@ -190,6 +217,8 @@ public interface GitHubReviewClient {
 
   /**
    * Replies in a review thread, with the throttle backoff described on {@link GitHubWriteRetry}.
+   * Like an inline comment it belongs to its thread rather than to the conversation, so it leaves a
+   * dropped-post notice behind (#578) without carrying one.
    */
   default PullRequestCommentResponse replyToReviewComment(
       String auth,
@@ -199,9 +228,14 @@ public interface GitHubReviewClient {
       int pullNumber,
       long commentId,
       ReplyToReviewCommentRequest request) {
-    return GitHubWriteRetry.DEFAULT.call(
-        "a reply to comment " + commentId + " on " + owner + "/" + repo + " #" + pullNumber,
-        () -> replyToReviewCommentOnce(auth, accept, owner, repo, pullNumber, commentId, request));
+    return GitHubLostWrites.SHARED.recording(
+        new GitHubLostWrites.Target(owner, repo, pullNumber),
+        () ->
+            GitHubWriteRetry.DEFAULT.call(
+                "a reply to comment " + commentId + " on " + owner + "/" + repo + " #" + pullNumber,
+                () ->
+                    replyToReviewCommentOnce(
+                        auth, accept, owner, repo, pullNumber, commentId, request)));
   }
 
   @DELETE

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubDroppedCommentNoticeTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubDroppedCommentNoticeTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.ws.rs.WebApplicationException;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end proof of #578, through a real REST client against a loopback GitHub: a reply GitHub
+ * threw away leaves a trace the user can actually see.
+ *
+ * <p>What is asserted is the body GitHub receives, because that is the only thing the user ever
+ * sees — the log line the retry already writes is exactly what #578 says is not enough.
+ *
+ * <p>The pull-request numbers are unique to this class: the registry behind the notice is
+ * process-wide by design, and a number nobody else posts to keeps this test from leaning on, or
+ * disturbing, anything else in the suite.
+ */
+@QuarkusTest
+class GitHubDroppedCommentNoticeTest {
+
+  private static final String ACCEPT = "application/vnd.github+json";
+
+  /** The PR whose reply is thrown away. */
+  private static final int LOSING_PR = 5781;
+
+  /** A different PR, to show the notice does not follow the bot around. */
+  private static final int OTHER_PR = 5782;
+
+  private static final String SECONDARY_LIMIT_BODY =
+      "{\"message\":\"You have exceeded a secondary rate limit. Please wait a few minutes before"
+          + " you try again.\",\"documentation_url\":\"https://docs.github.com/rest\"}";
+
+  private HttpServer server;
+  private GitHubCommentClient client;
+  private final AtomicBoolean throttling = new AtomicBoolean(true);
+  private final List<String> received = new CopyOnWriteArrayList<>();
+
+  @BeforeEach
+  void startGitHub() throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext(
+        "/",
+        exchange -> {
+          received.add(
+              new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+          if (throttling.get()) {
+            exchange.getResponseHeaders().add("Retry-After", "0");
+            exchange.getResponseHeaders().add("x-ratelimit-remaining", "0");
+            respond(exchange, 403, SECONDARY_LIMIT_BODY);
+          } else {
+            respond(exchange, 201, "{\"id\":42,\"html_url\":\"https://github.test/c/42\"}");
+          }
+        });
+    server.start();
+    client =
+        QuarkusRestClientBuilder.newBuilder()
+            .baseUri(URI.create("http://127.0.0.1:" + server.getAddress().getPort()))
+            .build(GitHubCommentClient.class);
+  }
+
+  @AfterEach
+  void stopGitHub() {
+    if (server != null) {
+      server.stop(0);
+      server = null;
+    }
+  }
+
+  private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+    var bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().add("Content-Type", "application/json");
+    exchange.sendResponseHeaders(status, bytes.length);
+    try (var out = exchange.getResponseBody()) {
+      out.write(bytes);
+    }
+  }
+
+  private void comment(int pullNumber, String body) {
+    client.createComment(
+        "Bearer token",
+        ACCEPT,
+        "owner",
+        "repo",
+        pullNumber,
+        new GitHubCommentClient.CreateCommentRequest(body));
+  }
+
+  @Test
+  void aReplyGitHubThrewAwayIsAnnouncedOnTheNextCommentThatLands() {
+    assertThrows(
+        WebApplicationException.class,
+        () -> comment(LOSING_PR, "the answer to /add-docs"),
+        "the throttled reply is dropped once the budget is spent");
+    assertEquals(GitHubWriteRetry.MAX_ATTEMPTS, received.size(), "the budget was actually spent");
+    received.clear();
+    throttling.set(false);
+
+    comment(LOSING_PR, "the answer to /describe");
+
+    // Without this the user sees a command that simply never answered, which is what #538 fixed
+    // for the decline case and what #578 is about for the dropped case.
+    var landed = received.getFirst();
+    assertTrue(landed.contains("[!WARNING]"), landed);
+    assertTrue(landed.contains("earlier reply on this pull request was never posted"), landed);
+    assertTrue(landed.contains("run the command again"), landed);
+    // It rides along with real content rather than costing a comment of its own.
+    assertTrue(landed.contains("the answer to /describe"), landed);
+  }
+
+  @Test
+  void theNoticeStaysOnThePullRequestThatLostTheReply() {
+    assertThrows(WebApplicationException.class, () -> comment(OTHER_PR + 100, "a lost answer"));
+    received.clear();
+    throttling.set(false);
+
+    comment(OTHER_PR, "an unrelated answer");
+
+    var landed = received.getFirst();
+    assertTrue(landed.contains("an unrelated answer"), landed);
+    assertFalse(landed.contains("[!WARNING]"), landed);
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWritesTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWritesTest.java
@@ -220,6 +220,55 @@ class GitHubLostWritesTest {
   }
 
   @Test
+  void aRegistryFullOfAlreadyDeliveredNoticesStillHasRoomForANewLoss() {
+    var carried = new ArrayList<String>();
+
+    // Both of the two slots this fixture allows are used and then settled: each pull request lost
+    // a post and each was told about it on its next comment.
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    post(PR, carried, null);
+    assertThrows(WebApplicationException.class, () -> post(OTHER_PR, carried, throttled()));
+    post(OTHER_PR, carried, null);
+
+    var third = new GitHubLostWrites.Target("owner", "repo", 9);
+    assertThrows(WebApplicationException.class, () -> post(third, carried, throttled()));
+    post(third, carried, null);
+
+    // Nothing is owed to either of the first two any more, so holding their slots until the TTL
+    // sweeps them would spend the cap on settled bookkeeping and silence a pull request that has
+    // genuinely lost a reply — the same silence, reached from the other end.
+    assertTrue(
+        carried.getLast().contains("An earlier reply"),
+        () ->
+            "the registry was full of already-delivered notices, so the new loss was only logged;"
+                + " the next comment carried: \""
+                + carried.getLast()
+                + "\"");
+  }
+
+  @Test
+  void aCarrierLeftOverFromASettledEntryCannotRetireALaterLoss() {
+    var carried = new ArrayList<String>();
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+
+    lost.carrying(
+        PR,
+        staleNotice -> {
+          carried.add(staleNotice);
+          // A second post delivers the same notice and settles the entry, then a later loss starts
+          // a fresh one. Both runs count one loss, so only the entry's identity separates them.
+          post(PR, carried, null);
+          assertThrows(
+              WebApplicationException.class, () -> lost.recording(PR, () -> throwIt(throttled())));
+          return "posted";
+        });
+    post(PR, carried, null);
+
+    // The stale carrier never carried the later loss, so completing must not retire it.
+    assertTrue(carried.get(3).contains("An earlier reply"), carried.get(3));
+  }
+
+  @Test
   void aFloodOfLosingPullRequestsCannotGrowTheRegistryWithoutEnd() {
     var carried = new ArrayList<String>();
     assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWritesTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWritesTest.java
@@ -146,6 +146,48 @@ class GitHubLostWritesTest {
   }
 
   @Test
+  void aLossThatLandsWhileTwoPostsCarryTheSameNoticeIsStillAnnouncedAfterwards() {
+    var carried = new ArrayList<String>();
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+
+    // Two posts on the same pull request overlap — the inner one runs entirely between the outer
+    // one's read of the pending notice and its completion, the interleaving a PR under a burst of
+    // commands produces — and a third post is thrown away while both are on the wire.
+    lost.carrying(
+        PR,
+        outerNotice -> {
+          carried.add(outerNotice);
+          lost.carrying(
+              PR,
+              innerNotice -> {
+                carried.add(innerNotice);
+                assertThrows(
+                    WebApplicationException.class,
+                    () -> lost.recording(PR, () -> throwIt(throttled())));
+                return "posted";
+              });
+          return "posted";
+        });
+    post(PR, carried, null);
+
+    // Both overlapping posts carried the first loss and neither carried the one that landed
+    // between them, so it has to still be waiting. Retiring it here — which subtracting each
+    // carrier's snapshot from one shared count does — is a user never hearing that their content
+    // was dropped, the exact silence #578 exists to remove.
+    assertTrue(
+        carried.get(1).contains("An earlier reply"), () -> "outer post carried: " + carried.get(1));
+    assertTrue(
+        carried.get(2).contains("An earlier reply"), () -> "inner post carried: " + carried.get(2));
+    assertTrue(
+        carried.get(3).contains("An earlier reply"),
+        () ->
+            "the loss recorded between the two overlapping posts was retired without ever being"
+                + " announced; the next comment carried: \""
+                + carried.get(3)
+                + "\"");
+  }
+
+  @Test
   void aNoticeIsScopedToThePullRequestThatLostThePost() {
     var carried = new ArrayList<String>();
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWritesTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWritesTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@link GitHubLostWrites} — what the pull request is told when the backoff budget runs out
+ * and a finished reply is thrown away, which #578 says is today's silent case.
+ *
+ * <p>The carrier is driven directly rather than through a REST client: what matters here is which
+ * post gets the notice, when it stops being repeated, and when it stops being said at all.
+ */
+class GitHubLostWritesTest {
+
+  private static final GitHubLostWrites.Target PR = new GitHubLostWrites.Target("owner", "repo", 7);
+  private static final GitHubLostWrites.Target OTHER_PR =
+      new GitHubLostWrites.Target("owner", "repo", 8);
+
+  private static final String SECONDARY_LIMIT_BODY =
+      "{\"message\":\"You have exceeded a secondary rate limit.\"}";
+
+  private final AtomicReference<Instant> now =
+      new AtomicReference<>(Instant.ofEpochSecond(1_800_000_000L));
+
+  private final GitHubLostWrites lost = new GitHubLostWrites(now::get, 2, Duration.ofHours(6));
+
+  private static WebApplicationException throttled() {
+    return new WebApplicationException(
+        Response.status(403).header("Retry-After", "1").entity(SECONDARY_LIMIT_BODY).build());
+  }
+
+  private static WebApplicationException refusal() {
+    return new WebApplicationException(
+        Response.status(403)
+            .entity("{\"message\":\"Resource not accessible by integration\"}")
+            .build());
+  }
+
+  /** Posts on {@code target}, failing with {@code failure} when one is given. */
+  private String post(
+      GitHubLostWrites.Target target, List<String> carried, WebApplicationException failure) {
+    return lost.carrying(
+        target,
+        notice -> {
+          carried.add(notice);
+          if (failure != null) {
+            throw failure;
+          }
+          return "posted";
+        });
+  }
+
+  @Test
+  void aPostOnAPullRequestThatLostNothingCarriesNoNotice() {
+    var carried = new ArrayList<String>();
+
+    assertEquals("posted", post(PR, carried, null));
+
+    assertEquals(List.of(""), carried);
+  }
+
+  @Test
+  void aDroppedReplyIsAnnouncedOnTheNextCommentThatLandsOnThatPullRequest() {
+    var carried = new ArrayList<String>();
+
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    post(PR, carried, null);
+
+    // The notice cannot be posted on its own — it would be the very call being throttled — so the
+    // next successful post carries it.
+    assertEquals("", carried.get(0));
+    assertTrue(carried.get(1).startsWith("> [!WARNING]"), carried.get(1));
+    assertTrue(carried.get(1).contains("An earlier reply"), carried.get(1));
+    assertTrue(carried.get(1).contains("run the command again"), carried.get(1));
+  }
+
+  @Test
+  void theNoticeIsSaidOnceAndNotOnEveryCommentAfterwards() {
+    var carried = new ArrayList<String>();
+
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    post(PR, carried, null);
+    post(PR, carried, null);
+
+    assertEquals("", carried.get(2));
+  }
+
+  @Test
+  void aNoticeThatCouldNotBeDeliveredIsKeptForTheNextTry() {
+    var carried = new ArrayList<String>();
+
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    // The post that should have carried the notice is itself thrown away.
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    post(PR, carried, null);
+
+    // Two losses now, and the notice was never cleared by the post that failed to deliver it.
+    assertTrue(carried.get(2).contains("2 earlier replies"), carried.get(2));
+  }
+
+  @Test
+  void aLossThatArrivesWhileTheNoticeIsInFlightIsStillAnnouncedNext() {
+    var carried = new ArrayList<String>();
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+
+    lost.carrying(
+        PR,
+        notice -> {
+          carried.add(notice);
+          // A concurrent post on the same PR is dropped while this one is on the wire.
+          assertThrows(
+              WebApplicationException.class, () -> lost.recording(PR, () -> throwIt(throttled())));
+          return "posted";
+        });
+    post(PR, carried, null);
+
+    assertTrue(carried.get(1).contains("An earlier reply"), carried.get(1));
+    assertTrue(carried.get(2).contains("An earlier reply"), carried.get(2));
+  }
+
+  @Test
+  void aNoticeIsScopedToThePullRequestThatLostThePost() {
+    var carried = new ArrayList<String>();
+
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    post(OTHER_PR, carried, null);
+
+    assertEquals("", carried.get(1));
+  }
+
+  @Test
+  void aRefusalThatWillNeverWorkIsNotAnnouncedOnThePullRequest() {
+    var carried = new ArrayList<String>();
+
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, refusal()));
+    post(PR, carried, null);
+
+    // A missing permission is a defect to fix, not a command to re-run.
+    assertEquals("", carried.get(1));
+  }
+
+  @Test
+  void aNoticeGoesStaleRatherThanBeingGluedOntoAMuchLaterComment() {
+    var carried = new ArrayList<String>();
+
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    now.set(now.get().plus(Duration.ofHours(7)));
+    post(PR, carried, null);
+
+    assertEquals("", carried.get(1));
+  }
+
+  @Test
+  void aFloodOfLosingPullRequestsCannotGrowTheRegistryWithoutEnd() {
+    var carried = new ArrayList<String>();
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    assertThrows(WebApplicationException.class, () -> post(OTHER_PR, carried, throttled()));
+
+    var third = new GitHubLostWrites.Target("owner", "repo", 9);
+    assertThrows(WebApplicationException.class, () -> post(third, carried, throttled()));
+    // A PR already holding a notice still counts its second loss even at capacity.
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+
+    post(third, carried, null);
+    post(PR, carried, null);
+    assertEquals("", carried.get(4), "the PR past the cap is only recorded in the log");
+    assertTrue(carried.get(5).contains("2 earlier replies"), carried.get(5));
+  }
+
+  @Test
+  void anExpiredNoticeMakesRoomForANewOne() {
+    var carried = new ArrayList<String>();
+    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    assertThrows(WebApplicationException.class, () -> post(OTHER_PR, carried, throttled()));
+    now.set(now.get().plus(Duration.ofHours(7)));
+
+    var third = new GitHubLostWrites.Target("owner", "repo", 9);
+    assertThrows(WebApplicationException.class, () -> post(third, carried, throttled()));
+    post(third, carried, null);
+
+    assertTrue(carried.get(3).contains("An earlier reply"), carried.get(3));
+  }
+
+  @Test
+  void aFailureThatIsNotAThrottleLeavesTheCallersExceptionAlone() {
+    var boom = new IllegalStateException("serialization failed");
+
+    var thrown =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                lost.recording(
+                    PR,
+                    () -> {
+                      throw boom;
+                    }));
+
+    assertSame(boom, thrown);
+  }
+
+  @Test
+  void theNoticeReadsAsOneOrManyAndIsEmptyWhenNothingWasLost() {
+    assertEquals("", GitHubLostWrites.notice(0));
+    assertTrue(GitHubLostWrites.notice(1).contains("An earlier reply"));
+    assertTrue(GitHubLostWrites.notice(3).contains("3 earlier replies"));
+  }
+
+  @Test
+  void theNoticeIsPutAboveTheBodyAndNeverInventsOne() {
+    assertEquals("the reply", GitHubLostWrites.prepend("", "the reply"));
+    assertNull(GitHubLostWrites.prepend("", null));
+    assertEquals("notice\n\nthe reply", GitHubLostWrites.prepend("notice", "the reply"));
+    assertEquals("notice", GitHubLostWrites.prepend("notice", null));
+    assertEquals("notice", GitHubLostWrites.prepend("notice", "   "));
+  }
+
+  @Test
+  void aTargetNamesThePullRequestItLostThePostOn() {
+    assertEquals("owner/repo #7", PR.toString());
+  }
+
+  private static String throwIt(WebApplicationException failure) {
+    throw failure;
+  }
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] ✨ Feature

## Description

The backoff from #568 is bounded, so a persistently throttled reply is still dropped once the
attempts are spent. Today that is logged and nothing else: from the pull request the command simply
never answered, which is indistinguishable from the silent-decline class #538 fixed. The user cannot
tell whether the bot ignored them, crashed, or lost the post — and nothing says the right move is to
run it again.

**The catch the issue names.** The obvious remedy — reply "this was throttled, please re-run" — is
itself a `createComment`: the exact call being throttled, sent at the exact moment GitHub is refusing
it. Giving it its own budget just spends more attempts on the same refusal.

**So the notice is never posted on its own.** `GitHubLostWrites` holds it, and the *next* content the
bot successfully lands on that pull request carries it up front:

> [!WARNING]
> **An earlier reply on this pull request was never posted.** GitHub was rate-limiting the bot and
> the retries ran out, so work it had already finished was thrown away. If you were waiting on an
> answer, run the command again.

That costs no additional content-creating request — which is the whole point of #579 — cannot be
throttled separately from the post it travels with, and appears on the pull request the loss
happened on rather than in a log the user cannot read. Of the three options the issue weighs, this
is the "persist the pending notice and post it on the next successful interaction" one; it also
needs no change in `review/` or `webhook/`, so every posting path inherits it at the client boundary
instead of each fail-soft handler having to learn about throttling.

**Which calls do what.** `createComment` and `createReview` both land in the conversation, so they
carry a notice. An inline comment and a thread reply are anchored to a diff line and are a poor place
to announce an unrelated loss, so they leave a notice behind without carrying one — losing an inline
finding is still a loss the PR should hear about. `updateComment` does neither: it identifies its
target by comment id, so this layer cannot tell which pull request it belongs to.

**What it deliberately does not claim.**

- *Only a throttle counts.* A permission 403 or a 422 is a defect to fix, not a command to re-run,
  and announcing those would put a warning on every single comment.
- *The wording does not name the command.* This layer sees a comment on a pull request, not the
  `/describe` or `/improve` behind it. An honest "if you were waiting on an answer, run it again"
  beats a guess.
- *A notice is cleared only once the post carrying it has landed*, so a post that is itself dropped
  does not take the notice with it — and a loss that arrives while a notice is in flight is still
  announced next time.
- *It cannot promise delivery* on a pull request the bot never writes to again. That case is no worse
  than today's log-only behaviour.

**Bounded, and quiet when stale.** A notice is forgotten after six hours, because "a reply was
dropped" glued onto a comment days later is noise rather than a signal, and the registry holds at
most 200 pull requests so a sustained outage cannot grow it without end.

**Why prepending is safe.** `ReviewContextLoader.isBotSummaryComment` matches the heading on any
line, not at the start of the body — precisely because the truncation banner already precedes it —
and no code in the repository matches a comment body with `startsWith`.

**How this composes with #568 and #579.** #579's pacer keeps the burst from being produced, #568's
backoff absorbs the throttling pacing cannot prevent, and this is the last resort for when even that
runs out. The three are strictly ordered by cost, and this one is the only one the user ever sees.

## Related Issues

Fixes #578

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

`GitHubLostWritesTest` drives the carrier directly on a hand-held clock: a quiet PR carrying nothing,
a dropped reply announced on the next comment, the notice said once rather than on everything
afterwards, a notice kept when the post meant to deliver it is itself dropped, a loss that lands
while a notice is in flight, scoping to the PR that lost the post, a permission refusal staying
silent, the six-hour staleness cut-off, the registry cap (including a PR already holding a notice
still counting at capacity) and an expired notice making room for a new one.

`GitHubDroppedCommentNoticeTest` is a `@QuarkusTest` driving a real REST client against a loopback
GitHub. It asserts on **the body GitHub receives**, because that is the only thing the user ever
sees; the log line the retry already writes is exactly what the issue says is not enough.

### Red/green proof

`GitHubDroppedCommentNoticeTest` compiles unchanged against the base commit, so it was run there:

```
2026-08-12 00:39:08,950 WARN  [dev.thiagogonzaga.thrillhousebot.github.GitHubWriteRetry] (main) GitHub still throttling a comment on owner/repo #5882 after 3 attempts — the generated content is lost and the command has to be re-run. status=403 retry-after=0 x-ratelimit-remaining=0 body={"message":"You have exceeded a secondary rate limit. Please wait a few minutes before you try again.","documentation_url":"https://docs.github.com/rest"}
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.392 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.github.GitHubDroppedCommentNoticeTest
[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubDroppedCommentNoticeTest.aReplyGitHubThrewAwayIsAnnouncedOnTheNextCommentThatLands -- Time elapsed: 0.452 s <<< FAILURE!
org.opentest4j.AssertionFailedError: {"body":"the answer to /describe"} ==> expected: <true> but was: <false>
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:232)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubDroppedCommentNoticeTest.aReplyGitHubThrewAwayIsAnnouncedOnTheNextCommentThatLands(GitHubDroppedCommentNoticeTest.java:135)
```

The assertion message is the whole defect in one line: the very next comment GitHub receives is
`{"body":"the answer to /describe"}` and nothing else. The log knows a reply was thrown away and the
pull request never hears about it.

### Gates

- `./mvnw -B spotless:apply` → BUILD SUCCESS
- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` → **Tests run: 2787, Failures: 0, Errors: 0, Skipped: 0**
- JaCoCo ∩ `git diff -U0 fda4bc7...HEAD` → **0 uncovered lines, 0 uncovered branches** across the 79
  trackable changed main-code lines (`GitHubLostWrites` 62, `GitHubReviewClient` 13,
  `GitHubCommentClient` 4)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

The loss still says so in the log, and now says what will happen about it:

```
WARN [GitHubWriteRetry] GitHub still throttling a comment on owner/repo #14 after 3 attempts — the generated content is lost and the command has to be re-run. status=403 retry-after=0 x-ratelimit-remaining=0 body={"message":"You have exceeded a secondary rate limit. ..."}
WARN [GitHubLostWrites] Lost a throttled post on owner/repo #14 — the next comment the bot lands there will say so (1 now pending)
```

## Additional Notes

Every file touched is inside `dev.thiagogonzaga.thrillhousebot.github`; no caller signature changed
and no fail-soft handler in `review/` or `webhook/` needed to move.

The companion PR for #579 (pacing content-creating calls) touches a disjoint set of files —
`GitHubWriteRetry`, a new limiter, `ThrillhouseConfig` and `application.properties` — so the two
merge cleanly in either order. Once both land, the notice becomes rarer: the pacer stops most of the
bursts that produce the throttling in the first place.


## Review follow-up

**"Concurrent carrying posts can clear a notice that arrived in flight."** Correct, reachable, and
fixed — this is the one direction the feature cannot afford to fail in.

The original `settle` subtracted each carrier's snapshot from one shared count. With two posts on
the same pull request in flight, both having read `pending = 1`, and a third post thrown away
between their reads and their completions:

| step | shared count | what happened |
| --- | --- | --- |
| both carriers read | 1 | each carries `notice(1)` |
| a third post is dropped | 2 | nobody has carried this one |
| carrier A settles (`carried = 1`) | 1 | `2 > 1`, so subtract |
| carrier B settles (`carried = 1`) | **0** | `1 > 1` is false, so the entry is **removed** |

The second loss is retired having been announced by nobody, and the user is never told their content
was dropped — precisely the silence this PR exists to remove. I had noted the *over*-announcing side
of this overlap as benign and accepted it; the review is right that the clearing side is the opposite
direction and is not acceptable.

**The fix** replaces the outstanding count with two monotonic watermarks, `lost` and `announced`
(`pending = lost - announced`). A delivered post advances `announced` towards the `lost` value it
actually carried, and the watermark never moves backwards, so a second carrier holding the same
snapshot finds `announced >= carried.lost` and leaves the entry alone. Replaying the table above:
carrier B advances `announced` to 1, carrier A is a no-op, and `pending` stays 1 — the third loss is
still waiting and rides the next comment. The overlap can now only ever repeat a notice, never drop
one, and repeating is the harmless direction.

No locking was added: serializing `carrying` per target would hold a lock across an HTTP call that
may itself back off for up to a minute.

### Red/green proof

`GitHubLostWritesTest.aLossThatLandsWhileTwoPostsCarryTheSameNoticeIsStillAnnouncedAfterwards`
nests one `carrying` inside another so the inner post runs entirely between the outer post's read
and its completion — the interleaving described above, deterministically. Against this PR's previous
head (`b0973e7`), where the other 14 cases in the class still pass:

```
[ERROR] Tests run: 15, Failures: 1, Errors: 0, Skipped: 0 -- in dev.thiagogonzaga.thrillhousebot.github.GitHubLostWritesTest
org.opentest4j.AssertionFailedError: the loss recorded between the two overlapping posts was retired without ever being announced; the next comment carried: "" ==> expected: <true> but was: <false>
	at dev.thiagogonzaga.thrillhousebot.github.GitHubLostWritesTest.aLossThatLandsWhileTwoPostsCarryTheSameNoticeIsStillAnnouncedAfterwards(GitHubLostWritesTest.java:181)
```

`the next comment carried: ""` is the defect verbatim: the pull request says nothing at all.


### Second round: "Announced (zero-pending) entries are never removed and can exhaust the registry cap"

Correct, and a regression the watermark fix above introduced. Before it, `settle` removed the entry
the moment nothing was outstanding; after it, a delivered entry sat at `pending == 0` with `lost ==
announced > 0` and only the TTL could retire it.

**What evicted an entry, before this round.** Two paths, both TTL:

```
snapshot() :169   pending.remove(target, loss)          — expired, on the read path
remember() :194   pending.values().removeIf(expired)    — expired, on the write path
announce() :184   computeIfPresent(...)                 — never removed anything
```

**So the TTL does not cover it.** It bounds growth — the map never exceeds the cap and a settled
entry is swept six hours after its *last loss*, since `announce` preserves `loss.at()`. What it does
not do is free the slot in the meantime. Once `DEFAULT_MAX_TARGETS` pull requests have lost a post
inside one six-hour window, every slot can be a settled entry, and the next pull request to lose one
takes the `pending.size() >= maxTargets && !pending.containsKey(target)` branch and is only logged —
the silence this PR removes, arriving from the other end, and with nothing outstanding to protect
the slots it was denied.

**The fix** drops an entry as soon as its last outstanding notice is delivered, so a slot is held
only while a pull request is genuinely still owed one — which is what `DEFAULT_MAX_TARGETS` claims
to bound.

**The guard the finding asked for is real, and it is load-bearing.** Both watermarks restart when a
later loss recreates an entry, so a carrier still in flight from the previous run holds a snapshot
whose `lost` can equal the new run's and would retire a loss it never carried. Each run of losses
now carries an `id`, and a delivery only counts when `loss.id() == carried.id()`. This is not
defensive coding: deleting that one condition and leaving everything else in place makes
`aCarrierLeftOverFromASettledEntryCannotRetireALaterLoss` fail.

### Red/green proof

`GitHubLostWritesTest.aRegistryFullOfAlreadyDeliveredNoticesStillHasRoomForANewLoss` fills both
slots of the two-target fixture, has both notices delivered, then loses a post on a third pull
request. Against the previous head (`c942633`), with the other 16 cases in the class still passing:

```
[ERROR] Tests run: 17, Failures: 1, Errors: 0, Skipped: 0 -- in dev.thiagogonzaga.thrillhousebot.github.GitHubLostWritesTest
org.opentest4j.AssertionFailedError: the registry was full of already-delivered notices, so the new loss was only logged; the next comment carried: "" ==> expected: <true> but was: <false>
	at dev.thiagogonzaga.thrillhousebot.github.GitHubLostWritesTest.aRegistryFullOfAlreadyDeliveredNoticesStillHasRoomForANewLoss(GitHubLostWritesTest.java:240)
```
