### PR TITLE
fix(review): classify what a function costs even after filing another defect

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -96,6 +96,23 @@ public final class PrReviewPrompts {
                    N+1) where one batched call would do.
                (d) a linear-time operation applied once per element — string concatenation building
                    a result in a loop, insertion at the head of an array, an O(n) copy per append.
+               The two levels are usually NOT one loop nested inside another in the same function,
+               and the disguised forms are the ones that go unreported:
+               (e) the inner scan lives in a HELPER the diff also shows — a function named
+                   contains…, has…, already…, exists…, find…, lookup…, indexOf… whose body walks a
+                   collection. Calling it once per element is the nested scan; the helper's own
+                   line is the inner level and its call site is the outer one.
+               (f) the outer level is not a loop statement at all but the per-item ENTRY POINT — a
+                   function invoked once per request, message, event, row or job that scans an
+                   accumulator earlier calls appended to. Handling n items costs O(n^2) even though
+                   no line in the diff shows two loops, and the accumulator that grows by one per
+                   call is the second level.
+               (g) the levels are two chained higher-order calls over the SAME collection:
+                   arr.filter((x, i) => arr.findIndex(r => r.id === x.id) === i), a .includes() or
+                   .some() inside a .filter()/.map(), a nested comprehension. The one-line
+                   deduplicate-by-id idiom is the canonical case and is quadratic in every
+                   language that spells it this way; a set or map keyed by the id makes it linear.
+                   Being the idiomatic spelling is not a bound.
                Report these at risk "medium", or "high" when the collection is request- or
                user-sized AND the path is a hot one, and name the concrete better structure in the
                description (a set for the membership test, one pass instead of two, hoisting the
@@ -273,6 +290,23 @@ public final class PrReviewPrompts {
               with "report each underlying defect exactly once" below: that rule forbids restating
               ONE defect at several lines; this one forbids burying a SECOND defect inside the
               first, even when it is what makes the first one true.
+            - Finding a defect in a function does not finish that function. An added quadratic is
+              rarely missed for want of looking: the usual way it is lost is that you read the
+              function closely, found a DIFFERENT real defect in it — a re-enqueue that fires
+              twice, a buffer nothing frees, a state update that keeps the wrong rows — filed that
+              one, and moved on without ever asking what the code costs. So for every function you
+              anchor a finding in, whatever dimension that finding is on, answer one more question
+              before you leave it: does it scan a collection once per element, once per call, or
+              once per chained callback (dimension 5, including the disguised forms (e)-(g))? A yes
+              is its own finding at its own risk, filed alongside the one you came for. Two defects
+              in one function is the ordinary case, and the bug you already found is not a reason
+              its cost is acceptable.
+            - The same applies to a structure you DESCRIBE rather than measure. When you discuss a
+              deduplicating accumulator — a seen list, a visited array, a pending queue, a cache —
+              for its scope, its lifetime, its correctness or its unbounded growth, say in the same
+              pass which lookup it uses. "Grows without bound" and "is scanned linearly per item"
+              are two different defects on two different dimensions; naming either one does not
+              report the other, and a finding about the accumulator's scope covers neither.
             - Before you finish, re-read what you have written — each finding's description, each
               file_summaries line, each description_gaps entry — for any statement that describes
               a defect no finding in your list covers, and promote each one into its own finding
@@ -393,7 +427,10 @@ public final class PrReviewPrompts {
               the diff shows either level bounded by a literal, an enum, a constant, or a small
               fixed collection, the finding is invalid. A single pass, or a lookup that is already
               hashed (a set/map membership test), is not quadratic — check which it is before
-              claiming it.
+              claiming it. The two quoted lines do NOT have to sit in the same function: the
+              scanning line inside a helper and the call site that runs it per element are the two
+              levels, and so are the scan inside a per-item entry point and the line that appends
+              to the collection it scans. Quote whichever pair the diff shows.
             - A config-key documentation-completeness claim (dimension 10) must quote the
               documented line from the diff AND the definition line — from the diff or from the
               config-key definitions section — that establishes the omitted fact, and name which

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -726,6 +726,79 @@ class PrReviewPromptsContentTest {
         "a fixed small bound must still exclude the finding — precision is unchanged (#537)");
   }
 
+  /**
+   * #537 round 3 — the three misses (c #22, zig #20, react #26) all hid the same shape behind a
+   * spelling dimension 5 did not enumerate: {@code already_seen}/{@code containsJob} put the inner
+   * scan inside a helper, {@code rotator_write} made the outer level a per-message entry point
+   * rather than a loop, and the React hook chained {@code findIndex} inside {@code filter} over one
+   * array. A reader looking for two nested {@code for} statements finds none of them.
+   */
+  @Test
+  void dimensionFiveEnumeratesTheNonNestedSpellingsOfAQuadratic() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "The two levels are usually NOT one loop nested inside another",
+        "the disguised forms must be introduced as the ones that go unreported (#537)");
+    assertContains(
+        sys,
+        "the inner scan lives in a HELPER the diff also shows",
+        "a scan hidden behind contains…/already… must count as the inner level (#537)");
+    assertContains(
+        sys,
+        "the outer level is not a loop statement at all but the per-item ENTRY POINT",
+        "a per-call scan over a growing accumulator must count as quadratic (#537)");
+    assertContains(
+        sys,
+        "the levels are two chained higher-order calls over the SAME collection",
+        "the chained filter/findIndex dedupe idiom must be named as a shape (#537)");
+    assertContains(
+        sys,
+        "Being the idiomatic spelling is not a bound",
+        "familiarity with the one-line dedupe must not excuse it (#537)");
+    // The self-check has to accept the evidence those shapes can actually produce.
+    assertContains(
+        sys,
+        "The two quoted lines do NOT have to sit in the same function",
+        "the quote-both-levels check must admit a helper and its call site (#537)");
+  }
+
+  /**
+   * #537 round 3 — the failure shape was NOT inattention: in all three misses the review examined
+   * the exact function, reported a different real defect in it, and never mentioned complexity. A
+   * threshold nudge cannot reach that, and neither can the promotion sweep below it, which only
+   * rescues defects already written down somewhere. This is the trigger that fires while the
+   * function is still in hand.
+   */
+  @Test
+  void aFindingOnAnotherDimensionMustNotEndTheExaminationOfTheFunction() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "Finding a defect in a function does not finish that function",
+        "one filed defect must not close the function to a second one (#537)");
+    assertContains(
+        sys,
+        "rarely missed for want of looking",
+        "the miss must be framed as a wrong-dimension failure, not a did-not-look one (#537)");
+    assertContains(
+        sys,
+        "anchor a finding in, whatever dimension that finding is on, answer one more question",
+        "anchoring any finding must trigger the cost question for that function (#537)");
+    assertContains(
+        sys,
+        "the bug you already found is not a reason",
+        "a different real defect must not stand in for the complexity classification (#537)");
+    assertContains(
+        sys,
+        "deduplicating accumulator — a seen list, a visited array, a pending queue",
+        "discussing a dedupe accumulator must trigger naming its lookup cost (#537)");
+    assertContains(
+        sys,
+        "are two different defects on two different dimensions",
+        "unbounded growth and a linear per-item lookup must not collapse into one (#537)");
+  }
+
   @Test
   void mockFidelityIsReportableFromTheSignatureAndLandsAtMedium() {
     assertContains(


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Re-scoped to **performance only** (comment-contradiction is holding; mock fidelity moved
to #587).

#545 took the performance dimension from 0/4 to 7/8 in round 2. Round 3 rebuilt the corpus
and missed it in three of eight — c #22, zig #20, react #26 — and all three failed
identically: **the review examined the exact function closely, reported a different real
defect in it, and never mentioned complexity.** Nothing was overlooked, so raising a
threshold or re-arguing "the shape is the evidence" has nothing to bite on.

Reading the three planted defects shows the second half of the problem. Dimension 5
described "a linear membership test inside a loop" and "a nested loop pair" — and not one
of the three is spelled that way:

| lang | the planted shape | why the description missed it |
|---|---|---|
| zig #20 | `enqueueBatch` loops over `jobs` and calls `containsJob(id)`, whose body scans `self.pending.items` | the inner scan is in a **helper**, a different function; neither function alone contains two loops |
| c #22 | `rotator_write` is called once per log message and calls `already_seen`, which walks every message ever written | the outer level is a **per-item entry point**, not a loop statement — there is no `for` around the call in the diff |
| react #26 | `merged.filter((result, i) => merged.findIndex(r => r.id === result.id) === i)` | the two levels are **two chained higher-order calls** over one array — and this is the idiomatic JS dedupe one-liner, which reads as correct rather than as quadratic |

A reader looking for two nested `for` statements finds none of them.

### The fix

Prompt text only, in three places:

- **Dimension 5 gains shapes (e)-(g)**, introduced as "the two levels are usually NOT one
  loop nested inside another in the same function": the scan behind a
  `contains…/has…/already…/find…/lookup…` helper the diff also shows; the per-item entry
  point scanning an accumulator earlier calls appended to ("handling n items costs O(n^2)
  even though no line in the diff shows two loops"); and two chained higher-order calls
  over the same collection, with the dedupe-by-id one-liner named outright and
  "being the idiomatic spelling is not a bound".
- **The emission rules gain the trigger**, next to the existing promotion sweep and doing
  what that sweep cannot. The sweep only rescues a defect already written down somewhere;
  in these three misses the complexity was never written down at all. So: *finding a defect
  in a function does not finish that function* — anchoring a finding there, on any
  dimension, obliges one more question about what that code costs before moving on, and
  "the bug you already found is not a reason its cost is acceptable". A second bullet
  covers the c case's near-miss specifically: when you discuss a dedupe accumulator for its
  scope, lifetime, correctness or unbounded growth, say in the same pass which lookup it
  uses — "grows without bound" and "is scanned linearly per item" are two defects on two
  dimensions, and the round-3 review filed the framing without either.
- **The quote-both-levels self-check** now says the two quoted lines need not sit in the
  same function, so a helper's scanning line plus its call site is admissible evidence.
  Without this the new shapes would be enumerated and then invalidated.

Precision guidance is untouched: the fixed-and-small-bound exclusion, the comment
justification, the already-hashed lookup check and the "state the cost in words unless one
n drives both levels" rule all stand. Round 3's precision (5 arguable false positives
against 15 verified true extras, every decline trap refused) is what those protect.

## Related Issues

Fixes #537

## How Has This Been Tested?

- [x] Unit tests

Two new `PrReviewPromptsContentTest` cases:
`dimensionFiveEnumeratesTheNonNestedSpellingsOfAQuadratic` (the three disguised shapes, the
idiom carve-out, and the self-check's cross-function admission) and
`aFindingOnAnotherDimensionMustNotEndTheExaminationOfTheFunction` (the trigger, its framing
as a wrong-dimension rather than did-not-look failure, and the accumulator split). The
existing #537 pins from #545 are left intact.

### Red proof

The round's standards exempt prompt-text changes, but the new pins do fail on the unfixed
prompt. With `PrReviewPrompts.java` restored to `469539e` (copied aside, not stashed):

```
[ERROR] Tests run: 52, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.122 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.ai.PrReviewPromptsContentTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.PrReviewPromptsContentTest.dimensionFiveEnumeratesTheNonNestedSpellingsOfAQuadratic -- Time elapsed: 0.014 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the disguised forms must be introduced as the ones that go unreported (#537) — missing marker: "The two levels are usually NOT one loop nested inside another" ==> expected: <true> but was: <false>

[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.PrReviewPromptsContentTest.aFindingOnAnotherDimensionMustNotEndTheExaminationOfTheFunction -- Time elapsed: 0.001 s <<< FAILURE!
org.opentest4j.AssertionFailedError: one filed defect must not close the function to a second one (#537) — missing marker: "Finding a defect in a function does not finish that function" ==> expected: <true> but was: <false>
```

### Gates

| Gate | Result |
|---|---|
| `spotless:apply` + `clean compile spotbugs:check spotless:check` | BUILD SUCCESS, `BugInstance size is 0` |
| `clean test` | `Tests run: 2849, Failures: 0, Errors: 0, Skipped: 0` |
| jacoco ∩ `git diff -U0 469539e...HEAD` (main code) | 0 uncovered lines, 0 uncovered branches — the three changed hunks are text-block content inside a constant, and JaCoCo instruments no line in any of them |

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

This issue is only settleable by re-measurement, not by a tree check — the corpus has to be
re-run against a deployed image carrying this prompt, with the three round-3 misses (c #22,
zig #20, react #26) as the specific cases to watch. No `README.md` or `docs/**` file is
touched, so the Docs workflow is not in play.
