### PR TITLE
fix(review): carve demonstrated sinks and standard-library semantics out of the verifier's downgrade pressure

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
@@ -48,6 +48,18 @@ public final class FindingVerifierPrompts {
               token: that is demonstrable here, so confirm or reject it against the manifest rather
               than rejecting it as unverifiable remembered behavior. Still reject a config claim
               that genuinely rests on cluster, provider, or registry state not shown in the diff.
+              This ground also does NOT cover documented semantics of the language or its own
+              standard library — that List.max or head on an empty collection throws, that indexing
+              past the end throws, that integer division truncates, that a strict parse throws on
+              malformed input. A reviewer is expected to know those, and they are documented
+              semantics rather than remembered behavior, so do not reject such a finding as "not
+              established by the provided material": judge it on whether the material shows the
+              triggering case (the empty collection, the out-of-range index) can reach the call.
+              Requiring the diff to prove the standard library makes whole classes of real defect
+              unreportable — a correct "crashes with UnsupportedOperationException on an empty
+              list" finding was deleted on exactly that ground. Keep this rejection ground for repo
+              state not shown (files, solution or project files, manifests), for unshown callers,
+              and for unshown configuration; those genuinely are outside the material.
             - suggestion_new is functionally equivalent to suggestion_old (an alias,
               reformatting, or a documented shorthand of the same call) — a fix that changes
               nothing disproves the finding.
@@ -195,6 +207,25 @@ public final class FindingVerifierPrompts {
             provided material, downgrade it to confidence "low" phrased as a verification request
             naming the definition to check — do not reject it as unverifiable framework behavior.
 
+            An injection-sink finding — one naming a sink the provided material shows (a
+            framework's HTML-injection escape hatch such as dangerouslySetInnerHTML,
+            bypassSecurityTrustHtml, v-html or innerHTML; a string-built SQL statement or shell
+            command; a filesystem path built from a request value) that a user-authored or
+            otherwise externally-supplied value reaches, and stating that the material shows
+            nothing sanitizing, escaping, encoding, validating or parameterizing that value on the
+            path to it — is NOT remembered framework behavior. The sink call and the tainted value
+            are both in front of you, so the defect is demonstrated by the material: do not reject
+            it as unverifiable, and do not cap it at "medium" risk / "low" confidence as remembered
+            "routing and rendering semantics" — that cap is what routed a demonstrated stored XSS
+            into the collapsed low-confidence block. A mitigating layer that might exist somewhere
+            not shown lowers CONFIDENCE, never the risk: severity is a property of the defect class
+            and its blast radius, and a sanitizer you cannot see is not a sanitizer. Confidence
+            "low" or "medium" with the sink line quoted and the unshown layer to verify named is
+            the expected shape. Reject it only when the provided material shows the neutralizing
+            step on that path (an escaping or encoding call, a parameterized statement, a
+            validating allow-list), when the value reaching the sink is a literal or is otherwise
+            not attacker-influenced, or when the sink it names is not in the diff at all.
+
             A producer→consumer contract finding (dimension 9) — one tracing a value from where it
             is produced to where it is consumed — spans two locations that are in different
             enclosing units by construction: the producer and the consumer are necessarily
@@ -211,7 +242,12 @@ public final class FindingVerifierPrompts {
             rule, a privileged container, a change that weakens the safety property the PR claims
             to add — IS demonstrable here and may be "high"; do not auto-downgrade it as remembered
             framework behavior. Unverifiable framework-behavior claims are at most "medium" risk
-            with "low" confidence. Claims about the contents or behavior of
+            with "low" confidence — but a claim resting on documented language or standard-library
+            semantics is not one of those, so that cap does not apply to it either; rate it by what
+            the failure costs. An injection-sink finding whose sink and tainted value are both
+            visible in the provided material is likewise demonstrable here and is not capped: keep
+            it at the risk its defect class carries and put any uncertainty about an unshown
+            sanitizing layer on confidence, never on risk. Claims about the contents or behavior of
             artifacts not shown in the diff (base images, registries, installed packages,
             remote services) are not demonstrable here: downgrade any such finding above
             "medium". A config-key documentation-completeness claim backed by the key's quoted

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPromptsContentTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Content guards on the verifier prompt's carve-outs. Prompt text is not executable, so what these
+ * pin is that a carve-out the corpus needed is still present and still says the thing it was added
+ * to say — the rejection ground it exempts, and the direction it must not reopen.
+ */
+class FindingVerifierPromptsContentTest {
+
+  private static void assertContains(String haystack, String needle, String why) {
+    assertTrue(haystack.contains(needle), why + " — missing marker: \"" + needle + "\"");
+  }
+
+  @Test
+  void verifierCarvesOutADemonstratedInjectionSink() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "An injection-sink finding",
+        "the verifier must judge a demonstrated injection sink on its own terms (#605)");
+    assertContains(
+        sys,
+        "dangerouslySetInnerHTML",
+        "the carve-out must name the framework HTML-injection escape hatches it covers");
+    assertContains(
+        sys,
+        "is NOT remembered framework behavior",
+        "a sink and tainted value both visible must not be demoted as remembered behavior (#605)");
+    assertContains(
+        sys,
+        "routing and rendering semantics",
+        "the carve-out must name the rejection ground it exempts, which reads exactly this way");
+    assertContains(
+        sys,
+        "lowers CONFIDENCE, never the risk",
+        "an unshown mitigating layer must move confidence, not severity (#570)");
+  }
+
+  @Test
+  void injectionSinkCarveOutStillRejectsASinkTheMaterialNeutralizes() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "Reject it only when the provided material shows the neutralizing",
+        "the carve-out must keep the rejection path for a sink the material shows is sanitized");
+    assertContains(
+        sys,
+        "not attacker-influenced",
+        "a sink fed a literal must stay rejectable, so the carve-out is not a blanket exemption");
+  }
+
+  @Test
+  void verifierDoesNotTreatStandardLibrarySemanticsAsUnestablished() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "This ground also does NOT cover documented semantics of the language or its own",
+        "the verifier must not reject a finding for resting on standard-library semantics (#589)");
+    assertContains(
+        sys,
+        "List.max or head on an empty collection throws",
+        "the carve-out must keep the Scala #21 regression example that was destroyed downstream");
+    assertContains(
+        sys,
+        "established by the provided material\": judge it on whether the material shows the",
+        "the carve-out must name the rejection wording it overrides (#589)");
+    assertContains(
+        sys,
+        "triggering case (the empty collection, the out-of-range index) can reach the call",
+        "such a finding must be judged on reachability of the triggering case, not on recall");
+  }
+
+  @Test
+  void standardLibraryCarveOutKeepsTheGroundForRepoStateAndUnshownCallers() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "state not shown (files, solution or project files, manifests), for unshown callers,",
+        "repo state must stay a valid rejection ground — the C# #24 half of #589 is defensible");
+    assertContains(
+        sys,
+        "and for unshown configuration; those genuinely are outside the material.",
+        "unshown callers and configuration must stay valid rejection grounds (#589)");
+  }
+
+  @Test
+  void severityCalibrationExemptsBothDemonstrableClassesFromTheMediumCap() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "semantics is not one of those, so that cap does not apply to it either",
+        "the medium/low cap must not apply to a standard-library semantics claim (#589)");
+    assertContains(
+        sys,
+        "visible in the provided material is likewise demonstrable here and is not capped",
+        "the medium/low cap must not apply to a demonstrated injection sink (#605)");
+  }
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔒 Security

