### PR TITLE
fix(review): salvage the verdicts that closed before the response-length cap

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -232,9 +232,7 @@ public class FindingVerificationService {
       }
       return apply(screened, parseOrSalvage(raw, screened.findings().size()));
     } catch (AiResponseTruncatedException e) {
-      // The verifier fails open by design; say why so a cap is not mistaken for a provider fault.
-      Log.warnf("Finding verification — keeping unverified findings. %s", e.getMessage());
-      return screened;
+      return salvageTruncatedVerdicts(screened, e);
     } catch (IOException | RuntimeException e) {
       Log.warnf(
           e,
@@ -266,18 +264,59 @@ public class FindingVerificationService {
       if (salvaged.isEmpty()) {
         throw e;
       }
-      var verified =
-          salvaged.stream()
-              .mapToInt(VerificationResponse.Verdict::id)
-              .filter(id -> id >= 1 && id <= candidates)
-              .distinct()
-              .count();
+      var verified = candidatesCovered(salvaged, candidates);
       Log.warnf(
           "Finding verification response was cut mid-JSON (%s); salvaged %d verdict(s) covering %d"
               + " of %d candidate finding(s) — the remaining %d stay unverified",
           e.getMessage(), salvaged.size(), verified, candidates, candidates - verified);
       return new VerificationResponse(salvaged);
     }
+  }
+
+  /**
+   * Applies the verdicts that closed before the model's response-length cap cut the body (#599).
+   * Same salvage as {@link #parseOrSalvage}, on the other lane that reaches a cut body: this one
+   * arrives as a reported {@code finish_reason=length} rather than as a parse failure, so it never
+   * passed through the parse path at all.
+   *
+   * <p>The cut text only became reachable here when {@link AiResponses#textOrThrowOnTruncation} was
+   * given {@link Result#content()} to carry on the failure (#592/#580) — before that the blocking
+   * lanes passed {@code null}, so a verification call cut mid-JSON discarded every verdict it had
+   * already paid for, including the complete ones. Nothing else about the lane changes: the
+   * truncation is still not retried, and a body with nothing recoverable in it (no partial body at
+   * all, or a cut before the first verdict closed) fails open exactly as before, keeping every
+   * unverified finding.
+   */
+  private ReviewResponse salvageTruncatedVerdicts(
+      ReviewResponse screened, AiResponseTruncatedException e) {
+    var candidates = screened.findings().size();
+    var salvaged =
+        salvager.salvageArray(e.partialBody(), VERDICTS, VerificationResponse.Verdict.class);
+    if (salvaged.isEmpty()) {
+      // The verifier fails open by design; say why so a cap is not mistaken for a provider fault.
+      Log.warnf("Finding verification — keeping unverified findings. %s", e.getMessage());
+      return screened;
+    }
+    var verified = candidatesCovered(salvaged, candidates);
+    Log.warnf(
+        "Finding verification was cut at the model's response-length cap; salvaged %d verdict(s)"
+            + " covering %d of %d candidate finding(s) — the remaining %d stay unverified. %s",
+        salvaged.size(), verified, candidates, candidates - verified, e.getMessage());
+    return apply(screened, new VerificationResponse(salvaged));
+  }
+
+  /**
+   * How many distinct candidates the salvaged verdicts actually cover. Salvage is best-effort over
+   * model output, so a verdict can carry an id outside the 1-based candidate range; counting only
+   * the ids in range keeps the log honest about what stayed unverified.
+   */
+  private static long candidatesCovered(
+      List<VerificationResponse.Verdict> salvaged, int candidates) {
+    return salvaged.stream()
+        .mapToInt(VerificationResponse.Verdict::id)
+        .filter(id -> id >= 1 && id <= candidates)
+        .distinct()
+        .count();
   }
 
   /**

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -364,6 +364,54 @@ class FindingVerificationServiceTest {
   }
 
   @Test
+  void appliesTheVerdictsThatClosedBeforeTheResponseLengthCapCutTheBody() {
+    // #599: the length-stop lane discarded the response whole. Since #592 the cut body travels on
+    // the truncation as its partial body, so the verdicts that closed before the cut are
+    // recoverable — the same salvage the no-finish-reason lane already runs. Every one of them was
+    // generated and billed; throwing them away bought nothing.
+    ReviewResponse original =
+        response(
+            finding("critical", "high", "Hallucinated API claim"),
+            finding("high", "high", "Speculative"),
+            finding("high", "high", "Verdict cut off"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiTruncated(
+                """
+            {"verdicts": [
+              {"id": 1, "verdict": "rejected", "reason": "framework idiom"},
+              {"id": 2, "verdict": "downgraded", "risk": "low", "confidence": "low", "reason": "r"},
+              {"id": 3, "verdict": "confi"""));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals(2, result.findings().size());
+    assertEquals("Speculative", result.findings().get(0).title());
+    assertEquals("low", result.findings().get(0).risk());
+    assertEquals("low", result.findings().get(0).confidence());
+    // The candidate whose verdict was on the far side of the cut stays untouched, never rejected.
+    var unverified = result.findings().get(1);
+    assertEquals("Verdict cut off", unverified.title());
+    assertEquals("high", unverified.risk());
+    assertEquals("high", unverified.confidence());
+    assertEquals(2, result.summary().totalFindings());
+  }
+
+  @Test
+  void keepsEveryFindingWhenTheCapCutTheBodyBeforeAnyVerdictClosed() {
+    // The fail-open contract is unchanged where there is nothing to salvage: a cut landing inside
+    // the first verdict, and a truncation carrying no partial body at all, both keep every finding.
+    ReviewResponse original =
+        response(finding("critical", "high", "Bug"), finding("low", "high", "Nit"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiTruncated("{\"verdicts\": [{\"id\": 1, \"verdict\": \"reje"), aiTruncated(null));
+
+    assertSame(original, service.verify(SESSION, original, "diff", "stack", ""));
+    assertSame(original, service.verify(SESSION, original, "diff", "stack", ""));
+  }
+
+  @Test
   void keepsUnverifiedFindingsWithoutParsingWhenTheModelReturnsNoBody() {
     // #534: with the whole output budget spent on reasoning tokens the provider returns a completed
     // response with no content body. That is the unwrap helper's documented "no response" soft


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`FindingVerificationService` discarded the whole verifier response on the length-stop path, even
though everything needed to salvage it was already in place:

- #592 changed `AiResponses.textOrThrowOnTruncation` to pass `result.content()` instead of `null`, so
  the paid-for, cut text now travels on the truncation as its partial body;
- #546 already added `salvageArray(body, "verdicts", …)` and the service already runs it on the
  *other* lane that reaches a cut body — the one where the provider reports no
  `finish_reason=length` at all and the cut surfaces as a parse failure.

Only the length-stop lane still threw everything away. A verification call cut mid-JSON discarded
every verdict it had already paid for, including the complete ones, so a body carrying nine closed
verdicts and a tenth cut off contributed nothing.

This wires the two together. `salvageTruncatedVerdicts` runs the same salvage over
`AiResponseTruncatedException.partialBody()` and applies what closed; the id-coverage count both
lanes log is now one helper rather than two copies.

Nothing else about the lane changes. The truncation is still not retried, the fail-open contract is
untouched, and a candidate whose verdict fell on the far side of the cut simply has no verdict —
`apply` keeps such a finding exactly as it stands, so a missing verdict never rejects or downgrades
anything. A truncation with nothing recoverable (no partial body at all, or a cut before the first
verdict closed) keeps every unverified finding exactly as before.

## Related Issues

Fixes #599

## How Has This Been Tested?

- [x] Unit tests

**Red output on unfixed code** (`./mvnw -B test -Dtest=FindingVerificationServiceTest` at `469539e`
with only the tests applied):

```
[ERROR] Tests run: 45, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.000 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.appliesTheVerdictsThatClosedBeforeTheResponseLengthCapCutTheBody -- Time elapsed: 0.036 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <2> but was: <3>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:569)
	at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.appliesTheVerdictsThatClosedBeforeTheResponseLengthCapCutTheBody(FindingVerificationServiceTest.java:388)
```

Three findings in, three findings out: the `rejected` verdict that had closed before the cut was
discarded along with everything else, so nothing was applied. Green, the rejected candidate is
dropped, the downgraded one is lowered, and the candidate past the cut survives untouched.

The second test pins the unchanged half of the contract from both directions — a cut landing inside
the first verdict, and a truncation carrying no partial body at all — so the fail-open path is not
quietly narrowed by the salvage.

Gates:

- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — `Tests run: 2849, Failures: 0, Errors: 0, Skipped: 0`
- jacoco ∩ `git diff -U0 469539e...HEAD` — 0 uncovered lines, 0 uncovered branches in changed main code

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Scope is `FindingVerificationService` only, as the issue asks — neither the salvage helper nor the
truncation type needed a change.
