### PR TITLE
fix(review): revive the dead heuristic failure-mode review dimension under token budgeting

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -68,19 +68,30 @@ public class FindingPipeline {
       List<ReviewResponse.Finding> findings,
       List<ReviewResponse.PreviousFindingStatus> statuses) {}
 
+  /** The rendered file-section header {@link ReviewDiffFormatter#formatFileSection} emits. */
+  private static final String SECTION_HEADER_PREFIX = "### ";
+
   /**
    * The shared prompt template for a review call plus the PR-level {@linkplain
    * #withheldMaterialNotice withheld-material notice}, so every call this class assembles material
    * for carries the same disclosure and the prefixing lives in one place. The notice rides inside
    * the diff slot's untrusted fence — the paths in it come from the pull request — while the rule
    * that acts on it is in the trusted system prompt.
+   *
+   * <p>The trailing guidance is extended per batch with the {@linkplain
+   * #heuristicFailureModesFor(DiffBudgetPlanner.DiffBatch) heuristic failure-mode dimension}, whose
+   * trigger is the diff — so it can only be decided once the batch's own text is known.
    */
   private record BatchPrompts(AiReviewService.PromptInputs template, String withheldNotice) {
 
     AiReviewService.PromptInputs forBatch(
         DiffBudgetPlanner.DiffBatch batch, String baseComparison) {
       return withDiff(
-          template, PromptTemplateEscaper.fence(withheldNotice + batch.text()), baseComparison);
+          template,
+          PromptTemplateEscaper.fence(withheldNotice + batch.text()),
+          baseComparison,
+          ReviewPromptAssembler.combineSections(
+              template.repoInstructions(), heuristicFailureModesFor(batch)));
     }
   }
 
@@ -693,16 +704,6 @@ public class FindingPipeline {
   }
 
   /**
-   * Unwraps a failed parallel batch future as {@link IllegalStateException} (preserving the cause).
-   * SpotBugs flags rethrowing a bare {@link RuntimeException}; callers still see {@link
-   * AiReviewException} via {@link Throwable#getCause()}.
-   */
-  static IllegalStateException unwrapParallelFailure(CompletionException e) {
-    var cause = e.getCause() != null ? e.getCause() : e;
-    return new IllegalStateException("Parallel batch review failed", cause);
-  }
-
-  /**
    * Degenerate budgeted plan: every reviewable file overflowed the budget, so no review call can
    * carry any diff within it. Sending the uncapped raw diff instead would bypass the budget on
    * exactly the PR it was meant to bound — skip the review call, keep the summary call (it never
@@ -802,11 +803,18 @@ public class FindingPipeline {
    * walkthrough renders at most {@link PrReviewPrompts#MAX_FILE_SUMMARIES} rows, so every rendered
    * row is grounded with a wide margin. Pinned by {@code
    * FindingPipelineTest#aPr532SizedOverviewKeepsFarMoreRowsThanTheWalkthroughRenders}.
+   *
+   * <p>Only the per-file rows are clampable. The {@linkplain ChangedFilesOverview#header() header
+   * block} — the pure-rename rollup and the PR-scope totals — is rendered first precisely so
+   * clamping can only take the tail, so a budget too small to hold it withholds the overview
+   * outright rather than emitting a rollup note in the header's place (#486 P4). That also keeps
+   * the note's count honest: everything it can drop is a file.
    */
