### PR TITLE
fix(review): bound the previous-findings context to a share of the input budget

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.regex.Pattern;
 
 /**
  * Splits a PR's reviewable files into token-budgeted batches so every file is covered by some model
@@ -45,6 +46,21 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 @ApplicationScoped
 public class DiffBudgetPlanner {
+
+  /**
+   * Share of the per-call input budget the previous-findings block may occupy before {@link
+   * #boundPreviousFindings} condenses it. It is shared overhead — repeated in full by every batch
+   * call — so it is charged against the whole per-call budget, not against one batch's diff. A
+   * quarter is deliberately generous: condensation costs the model the prose it uses to judge a
+   * finding resolved, so the bound should bite on the accumulation this exists to stop, not on an
+   * ordinary follow-up round.
+   */
+  private static final double PREVIOUS_FINDINGS_BUDGET_SHARE = 0.25;
+
+  /**
+   * Opening shape of a numbered previous finding: {@code "12. [HIGH] path/File.java:7 — Title"}.
+   */
+  private static final Pattern NUMBERED_ENTRY = Pattern.compile("^\\d+\\. \\[");
 
   private final ReviewDiffFormatter formatter;
   private final TokenCounter tokenCounter;
@@ -255,6 +271,11 @@ public class DiffBudgetPlanner {
     if (activeModel.maxInputTokens() <= 0) {
       return plan(reviewable, 0, 1);
     }
+    // Size the overhead from the same bounded block the calls actually carry (#583): planning
+    // against the raw block and sending a bounded one — or the reverse — would make the estimate
+    // a fiction. boundPreviousFindings is idempotent, so the caller applying it first is a no-op
+    // here.
+    var bounded = boundPreviousFindings(inputs);
     // fence(" ") produces the two real fence lines (fence of empty content is a no-op by design),
     // counting the per-review scaffolding the pipeline wraps each batch in — small, but the safety
     // margin should absorb estimate error, not known constants.
@@ -262,14 +283,189 @@ public class DiffBudgetPlanner {
         PrReviewPrompts.SYSTEM
             + PrReviewPrompts.USER
             + PromptTemplateEscaper.fence(" ")
-            + inputs.prContext()
-            + inputs.baseComparison()
-            + inputs.projectStack()
-            + inputs.relatedTests()
-            + inputs.previousFindings()
-            + inputs.repoInstructions();
+            + bounded.prContext()
+            + bounded.baseComparison()
+            + bounded.projectStack()
+            + bounded.relatedTests()
+            + bounded.previousFindings()
+            + bounded.repoInstructions();
     return plan(
         reviewable, sharedOverhead, perCallInputBudget(), Math.max(1, review.maxAiCalls() - 1));
+  }
+
+  /**
+   * Bounds the previous-findings block to {@link #PREVIOUS_FINDINGS_BUDGET_SHARE} of the per-call
+   * input budget, returning the inputs the review should actually be run with (#583).
+   *
+   * <p>The block is the one section of the shared overhead that grows monotonically: every round
+   * appends the previous round's findings, their prose and their whole comment threads, and nothing
+   * ever retires them on a long-lived PR whose head keeps advancing. Because the overhead is
+   * <em>shared</em> — repeated verbatim in every batch call — adding batches multiplies it instead
+   * of dividing it, so the planner's only other lever (shrinking the diff budget) starves the
+   * review of the code it is supposed to read, and past that, the request is rejected outright. On
+   * this repository's own release PR the block reached ~437K tokens against 57–74K for a normal
+   * review.
+   *
+   * <p>The bound is deliberately <em>not</em> a blind truncation. What the follow-up pass needs
+   * from a previous finding is its identity and location — the id it must report a status for, the
+   * file and line it must look at, and the title it matches against — not the prose. So the block
+   * degrades by <em>condensation</em>: every entry keeps its own line (id, risk, {@code file:line},
+   * title) and loses only its continuation lines (description, quoted code, thread replies). No
+   * finding disappears, no id shifts, and the deterministic machinery that decides resolved /
+   * unresolved is untouched by this — it runs off the structured previous-findings list, never off
+   * this prompt text.
+   *
+   * <p>Only if the condensed block still does not fit are entries dropped, from the tail, so the
+   * numbered findings whose ids {@code previous_findings_status} is keyed to outlive the advisory
+   * "answered in earlier rounds" list that follows them. That is real forgetting, so it degrades
+   * the safe way: an unreported finding is held open by the approve backstop rather than counted
+   * resolved, and the elision is disclosed — in-band to the model, which is the consumer of the
+   * block, and at {@code WARN} to the operator, the same channel the existing overhead shortfall
+   * uses.
+   *
+   * <p>Idempotent: a block already at or under its share is returned untouched, and so is the very
+   * same {@code inputs} instance.
+   */
+  public AiReviewService.PromptInputs boundPreviousFindings(AiReviewService.PromptInputs inputs) {
+    var previousFindings = inputs.previousFindings();
+    if (previousFindings == null || previousFindings.isBlank()) {
+      return inputs;
+    }
+    if (activeModel.maxInputTokens() <= 0) {
+      // Budgeting is explicitly off: the operator asked for no cap, and this is not the place to
+      // reintroduce one.
+      return inputs;
+    }
+    var cap = Math.max(1, (int) (perCallInputBudget() * PREVIOUS_FINDINGS_BUDGET_SHARE));
+    var before = tokenCounter.estimateTokens(previousFindings);
+    if (before <= cap) {
+      return inputs;
+    }
+    var bounded = condensePreviousFindings(previousFindings, cap);
+    Log.warnf(
+        "Previous-findings context (%d tokens) exceeds its %d-token share of the input budget;"
+            + " condensed %d finding(s) to id, location and title%s",
+        before,
+        cap,
+        bounded.keptEntries(),
+        bounded.droppedEntries() == 0
+            ? ""
+            : " and omitted " + bounded.droppedEntries() + " that still did not fit");
+    return new AiReviewService.PromptInputs(
+        inputs.diff(),
+        inputs.prContext(),
+        inputs.baseComparison(),
+        inputs.projectStack(),
+        inputs.relatedTests(),
+        bounded.text(),
+        inputs.repoInstructions());
+  }
+
+  /** A bounded previous-findings block: its text and what the bounding cost. */
+  private record BoundedFindings(String text, int keptEntries, int droppedEntries) {}
+
+  /**
+   * Condenses the block to entry lines only and, if that still overruns {@code capTokens}, keeps
+   * the longest prefix of entries that fits. The fence lines are structural, not entries: they are
+   * carried across the cut so the untrusted region can never end up unterminated with the trailing
+   * notice — our own instruction — swallowed inside it.
+   */
+  private BoundedFindings condensePreviousFindings(String block, int capTokens) {
+    var all = block.split("\n", -1);
+    var fenced =
+        all.length > 2
+            && all[0].startsWith(PromptTemplateEscaper.fencePrefix())
+            && all[0].equals(all[all.length - 1]);
+    var body = fenced ? List.of(all).subList(1, all.length - 1) : List.of(all);
+
+    var condensed = new ArrayList<String>(body.size());
+    var entries = 0;
+    var inEntry = false;
+    for (var line : body) {
+      var startsEntry = startsEntry(line);
+      if (startsEntry) {
+        entries++;
+        inEntry = true;
+      }
+      if (startsEntry || !inEntry) {
+        condensed.add(line);
+      }
+    }
+
+    // The disclosure has to survive the cap that forced it, so its cost — and the fences' — comes
+    // off the top rather than being what gets dropped.
+    var reserve = tokenCounter.estimateTokens(elisionNotice(entries));
+    if (fenced) {
+      reserve += 2 * tokenCounter.estimateTokens(all[0]);
+    }
+    var kept = new ArrayList<String>(condensed.size());
+    var used = reserve;
+    var dropped = 0;
+    var cutting = false;
+    for (var line : condensed) {
+      if (!cutting) {
+        var cost = tokenCounter.estimateTokens(line);
+        if (used + cost <= capTokens) {
+          kept.add(line);
+          used += cost;
+          continue;
+        }
+        cutting = true;
+      }
+      if (startsEntry(line)) {
+        dropped++;
+      }
+    }
+
+    var text = new StringBuilder();
+    if (fenced) {
+      text.append(all[0]).append('\n');
+    }
+    text.append(String.join("\n", kept));
+    if (fenced) {
+      text.append('\n').append(all[0]);
+    }
+    text.append('\n').append(elisionNotice(dropped));
+    return new BoundedFindings(text.toString(), entries - dropped, dropped);
+  }
+
+  /**
+   * Whether the line opens a previous-findings entry: a numbered finding ({@code "3. [HIGH] …"},
+   * the id space {@code previous_findings_status} references) or an answered-earlier bullet. Detail
+   * lines — descriptions, quoted code, thread replies — are indented under their entry, so they
+   * never match; an untrusted description line that mimics the shape at most survives condensation,
+   * which is what it already did before it.
+   */
+  private static boolean startsEntry(String line) {
+    return line.startsWith("- ") || NUMBERED_ENTRY.matcher(line).find();
+  }
+
+  /**
+   * The elision disclosure, appended outside the fence so it reads as instruction rather than as
+   * more untrusted data. It tells the model what it is looking at (identity only) and forbids the
+   * one dangerous inference — that a finding it cannot see in full has been dealt with.
+   *
+   * <p>It also restates what the block's own section header used to say about the unnumbered
+   * entries. That header is a detail line under the entry above it and condenses away with the
+   * rest; saying it here instead makes the meaning survive the elision, keeps it out of the
+   * untrusted region, and does not make the bound depend on matching another class's prose.
+   */
+  private static String elisionNotice(int droppedEntries) {
+    var condensed =
+        "(The previous findings above were condensed to id, location and title to fit this"
+            + " review's token budget; their descriptions and comment threads are not shown. Judge"
+            + " each by its location and title; one you cannot see in full is still open unless"
+            + " this diff shows it fixed. An entry with no id, written \"- file:line — title\", was"
+            + " answered in an earlier round: do not raise it again and do not include it in"
+            + " previous_findings_status.)";
+    if (droppedEntries <= 0) {
+      return condensed;
+    }
+    return condensed
+        + "\n("
+        + droppedEntries
+        + " further previous finding(s) did not fit and were omitted entirely. Never report a"
+        + " finding you cannot see as resolved, and do not re-raise one as if it were new.)";
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -260,7 +260,9 @@ public class ReviewOrchestrator {
       var inlineComments = ctx.inlineComments();
       var lineResolver = ctx.lineResolver();
 
-      var promptInputs = promptAssembler.assemble(ctx, req);
+      // Bound the one prompt section that grows every round before anything is sized or sent, so
+      // the plan's overhead estimate and the text the calls actually carry are the same (#583).
+      var promptInputs = budgetPlanner.boundPreviousFindings(promptAssembler.assemble(ctx, req));
       var plan = budgetPlanner.plan(ctx.reviewableFiles(), promptInputs);
 
       final var ciReq = req;

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -18,6 +18,7 @@ package dev.thiagogonzaga.thrillhousebot.review;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
@@ -597,6 +598,243 @@ class DiffBudgetPlannerTest {
     models.put(MODEL, modelSettings(Optional.of(64_000), Optional.empty(), Optional.empty()));
     when(reviewConfig.maxInputTokens()).thenReturn(0);
     assertEquals(Integer.MAX_VALUE, planner.perCallInputBudget());
+  }
+
+  /**
+   * A previous-findings block in the shape {@code FollowUpAnalyzer} builds: numbered entries with
+   * id, risk, location and title on one line, prose and quoted thread replies indented under it,
+   * then the unnumbered "answered in earlier rounds" list.
+   */
+  private static String previousFindingsBlock(int findings, int descriptionLines) {
+    var sb = new StringBuilder();
+    for (var i = 1; i <= findings; i++) {
+      sb.append(i)
+          .append(". [HIGH] src/File")
+          .append(i)
+          .append(".java:")
+          .append(i * 3)
+          .append(" — Finding ")
+          .append(i)
+          .append(" title\n");
+      for (var d = 0; d < descriptionLines; d++) {
+        sb.append("   The call site never checks the returned handle, so a failure here is")
+            .append(" swallowed and the caller proceeds on stale state, line ")
+            .append(d)
+            .append(".\n");
+      }
+      sb.append("   Thread replies:\n").append("   - @maintainer: not fixing this right now\n");
+    }
+    sb.append("\nAnswered in earlier rounds — do NOT raise these again and do NOT")
+        .append(" include them in previous_findings_status:\n")
+        .append("- src/Old.java:12 — An older answered finding\n")
+        .append("   Thread replies:\n")
+        .append("   - @maintainer: answered already\n");
+    return sb.toString();
+  }
+
+  private static AiReviewService.PromptInputs inputsWith(String previousFindings) {
+    return new AiReviewService.PromptInputs("d", "ctx", "base", "s", "t", previousFindings, "");
+  }
+
+  /** Budget knobs with no safety margin and no output buffer, so the per-call budget is exact. */
+  private void budget(int maxInputTokens) {
+    models.put(
+        MODEL, modelSettings(Optional.of(maxInputTokens), Optional.empty(), Optional.empty()));
+    when(reviewConfig.maxInputTokens()).thenReturn(maxInputTokens);
+    lenient().when(reviewConfig.tokenSafetyMargin()).thenReturn(1.0);
+    lenient().when(reviewConfig.outputBufferTokens()).thenReturn(0);
+    lenient().when(reviewConfig.maxAiCalls()).thenReturn(6);
+  }
+
+  @Test
+  void anAccumulatedPreviousFindingsBlockNoLongerStarvesTheDiffBudget() {
+    // #583: the block is shared overhead — every batch call repeats it in full — and it grows every
+    // round on a long-lived PR whose head keeps advancing and whose findings therefore never
+    // retire. Unbounded, it swallows the whole input budget and every file is omitted by name: the
+    // review stops reading code in order to re-read what it already said.
+    budget(20_000);
+    var files = List.of(file("dir/f1.java", 5, patch(5)), file("dir/f2.java", 5, patch(5)));
+
+    var plan =
+        planner.plan(files, inputsWith(PromptTemplateEscaper.fence(previousFindingsBlock(300, 6))));
+
+    assertTrue(plan.omittedFiles().isEmpty(), "the diff budget must survive the previous findings");
+    assertEquals(List.of("dir/f1.java", "dir/f2.java"), coveredFilenames(plan));
+  }
+
+  @Test
+  void anOversizedBlockIsCondensedToIdentityRatherThanTruncated() {
+    // Blind truncation would make the follow-up pass forget findings it already reported. What that
+    // pass needs is identity and location — the id it reports a status for, the file:line it looks
+    // at, the title it matches on — not the prose, so every entry keeps its own line and loses only
+    // its continuation lines.
+    budget(20_000);
+    var inputs = inputsWith(PromptTemplateEscaper.fence(previousFindingsBlock(40, 6)));
+
+    var bounded = planner.boundPreviousFindings(inputs);
+
+    for (var i = 1; i <= 40; i++) {
+      assertTrue(
+          bounded
+              .previousFindings()
+              .contains(i + ". [HIGH] src/File" + i + ".java:" + (i * 3) + " — Finding " + i),
+          "finding " + i + " lost its identity line");
+    }
+    assertTrue(
+        bounded.previousFindings().contains("- src/Old.java:12 — An older answered finding"),
+        "the answered-earlier list keeps its entries too");
+    assertFalse(
+        bounded.previousFindings().contains("The call site never checks"), "prose must be dropped");
+    assertFalse(bounded.previousFindings().contains("@maintainer"), "replies must be dropped");
+    assertTrue(
+        bounded.previousFindings().contains("condensed to id, location and title"),
+        "the elision must be disclosed");
+    assertFalse(
+        bounded.previousFindings().contains("Answered in earlier rounds"),
+        "the section header is a detail line and condenses away with the rest");
+    assertTrue(
+        bounded.previousFindings().contains("answered in an earlier round"),
+        "so the disclosure carries its meaning instead, outside the fence");
+    assertFalse(
+        bounded.previousFindings().contains("did not fit and were omitted entirely"),
+        "nothing was dropped, so nothing may claim it was");
+    assertTrue(
+        tokenCounter.estimateTokens(bounded.previousFindings()) <= 20_000 / 4,
+        "the bounded block must fit its share of the budget");
+    assertEquals("d", bounded.diff(), "no other prompt section is touched");
+    assertEquals("ctx", bounded.prContext());
+    assertEquals("base", bounded.baseComparison());
+    assertEquals("s", bounded.projectStack());
+    assertEquals("t", bounded.relatedTests());
+    assertEquals("", bounded.repoInstructions());
+  }
+
+  @Test
+  void condensingKeepsTheUntrustedRegionFencedWithTheDisclosureOutsideIt() {
+    // The fence is the data/instruction boundary. Dropping the closing line would leave the notice
+    // — our own instruction — inside the untrusted region, so both lines survive the cut.
+    budget(20_000);
+    var fenced = PromptTemplateEscaper.fence(previousFindingsBlock(40, 6));
+    var fence = fenced.lines().findFirst().orElseThrow();
+
+    var bounded = planner.boundPreviousFindings(inputsWith(fenced)).previousFindings();
+
+    var lines = bounded.lines().toList();
+    assertEquals(fence, lines.get(0), "the opening fence must survive");
+    assertEquals(2, lines.stream().filter(fence::equals).count(), "the fence must stay balanced");
+    assertTrue(
+        bounded.indexOf("condensed to id, location and title") > bounded.lastIndexOf(fence),
+        "the disclosure must sit outside the fence");
+  }
+
+  @Test
+  void entriesThatStillDoNotFitAreDroppedFromTheTailAndDisclosed() {
+    // Real forgetting, so it degrades the safe way: the numbered ids previous_findings_status is
+    // keyed to outlive the advisory answered-earlier list, and the model is told never to call a
+    // finding it cannot see resolved — the approve backstop then holds it open by itself.
+    budget(1_200);
+    var inputs = inputsWith(previousFindingsBlock(60, 2));
+
+    var bounded = planner.boundPreviousFindings(inputs).previousFindings();
+
+    assertTrue(bounded.contains("1. [HIGH] src/File1.java:3"), "the ids in use must be kept");
+    assertFalse(bounded.contains("60. [HIGH] src/File60.java"), "the tail must be dropped");
+    assertFalse(
+        bounded.contains("- src/Old.java:12"), "the advisory list yields before the numbered ids");
+    assertTrue(
+        bounded.contains("did not fit and were omitted entirely"), "the drop must be disclosed");
+    assertTrue(
+        bounded.contains("Never report a finding you cannot see as resolved"),
+        "the dangerous inference must be forbidden explicitly");
+    assertTrue(tokenCounter.estimateTokens(bounded) <= 300, "the cap must actually hold");
+  }
+
+  @Test
+  void aBlockTooSmallToHoldItsOwnDisclosureStillCarriesTheDisclosure() {
+    // Pathological cap: not one entry fits. The disclosure is the one thing that must not be what
+    // gets dropped — a silently empty block is exactly the forgetting this bound exists to prevent.
+    // A block that opens with a section header (the answered-earlier list, when no round raised
+    // numbered findings) loses the header without it counting as a dropped finding: the count
+    // must report findings, not lines.
+    budget(4);
+    var inputs =
+        inputsWith(
+            "Answered in earlier rounds — do NOT raise these again:\n"
+                + "- src/Old.java:12 — An older answered finding");
+
+    var bounded = planner.boundPreviousFindings(inputs).previousFindings();
+
+    assertFalse(bounded.contains("src/Old.java"), "nothing fits under this cap");
+    assertFalse(bounded.contains("Answered in earlier rounds — do NOT"), "nor does the header");
+    assertTrue(bounded.contains("1 further previous finding(s) did not fit"));
+  }
+
+  @Test
+  void aBlockWithinItsShareIsUntouchedAndBoundingIsIdempotent() {
+    // An ordinary follow-up round must pay nothing for this, and re-bounding an already bounded
+    // block must not stack disclosures — plan() bounds again when it sizes the shared overhead.
+    budget(20_000);
+    var small = inputsWith(previousFindingsBlock(3, 1));
+
+    assertSame(small, planner.boundPreviousFindings(small));
+
+    var big = inputsWith(PromptTemplateEscaper.fence(previousFindingsBlock(40, 6)));
+    var bounded = planner.boundPreviousFindings(big);
+    assertNotSame(big, bounded);
+    assertSame(bounded, planner.boundPreviousFindings(bounded));
+  }
+
+  @Test
+  void anUnfencedBlockIsBoundedToo() {
+    // The review path fences the block, but the bound is a property of the text, not of its
+    // wrapper: an unfenced block condenses the same way, with no fence line invented for it.
+    budget(20_000);
+
+    var bounded =
+        planner.boundPreviousFindings(inputsWith(previousFindingsBlock(40, 6))).previousFindings();
+
+    assertFalse(
+        bounded.contains(PromptTemplateEscaper.fencePrefix()), "no fence may be invented here");
+    assertTrue(bounded.contains("40. [HIGH] src/File40.java:120"), "every id must survive");
+    assertFalse(bounded.contains("The call site never checks"));
+  }
+
+  @Test
+  void aBlockThatOnlyLooksFencedIsCondensedAsPlainText() {
+    // A leading fence line with no matching closing line is not a fence — that block was already
+    // unterminated — so it is condensed as ordinary text rather than having a boundary invented.
+    budget(20_000);
+    var fenced = PromptTemplateEscaper.fence(previousFindingsBlock(40, 6));
+    var fence = fenced.lines().findFirst().orElseThrow();
+
+    var bounded =
+        planner.boundPreviousFindings(inputsWith(fenced + "\ntrailing text")).previousFindings();
+
+    assertEquals(
+        1,
+        bounded.lines().filter(fence::equals).count(),
+        "the unmatched line is ordinary text: none is added, and the one buried among the entries"
+            + " condenses away like any other detail line");
+    assertTrue(bounded.contains("40. [HIGH] src/File40.java:120"));
+  }
+
+  @Test
+  void anAbsentOrEmptyBlockIsLeftAlone() {
+    budget(20_000);
+    var absent = inputsWith(null);
+    var empty = inputsWith("   ");
+
+    assertSame(absent, planner.boundPreviousFindings(absent));
+    assertSame(empty, planner.boundPreviousFindings(empty));
+  }
+
+  @Test
+  void disabledBudgetingLeavesThePreviousFindingsBlockUncapped() {
+    // max-input-tokens=0 is an explicit "no cap at all"; this is not the place to reintroduce one.
+    when(reviewConfig.maxInputTokens()).thenReturn(0);
+    var inputs = inputsWith(PromptTemplateEscaper.fence(previousFindingsBlock(300, 6)));
+
+    assertSame(inputs, planner.boundPreviousFindings(inputs));
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`previousFindings` is the one prompt section that grows monotonically. Every review round appends the
previous round's findings, their prose and their whole comment threads, and on a long-lived PR whose
head keeps advancing nothing ever retires them. It is also **shared** overhead — repeated verbatim in
every batch call — so `DiffBudgetPlanner` counting it in `sharedOverhead` only tells it the prompt is
large: adding batches multiplies the block instead of dividing it, and the planner's only lever
(shrinking the diff budget) starves the review of the code it exists to read. On this repo's own
release PR (#532) the block reached ~437K tokens against 57–74K for a normal review, and before #584
it made that PR unreviewable outright.

### What was chosen, and why

**The bound is a share of the per-call input budget (25%), not a character cap.** The block is charged
against the whole per-call budget because every call carries it; a quarter is deliberately generous so
the bound bites on accumulation, not on an ordinary follow-up round.

**It degrades by condensation, not truncation.** Dropping the oldest findings silently would make the
follow-up pass forget what it already reported — the mechanism behind several resolved/unresolved
bugs. What that pass actually needs is *identity and location*: the id it must report a status for,
the `file:line` it must look at, the title it matches on. So every entry keeps its own line
(`3. [HIGH] path/File.java:42 — Title`) and loses only its continuation lines — description, quoted
code, thread replies. No finding disappears and no id shifts. The deterministic resolution machinery
is unaffected either way: the approve backstop and `unresolvedFindings` run off
`ctx.previousFindingsList()` (structured objects), never off this prompt text.

**Only if the condensed block still does not fit are entries dropped, and then from the tail** — so
the numbered findings whose ids `previous_findings_status` is keyed to outlive the advisory
"answered in earlier rounds" list that follows them. That is real forgetting, so it degrades the safe
way: a finding the model cannot report on is not counted resolved, it is held open by the approve
backstop (`unreportedUnresolvedStatuses`), so approval is withheld rather than granted.

**The elision is disclosed** the way the existing overhead shortfall is — a `WARN` naming the before
size, the share and the counts — and additionally **in-band to the model**, which is the consumer of
this block: a trailing notice says the entries are condensed, forbids the one dangerous inference
("never report a finding you cannot see as resolved"), and restates what the block's own
"answered in earlier rounds" header used to say, since that header is a detail line and condenses
away with the rest. Saying it in our own notice keeps the meaning without making the bound depend on
matching another class's prose.

Deliberately **not** added: a coverage-style disclosure on the posted review. Condensation is not a
coverage gap — no file goes unread, no finding loses its identity, and `truncated()` / the APPROVE
gate are untouched — so listing it beside "files omitted by name" would misdescribe it. (Surfacing
the *drop* tier in the posted review would mean touching `VerdictBuilder` and `ReviewResult`; it is
unreachable at any sane budget — 61 entries fit in ~300 tokens — and the backstop already holds
approval when it fires.)

**Fence safety:** the notice is appended *outside* the CSPRNG fence so it reads as instruction, not as
more untrusted data, and both fence lines are carried across the cut so the untrusted region can never
end up unterminated with our instruction swallowed inside it.

`ReviewOrchestrator` applies the bound once, before anything is sized or sent, so the plan's overhead
estimate and the text the calls actually carry are the same string; `plan(...)` bounds again when it
sizes the overhead, and the operation is idempotent.

## Related Issues

Fixes #583

## How Has This Been Tested?

- [x] Unit tests

**Red**, against `469539e` with `anAccumulatedPreviousFindingsBlockNoLongerStarvesTheDiffBudget` in
place and no production change (300 accumulated findings, 20K-token per-call budget, two small files):

```
2026-08-12 09:32:39,357 WARN  [dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlanner] (main) Shared prompt overhead (69587 tokens) consumes the whole input budget (20000 tokens); batching with a minimal diff budget — most files will be omitted by name
2026-08-12 09:32:39,364 WARN  [dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlanner] (main) File section exceeds the 1-token budget even after clipping; omitting the file by name
2026-08-12 09:32:39,365 WARN  [dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlanner] (main) File section exceeds the 1-token budget even after clipping; omitting the file by name
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.989 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlannerTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlannerTest.anAccumulatedPreviousFindingsBlockNoLongerStarvesTheDiffBudget -- Time elapsed: 0.111 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the diff budget must survive the previous findings ==> expected: <true> but was: <false>
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:232)
	at dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlannerTest.anAccumulatedPreviousFindingsBlockNoLongerStarvesTheDiffBudget(DiffBudgetPlannerTest.java:650)
```

Every file omitted by name, exactly as #532 behaved. Green with the fix; the same scenario now logs
`Previous-findings context (60406 tokens) exceeds its 5000-token share of the input budget; condensed
301 finding(s) to id, location and title` and packs both files.

Nine further tests cover: condensation keeping every id/location/title while dropping prose and
replies; the fence staying balanced with the disclosure outside it; the tail drop and its disclosure;
a cap too small to hold even one entry; pass-through and idempotence; unfenced and
only-looks-fenced blocks; absent/blank blocks; and `max-input-tokens=0` leaving the block uncapped.

Gates on `c0f42e2`:

- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` → `Tests run: 2857, Failures: 0, Errors: 0, Skipped: 0`
- jacoco ∩ `git diff -U0 469539e...HEAD` → 82 trackable changed main lines, zero uncovered lines,
  zero uncovered branches

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

One line lands outside `DiffBudgetPlanner`: `ReviewOrchestrator` has to adopt the bounded inputs, or
the planner would bound a copy nobody sends. Everything else — the share, the condenser, the cut, the
disclosure — is in the planner and its test.

The block still grows with the number of open findings, just at ~1 line each instead of a paragraph
plus a comment thread; the cap is what makes it bounded, and the cap is what the review can afford.
