### PR TITLE
fix(review): keep the file header when a section clips to one line

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
@@ -588,13 +588,33 @@ public class ReviewDiffFormatter {
       return section;
     }
     if (maxLines == 1) {
-      return "(patch truncated)\n";
+      return clippedHeader(lines[0]);
     }
 
     int fenceStart = diffFenceStart(lines);
     return fenceStart < 0
         ? truncatePlain(section, lines, maxLines)
         : truncateFenced(lines, fenceStart, maxLines);
+  }
+
+  /**
+   * The one-line degradation of a section (#603). The {@code ### <path>} header is structural, not
+   * clippable content: dropping it leaves the prompt holding a file's slot with no file name, so
+   * the model is asked to review a change it cannot identify and any path-keyed instruction has
+   * nothing to bind to. The worst case must be a named file with no visible patch.
+   *
+   * <p>The truncation notice folds into the header's own parenthetical instead of trailing it, so
+   * the line still reads as {@code ### <path> (…)} for consumers that scope by file (see {@code
+   * FindingQuoteValidator.indexDiff}, which cuts the path at the last {@code " ("}). A first line
+   * that is not a section header is left as the bare notice.
+   */
+  private static String clippedHeader(String firstLine) {
+    if (!firstLine.startsWith("### ")) {
+      return "(patch truncated)\n";
+    }
+    return firstLine.endsWith(")")
+        ? firstLine.substring(0, firstLine.length() - 1) + ", patch truncated)\n"
+        : firstLine + " (patch truncated)\n";
   }
 
   /** Index of the opening ```` ```diff ```` fence, or -1 when the section has no fenced patch. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatterTest.java
@@ -364,8 +364,58 @@ class ReviewDiffFormatterTest {
     }
 
     @Test
-    void shouldReturnPatchTruncatedPlaceholderWhenBudgetIsOneLine() {
+    void shouldReturnPatchTruncatedPlaceholderWhenBudgetIsOneLineAndSectionHasNoHeader() {
       assertEquals("(patch truncated)\n", ReviewDiffFormatter.truncateSection("a\nb\nc\n", 1));
+    }
+
+    @Test
+    void shouldKeepFileHeaderWhenBudgetIsOneLine() {
+      // #603: the ### header is structural, not clippable content — a one-line clip must still name
+      // the file, or the prompt holds a slot the model cannot attribute a finding to.
+      var section = "### src/App.java (modified, +9 -2)\n```diff\n@@ -1,2 +1,9 @@\n+x\n```\n\n";
+
+      var truncated = ReviewDiffFormatter.truncateSection(section, 1);
+
+      assertTrue(truncated.contains("src/App.java"), "clipped section must still name the file");
+      assertTrue(truncated.startsWith("### "), "the file header must survive as a header line");
+      assertTrue(truncated.contains("patch truncated"), "the dropped patch must stay disclosed");
+      assertEquals(1, ReviewDiffFormatter.lineCount(truncated), "must respect the one-line budget");
+    }
+
+    @Test
+    void shouldKeepFileHeaderParseableAsSectionHeaderWhenBudgetIsOneLine() {
+      // The truncation notice folds into the header's own parenthetical so consumers that scope by
+      // file (FindingQuoteValidator.indexDiff) still read the path out of "### <path> (…)".
+      var section = "### src/App.java (modified, +9 -2)\n```diff\n@@ -1,2 +1,9 @@\n+x\n```\n\n";
+
+      var truncated = ReviewDiffFormatter.truncateSection(section, 1).stripTrailing();
+
+      assertEquals("### src/App.java (modified, +9 -2, patch truncated)", truncated);
+      assertEquals(
+          "src/App.java",
+          truncated.substring(4, truncated.lastIndexOf(" (")).strip(),
+          "path parse");
+    }
+
+    @Test
+    void shouldNameFileWhenHeaderHasNoParentheticalAndBudgetIsOneLine() {
+      var truncated = ReviewDiffFormatter.truncateSection("### src/App.java\n+x\n+y\n", 1);
+
+      assertEquals("### src/App.java (patch truncated)\n", truncated);
+    }
+
+    @Test
+    void shouldKeepFileNamedWhenPlannerClipsSectionToOneLine() {
+      // End-to-end through the line budget: the last section is squeezed to a one-line clip.
+      var formatter = new ReviewDiffFormatter(List.of(), 10);
+      var files =
+          List.of(
+              file("kept.java", "modified", 1, 0, "@@ -1,1 +1,1 @@\n+a"),
+              file("squeezed.java", "modified", 40, 0, "@@ -1,1 +1,40 @@\n+b\n+c\n+d\n+e"));
+
+      var result = formatter.buildDiffString(files);
+
+      assertTrue(result.contains("squeezed.java"), "the clipped file must still be named");
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`ReviewDiffFormatter.truncateSection(section, 1)` — reached when `DiffBudgetPlanner.clipToBudget`
squeezes a section down to `maxLines == 1` — emitted only the bare `(patch truncated)` notice. The
`### <path> (…)` header is part of the truncated content, so it disappeared too: the batch prompt
kept the file's slot but lost its name. The model was asked to review a change it cannot identify,
and any instruction keyed to the path ("report findings against the file they occur in") had nothing
to bind to. This is most likely on very large PRs, where budgets are tightest, sections clip hardest,
and a silently anonymous file is least likely to be noticed among many.

The fix treats the header as structural rather than clippable content. A one-line clip now emits the
header itself, with the truncation notice folded into the header's own parenthetical:

    ### src/App.java (modified, +9 -2, patch truncated)

Folding rather than appending matters: the notice is placed inside the existing parenthetical so the
line still reads as `### <path> (…)`, and consumers that scope by file keep parsing the path —
`FindingQuoteValidator.indexDiff` cuts the path at the *last* `" ("`, which a trailing
`… (modified, +9 -2) (patch truncated)` would have broken. A header without a parenthetical gets
` (patch truncated)` appended (still parseable), and a first line that is not a `### ` header keeps
the old bare notice.

The worst case is now a named file with no visible patch instead of an unnamed one. The clip stays
within its one-line budget, so the line accounting in `formatWithLineBudget` and the monotonic
re-clip loop in `clipToBudget` are unaffected.

## Related Issues

Fixes #603

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Four new tests in `ReviewDiffFormatterTest`: the one-line clip names the file and stays one line;
the emitted header still parses back to the path; a header with no parenthetical still names the
file; and an end-to-end `buildDiffString` render whose line budget squeezes the last section to a
one-line clip still names it. The existing one-line test was renamed to state what it now pins —
the headerless fallback.

### Red proof (tests against unfixed `ReviewDiffFormatter`)

```
[ERROR] Tests run: 16, Failures: 4, Errors: 0, Skipped: 0, Time elapsed: 0.020 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.ReviewDiffFormatterTest$TruncationHelpers
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ReviewDiffFormatterTest.shouldKeepFileHeaderParseableAsSectionHeaderWhenBudgetIsOneLine -- Time elapsed: 0.005 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <### src/App.java (modified, +9 -2, patch truncated)> but was: <(patch truncated)>
	at dev.thiagogonzaga.thrillhousebot.review.ReviewDiffFormatterTest$TruncationHelpers.shouldKeepFileHeaderParseableAsSectionHeaderWhenBudgetIsOneLine(ReviewDiffFormatterTest.java:393)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.ReviewDiffFormatterTest.shouldKeepFileHeaderWhenBudgetIsOneLine -- Time elapsed: 0.001 s <<< FAILURE!
org.opentest4j.AssertionFailedError: clipped section must still name the file ==> expected: <true> but was: <false>
	at dev.thiagogonzaga.thrillhousebot.review.ReviewDiffFormatterTest$TruncationHelpers.shouldKeepFileHeaderWhenBudgetIsOneLine(ReviewDiffFormatterTest.java:379)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.ReviewDiffFormatterTest.shouldKeepFileNamedWhenPlannerClipsSectionToOneLine -- Time elapsed: 0.001 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the clipped file must still be named ==> expected: <true> but was: <false>
	at dev.thiagogonzaga.thrillhousebot.review.ReviewDiffFormatterTest$TruncationHelpers.shouldKeepFileNamedWhenPlannerClipsSectionToOneLine(ReviewDiffFormatterTest.java:418)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.ReviewDiffFormatterTest.shouldNameFileWhenHeaderHasNoParentheticalAndBudgetIsOneLine -- Time elapsed: 0 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
expected: <### src/App.java (patch truncated)
> but was: <(patch truncated)
>
	at dev.thiagogonzaga.thrillhousebot.review.ReviewDiffFormatterTest$TruncationHelpers.shouldNameFileWhenHeaderHasNoParentheticalAndBudgetIsOneLine(ReviewDiffFormatterTest.java:404)
```

With the fix applied all four pass.

### Gates

- `./mvnw -B spotless:apply` → BUILD SUCCESS
- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` → Tests run: 2851, Failures: 0, Errors: 0, Skipped: 0
- JaCoCo ∩ `git diff -U0 469539e...HEAD` on changed main code → 0 uncovered lines, 0 uncovered
  branches (both sides of each new condition are exercised)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Behavior for every other budget is unchanged: at `maxLines >= 2` the header already survived through
`truncatePlain` / `truncateWithoutFence`. Only the `maxLines == 1` degradation changes.