## Description

Two verifier-prompt carve-outs, both in `FindingVerifierPrompts.SYSTEM`, both driven by prompt text
rather than by `FindingVerificationService` logic — which is why they ship together.

### #605 — no carve-out for a demonstrated injection sink

`SYSTEM` already carves config/IaC, mock-fidelity, heuristic and producer→consumer findings out of
its own downgrade grounds. It had nothing for an injection sink whose tainted value and sink call
are both in the diff — and the prompt names "routing and rendering semantics" as remembered
framework behaviour capped at `medium` risk / `low` confidence, which is exactly how
`dangerouslySetInnerHTML` and `bypassSecurityTrustHtml` read. So the verifier spent a downgrade on a
defect the material in front of it demonstrates.

The new paragraph follows the shape of the existing carve-outs: it states what the class is, says it
is **not** remembered framework behaviour, names the rejection ground and the severity cap it
exempts, puts the uncertainty about an unshown sanitizing layer on **confidence and never on risk**,
and keeps an explicit rejection path so it is not a blanket exemption — a sink the material shows is
neutralized, a sink fed a literal, or a sink not in the diff is still rejected. The severity
calibration paragraph gained the matching half.

The deterministic floor from #594 already makes the published outcome correct, so this is not
user-visible today. It is still worth fixing at the source: the floor is a backstop over a decision
that is still wrong, and any future path that does not run through the floor inherits the bug.

### #589 — standard-library semantics treated as unestablished

The first rejection ground ("remembered external framework or library behavior ... that the provided
diff and project stack do not support") was applied to core language semantics. Round-3 logs, verbatim:

> Verifier rejected finding 'logLatestTimestamp crashes with UnsupportedOperationException on empty
> uniqueEvents': The crash claim depends on Scala 2.13 List.max behavior on empty lists, which is
> external library behavior not established by the diff or project stack.

That was the PR's planted functional defect. The reviewer found it, named it and pointed at the
right line; the verifier deleted it before publication, and round-3 scoring recorded the dimension as
"not mentioned anywhere" — measured recall understating the reviewer because a true positive was
destroyed downstream.

The ground now excludes documented semantics of the language and its own standard library, and says
what to judge such a finding on instead (whether the material shows the triggering case can reach
the call). It explicitly **keeps** the ground for repo state not shown, unshown callers and unshown
configuration — the C# #24 half of the issue, which the issue itself calls defensible, still
rejects. The severity calibration paragraph gained the matching half so the medium/low cap does not
re-impose what the rejection ground no longer does.

## Related Issues

Fixes #605
Fixes #589

## How Has This Been Tested?

- [x] Unit tests

Prompt-text changes, so there is no red/green proof to give — nothing executable changed. Per the
repo's convention for this class of change, the guard is a content test: new
`FindingVerifierPromptsContentTest` pins each carve-out by the markers that carry its meaning — the
rejection ground it exempts, the direction it must not reopen (a neutralized sink and a non-attacker
value stay rejectable; repo state, unshown callers and unshown configuration stay rejection
grounds), and the severity-cap exemptions. It is a new file rather than an addition to
`PrReviewPromptsContentTest` so the verifier prompt's guards live with the prompt they guard.

Gates:

- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — `Tests run: 2852, Failures: 0, Errors: 0, Skipped: 0`
- jacoco ∩ `git diff -U0 469539e...HEAD` — 0 uncovered lines, 0 uncovered branches in changed main code

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Both carve-outs are additive to the prompt; no existing ground or cap was removed, and every
existing `PrReviewPromptsContentTest` assertion on `FindingVerifierPrompts.SYSTEM` still holds.