-  private String clampOverview(String overview, AiReviewService.PromptInputs promptInputs) {
+  private String clampOverview(
+      ChangedFilesOverview overview, AiReviewService.PromptInputs promptInputs) {
     var budget = budgetPlanner.perCallInputBudget();
     if (budget == Integer.MAX_VALUE) {
-      return overview;
+      return overview.text();
     }
     var inherited =
         PrReviewPrompts.SUMMARY_SYSTEM
@@ -815,28 +823,29 @@ public class FindingPipeline {
             + promptInputs.previousFindings()
             + promptInputs.repoInstructions();
     var overviewBudget = (budget - tokenCounter.estimateTokens(inherited)) / 2;
-    if (overviewBudget <= 0) {
+    var rows = overview.fileRows();
+    // Rollup-note tokens are reserved up front so post-truncation append cannot exceed the share.
+    var noteReserve = tokenCounter.estimateTokens(overviewRollupNote(rows.length));
+    var headerTokens = tokenCounter.estimateTokens(overview.header());
+    if (overviewBudget - noteReserve < headerTokens) {
       return "(changed-files overview withheld — summary input budget exhausted)\n";
     }
-    var lines = overview.split("\n");
-    // Rollup-note tokens are reserved up front so post-truncation append cannot exceed the share.
-    var noteReserve = tokenCounter.estimateTokens(overviewRollupNote(lines.length));
-    var sb = new StringBuilder();
-    var used = 0;
+    var sb = new StringBuilder(overview.header());
+    var used = headerTokens;
     var listed = 0;
-    while (listed < lines.length) {
-      var lineTokens = tokenCounter.estimateTokens(lines[listed] + "\n");
-      if (used + lineTokens > overviewBudget - noteReserve) {
+    while (listed < rows.length) {
+      var rowTokens = tokenCounter.estimateTokens(rows[listed] + "\n");
+      if (used + rowTokens > overviewBudget - noteReserve) {
         break;
       }
-      sb.append(lines[listed]).append('\n');
-      used += lineTokens;
+      sb.append(rows[listed]).append('\n');
+      used += rowTokens;
       listed++;
     }
-    if (listed == lines.length) {
-      return overview;
+    if (listed == rows.length) {
+      return overview.text();
     }
-    sb.append(overviewRollupNote(lines.length - listed));
+    sb.append(overviewRollupNote(rows.length - listed));
     return sb.toString();
   }
 
@@ -1027,9 +1036,84 @@ public class FindingPipeline {
         : previous + " → " + file.filename();
   }
 
-  /** Copies the shared prompt context, swapping the diff and base-comparison slots. */
+  /**
+   * The heuristic failure-mode review dimension (#123 / #420) for one batch, appended to that
+   * batch's trailing guidance.
+   *
+   * <p>{@link ReviewPromptAssembler} decides this section from {@code ctx.diff()}, which {@link
+   * ReviewContextLoader} leaves empty whenever token budgeting is on — the shipped default — so the
+   * whole dimension was silently absent from every default-configuration review (#486 P3). It is
+   * decided here instead because this is the first point that holds the material the call actually
+   * receives: the plan's batch text. Only the batches whose own slice introduces a decision rule
+   * pay for it, which is stricter than the whole-diff gate it replaces. The two cannot both emit
+   * the section: this runs only on a budgeted plan, and the assembler's gate only has material when
+   * budgeting is off — the loader keys the empty {@code ctx.diff()} on the setting the planner keys
+   * {@code budgeted} on.
+   *
+   * <p>Sizing: the section is a single fixed constant, and the planner sized the shared overhead
+   * before it existed. That mirrors the {@linkplain #withheldMaterialNotice withheld-material
+   * notice} this class already adds after planning, and it is what the token safety margin (10% of
+   * the input cap by default, ~4800 tokens against this section's ~700) is held back for.
+   */
+  private static String heuristicFailureModesFor(DiffBudgetPlanner.DiffBatch batch) {
+    var scanned = heuristicScanSource(batch.text());
+    if (scanned.isBlank()) {
+      // Loud on purpose: an empty input is exactly what made this dimension die unnoticed, and a
+      // detector fed nothing reports "no heuristic code" in the same voice as a detector that read
+      // the diff and found none.
+      Log.warnf(
+          "Review batch covering %d file(s) carries no diff text, so the heuristic failure-mode"
+              + " review dimension has no material to evaluate and is omitted from that call —"
+              + " this is a planning defect, not a pull request that introduces no heuristic code",
+          batch.files().size());
+      return "";
+    }
+    return ReviewPromptAssembler.heuristicFailureModesSection(scanned);
+  }
+
+  /**
+   * The batch text with each rendered {@code ### path (status, +a -d)} header rewritten to the
+   * unified-diff {@code +++ b/path} form {@link HeuristicCodeDetector} scopes files by. Without it
+   * the detector sees one unattributed run of added lines: its test-file exclusion stops applying
+   * (a fixture regex is not new production logic) and its JavaScript regex-literal signal, which is
+   * only enabled for JS/TS paths, never fires. Everything else is passed through verbatim, so the
+   * detector reads exactly the added lines the model was given — clipping included.
+   */
+  static String heuristicScanSource(String batchText) {
+    if (batchText == null || batchText.isBlank()) {
+      return "";
+    }
+    var lines = batchText.split("\n", -1);
+    var sb = new StringBuilder(batchText.length());
+    for (var i = 0; i < lines.length; i++) {
+      if (i > 0) {
+        sb.append('\n');
+      }
+      var line = lines[i];
+      sb.append(line.startsWith(SECTION_HEADER_PREFIX) ? "+++ b/" + sectionFilename(line) : line);
+    }
+    return sb.toString();
+  }
+
+  /**
+   * The path out of a rendered section header, dropping the {@code " (status, +a -d)"} suffix when
+   * one is present — the same parse {@link FindingQuoteValidator} does on the same headers.
+   */
+  private static String sectionFilename(String headerLine) {
+    var name = headerLine.substring(SECTION_HEADER_PREFIX.length());
+    var suffix = name.lastIndexOf(" (");
+    return (suffix > 0 ? name.substring(0, suffix) : name).strip();
+  }
+
+  /**
+   * Copies the shared prompt context, swapping the diff, base-comparison and trailing-guidance
+   * slots.
+   */
   private static AiReviewService.PromptInputs withDiff(
-      AiReviewService.PromptInputs base, String diff, String baseComparison) {
+      AiReviewService.PromptInputs base,
+      String diff,
+      String baseComparison,
+      String repoInstructions) {
     return new AiReviewService.PromptInputs(
         diff,
         base.prContext(),
@@ -1037,7 +1121,7 @@ public class FindingPipeline {
         base.projectStack(),
         base.relatedTests(),
         base.previousFindings(),
-        base.repoInstructions());
+        repoInstructions);
   }
 
   private String findingsJson(List<ReviewResponse.Finding> findings) {
@@ -1050,21 +1134,39 @@ public class FindingPipeline {
   }
 
   /**
+   * The summary call's changed-files overview, split at the seam {@link #clampOverview} clamps on:
+   * the {@code header} block that must survive any clamp (pure-rename rollup, PR-scope totals) and
+   * the newline-separated per-file {@code rows} that may be rolled up by count from the tail.
+   */
+  private record ChangedFilesOverview(String header, String rows) {
+
+    String text() {
+      return header + rows;
+    }
+
+    /** The per-file rows as lines, empty when there are none — never a single blank row. */
+    String[] fileRows() {
+      return rows.isEmpty() ? new String[0] : rows.split("\n");
+    }
+  }
+
+  /**
    * Every changed file by name + change counts, so the summary covers files with no findings too.
    * Hunk-clipped files are marked partially analyzed — presenting them with bare change counts
    * would tell the summary they were fully covered when most of the patch was never sent.
    */
-  private static String changedFilesOverview(
+  private static ChangedFilesOverview changedFilesOverview(
       ReviewContextLoader.ReviewContext ctx, DiffBudgetPlanner.BudgetPlan plan) {
-    var sb = new StringBuilder();
+    var header = new StringBuilder();
     // Pure-rename rollup first so clampOverview (keeps a prefix) never drops the disclosure on
     // large multi-call reviews (#386).
     var pureRenames = ReviewDiffFormatter.pureRenameFiles(ctx.files());
     if (!pureRenames.isEmpty()) {
-      sb.append(ReviewDiffFormatter.formatPureRenameRollup(pureRenames));
+      header.append(ReviewDiffFormatter.formatPureRenameRollup(pureRenames));
     }
     // Scope totals next, ahead of the per-file rows, for the same reason: clamping drops the tail.
-    sb.append(changeScopeSummary(ctx));
+    header.append(changeScopeSummary(ctx));
+    var sb = new StringBuilder();
     var omitted = Set.copyOf(plan.omittedFiles());
     var uncovered = Set.copyOf(plan.runtimeUncoveredFiles());
     // effectiveClippedFiles drops any clipped file a failed batch left wholly uncovered, so it is
@@ -1097,7 +1199,7 @@ public class FindingPipeline {
           .append(
               " (not reviewed — the review call for it did not complete; treated as uncovered)\n");
     }
-    return sb.toString();
+    return new ChangedFilesOverview(header.toString(), sb.toString());
   }
 
   /** The per-file coverage caveat for the summary overview, or empty for full coverage. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -53,7 +53,6 @@ import dev.thiagogonzaga.thrillhousebot.review.ai.TokenSpendCeilingExceededExcep
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -599,25 +598,6 @@ class FindingPipelineTest {
     verify(aiReviewService).reviewBatch(eq(session), any(), eq(2), anyInt());
     assertEquals(2, result.findings().size());
     assertSame(summary, result.summary());
-  }
-
-  @Test
-  void unwrapParallelFailureUsesCompletionExceptionWhenCauseMissing() {
-    var missingCause = new CompletionException((Throwable) null);
-    var wrapped = FindingPipeline.unwrapParallelFailure(missingCause);
-    assertEquals("Parallel batch review failed", wrapped.getMessage());
-    assertSame(missingCause, wrapped.getCause());
-  }
-
-  @Test
-  void unwrapParallelFailurePreservesTheUnderlyingCause() {
-    // The caller distinguishes an AI failure from a wiring failure through getCause(), so the
-    // real cause must survive the IllegalStateException wrapper SpotBugs requires.
-    var cause = new IllegalArgumentException("model refused");
-    var wrapped = FindingPipeline.unwrapParallelFailure(new CompletionException(cause));
-
-    assertEquals("Parallel batch review failed", wrapped.getMessage());
-    assertSame(cause, wrapped.getCause());
   }
 
   @Test
@@ -1228,27 +1208,9 @@ class FindingPipelineTest {
     assertEquals("unresolved", result.previousFindingsStatus().get(0).status());
   }
 
-  @Test
-  void oversizedOverviewIsClampedWithARollupNote() {
-    var session = ReviewSession.create("owner/repo", 1, "Huge PR", "sha");
-    var ctx = reviewContext();
-    var template = new AiReviewService.PromptInputs("d", "d", "", "", "", "", "");
-    var tokenCounter = new TokenCounter();
-    var inherited = PrReviewPrompts.SUMMARY_SYSTEM + PrReviewPrompts.SUMMARY_USER + "d";
-    when(budgetPlanner.perCallInputBudget())
-        .thenReturn(tokenCounter.estimateTokens(inherited) + 20);
-    when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
-        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
-    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
-    when(aiReviewService.summarize(eq(session), captor.capture()))
-        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
-
-    pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
-
-    assertTrue(
-        captor.getValue().changedFiles().contains("more changed files"),
-        captor.getValue().changedFiles());
-  }
+  // The rollup note at this budget is covered by the two #486 P4 cases at the end of this class:
+  // a budget too small for the scope header withholds the overview instead of emitting a bare
+  // rollup in its place, and a budget that holds the header rolls the row tail up by file count.
 
   /**
    * #547 — the clamp keeps a prefix and drops the tail, so a walkthrough row could in principle be
@@ -1931,5 +1893,287 @@ class FindingPipelineTest {
     assertTrue(
         captor.getValue().findings().contains("more findings not shown"),
         captor.getValue().findings());
+  }
+
+  /**
+   * A batch whose rendered text is one {@link ReviewDiffFormatter#formatFileSection} section
+   * carrying the given added lines — the shape {@link DiffBudgetPlanner} packs.
+   */
+  private static DiffBudgetPlanner.DiffBatch batchAdding(String name, String... addedLines) {
+    var patch = new StringBuilder("@@ -1 +1," + addedLines.length + " @@\n");
+    for (var line : addedLines) {
+      patch.append('+').append(line).append('\n');
+    }
+    var file =
+        new FileDiff(name, "modified", addedLines.length, 0, addedLines.length, patch.toString());
+    var text =
+        "### " + name + " (modified, +" + addedLines.length + " -0)\n```diff\n" + patch + "```\n\n";
+    return new DiffBudgetPlanner.DiffBatch(text, List.of(file), 10);
+  }
+
+  private static final String REGEX_ADDITION =
+      "  private static final Pattern P = Pattern.compile(\"/pause\");";
+
+  /**
+   * #486 P3 — under the shipped default ({@code max-input-tokens=48000}) the context loader leaves
+   * {@code ctx.diff()} empty, so the assembler's {@code ctx.diff()}-gated heuristic section is
+   * always blank: the template's trailing guidance arrives here carrying nothing. The dimension has
+   * to be re-derived from the material the call actually gets — this batch's own text.
+   */
+  @Test
+  void aBudgetedBatchThatIntroducesHeuristicCodeCarriesTheFailureModeDimension() {
+    var session = ReviewSession.create("owner/repo", 1, "Add a trigger regex", "sha");
+    var ctx = reviewContext();
+    // repoInstructions is what assemble() produces under budgeting: no heuristic section in it.
+    var template =
+        new AiReviewService.PromptInputs("", "ctx", "", "stack", "tests", "", "repo rules");
+    var captor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
+    when(aiReviewService.review(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(
+        session,
+        template,
+        ctx,
+        singleBatchPlan(batchAdding("src/main/java/app/Trigger.java", REGEX_ADDITION), List.of()),
+        new DiffLineResolver(Map.of()));
+
+    var guidance = captor.getValue().repoInstructions();
+    assertTrue(guidance.contains(PrReviewPrompts.HEURISTIC_FAILURE_MODES_REQUEST), guidance);
+    assertTrue(guidance.startsWith("repo rules"), guidance);
+  }
+
+  /** Only the batch whose own slice introduces the rule pays for the dimension. */
+  @Test
+  void theHeuristicDimensionIsScopedToTheBatchThatIntroducesTheRule() {
+    var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("", "ctx", "", "stack", "tests", "", "");
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(
+                batchAdding("src/main/java/app/Trigger.java", REGEX_ADDITION),
+                batchAdding("src/main/java/app/Plain.java", "  var total = a + b;")),
+            List.of(),
+            List.of(),
+            true,
+            null,
+            null,
+            null,
+            null);
+    var captor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
+    when(aiReviewService.reviewBatch(eq(session), captor.capture(), anyInt(), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+    when(aiReviewService.summarize(eq(session), any()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    var withRule =
+        captor.getAllValues().stream()
+            .filter(i -> i.diff().contains("Trigger.java"))
+            .findFirst()
+            .orElseThrow();
+    var withoutRule =
+        captor.getAllValues().stream()
+            .filter(i -> i.diff().contains("Plain.java"))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(
+        withRule.repoInstructions().contains(PrReviewPrompts.HEURISTIC_FAILURE_MODES_REQUEST),
+        withRule.repoInstructions());
+    assertEquals("", withoutRule.repoInstructions());
+  }
+
+  /**
+   * The detector scopes files by the unified-diff {@code +++ b/} header, which a rendered batch
+   * section does not carry — so the batch's own {@code ### path} headers have to be translated, or
+   * its test-file exclusion (a fixture regex is not new production logic) silently stops applying.
+   */
+  @Test
+  void aBatchOfTestFilesDoesNotTriggerTheHeuristicDimension() {
+    var session = ReviewSession.create("owner/repo", 1, "Add a test", "sha");
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("", "ctx", "", "stack", "tests", "", "");
+    var captor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
+    when(aiReviewService.review(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(
+        session,
+        template,
+        ctx,
+        singleBatchPlan(
+            batchAdding("src/test/java/app/TriggerTest.java", REGEX_ADDITION), List.of()),
+        new DiffLineResolver(Map.of()));
+
+    assertEquals("", captor.getValue().repoInstructions());
+  }
+
+  /** {@code DiffBatch} does not reject a null text, so the scan source must not dereference one. */
+  @Test
+  void aNullBatchTextScansAsNoMaterial() {
+    assertEquals("", FindingPipeline.heuristicScanSource(null));
+  }
+
+  /** A section header rendered without the {@code " (status, +a -d)"} suffix still scopes. */
+  @Test
+  void aSectionHeaderWithoutItsStatsSuffixStillScopesTheHeuristicDetector() {
+    var session = ReviewSession.create("owner/repo", 1, "Add a test", "sha");
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("", "ctx", "", "stack", "tests", "", "");
+    var bare =
+        new DiffBudgetPlanner.DiffBatch(
+            "### src/test/java/app/TriggerTest.java\n```diff\n@@ -1 +1 @@\n+"
+                + REGEX_ADDITION
+                + "\n```\n\n",
+            List.of(new FileDiff("src/test/java/app/TriggerTest.java", "modified", 1, 0, 1, "")),
+            10);
+    var captor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
+    when(aiReviewService.review(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(
+        session, template, ctx, singleBatchPlan(bare, List.of()), new DiffLineResolver(Map.of()));
+
+    assertEquals("", captor.getValue().repoInstructions());
+  }
+
+  /**
+   * The failure mode that made the dimension die silently was an empty input, so an empty input is
+   * now stated rather than read as "this PR introduces no heuristic code".
+   */
+  @Test
+  void aBatchWithNoTextSaysTheHeuristicDimensionCouldNotBeEvaluated() {
+    var session = ReviewSession.create("owner/repo", 1, "Empty batch", "sha");
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("", "ctx", "", "stack", "tests", "", "");
+    var empty =
+        new DiffBudgetPlanner.DiffBatch(
+            "", List.of(new FileDiff("a.java", "modified", 1, 0, 1, "")), 0);
+    var captor = ArgumentCaptor.forClass(AiReviewService.PromptInputs.class);
+    when(aiReviewService.review(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    var logged = new ArrayList<String>();
+    var logger = java.util.logging.Logger.getLogger(FindingPipeline.class.getName());
+    var handler =
+        new java.util.logging.Handler() {
+          @Override
+          public void publish(java.util.logging.LogRecord record) {
+            logged.add(String.valueOf(record.getMessage()));
+          }
+
+          @Override
+          public void flush() {}
+
+          @Override
+          public void close() {}
+        };
+    logger.addHandler(handler);
+    try {
+      pipeline.run(
+          session,
+          template,
+          ctx,
+          singleBatchPlan(empty, List.of()),
+          new DiffLineResolver(Map.of()));
+    } finally {
+      logger.removeHandler(handler);
+    }
+
+    assertEquals("", captor.getValue().repoInstructions());
+    assertTrue(
+        logged.stream().anyMatch(m -> m.contains("heuristic failure-mode")),
+        "the skipped dimension must be stated, not silent: " + logged);
+  }
+
+  /**
+   * #486 P4 — the packing loop could break at zero listed lines, emitting a bare rollup note in
+   * place of the PR-scope header {@code changedFilesOverview} renders first precisely so clamping
+   * can only take the tail. The note also counted lines while reading "changed files", so the
+   * header rows inflated it above the real file count.
+   */
+  @Test
+  void anOverviewTooSmallForItsScopeHeaderIsWithheldNotReducedToABareRollup() {
+    var session = ReviewSession.create("owner/repo", 1, "Huge PR", "sha");
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "d", "", "", "", "", "");
+    var inherited = PrReviewPrompts.SUMMARY_SYSTEM + PrReviewPrompts.SUMMARY_USER + "d";
+    when(budgetPlanner.perCallInputBudget())
+        .thenReturn(new TokenCounter().estimateTokens(inherited) + 20);
+    when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
+    when(aiReviewService.summarize(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+
+    var changedFiles = captor.getValue().changedFiles();
+    assertTrue(changedFiles.contains("overview withheld"), changedFiles);
+    // The PR has two changed files; the line-counting rollup claimed five.
+    assertFalse(changedFiles.contains("more changed files"), changedFiles);
+  }
+
+  /** A clamped overview with no per-file row at all is its header, with no rollup note. */
+  @Test
+  void aClampedOverviewWithNoFileRowsIsJustItsScopeHeader() {
+    var session = ReviewSession.create("owner/repo", 1, "All files ignored", "sha");
+    var ctx = reviewContext(List.of(), List.of(), new ReviewContextLoader.PrTotals(23, 1612, 240));
+    var template = new AiReviewService.PromptInputs("d", "d", "", "", "", "", "");
+    var inherited = PrReviewPrompts.SUMMARY_SYSTEM + PrReviewPrompts.SUMMARY_USER + "d";
+    when(budgetPlanner.perCallInputBudget())
+        .thenReturn(new TokenCounter().estimateTokens(inherited) + 400);
+    when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
+    when(aiReviewService.summarize(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+
+    assertEquals(
+        "PR scope (whole pull request): 23 files changed, +1612 -240\n",
+        captor.getValue().changedFiles());
+  }
+
+  /** With room for the header, the tail is still rolled up — by file count, and only files. */
+  @Test
+  void aClampedOverviewKeepsItsScopeHeaderAndCountsOnlyTheDroppedFiles() {
+    var session = ReviewSession.create("owner/repo", 1, "Wide PR", "sha");
+    var files = new ArrayList<FileDiff>();
+    for (var i = 0; i < 60; i++) {
+      files.add(
+          new FileDiff(
+              String.format("src/main/java/app/Component%02d.java", i), "modified", 3, 0, 3, ""));
+    }
+    var ctx = reviewContext(List.of(), files, null);
+    var template = new AiReviewService.PromptInputs("d", "d", "", "", "", "", "");
+    var inherited = PrReviewPrompts.SUMMARY_SYSTEM + PrReviewPrompts.SUMMARY_USER + "d";
+    when(budgetPlanner.perCallInputBudget())
+        .thenReturn(new TokenCounter().estimateTokens(inherited) + 400);
+    when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
+    when(aiReviewService.summarize(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+
+    var changedFiles = captor.getValue().changedFiles();
+    assertTrue(changedFiles.startsWith("PR scope (whole pull request): 60 files"), changedFiles);
+    assertTrue(changedFiles.contains("Directories touched: 1"), changedFiles);
+    var listed = 0;
+    var rolledUp = -1;
+    for (var line : changedFiles.split("\n")) {
+      if (line.contains(" (modified, +3 -0)")) {
+        listed++;
+      } else if (line.startsWith("(+")) {
+        rolledUp = Integer.parseInt(line.substring(2, line.indexOf(' ')));
+      }
+    }
+    assertTrue(listed > 0, changedFiles);
+    assertEquals(files.size() - listed, rolledUp, changedFiles);
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Three of the defects grouped in #486, all inside `FindingPipeline`.

### 1. The heuristic failure-mode dimension was dead under the shipped default (P3)

`ReviewPromptAssembler.assemble` gates `HEURISTIC_FAILURE_MODES_REQUEST` on `ctx.diff()`, and
`ReviewContextLoader.load` sets `diff` to `""` whenever `activeModel.maxInputTokens() > 0` — which
`thrillhousebot.review.max-input-tokens` defaults to `48000`. So on the shipped configuration the
detector was always handed an empty string, always answered "no heuristic code", and the whole
review dimension (#123 / #420) was never appended to a single review call. Nothing failed; the
dimension just silently contributed nothing.

The section is now decided in `FindingPipeline`, which is the first point that holds the material
the call actually receives — the plan's batch text — and it is decided **per batch**, so only the
batches whose own slice introduces a decision rule pay for the guidance. This is the same fallback
`VerdictBuilder.reviewedCode` already applies for the decline recheck ("with token budgeting on,
`ctx.diff()` is empty and the planned batches are authoritative"); the prompt-assembly path was the
one still reading the empty slot.

Two supporting details:

- **The failure is loud now.** A batch whose text is blank logs a WARN naming the dimension it
  could not evaluate, instead of being indistinguishable from a PR that genuinely introduces no
  heuristic code. That silence is what let the gap survive from before the feature existed.
- **File scoping is restored.** `HeuristicCodeDetector` scopes files by the unified-diff
  `+++ b/path` header, which the bot's rendered `### path (status, +a -d)` sections do not carry —
  so with the raw section text the detector's test-file exclusion (a fixture regex is not new
  production logic) would stop applying and its JS/TS regex-literal signal would never fire. The
  batch's own headers are translated before the scan; everything else passes through verbatim, so
  the detector reads exactly the added lines the model was given, clipping included.

Sizing note: the planner sized the shared overhead before this section existed, so a batch that
triggers it runs ~700 tokens over the planned overhead. That is the same shape as the
withheld-material notice this class already prepends after planning, and it is comfortably inside
the token safety margin (10% of 48000 ≈ 4800 tokens by default).

**Audit of the rest of the `combineSections` chain**, as the issue asks: `heuristicFailureModesSection`
is the only `ctx.diff()`-gated section. The others are driven by `repoLabels`, config, `relatedTests`
(derived from `reviewableFiles`, not the diff), `prDescription` + `linkedIssuesContext`,
`configKeyContext`, `patchCoverage` and the instruction resolvers — none reads `ctx.diff()`. The
`fencedDiff` slot itself does, and the pipeline already replaces it per batch.

### 2. `clampOverview` dropped the head it exists to protect, and miscounted (P4)

All three sub-issues, fixed as one: the overview is now split at the seam the clamp acts on — a
header block (pure-rename rollup + PR-scope totals, rendered first precisely so clamping can only
take the tail) and the per-file rows.

- The packing loop can no longer break at zero listed lines and emit a bare rollup note in the
  header's place. A budget too small to hold the header withholds the overview outright.
- The rollup note now counts files, because rows are all it can drop. Previously it counted lines,
  so the scope header, "Directories touched:" and the per-directory rows inflated it — a two-file
  PR was reported as "(+5 more changed files)".
- The `overviewBudget <= 0` guard became `overviewBudget - noteReserve < headerTokens`, so the
  "overview withheld" message is no longer bypassed when the budget is positive but below what the
  note and header need.

### 3. `unwrapParallelFailure` was dead code (P8, first half)

No production caller — the real retry path inlines the throw. Deleted, along with the two tests
that were keeping it alive.

### Explicitly not in this PR

The remaining parts of #486 live in files held by other agents in this round, so they are untouched
here rather than silently dropped: `/improve`'s budget-exhaustion message (P5, `PrImprovementService`),
the `max-ai-calls` and `max-diff-lines` javadoc drift (P6 / P8's second half, `ThrillhouseConfig`),
and the unbounded legacy render at `max-input-tokens <= 0` (P7, `DiffBudgetPlanner`).

One further gap found while verifying P3 and **not** fixed here: on the non-default
`max-input-tokens <= 0` path the assembler still feeds the detector `ctx.diff()`, which is rendered
in the same header-less `### path` form — so file scoping does not apply there either. Closing that
needs `ReviewPromptAssembler` or `HeuristicCodeDetector`, both outside this PR's scope.

## Related Issues

Partially fixes #486 (P3, P4, and P8's dead-code half).

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

New tests in `FindingPipelineTest`, failing on the unfixed code exactly as claimed:

```
[ERROR] Tests run: 67, Failures: 4, Errors: 0, Skipped: 0, Time elapsed: 6.119 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.anOverviewTooSmallForItsScopeHeaderIsWithheldNotReducedToABareRollup -- Time elapsed: 0.108 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
(+5 more changed files — overview truncated to fit the summary budget)
 ==> expected: <true> but was: <false>

[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.theHeuristicDimensionIsScopedToTheBatchThatIntroducesTheRule -- Time elapsed: 0.062 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>

[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.aBatchWithNoTextSaysTheHeuristicDimensionCouldNotBeEvaluated -- Time elapsed: 0.064 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the skipped dimension must be stated, not silent: [] ==> expected: <true> but was: <false>

[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.aBudgetedBatchThatIntroducesHeuristicCodeCarriesTheFailureModeDimension -- Time elapsed: 0.055 s <<< FAILURE!
org.opentest4j.AssertionFailedError: repo rules ==> expected: <true> but was: <false>
```

The first failure is the P4 proof in one line: the PR under test has two changed files, and the
clamp announced five — the head was dropped and the note counted lines.

Gates: `spotless:apply`, `clean compile spotbugs:check spotless:check` (BugInstance size is 0),
`clean test` (full suite green).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Scope is deliberately limited to `FindingPipeline` and its tests; the other #486 groups are listed
above so the issue can be closed only once they are all covered.
