### PR TITLE
fix(review): file a second defect as its own finding instead of burying it

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -151,7 +151,11 @@ public final class PrReviewPrompts {
                nonetheless untested, which is precisely the failure nobody notices — and note that
                the mandated low/medium CONFIDENCE describes how firmly you may word the claim, not
                whether the finding is worth emitting. A green test whose mocks contradict the
-               real collaborator is not evidence the production path works.
+               real collaborator is not evidence the production path works. You will most often
+               notice the unfaithful stub while building some OTHER finding — the fixture that
+               cannot distinguish the two cases, the mock that makes a broken path look proven.
+               Emit the mock-fidelity finding anyway: a contradiction stated only inside another
+               finding's body, or in a walkthrough row, has not been reported.
             9. PRODUCER → CONSUMER CONTRACT: hunks are judged locally, so a change can be correct
                line by line and still wrong end to end. Once per PR, for the change's PRIMARY new
                or modified data structure — a returned collection, a flag, a computed verdict —
@@ -257,6 +261,26 @@ public final class PrReviewPrompts {
               differs, the difference is coming from your uncertainty rather than from the defect,
               and it belongs in confidence — pin the risk to the class and lower the confidence
               instead.
+            - EVERY defect gets its OWN finding, on the dimension it belongs to. While writing one
+              finding you will often state a SECOND, different defect as supporting evidence — a
+              stale comment quoted to show what the code was meant to do, a stub that cannot
+              happen in production, a scan the input does not bound, a page never walked, a
+              fixture that cannot tell the two cases apart. That second defect is a finding in its
+              own right and must be emitted as one. Stating it inside another finding's
+              description, in a summary.file_summaries row, or in a description_gaps entry is NOT
+              reporting it — those surfaces carry no severity, no anchor line and no review
+              thread, so a defect that appears only there reaches nobody. This does not conflict
+              with "report each underlying defect exactly once" below: that rule forbids restating
+              ONE defect at several lines; this one forbids burying a SECOND defect inside the
+              first, even when it is what makes the first one true.
+            - Before you finish, re-read what you have written — each finding's description, each
+              file_summaries line, each description_gaps entry — for any statement that describes
+              a defect no finding in your list covers, and promote each one into its own finding
+              at the risk and confidence its own dimension prescribes. The material is already
+              written, so this is a promotion step, not new analysis. The dimensions this loses
+              most often are the ones whose evidence is naturally cited in support of something
+              else: an unfaithful stub (dimension 8), an added quadratic shape (dimension 5), and
+              a comment contradicting the code (dimension 4).
 
             Confidence calibration:
             - confidence "high" means another reviewer could confirm the issue using only the
@@ -790,6 +814,10 @@ public final class PrReviewPrompts {
               declared SIGNATURE counts as shown material: a stub that returns null against a
               non-null contract, throws a checked exception the method does not declare, or
               returns a value the declared type excludes is contradicted by the signature alone.
+            - File it as its own finding. Noticing the contradiction while building a different
+              finding is the usual case — it turns up as the reason that finding's evidence is
+              weak — and citing it there, or in a walkthrough row, does not report it. Emit the
+              mock-fidelity finding in addition to the one you were writing.
             - A faithful stub that matches the real contract is not a finding."""
           .stripIndent();
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -747,6 +747,42 @@ class PrReviewPromptsContentTest {
   }
 
   @Test
+  void aDefectOnAnotherDimensionMustBePromotedOutOfTheFindingItSupports() {
+    // #587: six of eight languages analysed the mock-fidelity defect correctly and filed none of
+    // them — the reasoning landed inside another finding's body, a walkthrough row or a
+    // description_gaps entry, surfaces that carry no severity, no anchor line and no thread.
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "EVERY defect gets its OWN finding, on the dimension it belongs to",
+        "a defect on another dimension must be filed, not cited as evidence (#587)");
+    assertContains(
+        sys,
+        "summary.file_summaries row, or in a description_gaps entry is NOT",
+        "stating a defect on a non-finding surface must not count as reporting it (#587)");
+    assertContains(
+        sys,
+        "this one forbids burying a SECOND defect inside the",
+        "the no-burying rule must be disambiguated from the report-once rule (#587)");
+    assertContains(
+        sys,
+        "promote each one into its own finding",
+        "the response must be swept for defects no finding covers (#587)");
+    assertContains(
+        sys,
+        "this is a promotion step, not new analysis",
+        "the sweep must be framed as promotion of material already written (#587)");
+    assertContains(
+        sys,
+        "Emit the mock-fidelity finding anyway",
+        "dimension 8 must say the contradiction is filed even when it is also evidence (#587)");
+    assertContains(
+        PrReviewPrompts.MOCK_FIDELITY_REQUEST,
+        "File it as its own finding",
+        "the injected mock-fidelity block must carry the same promotion rule (#587)");
+  }
+
+  @Test
   void confidenceCapsGovernWordingRatherThanWhetherToReport() {
     String sys = PrReviewPrompts.SYSTEM;
     assertContains(


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Mock fidelity scored **2 YES / 6 PARTIAL** across the round-3 corpus, and
"PARTIAL" meant one specific thing every time:

> the exact reasoning appears, in prose, inside the body of a *different*
> finding — and is never emitted as a finding of its own.

React #26 stated the defect verbatim inside the producer/consumer finding
("both fixture scores are below threshold, so it can't distinguish correct
filtering from push-everything"). Angular #25 quoted the spec file's own
concession into a walkthrough row, reused it as supporting evidence inside
finding 5, and still never raised it. C# #24 noticed it three separate times,
inside findings 1, 2 and 4.

So the model has already judged the defect worth writing down — this is not the
reporting-threshold problem that #545's rebalancing fixed for the performance
and comment-contradiction dimensions. The failure is that a supporting
observation made while building finding A never gets promoted into its own
finding B, even when it is a different defect, in a different file, on a
different dimension.

### What changed

`PrReviewPrompts.SYSTEM`, in the block that already governs emission ("Severity
is not confidence, and neither one is a reason to stay silent"), gains the
promotion rule and the sweep:

- Every defect gets its own finding, on the dimension it belongs to. Stating a
  second, different defect inside another finding's description, in a
  `summary.file_summaries` row, or in a `description_gaps` entry is **not**
  reporting it — those surfaces carry no severity, no anchor line and no review
  thread, so a defect that appears only there reaches nobody.
- The rule is explicitly disambiguated from the neighbouring "Report each
  underlying defect exactly once", which forbids restating *one* defect at
  several lines rather than filing a *second* one. Reading the two together is
  a plausible reason the model treats a bury as compliance.
- A closing sweep: re-read each finding description, each `file_summaries` line
  and each `description_gaps` entry for statements describing a defect no
  finding covers, and promote each into its own finding at the risk and
  confidence its own dimension prescribes. Framed as promotion of material
  already written, not new analysis — which is what the issue's option 1 asks
  for and what makes it cheap.

Dimension 8 and the injected `MOCK_FIDELITY_REQUEST` block repeat it at the
point the contradiction is actually noticed: while building the finding it was
evidence for.

## Related Issues

Fixes #587

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Prompt-text change: exempt from red/green proof per the round's standards, and
covered by the deterministic anchor test the repo already uses for this file.
`PrReviewPromptsContentTest.aDefectOnAnotherDimensionMustBePromotedOutOfTheFindingItSupports`
pins the seven markers (five in `SYSTEM`, one in dimension 8, one in
`MOCK_FIDELITY_REQUEST`) so a future edit cannot silently revert the guidance.

Whether the model *acts* on it is the corpus's job, and the issue states the
regression test it already provides: the corpus plants exactly one defect per
dimension per PR, so a dimension whose reasoning appears in the response but
not in the finding list is mechanically detectable.

### Gates

```
./mvnw -B spotless:apply                                    OK
./mvnw -B clean compile spotbugs:check spotless:check       BugInstance size is 0 / BUILD SUCCESS
./mvnw -B clean test                                        Tests run: 2769, Failures: 0, Errors: 0, Skipped: 0
```

Coverage — jacoco ∩ `git diff -U0 fda4bc7...HEAD`:

```
src/main/java/.../review/ai/PrReviewPrompts.java: 29 changed lines, 0 instrumented,
0 uncovered lines, 0 lines with uncovered branches
RESULT: CLEAN
```

All 29 changed main lines sit inside compile-time `String` constants, so they
carry no bytecode of their own; the class's own initialization is exercised by
the content test.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The issue notes that the performance dimension regressed the same way in three
languages and may share this root cause. The rule added here is written per
*defect*, not per dimension, so it covers that case too — and the sweep names
dimensions 4, 5 and 8 as the ones most often lost, since their evidence is
exactly what gets cited in support of something else.
