### PR TITLE
fix(review): refuse the claims a withheld path licenses, not only the first

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -427,6 +427,20 @@ public final class PrReviewPrompts {
               work whose only evidence would live in a withheld path, the claim is unverifiable
               here, not false: say nothing about it. A rename the description states and the
               withheld list confirms is DONE, not missing.
+            - The same rule governs every claim BUILT on a withheld path, not only the claim that
+              names it. Deciding that the implementing change is absent licenses a second, worse
+              statement: that the documentation, comment, configuration value or test which IS in
+              your material makes a claim nothing supports. Never write that one. Material of yours
+              that describes behavior whose implementation would live in a withheld path is not
+              unbacked, unverified, unimplemented, aspirational, premature, or "documented but not
+              done" — the code that backs it is in this pull request, on the path the disclosure
+              names, and you were simply not shown it. Build and dependency manifests (pom.xml,
+              build.gradle, package.json, go.mod, Cargo.toml, requirements.txt, lockfiles) are what
+              ignore lists withhold most often, so "the diff changes no build or dependency file"
+              is the likeliest shape of this error: before writing any sentence that asserts the
+              diff does not contain some change, read the withheld list for a path that would carry
+              it. Whenever the truthful statement would be "the file that settles this was never
+              shown to me", there is no finding and no gap — write nothing.
             - A suggestion must not contradict a convention visible in the provided material —
               for example, suggesting an unpinned reference when every similar reference nearby
               is pinned. When the obvious fix conflicts with such a convention, describe the
@@ -494,7 +508,9 @@ public final class PrReviewPrompts {
               claimed change counts as missing ONLY when the file that would carry it is in your
               material and does not carry it; never enter one here because you could not find it in
               a path the material lists as omitted from AI review, and never contradict a
-              disclosure the same material already makes.
+              disclosure the same material already makes. A documentation or configuration change
+              you CAN see is not a gap either because the code implementing it sits on that omitted
+              list — that entry is the same error one step removed.
             - file_summaries: an array of { path, summary } objects, one per changed file, that gives
               reviewers a file-by-file walkthrough. The object keys must be spelled exactly "path"
               and "summary" — not "file", "filename" or "description" — and the field itself
@@ -631,6 +647,8 @@ public final class PrReviewPrompts {
               list marks as a pure rename, omitted from AI review, or not reviewed IS part of this
               change and was withheld from review on purpose: never report the work it carries as
               missing or unimplemented, and never contradict a disclosure that list already makes.
+              Nor is the documentation or configuration this change does show unbacked because the
+              code implementing it sits on that list — that is the same error one step removed.
             - file_summaries: REQUIRED, and the field this call most often gets wrong. It is an
               array of { path, summary } objects that fills the rendered file-by-file walkthrough
               table; omitting it, or emitting [], leaves every row of that table blank, which is

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -915,6 +915,40 @@ class PrReviewPromptsContentTest {
   }
 
   /**
+   * #566 — the production instance on this repo's own PR #564. {@code **}{@code /pom.xml} is on the
+   * shipped default ignore list, so the review was handed the README and application.properties
+   * comments describing a dependency-scope change but not the pom hunk performing it. It said the
+   * diff contained no pom.xml change, and then — building on that — that the documentation it COULD
+   * see claimed something nothing in the diff implemented. One withheld file, two false statements,
+   * covering the pull request's entire substantive change. Refusing only the first sentence leaves
+   * the second, so the rule has to reach every claim derived from the withheld path.
+   */
+  @Test
+  void aClaimBuiltOnAWithheldPathIsRefusedAlongWithTheClaimThatNamesIt() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "The same rule governs every claim BUILT on a withheld path",
+        "the withheld-material rule must extend past the sentence that names the path (#566)");
+    assertContains(
+        sys,
+        "unbacked, unverified, unimplemented, aspirational, premature",
+        "visible documentation must not be called unsupported when its code was withheld (#566)");
+    assertContains(
+        sys,
+        "build.gradle, package.json, go.mod, Cargo.toml, requirements.txt",
+        "the manifests ignore lists withhold most often must be named outright (#566)");
+    assertContains(
+        sys,
+        "read the withheld list for a path that would carry",
+        "the check must fire before an absence is asserted, not after (#566)");
+    assertContains(
+        sys,
+        "there is no finding and no gap — write nothing",
+        "an unverifiable-because-withheld claim must be dropped, not hedged (#566)");
+  }
+
+  /**
    * #570 — the round-2 corpus planted the same stored-XSS defect in Angular ({@code
    * bypassSecurityTrustHtml}) and React ({@code dangerouslySetInnerHTML}) and got HIGH inline for
    * one and LOW in the collapsed section for the other, on the reasoning that the backend might
@@ -990,5 +1024,14 @@ class PrReviewPromptsContentTest {
         PrReviewPrompts.SUMMARY_SYSTEM,
         "pure rename, omitted from AI review, or not reviewed IS part of this",
         "the summary call's description_gaps must exclude withheld paths (#569)");
+    // #566 — the derived form: the visible docs called unbacked because their code was withheld.
+    assertContains(
+        PrReviewPrompts.SYSTEM,
+        "is not a gap either because the code implementing it sits",
+        "the review call's description_gaps must refuse the derived claim too (#566)");
+    assertContains(
+        PrReviewPrompts.SUMMARY_SYSTEM,
+        "Nor is the documentation or configuration this change does show unbacked",
+        "the summary call's description_gaps must refuse the derived claim too (#566)");
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

#573 gave the review call the disclosure it was missing: every path this pull request
changes that the call was not shown, with the reason (pure rename, ignore list, budget).
The rule that reads it stops one sentence too early.

On this repository's own PR #564 — README.md, pom.xml, application.properties, with
`**/pom.xml` on the shipped default `THRILLHOUSEBOT_REVIEW_IGNORED_FILES` — the review
posted **two** false statements from that one withheld file:

> The PR title and description state that quarkus-jdbc-h2 is moved to `provided` scope in pom.xml, but the diff contains no pom.xml change; only README.md and application.properties comments/docs are present.
> The README and application.properties now claim the H2 driver is a `provided` dependency that is not packaged into the runtime image, but nothing in the diff implements or verifies that claim.

The pom hunk was present and correct. The first sentence is what the existing rule
forbids. The second is the one that does the damage: it is about files the call **could**
see, and it says their documentation is unsupported — a conclusion reachable only from
the first error. One withheld file, two wrong claims, on the PR's entire substantive
change, and it was the sole reason that PR sat at REQUEST_CHANGES.

### The fix

Prompt text only, in three places:

- **The withheld-material self-check** gains the derived case. Material of yours that
  describes behavior whose implementation would live in a withheld path is not unbacked,
  unverified, unimplemented, aspirational, premature, or "documented but not done". It
  names the paths ignore lists actually withhold — `pom.xml`, `build.gradle`,
  `package.json`, `go.mod`, `Cargo.toml`, `requirements.txt`, lockfiles — so the model
  can recognize the shape, and moves the check **ahead** of the sentence: read the
  withheld list for a path that would carry the change *before* asserting the diff does
  not contain one. When the truthful statement is "the file that settles this was never
  shown to me", there is no finding and no gap.
- **`SYSTEM`'s `description_gaps` spec**: a documentation or configuration change you can
  see is not a gap because the code implementing it sits on the omitted list.
- **`SUMMARY_SYSTEM`'s `description_gaps` spec**: the same guard on the other surface that
  emits the field.

Nothing else changes. The material half is already shipped (#573), the ignore list is
untouched, and no plumbing is edited.

### Scope — what this does not do

`FindingPipeline.changedFilesOverview` builds the **summary** call's changed-file list
from `ctx.reviewableFiles()`, so an ignore-listed path is still absent from that list
entirely on a multi-call review: the summary prompt's guard has nothing to match there.
PR #564 is small enough to go through the single budgeted review call, which does carry
the notice, so this PR fixes the reported instance — but the summary-overview gap is real
and lives in `FindingPipeline`, outside this PR's lane. `/describe` reproduces the same
false claim on its own prompt surface and is likewise untouched.

## Related Issues

Fixes #566

## How Has This Been Tested?

- [x] Unit tests

Two `PrReviewPromptsContentTest` changes: a new
`aClaimBuiltOnAWithheldPathIsRefusedAlongWithTheClaimThatNamesIt` pinning the derived-claim
rule, the named manifests, the check-before-you-assert ordering and the write-nothing
outcome; and two anchors added to `bothPromptsKeepWithheldPathsOutOfDescriptionGaps` for
the guard on both `description_gaps` surfaces.

### Red proof

The round's standards exempt prompt-text changes, but the new pins do fail on the unfixed
prompt. With `PrReviewPrompts.java` restored to `469539e` (copied aside, not stashed):

```
[ERROR] Tests run: 51, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.101 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.ai.PrReviewPromptsContentTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.PrReviewPromptsContentTest.bothPromptsKeepWithheldPathsOutOfDescriptionGaps -- Time elapsed: 0.006 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the review call's description_gaps must refuse the derived claim too (#566) — missing marker: "is not a gap either because the code implementing it sits" ==> expected: <true> but was: <false>

[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.PrReviewPromptsContentTest.aClaimBuiltOnAWithheldPathIsRefusedAlongWithTheClaimThatNamesIt -- Time elapsed: 0.001 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the withheld-material rule must extend past the sentence that names the path (#566) — missing marker: "The same rule governs every claim BUILT on a withheld path" ==> expected: <true> but was: <false>
```

### Gates

| Gate | Result |
|---|---|
| `spotless:apply` + `clean compile spotbugs:check spotless:check` | BUILD SUCCESS, `BugInstance size is 0` |
| `clean test` | `Tests run: 2848, Failures: 0, Errors: 0, Skipped: 0` |
| jacoco ∩ `git diff -U0 469539e...HEAD` (main code) | 0 uncovered lines, 0 uncovered branches — the three changed hunks are text-block content inside a constant, and JaCoCo instruments no line in any of them |

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No `README.md` or `docs/**` file is touched, so the Docs workflow is not in play.
The regression case is preserved: re-running the review over PR #564's diff should
produce neither sentence.
