### PR TITLE
fix(review): scope the injection-sink floor's defeaters to asserted clauses

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -157,8 +157,8 @@ public class FindingVerificationService {
 
   /**
    * A conditional clause — a hypothesis the finding raises, not a fact it states. Matches from the
-   * conditional marker to the end of that clause (the next comma, colon, dash or sentence end), so
-   * only the hypothetical span is removed and whatever the finding asserts around it survives.
+   * conditional marker to the end of that clause, so only the hypothetical span is removed and
+   * whatever the finding asserts around it survives.
    *
    * <p>Both floor defeaters are assertion tests, and neither regex can carry mood: "If the feedback
    * API sanitizes body on write, the exploit is neutralized" satisfies {@link #MITIGATION_ASSERTED}
@@ -169,15 +169,32 @@ public class FindingVerificationService {
    * as a mitigation (#608). Scoping to the clause is the same narrowing the hedging scan already
    * needed for the same reason.
    *
-   * <p>Scoped to the conditional CLAUSE rather than the sentence carrying it, because over-firing
-   * the floor is the dangerous direction (#594): "If you follow the render path, React escapes the
-   * value" asserts the mitigation outside its conditional, and that assertion must still defeat the
-   * floor.
+   * <p>The clause ends at a real clause boundary — strong punctuation, or a coordinator that opens
+   * the consequent ("but", "so", "then"...) — and deliberately NOT at a comma. A protasis carries
+   * its own commas ("If the feedback API, per its own contract, always sanitizes the body on write,
+   * ..."), and stopping at the first one left the mitigation verb sitting in text read as asserted,
+   * which is the very under-firing this pattern exists to remove. The coordinator boundary is what
+   * keeps the consequent: "If it were stored as plain text this would be moot, but React escapes it
+   * at render" still asserts its mitigation, and that assertion must still defeat the floor, since
+   * over-firing the floor is the dangerous direction (#594).
+   *
+   * <p>Residual trade-off, chosen deliberately: a consequent separated by a bare comma and nothing
+   * else ("If you follow the render path, React escapes the value") is swallowed with the protasis,
+   * so its mitigation no longer defeats the floor. Commas cannot serve both roles, and this is the
+   * safer half — the finding must ALSO name a sink and ALSO claim nothing sanitizes it before the
+   * floor can fire at all, and the floor only lifts risk, leaving confidence and every other signal
+   * where the model put them.
+   *
+   * <p>Plain "should" is NOT a marker. Only inverted "Should the API sanitize ..." is a hypothesis,
+   * and its bare infinitive matches none of {@link #MITIGATION_ASSERTED}'s verb forms, so listing
+   * it bought nothing — while "It should be noted that the API sanitizes body on write" is an
+   * assertion, and treating it as a hypothesis hid a real mitigation from the defeater.
    */
   private static final Pattern CONDITIONAL_CLAUSE =
       Pattern.compile(
-          "\\b(if|unless|whether|in case|assuming|provided that|should)\\b"
-              + "[^,;:.!?\\n\\r\\u2013\\u2014]*",
+          "\\b(if|unless|whether|in case|assuming|provided that)\\b"
+              + "(?:(?!\\b(but|so|then|however|therefore|otherwise)\\b)"
+              + "[^;:.!?\\n\\r\\u2013\\u2014])*",
           Pattern.CASE_INSENSITIVE);
 
   /** The floor an unmitigated-injection-sink finding may never publish below (#570). */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -155,6 +155,31 @@ public class FindingVerificationService {
               + "(sanitizes|escapes|validates|parameterizes|encodes)\\b",
           Pattern.CASE_INSENSITIVE);
 
+  /**
+   * A conditional clause — a hypothesis the finding raises, not a fact it states. Matches from the
+   * conditional marker to the end of that clause (the next comma, colon, dash or sentence end), so
+   * only the hypothetical span is removed and whatever the finding asserts around it survives.
+   *
+   * <p>Both floor defeaters are assertion tests, and neither regex can carry mood: "If the feedback
+   * API sanitizes body on write, the exploit is neutralized" satisfies {@link #MITIGATION_ASSERTED}
+   * on the token pair "API sanitizes" even though the sentence goes on to reject the hypothesis
+   * ("but a sanitizer you cannot see is not a sanitizer"). That phrasing is not incidental — #575's
+   * review prompt REQUIRES a demonstrated-sink finding whose mitigating layer was not shown to name
+   * the exact layer to verify, so the instruction manufactures the wording the defeater then reads
+   * as a mitigation (#608). Scoping to the clause is the same narrowing the hedging scan already
+   * needed for the same reason.
+   *
+   * <p>Scoped to the conditional CLAUSE rather than the sentence carrying it, because over-firing
+   * the floor is the dangerous direction (#594): "If you follow the render path, React escapes the
+   * value" asserts the mitigation outside its conditional, and that assertion must still defeat the
+   * floor.
+   */
+  private static final Pattern CONDITIONAL_CLAUSE =
+      Pattern.compile(
+          "\\b(if|unless|whether|in case|assuming|provided that|should)\\b"
+              + "[^,;:.!?\\n\\r\\u2013\\u2014]*",
+          Pattern.CASE_INSENSITIVE);
+
   /** The floor an unmitigated-injection-sink finding may never publish below (#570). */
   private static final RiskLevel INJECTION_SINK_FLOOR = RiskLevel.HIGH;
 
@@ -363,8 +388,11 @@ public class FindingVerificationService {
    * that happens to say "unvalidated". Both halves are token matches, though, so a sentence that
    * RULES THE SINK OUT can satisfy them out of its own negation ("not concatenated but
    * parameterized, so no SQL injection is possible"); two defeaters — a denied sink, and a
-   * mitigation the finding says IS present — suppress the floor for exactly those. A critical keeps
-   * its level: the floor lifts, never lowers.
+   * mitigation the finding says IS present — suppress the floor for exactly those. Both are read on
+   * what the finding ASSERTS, with {@linkplain #CONDITIONAL_CLAUSE conditional clauses} removed
+   * first: a hypothesis the finding raises and rejects in the same breath is not a statement that
+   * the sink is safe, and the review prompt requires that hypothesis on this very class (#608). A
+   * critical keeps its level: the floor lifts, never lowers.
    */
   static ReviewResponse floorInjectionSinkRisk(ReviewResponse response) {
     if (response.findings().isEmpty()) {
@@ -408,13 +436,17 @@ public class FindingVerificationService {
         (finding.title() == null ? "" : finding.title())
             + "\n"
             + (finding.description() == null ? "" : finding.description());
+    // The trigger is read on the whole finding; the defeaters only on what it ASSERTS. A denial or
+    // a mitigation raised as a hypothesis the finding then rejects is not a statement that the sink
+    // is safe, and the review prompt mandates exactly that hypothesis on this class (#608).
+    String asserted = CONDITIONAL_CLAUSE.matcher(text).replaceAll(" ");
     return namesInjectionSink(text)
         && NO_MITIGATION.matcher(text).find()
-        // Either defeater anywhere in the finding suppresses the floor. Under-firing costs a
-        // finding the lift it should have had, which is where this class already stood; over-firing
-        // escalates a non-defect and, at high confidence, blocks the merge on it.
-        && !SINK_DENIED.matcher(text).find()
-        && !MITIGATION_ASSERTED.matcher(text).find();
+        // Either defeater anywhere in the finding's assertions suppresses the floor. Under-firing
+        // costs a finding the lift it should have had, which is where this class already stood;
+        // over-firing escalates a non-defect and, at high confidence, blocks the merge on it.
+        && !SINK_DENIED.matcher(asserted).find()
+        && !MITIGATION_ASSERTED.matcher(asserted).find();
   }
 
   private static boolean namesInjectionSink(String text) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -985,7 +985,8 @@ class FindingVerificationServiceTest {
   void stillHonoursAMitigationAssertedOutsideTheConditionalClause() {
     // The scoping is the conditional clause itself, not the sentence carrying it: over-firing the
     // floor is the dangerous direction (#594), so a finding whose conditional is incidental and
-    // which then states the mitigation as fact must still defeat the floor.
+    // which then states the mitigation as fact must still defeat the floor. The consequent is
+    // recognised by the coordinator that opens it, which is what survives the clause scan.
     when(reviewConfig.verifierEnabled()).thenReturn(false);
     ReviewResponse original =
         response(
@@ -995,7 +996,59 @@ class FindingVerificationServiceTest {
                 "src/components/Profile.tsx",
                 12,
                 "dangerouslySetInnerHTML receives an unsanitized note",
-                "If you follow the render path, React escapes the value before it reaches the DOM.",
+                "If it were stored as plain text this would be moot, but React escapes it at"
+                    + " render, so the exposure is limited.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    assertEquals("low", result.findings().get(0).risk());
+  }
+
+  @Test
+  void floorsAnInjectionSinkFindingWhoseConditionalCarriesItsOwnCommas() {
+    // A protasis carries its own commas, so ending the conditional at the FIRST one left the
+    // mitigation verb ("always sanitizes") in text read as asserted and the floor stayed suppressed
+    // — the #608 failure reached through a sentence one comma away from the one it names.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "medium",
+                "medium",
+                "src/components/FeedbackItem.tsx",
+                37,
+                "Stored XSS: feedback body rendered via dangerouslySetInnerHTML",
+                "No sanitization or escaping of body is visible in the provided material. If the"
+                    + " feedback API, per its own contract, always sanitizes the body on write, the"
+                    + " exploit is neutralized.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("high", result.findings().get(0).risk());
+    assertEquals("medium", result.findings().get(0).confidence());
+  }
+
+  @Test
+  void doesNotReadAnAssertiveShouldFrameAsAConditional() {
+    // "should" is an ordinary auxiliary in an assertive frame, so treating it as a hypothesis hid a
+    // genuine mitigation from the defeater and floored a finding that says the value IS sanitized.
+    // Only inverted "Should the API sanitize ..." is a hypothesis, and its bare infinitive matches
+    // none of the defeater's verb forms — so the marker only ever cost accuracy.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "low",
+                "high",
+                "src/components/FeedbackItem.tsx",
+                37,
+                "Feedback body reaches dangerouslySetInnerHTML unsanitized in this component",
+                "It should be noted that the API sanitizes body on write.",
                 null,
                 null));
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -926,6 +926,85 @@ class FindingVerificationServiceTest {
     assertEquals("low", result.findings().get(0).risk());
   }
 
+  /**
+   * Round 4's React half of the planted pair, verbatim from ThrillhouseBot-test #38: it names the
+   * unshown layer to verify exactly as the review prompt requires, then rejects that hypothesis in
+   * the same sentence and concludes the class is critical.
+   */
+  private static ReviewResponse.Finding reactConditionalXss(String risk, String confidence) {
+    return new ReviewResponse.Finding(
+        risk,
+        confidence,
+        "src/components/FeedbackItem.tsx",
+        37,
+        "Stored XSS: feedback body rendered via dangerouslySetInnerHTML with no sanitization",
+        "No sanitization, escaping, or validation of body is visible anywhere in the provided"
+            + " material. This is the stored-XSS defect class: user-authored stored content"
+            + " rendered back to other users via a raw-HTML sink. If the feedback API sanitizes"
+            + " body on write, the exploit is neutralized — verify that layer — but a"
+            + " sanitizer you cannot see is not a sanitizer, so severity stays at critical while"
+            + " confidence is medium.",
+        null,
+        null);
+  }
+
+  @Test
+  void floorsAnInjectionSinkFindingWhoseOnlySanitizerMentionIsAConditionalItRejects() {
+    // #608: the finding argues its own severity is critical and publishes MEDIUM, because
+    // MITIGATION_ASSERTED read "API sanitizes" out of the conditional "If the feedback API
+    // sanitizes body on write" — a hypothesis the very next clause rejects. #575's prompt REQUIRES
+    // that clause on this class, so the defeater fired on wording the prompt guarantees is there.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original = response(reactConditionalXss("medium", "medium"));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("high", result.findings().get(0).risk());
+    assertEquals("medium", result.findings().get(0).confidence());
+    assertEquals(1, result.summary().high());
+    assertEquals(0, result.summary().medium());
+  }
+
+  @Test
+  void ratesTheConditionallyHedgedHalfOfThePlantedPairLikeItsTwin() {
+    // #608's acceptance case: the same class in two frameworks, one of them phrased with the
+    // mandated verification clause, must publish at the same severity and both inline.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(angularXss("critical", "high"), reactConditionalXss("medium", "medium"));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertTrue(Finding.fromAiResponse(result.findings().get(0)).postsInline());
+    assertTrue(Finding.fromAiResponse(result.findings().get(1)).postsInline());
+    assertEquals("critical", result.findings().get(0).risk());
+    assertEquals("high", result.findings().get(1).risk());
+  }
+
+  @Test
+  void stillHonoursAMitigationAssertedOutsideTheConditionalClause() {
+    // The scoping is the conditional clause itself, not the sentence carrying it: over-firing the
+    // floor is the dangerous direction (#594), so a finding whose conditional is incidental and
+    // which then states the mitigation as fact must still defeat the floor.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "low",
+                "high",
+                "src/components/Profile.tsx",
+                12,
+                "dangerouslySetInnerHTML receives an unsanitized note",
+                "If you follow the render path, React escapes the value before it reaches the DOM.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    assertEquals("low", result.findings().get(0).risk());
+  }
+
   @Test
   void leavesCriticalInjectionFindingsAndUnrelatedRatingsAlone() {
     // The floor only lifts, so a critical keeps its level; and it never fires unless the finding


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔒 Security

## Description

The deterministic severity floor for an unmitigated injection sink (#594, for #570) did not fire on
the round-4 acceptance case: its own `MITIGATION_ASSERTED` defeater matched a **conditional
hypothetical the finding immediately rejects**.

Round 4 planted the same stored-XSS class in Angular and React. The Angular half published
`CRITICAL`; the React half argued its own severity was critical and published `MEDIUM`:

> No sanitization, escaping, or validation of body is visible anywhere in the provided material.
> This is the stored-XSS defect class ... If the feedback API sanitizes body on write, the exploit
> is neutralized — verify that layer — but a sanitizer you cannot see is not a sanitizer, so
> severity stays at critical while confidence is medium.

Running the two defeaters against that text: `MITIGATION_ASSERTED` matches `API sanitizes` (second
alternation, `\w+\s+(sanitizes|escapes|...)`) out of the conditional clause; `SINK_DENIED` correctly
does not match. So the floor was defeated by a hypothesis the very next clause rejects.

The phrasing is not incidental. #575's review prompt REQUIRES a demonstrated-sink finding whose
mitigating layer was not shown to **name the exact layer to verify** — the instruction manufactures
the wording the defeater reads as a mitigation. Meanwhile #594's defeaters exist because the floor
was demonstrably over-firing on findings that *deny* the sink ("so no SQL injection is possible").
Both directions are real, and the fix has to keep both.

### Fix: option 1 (clause-scoping), and why not 2 or 3

The trigger (`INJECTION_SINK` + `NO_MITIGATION`) is still read on the whole finding. The two
**defeaters** now run on what the finding *asserts*: conditional clauses are removed first, matching
`if|unless|whether|in case|assuming|provided that|should` from the marker to the end of that clause
(next comma, colon, semicolon, dash, or sentence end). This is the same narrowing the hedging scan
already needed in #594 for the same reason — a token regex cannot carry mood.

Scoped to the **clause**, not the sentence carrying it, because over-firing is the dangerous
direction: `..., but React escapes it at render` asserts the mitigation *outside* its conditional and
must still defeat the floor. A whole-sentence exclusion would have lost that.

### Second commit: both edges of the clause scan were wrong

Review found two defects in the first commit, pulling in opposite directions. Both reproduce, both
are fixed, both are pinned by a test.

**Under-firing — the clause ended at the first comma.** A protasis carries its own commas, so
`If the feedback API, per its own contract, always sanitizes the body on write, ...` had only
`If the feedback API` removed; `always sanitizes` stayed in the asserted text, `MITIGATION_ASSERTED`
matched, and the floor stayed suppressed. That is #608 itself, reached through a sentence one comma
away from the one the issue names. The clause now ends at a real boundary — strong punctuation
(`; : . ! ?`, newline, en/em dash) or a coordinator that opens the consequent
(`but`, `so`, `then`, `however`, `therefore`, `otherwise`) — and no longer at a bare comma.

**Over-firing — plain `should` was treated as a conditional marker.** `It should be noted that the
API sanitizes body on write.` is an assertion, and reading it as a hypothesis removed the whole
sentence from the defeater's view, so a finding that explicitly says the value IS sanitized got
floored to high. `should` is dropped. It cost nothing to drop: only inverted `Should the API
sanitize ...` is a hypothesis, and its bare infinitive matches none of `MITIGATION_ASSERTED`'s verb
forms, so the marker never bought a single correct exclusion.

### Third commit: the span mechanism is retired

A third review pass found a third leaking shape — a coordinator sitting *inside* the protasis, so
`If the API sanitizes nothing on write but silently escapes the body on read, ...` truncates at
`but` and `silently escapes` reads as asserted. Testing that fix turned up a fourth shape nobody had
reported: a postposed conditional, `The API sanitizes the body only if the request is trusted`,
where the marker comes **after** the verb it governs, so no span starting at the marker can ever
cover it.

That is three passes, four shapes, one hole. The pattern is not bad luck about which stop tokens
were chosen — it is structural. A protasis is a syntactic constituent, and **no lexical token marks
where it ends**: commas occur inside it, coordinators occur inside it, dashes occur inside it, and
in the postposed form it does not start where the marker is. Any span-delimiting rule is a guess at
a boundary that is not lexically marked, so for every terminator there exists a sentence that puts
that terminator inside the protasis. The shape space is open, and every leak lands on the
**under-firing** side — the direction #570 has failed on for three rounds.

So the span is retired rather than refined again, which is the same move #596 made when it stopped
tuning a similarity score that could not carry negation.

**What replaces it:** the unit of judgement is the sentence. A sentence containing a conditional
marker is not read for defeaters at all. `CONDITIONAL_CLAUSE` (a tempered-greedy span regex) becomes
`CONDITIONAL_MARKER` (a plain word alternation), and the scan reuses `CLAUSE_BOUNDARY`, the sentence
split the hedging scan in this same class already uses. Net effect on the diff: less code, one fewer
regex construct, no span arithmetic.

**Why the shape space is now closed, not merely smaller.** The boundary question is gone rather than
answered. A hypothesis and its marker always occupy the same sentence — that is what a conditional
*is*, in every English word order, fronted or postposed — so excluding the whole sentence cannot
leak a hypothetical verb into asserted text regardless of what the sentence contains. There is no
terminator left for a sentence shape to sit inside. The postposed case is closed by construction
rather than by a fifth rule, which is the concrete evidence that this is a different mechanism and
not a smaller edge: it was fixed without being enumerated.

**The one remaining error, pinned rather than buried.** A mitigation asserted in the *same sentence*
as a conditional (`If it were stored as plain text this would be moot, but React escapes it at
render`) is read as hypothetical, and the floor lifts a finding it should have left alone. This is
the only way the rule can be wrong, and it is now an explicit characterization test
(`liftsAFindingThatAssertsItsMitigationInsideAHypotheticalSentence`) rather than an undocumented
edge. It is accepted deliberately:

- it errs toward the safe direction — over-firing, not under-firing;
- it still requires the finding to name a sink **and** claim nothing sanitizes it before the floor
  can fire at all;
- only risk moves; confidence, placement and every other signal stay where the model put them;
- a mitigation stated in its own sentence still defeats the floor, which is how findings state one
  (`stillHonoursAMitigationAssertedInItsOwnSentence`);
- and every token-level attempt to keep this case reopened an under-fire instead — the coordinator
  carve-out from the second commit was exactly that attempt, and it is what the third review pass
  broke.

## Related Issues

Fixes #608

## How Has This Been Tested?

- [x] Unit tests

Eight tests added to `FindingVerificationServiceTest`, and #594's two over-firing tests
(`doesNotFloorAFindingThatDeniesTheSinkItNames`,
`doesNotFloorAFindingThatDescribesTheMitigationAsPresent`) stay green unchanged.

**Red output on unfixed code** (`./mvnw -B test -Dtest=FindingVerificationServiceTest` at
`469539e` with only the tests applied):

```
[ERROR] Tests run: 46, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 1.439 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.ratesTheConditionallyHedgedHalfOfThePlantedPairLikeItsTwin -- Time elapsed: 0.007 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <high> but was: <medium>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1199)
	at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.ratesTheConditionallyHedgedHalfOfThePlantedPairLikeItsTwin(FindingVerificationServiceTest.java:981)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.floorsAnInjectionSinkFindingWhoseOnlySanitizerMentionIsAConditionalItRejects -- Time elapsed: 0.001 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <high> but was: <medium>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1199)
	at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.floorsAnInjectionSinkFindingWhoseOnlySanitizerMentionIsAConditionalItRejects(FindingVerificationServiceTest.java:962)
```

Both are the exact published-vs-argued contradiction the issue measures: the finding text is the
round-4 comment verbatim, rated `medium`, and the floor did not lift it.

**Red output for the second commit's two defects** (same command at `f55d7d7`'s tests over the
first commit's implementation):

```
[ERROR] Tests run: 48, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 2.098 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.floorsAnInjectionSinkFindingWhoseConditionalCarriesItsOwnCommas -- Time elapsed: 0.012 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <high> but was: <medium>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1199)
	at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.floorsAnInjectionSinkFindingWhoseConditionalCarriesItsOwnCommas(FindingVerificationServiceTest.java:1032)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.doesNotReadAnAssertiveShouldFrameAsAConditional -- Time elapsed: 0.019 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <...risk=low...> but was: <...risk=high...>
	at org.junit.jupiter.api.Assertions.assertSame(Assertions.java:2962)
	at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.doesNotReadAnAssertiveShouldFrameAsAConditional(FindingVerificationServiceTest.java:1057)
```

The two failures are the two directions: the comma case published `medium` where the floor should
have lifted it, and the `should` case was lifted to `high` on a finding that asserts a mitigation.

**Red output for the third commit** (the three new tests over the second commit's implementation):

```
[ERROR] Tests run: 51, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 1.289 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.floorsAnInjectionSinkFindingWhoseConditionalMarkerFollowsTheVerbItGoverns -- Time elapsed: 0.007 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <high> but was: <medium>
	at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.floorsAnInjectionSinkFindingWhoseConditionalMarkerFollowsTheVerbItGoverns(FindingVerificationServiceTest.java:1055)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.floorsAnInjectionSinkFindingWhoseConditionalContainsACoordinator -- Time elapsed: 0.002 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <high> but was: <medium>
	at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.floorsAnInjectionSinkFindingWhoseConditionalContainsACoordinator(FindingVerificationServiceTest.java:1031)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.liftsAFindingThatAssertsItsMitigationInsideAHypotheticalSentence -- Time elapsed: 0.002 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <high> but was: <low>
	at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.liftsAFindingThatAssertsItsMitigationInsideAHypotheticalSentence(FindingVerificationServiceTest.java:1082)
```

The first two are the two leaking shapes, both publishing `medium` where the floor should have
lifted them. The third is the accepted cost, red because it pins the new behaviour.

Gates:

- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — `Tests run: 2855, Failures: 0, Errors: 0, Skipped: 0`
- jacoco ∩ `git diff -U0 469539e...HEAD` — 0 uncovered lines, 0 uncovered branches in changed main code

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Behaviour is unchanged for any finding with no conditional marker in its title or description, which
is every existing test case bar the new ones.


