### PR TITLE
fix(review): keep an unmatched-quote finding instead of deleting it

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidator.java
@@ -31,9 +31,19 @@ import java.util.Set;
  * occasionally reviews a paraphrase of the change instead of the change itself and then flags
  * defects in code nobody wrote.
  *
- * <p>The check is conservative: a finding is dropped only when none of its quoted lines exist in
- * the diff (pure phantom). When the quote is partially wrong, the unreliable suggestion block is
- * removed and confidence is capped at "low" so the finding can still surface but cannot block.
+ * <p>The check never deletes a finding. Every unreliable-quote verdict gets the same conservative
+ * response: the suggestion block is removed and confidence is capped at "low", so the finding still
+ * surfaces — carrying its low-confidence disclaimer and unable to block — with its untrusted
+ * suggestion gone.
+ *
+ * <p>Deleting on a fully unmatched quote was tried and cost more than it saved. The match is
+ * per-line and exact, so a quote that matches nothing is not proof of a phantom: a model that
+ * rewraps a construct the source splits across lines — a multi-line SQL literal, an
+ * implicitly-concatenated f-string — writes a quote of which <em>no</em> line equals a diff line
+ * even though the code is wholly in the diff. On files a PR adds in full, where the quoted code is
+ * most certainly present because the entire file is in the diff, that silently destroyed true
+ * findings and left nothing in the posted review to tell a maintainer a finding had existed. An
+ * unanchored true finding is useful; a silently deleted one is not.
  *
  * <p>The same demotion applies when a finding's {@code suggestion_old} genuinely matches the diff
  * but its free-text {@code description} cites a chained call expression as existing source that
