### PR TITLE
test(review): size the /changelog batching fixtures above the fence jitter

### DIFF
--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ChangelogEntryGeneratorTest.java
@@ -47,20 +47,67 @@ class ChangelogEntryGeneratorTest {
 
   private static final String AUTH = "token gh-abc";
 
+  /**
+   * Filler lines appended to each fixture patch, on top of its three meaningful ones.
+   *
+   * <p>The batching tests below assert a <em>plan shape</em> — one file per batch, nothing clipped
+   * — that the planner decides by comparing each file section's token estimate against the diff
+   * budget. That budget is only approximate, and not because of the estimator: {@link
+   * PromptTemplateEscaper#fence} mints a fresh CSPRNG token per call, so the shared-prompt overhead
+   * {@link #budgetFor} sizes from one draw and the overhead the planner subtracts from another draw
+   * differ by however much the two random tokens differ in BPE width — around 30 tokens, either
+   * way. The effective diff budget therefore lands in a window that wide around the requested one.
+   *
+   * <p>So every margin here has to be wider than that window. With the original three-line patches
+   * a section was ~50 tokens against a 40-token request, leaving a ~10-token margin the swing
+   * cleared often enough to flip the plan about once in 1500 runs — #586, seen once in CI and never
+   * locally. Padding the sections to a few hundred tokens (and {@link #ROOM_FOR_ONE_FILE} with
+   * them) makes the fence swing a rounding error rather than the deciding term. {@link
+   * #batchingFixturesLeaveMarginWiderThanTheFenceJitter} pins the margins so shrinking either one
+   * fails loudly instead of flaking.
+   */
+  private static final int PAD_LINES = 30;
+
+  /**
+   * Upper bound on how far two {@link PromptTemplateEscaper#fence} draws can differ in BPE width. A
+   * fence wraps its content in two identical lines whose only variable part is a 32-character hex
+   * token, so 64 characters vary across the pair — and no BPE token covers fewer than one
+   * character, so no two draws can differ by more than 64 tokens. Every batching margin below is
+   * required to exceed this.
+   */
+  private static final int FENCE_JITTER_TOKENS = 64;
+
+  /** Added lines per fixture file: its three meaningful ones plus {@link #PAD_LINES} of filler. */
+  private static final int ADDED_LINES = 3 + PAD_LINES;
+
+  /**
+   * Diff room requested for the tests that need each fixture file in a batch of its own: above any
+   * one section (so nothing is clipped) and below two of them (so they cannot share a bin), with
+   * margins far wider than the fence swing described on {@link #PAD_LINES}.
+   */
+  private static final int ROOM_FOR_ONE_FILE = 400;
+
+  /** Diff room that comfortably fits every fixture file in a single batch. */
+  private static final int ROOM_FOR_EVERY_FILE = 4000;
+
   private static final String PATCH =
-      """
-      @@ -0,0 +1,3 @@
-      +var in = Files.newInputStream(path);
-      +int total = 0;
-      +total += items.size();""";
+      patchOf("var in = Files.newInputStream(path);", "int total = 0;", "total += items.size();");
 
   /** A second file, so the line cap has something to drop and the planner something to batch. */
   private static final String OTHER_PATCH =
-      """
-      @@ -0,0 +1,3 @@
-      +int retries = 0;
-      +while (retries < 3) { call(); }
-      +log.info("done");""";
+      patchOf("int retries = 0;", "while (retries < 3) { call(); }", "log.info(\"done\");");
+
+  /** A unified-diff patch adding {@code lines}, padded out to {@link #ADDED_LINES} added lines. */
+  private static String patchOf(String... lines) {
+    var patch = new StringBuilder("@@ -0,0 +1,").append(ADDED_LINES).append(" @@");
+    for (var line : lines) {
+      patch.append("\n+").append(line);
+    }
+    for (var i = 0; i < PAD_LINES; i++) {
+      patch.append("\n+int filler").append(i).append(" = ").append(i).append(";");
+    }
+    return patch.toString();
+  }
 
   @Mock private GitHubPullRequestClient prClient;
   @Mock private InstructionsResolver instructionsResolver;
@@ -106,11 +153,11 @@ class ChangelogEntryGeneratorTest {
   }
 
   private static FileDiff foo() {
-    return new FileDiff("src/Foo.java", "modified", 3, 0, 3, PATCH);
+    return new FileDiff("src/Foo.java", "modified", ADDED_LINES, 0, ADDED_LINES, PATCH);
   }
 
   private static FileDiff otherFile() {
-    return new FileDiff("src/Other.java", "modified", 3, 0, 3, OTHER_PATCH);
+    return new FileDiff("src/Other.java", "modified", ADDED_LINES, 0, ADDED_LINES, OTHER_PATCH);
   }
 
   private void prWithFiles(FileDiff... files) {
@@ -143,10 +190,15 @@ class ChangelogEntryGeneratorTest {
   }
 
   /**
-   * A per-call input budget of exactly the shared prompt overhead plus {@code diffTokens}. Derived
+   * A per-call input budget of about the shared prompt overhead plus {@code diffTokens}. Derived
    * from {@code /changelog}'s own prompts rather than hardcoded, so editing a prompt cannot
    * silently turn these tests into no-ops by making every file overflow — and so a regression that
    * sized the overhead from another command's prompts would show up here.
+   *
+   * <p><em>About</em>, not exactly: the fence line this counts is drawn from a CSPRNG here and
+   * again inside the planner, and the two draws differ in BPE width, so the diff room the planner
+   * actually ends up with is {@code diffTokens} give or take ~30 tokens. Callers must leave margins
+   * wider than that — see {@link #PAD_LINES}.
    */
   private static int budgetFor(int diffTokens) {
     var overhead =
@@ -345,12 +397,42 @@ class ChangelogEntryGeneratorTest {
   // ---------------------------------------------------------------------------------------------
 
   @Test
+  void batchingFixturesLeaveMarginWiderThanTheFenceJitter() {
+    // #586: every batching test below asserts a plan shape the planner decides by comparing a file
+    // section's tokens against the diff room, and that room is only accurate to a fence draw (see
+    // PAD_LINES). Pin the three margins that shape rests on here, so shrinking a fixture or a room
+    // constant fails on this one test rather than as a rare flake spread across the whole class.
+    var tokenCounter = new TokenCounter();
+    var names = ReviewDiffFormatter.namesOf(List.of(foo(), otherFile()));
+    var biggestSection = 0;
+    var bothSections = 0;
+    for (var file : List.of(foo(), otherFile())) {
+      var tokens = tokenCounter.estimateTokens(diffFormatter.formatFileSection(file, names));
+      biggestSection = Math.max(biggestSection, tokens);
+      bothSections += tokens;
+    }
+
+    // Room for one file: above the larger section, so neither file is ever clipped…
+    assertTrue(
+        ROOM_FOR_ONE_FILE - biggestSection > FENCE_JITTER_TOKENS,
+        "biggest section " + biggestSection + " too close to room " + ROOM_FOR_ONE_FILE);
+    // …and below both together, so the two files never share a batch.
+    assertTrue(
+        bothSections - ROOM_FOR_ONE_FILE > FENCE_JITTER_TOKENS,
+        "both sections " + bothSections + " too close to room " + ROOM_FOR_ONE_FILE);
+    // Room for every file: above both together, so one batch always covers the whole PR.
+    assertTrue(
+        ROOM_FOR_EVERY_FILE - bothSections > FENCE_JITTER_TOKENS,
+        "both sections " + bothSections + " too close to room " + ROOM_FOR_EVERY_FILE);
+  }
+
+  @Test
   void draftsFromFilesThatTheLineCapWouldHaveDroppedEntirely() {
     // The whole point of the change. With a line cap this small the rendered diff string keeps only
     // the first file, so the pre-batching implementation drafted the entry from a diff that never
     // mentioned src/Other.java. Batching sizes by tokens over the file list instead.
     var lineCapped = new ReviewDiffFormatter(List.of(), 4);
-    budgetWithDiffRoom(4000);
+    budgetWithDiffRoom(ROOM_FOR_EVERY_FILE);
     prWithFiles(foo(), otherFile());
     draftReturns("### Added\n- x (#7)");
 
@@ -367,7 +449,7 @@ class ChangelogEntryGeneratorTest {
     // Two batches produce two candidate entries. The command must post exactly one entry, and two
     // candidates that describe the same change in different words can only be collapsed by the
     // merge call — so its answer is what gets posted, not the concatenation.
-    budgetWithDiffRoom(40);
+    budgetWithDiffRoom(ROOM_FOR_ONE_FILE);
     prWithFiles(foo(), otherFile());
     when(changelogAssistant.draft(any(), any(), any(), any(), any()))
         .thenAnswer(
@@ -412,7 +494,7 @@ class ChangelogEntryGeneratorTest {
   void spendsNoMergeCallWhenOnlyOneBatchFoundAnythingWorthReporting() {
     // A batch that declines with NONE contributes no candidate, so a PR whose changelog-worthy
     // change sits in one batch still posts that batch's entry unmerged.
-    budgetWithDiffRoom(40);
+    budgetWithDiffRoom(ROOM_FOR_ONE_FILE);
     prWithFiles(foo(), otherFile());
     when(changelogAssistant.draft(any(), any(), any(), any(), any()))
         .thenAnswer(
@@ -431,7 +513,7 @@ class ChangelogEntryGeneratorTest {
 
   @Test
   void returnsNullWhenEveryBatchDeclines() {
-    budgetWithDiffRoom(40);
+    budgetWithDiffRoom(ROOM_FOR_ONE_FILE);
     prWithFiles(foo(), otherFile());
     draftReturns("NONE");
 
@@ -443,7 +525,7 @@ class ChangelogEntryGeneratorTest {
   void returnsNullWhenTheMergeDeclines() {
     // The merge may still conclude that nothing is worth an entry; a literal NONE must never be
     // posted as if it were the changelog text.
-    budgetWithDiffRoom(40);
+    budgetWithDiffRoom(ROOM_FOR_ONE_FILE);
     prWithFiles(foo(), otherFile());
     draftReturns("### Added\n- x (#7)");
     when(changelogAssistant.merge(any(), any(), any(), any(), any())).thenReturn(aiOk("**NONE**"));
@@ -456,7 +538,7 @@ class ChangelogEntryGeneratorTest {
     // max-ai-calls bounds the whole run, merge included: with an allowance of 3 the command may
     // spend at most 2 batch calls, or the reduce step would push the run over the operator's cap.
     when(reviewConfig.maxAiCalls()).thenReturn(3);
-    budgetWithDiffRoom(40);
+    budgetWithDiffRoom(ROOM_FOR_ONE_FILE);
     prWithFiles(foo(), otherFile(), thirdFile());
     draftReturns("### Added\n- x (#7)");
     when(changelogAssistant.merge(any(), any(), any(), any(), any()))
@@ -474,7 +556,7 @@ class ChangelogEntryGeneratorTest {
     // Drafting from only the first N batches and saying nothing would be the same class of defect
     // as the line cap this replaced, just relocated, so the uncovered files are named.
     when(reviewConfig.maxAiCalls()).thenReturn(2);
-    budgetWithDiffRoom(40);
+    budgetWithDiffRoom(ROOM_FOR_ONE_FILE);
     prWithFiles(foo(), otherFile());
     draftReturns("### Added\n- x (#7)");
 
@@ -523,7 +605,7 @@ class ChangelogEntryGeneratorTest {
 
   @Test
   void discloseTheShortfallWhenOneBatchFails() {
-    budgetWithDiffRoom(40);
+    budgetWithDiffRoom(ROOM_FOR_ONE_FILE);
     prWithFiles(foo(), otherFile());
     when(changelogAssistant.draft(any(), any(), any(), any(), any()))
         .thenAnswer(


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

### Verdict: not a race — a CSPRNG term in the test's own budget arithmetic

`#586` asked first whether disclosure classification races under the parallel batch pass, or
whether the test is order/timing dependent. Neither, exactly. The evidence says:

**There is no concurrency on this path at all.** `/changelog` does not use the parallel batch
pass. `ChangelogEntryGenerator.draftEachBatch` is a plain sequential `for` loop over
`plan.batches()`, and it never touches the shared `BudgetPlan` accumulators
(`recordUncoveredFiles` / `recordClippedFiles` / `recordResponseCutFiles`) — those are written
only from `FindingPipeline`, which this command never enters. The disclosure this test asserts
comes from `AbstractPrSuggestionGenerator.disclosure(plan)`, which reads `plan.omittedFiles()` /
`plan.clippedFiles()`: both `List.copyOf`-immutable, fixed at plan time, before a single model
call. There is no shared mutable state for two threads to reach, because there is only one thread.

**The nondeterminism is real, and it is in the budget the test computes.**
`PromptTemplateEscaper.fence()` mints a fresh 32-hex-character CSPRNG token per call (the
"random sequence enclosure" defense). The test's `budgetFor(n)` sizes the shared prompt overhead
by calling `fence(" ")`; `AbstractPrSuggestionGenerator.sharedPromptOverhead` then calls
`fence(" ")` **again** for the estimate the planner subtracts. Two independent draws, and a random
hex string does not tokenize to a fixed BPE width:

```
fence(" ") token histogram over 2000 draws:
{53=1, 55=8, 57=34, 59=106, 61=218, 63=365, 65=386, 67=378, 69=269, 71=134, 73=63, 75=28, 77=8, 79=1, 81=1}
spread=28  min=53  max=81
```

So `budgetWithDiffRoom(40)` did not give the planner 40 tokens of diff room. It gave it
`40 + (draw_test − draw_planner)`, i.e. anywhere from ~12 to ~68 tokens. The fixture sections were
50 and 54 tokens, so that window straddled every decision boundary the test depends on. Sweeping
the real diff budget across the window shows exactly where it breaks:

```
budget=1..2    0 batches, both omitted            -> NOT_COVERED body, no entry
budget=3..5    2 batches, neither file named      -> 2 candidates -> unstubbed merge -> null body
budget=6..20   1 batch,  neither file named       -> 1 candidate,  no failing batch   <-- the CI failure
budget=21..49  2 batches, both named              -> passes
budget=50..53  2 batches, src/Other.java clipped  -> passes
budget=54+     2 batches, nothing clipped         -> passes
```

The `6..20` row is the observed failure. At that budget `clipToBudget` drives
`ReviewDiffFormatter.truncateSection` down to `maxLines == 1`, whose output is the bare
`"(patch truncated)"` notice — the `### src/Other.java (…)` header is gone. The stub keys off
`getArgument(0).contains("src/Other.java")`, so it never throws, `failedBatches` stays 0, and no
`**Partial pass.**` note is appended. The clipped-file disclosure is still correct and still names
both files; the note the test looks for is simply not warranted on that run.

**So production is not misreporting anything.** The plan classified both files as clipped and
disclosed them as clipped; that was true. The random fence in the overhead estimate is an unbiased
estimate of an overhead that genuinely is random per call — the real prompt carries a real fence of
that same distribution — and the ~30-token error it carries is absorbed by `token-safety-margin` on
budgets of 10^5. It only mattered here because the test asked for a 40-token margin.

### The fix

Take the fence swing out of the deciding position, rather than relax the assertions:

- Pad each fixture patch to ~290 tokens (`PAD_LINES`), built by `patchOf(...)` so the hunk header
  and the `FileDiff` add/change counts stay consistent.
- Raise the requested diff room to a named `ROOM_FOR_ONE_FILE = 400` (and `ROOM_FOR_EVERY_FILE`
  for the single-batch tests). Measured margins are now **106 tokens** below the larger section
  and **184 tokens** above both together.
- Add `batchingFixturesLeaveMarginWiderThanTheFenceJitter`, which pins all three margins against
  `FENCE_JITTER_TOKENS = 64` — an exact upper bound, since only 64 characters vary across a fence
  pair and no BPE token covers fewer than one character. Shrinking a fixture or a room constant now
  fails on one deterministic assertion instead of resurfacing as a 1-in-1500 flake.

No production file is touched.

## Related Issues

Fixes #586

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**Red — reproduced on unfixed code**, by repeating the unchanged test 3000× in one JVM
(`@RepeatedTest(3000)`, reverted before commit). 2 failures in 3000 (~1 in 1500), matching
"once in CI, 5/5 green locally". The failure body is byte-identical to the CI failure on #585:

```
Tests run: 3000, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 285.8 s
dev.thiagogonzaga.thrillhousebot.review.ChangelogEntryGeneratorTest.discloseTheShortfallWhenOneBatchFails()[157] -- Time elapsed: 0.114 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
## 🤖 ThrillhouseBot — suggested CHANGELOG entry

### Added
- Streams are closed (#7)

---
*Suggestion only — nothing was committed. Copy whatever fits into `CHANGELOG.md` under the `[Unreleased]` section. Re-run with `/changelog`.*


> ⚠️ **Large PR — partial coverage.** 2 file(s) were only partially analyzed (src/Foo.java, src/Other.java) because the diff exceeded the review budget, so this covers only part of the diff. ==> expected: <true> but was: <false>
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:232)
	at dev.thiagogonzaga.thrillhousebot.review.ChangelogEntryGeneratorTest.discloseTheShortfallWhenOneBatchFails(ChangelogEntryGeneratorTest.java:541)
```

**Green — same harness on the fixed fixtures:**

```
Tests run: 3000, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 284.2 s
BUILD SUCCESS
```

Gates:

- `./mvnw -B spotless:apply` then `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — `Tests run: 2769, Failures: 0, Errors: 0, Skipped: 0`, BUILD SUCCESS
- Coverage: test-only change, `git diff --name-only fda4bc7...HEAD -- 'src/main/**'` is empty, so the jacoco ∩ diff intersection has zero changed main lines and zero changed main branches.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Included above.

## Additional Notes

Two things a maintainer may want to pick up separately, both outside this PR's file lane:

1. **The same fence swing sizes every other budgeted command.** `sharedPromptOverhead` is shared by
   `/describe`, `/improve`, `/add-docs` and `/generate-tests`, and `DiffBudgetPlanner.plan(...)`
   draws its own `fence(" ")` for the review path. This is not a bug — the estimate is unbiased and
   dwarfed by the safety margin at real budgets — but sizing the overhead from a fixed-width
   representative fence instead of a live draw would make the plan reproducible run to run, which
   is worth something for a disclosure the user reads. Any sibling test that leans on a small
   `max-input-tokens` has the same latent fragility this PR removed here.

2. **`truncateSection(section, 1)` drops the file header.** At `maxLines == 1` a section becomes the
   bare `"(patch truncated)"` notice, so the batch prompt contains a file the model cannot name.
   That is what made the failure invisible to the test's stub. It is only reachable at
   pathologically small budgets, but a one-line clip that keeps the `###` header would be strictly
   more useful to the model. `ReviewDiffFormatter` is outside this lane, so it is left alone.