@@ -65,50 +75,19 @@ public class FindingQuoteValidator {
     var kept = new ArrayList<ReviewResponse.Finding>(response.findings().size());
     var changed = false;
     for (ReviewResponse.Finding finding : response.findings()) {
-      switch (classifyQuote(finding, index)) {
-        case PARTIAL -> {
-          Log.infof(
-              "Finding '%s' (%s:%d) quotes code only partially present in the diff —"
-                  + DEMOTION_SUFFIX,
-              finding.title(),
-              finding.file(),
-              finding.line());
-          kept.add(withoutSuggestion(finding));
-          changed = true;
-        }
-        case AMBIGUOUS -> {
-          Log.infof(
-              "Finding '%s' (%s:%d) quotes code that appears in multiple locations, but the finding's line is ambiguous —"
-                  + DEMOTION_SUFFIX,
-              finding.title(),
-              finding.file(),
-              finding.line());
-          kept.add(withoutSuggestion(finding));
-          changed = true;
-        }
-        case NONE -> {
-          Log.infof(
-              "Dropping finding '%s' (%s:%d) — the code it quotes does not appear in the diff",
-              finding.title(), finding.file(), finding.line());
-          changed = true;
-        }
-        // FULL and NO_QUOTE fall through here; default also keeps any future verdict rather than
-        // silently dropping it.
-        default -> {
-          if (descriptionCitesAbsentCode(finding, index)) {
-            Log.infof(
-                "Finding '%s' (%s:%d) cites code in its description that appears nowhere in the diff —"
-                    + DEMOTION_SUFFIX,
-                finding.title(),
-                finding.file(),
-                finding.line());
-            kept.add(withoutSuggestion(finding));
-            changed = true;
-          } else {
-            kept.add(finding);
-          }
-        }
+      String reason = demotionReason(finding, index);
+      if (reason == null) {
+        kept.add(finding);
+        continue;
       }
+      Log.infof(
+          "Finding '%s' (%s:%d) %s" + DEMOTION_SUFFIX,
+          finding.title(),
+          finding.file(),
+          finding.line(),
+          reason);
+      kept.add(withoutSuggestion(finding));
+      changed = true;
     }
     if (!changed) {
       return response;
@@ -120,13 +99,35 @@ public class FindingQuoteValidator {
   }
 
   /**
+   * Why this finding's quote cannot be trusted — a log fragment ending in an em dash, to which
+   * {@link #DEMOTION_SUFFIX} is appended — or {@code null} when the finding passes untouched.
+   *
+   * <p>Every verdict but a clean one resolves to a demotion; none deletes the finding. A future
+   * verdict falls through to the sound-quote branch rather than silently suppressing anything.
+   */
+  private static String demotionReason(ReviewResponse.Finding finding, DiffIndex index) {
+    return switch (classifyQuote(finding, index)) {
+      case PARTIAL -> "quotes code only partially present in the diff —";
+      case AMBIGUOUS ->
+          "quotes code that appears in multiple locations, but the finding's line is ambiguous —";
+      case NONE -> "quotes code that does not appear in the diff —";
+      // FULL and NO_QUOTE: the quote itself is sound, so only a fabricated mechanism in the
+      // finding's prose can demote it.
+      default ->
+          descriptionCitesAbsentCode(finding, index)
+              ? "cites code in its description that appears nowhere in the diff —"
+              : null;
+    };
+  }
+
+  /**
    * The quote verdict for one finding. Starts from {@link #matchQuote}'s per-line presence, then
    * tightens a multi-line FULL verdict to also require a contiguous in-order run on one side of the
    * diff — a recombination of real-but-scattered lines is demoted to PARTIAL so a fabricated
    * suggestion is not kept; single-line quotes are trivially contiguous and unaffected. Finally a
    * FULL quote is disambiguated by line when it appears in multiple locations.
    */
-  private QuoteMatch classifyQuote(ReviewResponse.Finding finding, DiffIndex index) {
+  private static QuoteMatch classifyQuote(ReviewResponse.Finding finding, DiffIndex index) {
     List<String> quoted = normalizedLines(finding.suggestionOld());
     QuoteMatch match = matchQuote(quoted, index.linesFor(finding.file()));
     if (match == QuoteMatch.FULL

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingQuoteValidatorTest.java
@@ -62,6 +62,21 @@ class FindingQuoteValidatorTest {
   }
 
   /**
+   * Asserts the response kept exactly one finding and demoted it: suggestion stripped, confidence
+   * capped at "low", risk untouched. This is the validator's only response to an untrustworthy
+   * quote — it never deletes the finding (#607).
+   */
+  private static ReviewResponse.Finding assertSingleDemoted(ReviewResponse result) {
+    assertEquals(1, result.findings().size());
+    var kept = result.findings().get(0);
+    assertNull(kept.suggestionOld());
+    assertNull(kept.suggestionNew());
+    assertEquals("low", kept.confidence());
+    assertEquals("critical", kept.risk());
+    return kept;
+  }
+
+  /**
    * Quotes that match the diff (regardless of indentation, diff markers, or embedded blank lines)
    * and findings without a quote at all must pass through untouched.
    */
@@ -80,15 +95,19 @@ class FindingQuoteValidatorTest {
     assertSame(response, validator.validate(response, DIFF));
   }
 
+  /**
+   * A quote that matches nothing demotes the finding instead of deleting it, and the summary keeps
+   * counting it — nothing is removed, so nothing needs disclosing.
+   */
   @Test
-  void dropsFindingWhoseQuoteIsNowhereInTheDiff() {
+  void demotesFindingWhoseQuoteIsNowhereInTheDiff() {
     var response = response(finding("SHA=\"${ steps.meta.outputs.sha }\""));
 
     var result = validator.validate(response, DIFF);
 
-    assertEquals(0, result.findings().size());
-    assertEquals(0, result.summary().totalFindings());
-    assertEquals(0, result.summary().critical());
+    assertSingleDemoted(result);
+    assertEquals(1, result.summary().totalFindings());
+    assertEquals(1, result.summary().critical());
   }
 
   @Test
@@ -134,20 +153,20 @@ class FindingQuoteValidatorTest {
   void fileHeaderAndHunkLinesAreNotMatchableContent() {
     var response = response(finding("+++ b/src/Main.java"));
 
-    var result = validator.validate(response, DIFF);
-
-    assertEquals(0, result.findings().size());
+    assertSingleDemoted(validator.validate(response, DIFF));
   }
 
   @Test
-  void mixedResponseKeepsValidFindingsAndDropsPhantoms() {
+  void mixedResponseKeepsValidFindingsUntouchedAndDemotesPhantoms() {
     var valid = finding("var repos = new ArrayList<RepoRef>();");
     var phantom = finding("code that was never written");
 
     var result = validator.validate(response(valid, phantom), DIFF);
 
-    assertEquals(1, result.findings().size());
+    assertEquals(2, result.findings().size());
     assertSame(valid, result.findings().get(0));
+    assertNull(result.findings().get(1).suggestionOld());
+    assertEquals("low", result.findings().get(1).confidence());
   }
 
   @Test
@@ -188,8 +207,9 @@ class FindingQuoteValidatorTest {
   }
 
   /**
-   * Misattributed quotes are dropped no matter how the model writes the path: exact, shortened, or
-   * expanded relative to the diff's section header.
+   * Misattributed quotes are demoted no matter how the model writes the path: exact, shortened, or
+   * expanded relative to the diff's section header. Scoping still refuses to let another file's
+   * text validate the quote — it just costs the finding its suggestion rather than its life.
    */
   @ParameterizedTest
   @CsvSource({
@@ -197,10 +217,8 @@ class FindingQuoteValidatorTest {
     "path/B.java, int onlyInA = 1;",
     "repo/nested/path/B.java, int onlyInA = 1;"
   })
-  void misattributedQuotesAreDroppedForAnyPathForm(String file, String quote) {
-    var result = validator.validate(response(findingOn(file, quote)), MULTI_FILE_DIFF);
-
-    assertEquals(0, result.findings().size());
+  void misattributedQuotesAreDemotedForAnyPathForm(String file, String quote) {
+    assertSingleDemoted(validator.validate(response(findingOn(file, quote)), MULTI_FILE_DIFF));
   }
 
   @Test
@@ -246,9 +264,7 @@ class FindingQuoteValidatorTest {
   void ambiguousPathScopesToItsCandidatesNotTheWholeDiff() {
     var misattributed = findingOn("Handler.java", "int inC = 3;");
 
-    var result = validator.validate(response(misattributed), AMBIGUOUS_DIFF);
-
-    assertEquals(0, result.findings().size());
+    assertSingleDemoted(validator.validate(response(misattributed), AMBIGUOUS_DIFF));
   }
 
   @Test
@@ -274,9 +290,7 @@ class FindingQuoteValidatorTest {
         """;
     var misattributed = findingOn("src/Plain.java", "int otherOnly = 4;");
 
-    var result = validator.validate(response(misattributed), diff);
-
-    assertEquals(0, result.findings().size());
+    assertSingleDemoted(validator.validate(response(misattributed), diff));
   }
 
   @Test
@@ -285,7 +299,7 @@ class FindingQuoteValidatorTest {
 
     var result = validator.validate(response, DIFF);
 
-    assertEquals(0, result.findings().size());
+    assertSingleDemoted(result);
     assertNull(result.summary());
   }
 
@@ -980,8 +994,114 @@ class FindingQuoteValidatorTest {
         """;
     var response = response(findingOn("src/Test.java", "\\ No newline at end of file"));
 
-    var result = validator.validate(response, diff);
+    assertSingleDemoted(validator.validate(response, diff));
+  }
 
-    assertEquals(0, result.findings().size());
+  /**
+   * Verbatim section for a wholly-added Go file from the round-4 corpus (ThrillhouseBot-test #28).
+   * Line 32 is the SQL literal the dropped finding quoted.
+   */
+  private static final String ADDED_GO_FILE_DIFF =
+      """
+      ### internal/store/store.go (added, +64 -0)
+      ```diff
+      @@ -0,0 +1,64 @@
+      +// Package store persists certificate check results.
+      +package store
+      +
+      +// Insert records a single check result using a parameterized query.
+      +func (s *Store) Insert(r CheckRecord) error {
+      +\t_, err := s.db.Exec(
+      +\t\t`INSERT INTO cert_checks (domain, checked_at, days_remaining, near_expiry) VALUES (?, ?, ?, ?)`,
+      +\t\tr.Domain, r.CheckedAt, r.DaysRemaining, r.NearExpiry,
+      +\t)
+      +\tif err != nil {
+      +\t\treturn fmt.Errorf("inserting check record: %w", err)
+      +\t}
+      +\treturn nil
+      +}
+      ```
+      """;
+
+  /**
+   * Verbatim section for a wholly-added Python file from the round-4 corpus (ThrillhouseBot-test
+   * #27). Lines 11-17 hold the alert the dropped finding quoted, with its f-string implicitly
+   * concatenated across two physical lines.
+   */
+  private static final String ADDED_PYTHON_FILE_DIFF =
+      """
+      ### src/cert_monitor/alerts.py (added, +27 -0)
+      ```diff
+      @@ -0,0 +1,27 @@
+      +\"\"\"Sends notifications about certificate health.\"\"\"
+      +
+      +
+      +def send_connectivity_alert(unreachable_domains):
+      +    \"\"\"Notify on-call when domains could not be reached at all.\"\"\"
+      +    if unreachable_domains:
+      +        print(
+      +            f"ALERT: {len(unreachable_domains)} domain(s) could not be reached: "
+      +            f"{', '.join(unreachable_domains)}"
+      +        )
+      +        return True
+      +    return False
+      ```
+      """;
+
+  /**
+   * A wholly-added file is indexed like any other section — a byte-exact quote of one of its lines
+   * validates. This rules out "added files are never fed to the matcher" as the cause of #607 and
+   * pins the surviving behavior.
+   */
+  @Test
+  void byteExactQuoteOfAWhollyAddedFileIsKept() {
+    var response =
+        response(
+            findingOn(
+                "internal/store/store.go",
+                "`INSERT INTO cert_checks (domain, checked_at, days_remaining, near_expiry)"
+                    + " VALUES (?, ?, ?, ?)`,"));
+
+    assertSame(response, validator.validate(response, ADDED_GO_FILE_DIFF));
+  }
+
+  /**
+   * #607, instance 1: the model rewrapped a multi-line Go call — the same characters, joined onto
+   * one line and with the trailing comma Go requires before a newline dropped — so no quoted line
+   * equals any diff line. The quoted code is unambiguously in the diff (the whole file is), and the
+   * finding was true. It must survive, demoted rather than deleted.
+   */
+  @Test
+  void rewrappedQuoteOfAWhollyAddedFileIsKeptDemoted() {
+    var response =
+        response(
+            findingOn(
+                "internal/store/store.go",
+                "_, err := s.db.Exec(`INSERT INTO cert_checks (domain, checked_at, days_remaining,"
+                    + " near_expiry) VALUES (?, ?, ?, ?)`, r.Domain, r.CheckedAt, r.DaysRemaining,"
+                    + " r.NearExpiry)"));
+
+    var kept = assertSingleDemoted(validator.validate(response, ADDED_GO_FILE_DIFF));
+
+    assertEquals("Title", kept.title());
+  }
+
+  /**
+   * #607, instance 2: the model collapsed an implicitly-concatenated f-string into a single literal
+   * — dropping the {@code " f"} the source needs between the fragments — so again no quoted line
+   * equals a diff line. This was the corpus's planted producer-consumer defect.
+   */
+  @Test
+  void collapsedFStringQuoteOfAWhollyAddedFileIsKeptDemoted() {
+    var response =
+        response(
+            findingOn(
+                "src/cert_monitor/alerts.py",
+                "        print(f\"ALERT: {len(unreachable_domains)} domain(s) could not be reached:"
+                    + " {', '.join(unreachable_domains)}\")"));
+
+    var kept = assertSingleDemoted(validator.validate(response, ADDED_PYTHON_FILE_DIFF));
+
+    assertEquals("Title", kept.title());
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`FindingQuoteValidator` was deleting correct findings whose quoted code **is** in the diff, on files
the PR adds in full.

### What the investigation ruled out

The issue asked whether added files reach the matcher at all. They do. `ReviewDiffFormatter` emits a
wholly-new file as an ordinary `### path (added, +N -0)` section with its full patch inside a
` ```diff ` fence, `indexDiff` indexes it like any other section, and a byte-exact quote of one of
its lines validates. `byteExactQuoteOfAWhollyAddedFileIsKept` pins that and passes both before and
after this change.

### The actual mechanism

`matchQuote` tests each `suggestion_old` line for **exact equality** (after `strip()`) against the
set of normalized diff lines. It is line-anchored, not whitespace-normalized across line boundaries.
So when the model rewraps a construct the source splits across lines, *every* quoted line fails and
the verdict is `NONE` — which deleted the entire finding.

Both round-4 corpus losses are exactly that:

* Go, `internal/store/store.go:32` — the source splits `s.db.Exec(...)` over four lines with the SQL
  literal on its own line and Go's mandatory trailing comma before the newline. Joined onto one line
  by the model, that comma disappears and no quoted line equals a diff line.
* Python, `src/cert_monitor/alerts.py:14` — the source uses implicit concatenation, so the f-string
  is two physical lines each with its own `f"` prefix. Collapsed into one literal, the intervening
  `" f"` disappears and again nothing matches.

Normalizing whitespace would not have saved either one: both rewraps *change tokens*, not just
spacing, so no containment test over compacted text finds them. Absence of an exact match simply is
not evidence of a phantom, and on an added file — where the whole file is in the diff and the quoted
code is most certainly present — acting on it as if it were destroyed true findings, one of them the
corpus's planted producer→consumer defect.

### The fix

An unmatched quote now draws the same conservative demotion a partial quote already did: the
untrusted suggestion block is removed and confidence is capped at `"low"`. The finding still
surfaces, carrying its low-confidence disclaimer, and `BlockingStrictness` still keeps it from
blocking.

This follows the issue's guidance that under-firing is the far safer direction here — an unanchored
true finding is useful, a silently deleted one is not. The validator now deletes nothing at all, so
the disclosure gap the issue raises ("nothing in the posted review says a finding was removed") is
closed by there being nothing to disclose; the summary keeps counting the finding.

The misattribution case (a quote whose text belongs to a different file in the diff) moves the same
way, from deletion to demotion, for the same reason: file scoping still refuses to let another
file's text validate the quote, it just costs the finding its suggestion rather than its life.

The three near-identical demotion arms in `validate` collapse into one `demotionReason` switch, so
every verdict shares a single keep-and-demote path and a future verdict cannot silently suppress
anything. The four log messages are byte-identical to before except the former drop line, which now
reads as a demotion.

## Related Issues

Fixes #607

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Three new tests in `FindingQuoteValidatorTest`, two of them built from the **verbatim patches** of
the corpus PRs (fetched from `ThrillhouseBot-test` #27 and #28):

* `byteExactQuoteOfAWhollyAddedFileIsKept` — added files are indexed (rules out the indexing
  hypothesis; green before and after).
* `rewrappedQuoteOfAWhollyAddedFileIsKeptDemoted` — instance 1, the Go SQL literal.
* `collapsedFStringQuoteOfAWhollyAddedFileIsKeptDemoted` — instance 2, the Python f-string.

### Red/green proof

Both reproductions fail on unfixed code with the finding gone, and with the issue's log line naming
the very files it names:

```
INFO  [dev.thiagogonzaga.thrillhousebot.review.FindingQuoteValidator] (main) Dropping finding 'Title' (internal/store/store.go:2) — the code it quotes does not appear in the diff
INFO  [dev.thiagogonzaga.thrillhousebot.review.FindingQuoteValidator] (main) Dropping finding 'Title' (src/cert_monitor/alerts.py:2) — the code it quotes does not appear in the diff

[ERROR] Tests run: 69, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 0.239 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.FindingQuoteValidatorTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingQuoteValidatorTest.rewrappedQuoteOfAWhollyAddedFileIsKeptDemoted -- Time elapsed: 0.006 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <1> but was: <0>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:569)
	at dev.thiagogonzaga.thrillhousebot.review.FindingQuoteValidatorTest.rewrappedQuoteOfAWhollyAddedFileIsKeptDemoted(FindingQuoteValidatorTest.java:1074)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingQuoteValidatorTest.collapsedFStringQuoteOfAWhollyAddedFileIsKeptDemoted -- Time elapsed: 0.001 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <1> but was: <0>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:569)
	at dev.thiagogonzaga.thrillhousebot.review.FindingQuoteValidatorTest.collapsedFStringQuoteOfAWhollyAddedFileIsKeptDemoted(FindingQuoteValidatorTest.java:1099)
```

`byteExactQuoteOfAWhollyAddedFileIsKept` is green in that same red run — the added file *was*
indexed; only the exact-equality match failed.

### Gates

| Gate | Result |
| --- | --- |
| `./mvnw -B spotless:apply` + `spotless:check` | clean |
| `./mvnw -B clean compile spotbugs:check` | `BugInstance size is 0` |
| `./mvnw -B clean test` | `Tests run: 2850, Failures: 0, Errors: 0, Skipped: 0` |
| jacoco ∩ `git diff -U0 469539e...HEAD` | 48 changed main lines, **0 uncovered lines, 0 uncovered branches** |

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

After the fix, the same input logs a demotion rather than a deletion:

```
Finding 'cert_checks table is never created' (internal/store/store.go:32) quotes code that does not appear in the diff — dropping its suggestion and capping confidence
```

## Additional Notes

Behavioral note for reviewers: `FindingQuoteValidator` no longer removes any finding. Phantom-quote
findings survive as low-confidence, suggestion-less notes rather than disappearing.
`FrameworkFalsePositiveFilter` is a separate guard and still filters on its own criteria.
