### PR TITLE
fix(config): ship deepseek-v4-flash on the shared window it really has

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,23 +133,28 @@ AI_TIMEOUT=300s
 
 # Per-model AI settings (thrillhousebot.ai.models.<model>.*, keyed by the AI_MODEL name like the
 # pricing map). Keep entries for several models and switch AI_MODEL freely — only the active
-# model's entry is read. max-input-tokens is the model's input hard cap (context window): the
-# review budget is min(REVIEW_MAX_INPUT_TOKENS, cap), 128000 default cap without an entry.
-# output-buffer-tokens/token-safety-margin override the REVIEW_* defaults per model; the
+# model's entry is read. max-input-tokens is the model's input hard cap: the review budget is
+# min(REVIEW_MAX_INPUT_TOKENS, cap), 128000 default cap without an entry. context-tokens is the
+# model's total context window; declare it and boot fails when max-input-tokens + max-output-tokens
+# (or the effective budget plus the largest response cap in play) cannot fit inside it on a shared
+# window. output-buffer-tokens/token-safety-margin override the REVIEW_* defaults per model; the
 # generation parameters temperature, top-p, max-output-tokens, frequency-penalty,
 # presence-penalty, and seed are sent on every chat call when set (no top_k on the
 # OpenAI-compatible wire). A low temperature (e.g. 0.2) makes reviews more deterministic.
 #
 # separate-output-budget (default false) says whether the model's response allowance is its own or
 # a slice of the input window. Left false, prompt and completion share one window: the budgeter
-# reserves output-buffer-tokens out of the input budget and max-output-tokens may not exceed that
-# reservation (boot fails if it does). Set it true for a model that publishes its output allowance
-# on top of the input window — e.g. deepseek-v4-flash at 1M in and 384000 out, which ships that way
-# by default. Getting the flag wrong is loud in one direction and quiet in the other: marking a
-# separate-budget model shared refuses to boot when its max-output-tokens exceeds the buffer
-# (deepseek-v4-flash's shipped pair does), while a model without a response cap silently loses
-# output-buffer-tokens of diff budget per call to a reservation its responses never draw on:
-#THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_FLASH_SEPARATE_OUTPUT_BUDGET=true
+# reserves output-buffer-tokens out of the input budget, max-output-tokens may not exceed that
+# reservation, and the caps are held to context-tokens (boot fails if either is broken). Set it
+# true ONLY for a model that really publishes its output allowance on top of the input window;
+# check the provider's documented context length first. deepseek-v4-flash used to ship that way
+# (1M in, 384000 out) and it was wrong — the provider counts the completion against the same
+# 1048576-token context, so it rejected every call for length, five retries deep. Getting the flag
+# wrong is loud in one direction and quiet in the other: marking a separate-budget model shared
+# refuses to boot when its max-output-tokens exceeds the buffer, while marking a shared-window
+# model separate switches off every guard and the requests fail at the provider instead:
+#THRILLHOUSEBOT_AI_MODELS_SOME_MODEL_SEPARATE_OUTPUT_BUDGET=true
+#THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_FLASH_CONTEXT_TOKENS=1048576
 #
 # Env form: the underscores depend on whether the key needs quoting in application.properties.
 # A hyphen-only key (deepseek-v4-pro) is unquoted there and takes SINGLE underscores; a key with a

--- a/README.md
+++ b/README.md
@@ -510,9 +510,13 @@ model's entry is read, so you can keep entries for every model you use and
 switch `AI_MODEL` freely:
 
 ```properties
-# Input hard cap (the model's context window). The effective review budget is
-# min(REVIEW_MAX_INPUT_TOKENS, cap); models without an entry get a 128000 cap.
+# Input hard cap. The effective review budget is min(REVIEW_MAX_INPUT_TOKENS,
+# cap); models without an entry get a 128000 cap.
 thrillhousebot.ai.models.deepseek-chat.max-input-tokens=64000
+# The model's total context window. On a shared window the prompt and the
+# completion are both charged to it, so boot fails when max-input-tokens +
+# max-output-tokens do not fit inside it. Omit it and the ceiling isn't checked.
+thrillhousebot.ai.models.deepseek-chat.context-tokens=128000
 # Per-model overrides of REVIEW_OUTPUT_BUFFER_TOKENS / REVIEW_TOKEN_SAFETY_MARGIN
 thrillhousebot.ai.models.deepseek-chat.output-buffer-tokens=8192
 thrillhousebot.ai.models.deepseek-chat.token-safety-margin=0.9
@@ -523,9 +527,10 @@ thrillhousebot.ai.models.deepseek-chat.max-output-tokens=8192
 thrillhousebot.ai.models.deepseek-chat.frequency-penalty=0.1
 thrillhousebot.ai.models.deepseek-chat.presence-penalty=0.1
 thrillhousebot.ai.models.deepseek-chat.seed=42
-# Set true only when the model's response allowance is separate from its input
-# window (1M in with 384K out on top, rather than 384K carved out of the 1M)
-thrillhousebot.ai.models.deepseek-v4-flash.separate-output-budget=true
+# Set true only when the provider really bills the response outside the context
+# window (1M in with 384K out on top, rather than 384K carved out of the 1M) —
+# it switches off both the reservation and the context-tokens ceiling
+thrillhousebot.ai.models.some-separate-budget-model.separate-output-budget=true
 ```
 
 Notes:
@@ -534,6 +539,15 @@ Notes:
   stays the spend knob; the per-model value keeps it from overshooting the
   model's real window. To use a large-context model beyond 128k, raise both.
   Startup logs a warning whenever the cap lowers your configured budget.
+- **`context-tokens` is the window itself**, and declaring it is what lets the
+  bot refuse an impossible request instead of paying for one. On a shared
+  window the provider charges the prompt *and* the completion to that one
+  context, so boot fails when `max-input-tokens + max-output-tokens` exceed it,
+  and again when your effective budget (`REVIEW_MAX_INPUT_TOKENS` clamped by the
+  cap) plus the largest response cap in play — `max-output-tokens` or
+  `REVIEW_CONCISE_MAX_OUTPUT_TOKENS` — exceeds it. Without it, an over-large
+  pair is only discovered when the provider rejects every call for length.
+  It is optional: a model that doesn't declare one is simply not checked.
 - **Quote keys with `.` or `/`** (`thrillhousebot.ai.models."gpt-5.5".…`), the
   same rule as the pricing map. Override via env — hyphen-only keys use underscores
   (`THRILLHOUSEBOT_AI_MODELS_DEEPSEEK_V4_PRO_MAX_INPUT_TOKENS=1000000`); dotted keys use the
@@ -576,11 +590,15 @@ Notes:
   `output-buffer-tokens` out of the input budget, and the buffer must cover
   `max-output-tokens`. Set it `true` for a model that publishes a response
   allowance *on top of* its input window rather than inside it — then the
-  budgeter stops reserving (the response never draws on the diff budget) and the
-  buffer no longer has to cover the cap. Getting it wrong is expensive in one
-  direction and unbootable in the other, so it is explicit rather than inferred:
-  a 384000-token cap on a 1M window silently costs ~40% of every call's diff
-  budget if the model is wrongly marked shared.
+  budgeter stops reserving (the response never draws on the diff budget), the
+  buffer no longer has to cover the cap, and the completion stops counting
+  against `context-tokens`. Getting it wrong is expensive in one direction and
+  unbootable in the other, so it is explicit rather than inferred: a
+  384000-token cap on a 1M window silently costs ~40% of every call's diff
+  budget if the model is wrongly marked shared — while marking a genuinely
+  shared model separate turns off every guard and the provider rejects the
+  calls instead, which is how `deepseek-v4-flash` shipped its wrong pair.
+  Verify against the provider's own documented window before setting it.
 - **`seed`** is a best-effort determinism hint (same seed + same parameters aims
   for the same sampling) on providers that support it; unsupported providers
   ignore it. For deterministic reviews, prefer a low `temperature` first.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -101,6 +101,7 @@ public class StartupConfigValidator {
     validateBlockingStrictness(problems, config.review());
     validateModelSettings(problems, config.ai().models());
     validateEffectiveBudget(problems);
+    validateActiveModelWindow(problems);
     validateReasoningEffort(problems, config.ai().reasoning());
     validateConciseResponseCap(problems);
 
@@ -213,6 +214,11 @@ public class StartupConfigValidator {
               .filter(v -> v < 1)
               .ifPresent(v -> problems.add(prefix + "max-output-tokens must be >= 1: " + v));
           settings
+              .contextTokens()
+              .filter(v -> v < 1)
+              .ifPresent(v -> problems.add(prefix + "context-tokens must be >= 1: " + v));
+          validateWindowFits(problems, name, settings);
+          settings
               .frequencyPenalty()
               .filter(v -> !Double.isFinite(v) || v < -2.0 || v > 2.0)
               .ifPresent(
@@ -227,6 +233,56 @@ public class StartupConfigValidator {
                       problems.add(
                           prefix + "presence-penalty must be in [-2, 2] and finite: " + v));
         });
+  }
+
+  /**
+   * Rejects a model entry whose declared caps cannot both fit its declared context window (#562).
+   * On a shared window the provider charges the prompt and the completion to one context, so a
+   * {@code max-input-tokens} + {@code max-output-tokens} pair larger than {@code context-tokens}
+   * describes a request no prompt budget can rescue — the provider rejects it for length before any
+   * review work happens, and (as shipped for deepseek-v4-flash) retries it at full price.
+   *
+   * <p>Checked for every configured entry rather than only the active model, for the #502 reason:
+   * an unbootable pair in the shipped table is invisible until a deployment names that model. Not
+   * applied to a {@code separate-output-budget} model, whose completion is not drawn from the
+   * window at all, and skipped entirely when the model declares no window.
+   */
+  private static void validateWindowFits(
+      List<String> problems,
+      String name,
+      ThrillhouseConfig.AiPricingConfig.ModelSettings settings) {
+    if (settings.separateOutputBudget().orElse(false)) {
+      return;
+    }
+    var window = settings.contextTokens().filter(v -> v >= 1);
+    if (window.isEmpty()) {
+      return;
+    }
+    long input = settings.maxInputTokens().orElse(0);
+    long output = settings.maxOutputTokens().orElse(0);
+    if (input + output <= window.get()) {
+      return;
+    }
+    problems.add(
+        "model '"
+            + name
+            + "' cannot fit its own caps: max-input-tokens ("
+            + input
+            + ") + max-output-tokens ("
+            + output
+            + ") = "
+            + (input + output)
+            + " exceeds context-tokens ("
+            + window.get()
+            + ") (thrillhousebot.ai.models.\""
+            + name
+            + "\".*). On a shared window the provider counts the completion against the same"
+            + " context as the prompt, so a call using this budget is rejected for length however"
+            + " the prompt was packed. Lower the caps to fit the window, or set"
+            + " thrillhousebot.ai.models.\""
+            + name
+            + "\".separate-output-budget=true if this model's response allowance really is"
+            + " independent of its input window.");
   }
 
   /**
@@ -278,6 +334,55 @@ public class StartupConfigValidator {
                           + "\".separate-output-budget=true if this model's response allowance is"
                           + " independent of its input window."));
     }
+  }
+
+  /**
+   * The same window arithmetic as {@link #validateWindowFits}, applied to the values the active
+   * deployment will actually send: the effective input budget (the smaller of {@code
+   * REVIEW_MAX_INPUT_TOKENS} and the model's cap) plus the largest response cap any lane may
+   * request on this model — its own {@code max-output-tokens} or the concise lane's {@code
+   * REVIEW_CONCISE_MAX_OUTPUT_TOKENS}, whichever is bigger, since both are charged to the same
+   * window as the prompt.
+   *
+   * <p>This is the rule an environment can trip without touching the shipped table: {@code
+   * REVIEW_MAX_INPUT_TOKENS=1000000} against a 1048576-token window leaves less room for the
+   * response than the caps ask for, and the provider then refuses every call (#562). Skipped when
+   * token budgeting is off (no per-call input budget to bound), when the model's response draws on
+   * a budget of its own, and when the model declares no window.
+   */
+  private void validateActiveModelWindow(List<String> problems) {
+    if (activeModel.maxInputTokens() <= 0 || activeModel.separateOutputBudget()) {
+      return;
+    }
+    var window =
+        Optional.ofNullable(config.ai().models().get(activeModel.modelName()))
+            .flatMap(ThrillhouseConfig.AiPricingConfig.ModelSettings::contextTokens)
+            .filter(v -> v >= 1);
+    long input = activeModel.maxInputTokens();
+    long response =
+        Math.max(activeModel.maxOutputTokens().orElse(0), conciseMaxOutputTokens.orElse(0));
+    if (window.isEmpty() || input + response <= window.get()) {
+      return;
+    }
+    problems.add(
+        "the effective per-call budget for model '"
+            + activeModel.modelName()
+            + "' (max input "
+            + input
+            + " + response cap "
+            + response
+            + " = "
+            + (input + response)
+            + ") exceeds its context window (thrillhousebot.ai.models.\""
+            + activeModel.modelName()
+            + "\".context-tokens="
+            + window.get()
+            + "): the provider counts the prompt and the completion against one context, so the"
+            + " call is rejected for length before any review work happens. Lower"
+            + " REVIEW_MAX_INPUT_TOKENS, lower the response caps (thrillhousebot.ai.models.\""
+            + activeModel.modelName()
+            + "\".max-output-tokens / REVIEW_CONCISE_MAX_OUTPUT_TOKENS), or raise context-tokens if"
+            + " the model's window really is larger.");
   }
 
   private static void requirePresent(
@@ -529,6 +634,7 @@ public class StartupConfigValidator {
   private static final List<String> MODEL_SETTING_SUFFIXES =
       List.of(
           "MAX_INPUT_TOKENS",
+          "CONTEXT_TOKENS",
           "OUTPUT_BUFFER_TOKENS",
           "TOKEN_SAFETY_MARGIN",
           "MAX_OUTPUT_TOKENS",

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/ThrillhouseConfig.java
@@ -666,13 +666,28 @@ public interface ThrillhouseConfig {
       int DEFAULT_MAX_INPUT_TOKENS = 128_000;
 
       /**
-       * Hard cap on the per-call input tokens for this model — its context window. The effective
-       * review budget is the smaller of {@code thrillhousebot.review.max-input-tokens} and this cap
-       * ({@link #DEFAULT_MAX_INPUT_TOKENS} when absent), so a raised global budget can never
-       * overshoot a model's real window unless the operator raises the cap too.
+       * Hard cap on the per-call input tokens for this model. The effective review budget is the
+       * smaller of {@code thrillhousebot.review.max-input-tokens} and this cap ({@link
+       * #DEFAULT_MAX_INPUT_TOKENS} when absent), so a raised global budget can never overshoot a
+       * model's real window unless the operator raises the cap too.
        */
       @WithName("max-input-tokens")
       Optional<Integer> maxInputTokens();
+
+      /**
+       * The model's total context window — the pool the provider counts a request against. On a
+       * shared window (the default contract, {@link #separateOutputBudget()} off) prompt
+       * <em>and</em> completion are both charged to it, so {@link #maxInputTokens()} plus {@link
+       * #maxOutputTokens()} must fit inside it or every call is rejected as too long no matter how
+       * well the prompt was budgeted; {@link StartupConfigValidator} refuses such a boot (#562).
+       *
+       * <p>Absent means "not declared", and the ceiling is simply not checked — a model with no
+       * entry keeps exactly the previous behaviour. Distinct from {@link #maxInputTokens()} on
+       * purpose: that is how much of the window the review may spend on input, this is how much
+       * window there is.
+       */
+      @WithName("context-tokens")
+      Optional<Integer> contextTokens();
 
       /**
        * Per-model override of {@code thrillhousebot.review.output-buffer-tokens} — tokens held back
@@ -731,7 +746,9 @@ public interface ThrillhouseConfig {
        *
        * <p>Deliberately explicit rather than inferred from a model declaring both caps: getting
        * this wrong silently picks the wrong arithmetic, and an operator should be able to read
-       * which contract a model is on straight from its config.
+       * which contract a model is on straight from its config. Claiming it for a model whose
+       * provider actually shares the window is the expensive direction — the caps stop being held
+       * to {@link #contextTokens()}, and the provider rejects every call instead (#562).
        */
       @WithName("separate-output-budget")
       Optional<Boolean> separateOutputBudget();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -99,9 +99,12 @@ thrillhousebot.ai.reasoning.effort=${AI_REASONING_EFFORT:low}
 thrillhousebot.ai.reasoning.concise-effort=${AI_REASONING_EFFORT_CONCISE:}
 # Per-model AI settings keyed by the model name (the AI_MODEL value), mirroring the pricing map's
 # key scheme (#50). Only the active model's entry is read, so entries for several models can be
-# kept and AI_MODEL switched freely. max-input-tokens is the model's input hard cap (its context
-# window): the effective review budget is min(REVIEW_MAX_INPUT_TOKENS, cap), with a 128000 default
-# cap for models without an entry. output-buffer-tokens and token-safety-margin override the
+# kept and AI_MODEL switched freely. max-input-tokens is the model's input hard cap: the effective
+# review budget is min(REVIEW_MAX_INPUT_TOKENS, cap), with a 128000 default cap for models without
+# an entry. context-tokens is the model's total context window, which on a shared window the prompt
+# AND the completion are both counted against — declare it and the startup validator refuses a boot
+# whose max-input-tokens + max-output-tokens cannot fit inside it (#562), instead of letting the
+# provider reject every call. output-buffer-tokens and token-safety-margin override the
 # review-level defaults per model; temperature, top-p, max-output-tokens, frequency-penalty,
 # presence-penalty, and seed are sent on every chat call when set (the OpenAI-compatible wire
 # carries no top_k). Keys containing '.' or '/' must be double-quoted.
@@ -122,15 +125,21 @@ thrillhousebot.ai.reasoning.concise-effort=${AI_REASONING_EFFORT_CONCISE:}
 #thrillhousebot.ai.models.deepseek-chat.seed=42
 #
 # deepseek-v4-flash is the exception below: it ships its real caps rather than empty stubs, so a
-# deployment gets the model's own 1M input window instead of the 128000 fallback, and its full
-# 384000-token response allowance instead of the provider default.
+# deployment gets the model's own large window instead of the 128000 fallback.
 #
-# separate-output-budget=true is what makes that pair correct. Those two numbers do not compete:
-# the 384000 output is on top of the 1M input, not carved out of it. Without the flag the budgeter
-# would reserve 384000 out of the input budget for a response that never draws on it (costing ~40%
-# of the per-call diff), and the startup validator would refuse to boot unless output-buffer-tokens
-# were raised to match. Leave the flag off for a shared-window model (OpenAI-style, where prompt +
-# completion share one context) — there the reservation and the ceiling are both correct.
+# That window is SHARED (#562). The provider counts the completion against the same 1048576-token
+# context as the prompt — it refuses with "maximum context length is 1048576 tokens. However, you
+# requested 2446275 tokens (2062275 in the messages, 384000 in the completion)". So the entry
+# declares context-tokens and leaves separate-output-budget off. The previously shipped pair
+# (1000000 in + 384000 out, marked separate) described a contract this model is not on and could
+# not fit the context even with a correctly sized prompt, so every call was rejected.
+#
+# max-input-tokens keeps 148576 tokens of the window clear for the response, and max-output-tokens
+# matches the shipped REVIEW_OUTPUT_BUFFER_TOKENS reservation so that what the budgeter holds back
+# and what the provider is licensed to generate are the same number; raising one means raising the
+# other. Set separate-output-budget=true only for a model that really publishes a response
+# allowance on top of its input window — there the budgeter reserves nothing, the buffer need not
+# cover the cap, and the completion is not counted against context-tokens.
 thrillhousebot.ai.models."gpt-5.5".max-input-tokens=
 thrillhousebot.ai.models."gpt-5.5-pro".max-input-tokens=
 thrillhousebot.ai.models."gpt-5.4".max-input-tokens=
@@ -138,9 +147,9 @@ thrillhousebot.ai.models."gpt-5.4-mini".max-input-tokens=
 thrillhousebot.ai.models."gpt-5.4-nano".max-input-tokens=
 thrillhousebot.ai.models.gpt-4o.max-input-tokens=
 thrillhousebot.ai.models.gpt-4o-mini.max-input-tokens=
-thrillhousebot.ai.models.deepseek-v4-flash.max-input-tokens=1000000
-thrillhousebot.ai.models.deepseek-v4-flash.max-output-tokens=384000
-thrillhousebot.ai.models.deepseek-v4-flash.separate-output-budget=true
+thrillhousebot.ai.models.deepseek-v4-flash.context-tokens=1048576
+thrillhousebot.ai.models.deepseek-v4-flash.max-input-tokens=900000
+thrillhousebot.ai.models.deepseek-v4-flash.max-output-tokens=8192
 thrillhousebot.ai.models.deepseek-v4-pro.max-input-tokens=
 thrillhousebot.ai.models.deepseek-chat.max-input-tokens=
 thrillhousebot.ai.models.deepseek-reasoner.max-input-tokens=

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/AiPricingConfigTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/AiPricingConfigTest.java
@@ -85,18 +85,56 @@ class AiPricingConfigTest {
   }
 
   @Test
-  void shouldShipDeepSeekV4FlashContextAndOutputCaps() {
+  void shouldShipDeepSeekV4FlashCapsThatFitItsSharedContextWindow() {
     // Unlike the other entries in the models map, deepseek-v4-flash ships real values rather than
     // an empty binding stub, so the caps are a shipped default a deployment inherits silently.
+    // #562: the provider counts the completion against the same 1048576-token context as the
+    // prompt ("2062275 in the messages, 384000 in the completion" against that limit), so the
+    // entry must describe a shared window — the shipped 1000000 in + 384000 out marked
+    // separate-output-budget could not fit that context under any prompt budget.
     var settings = config.ai().models().get("deepseek-v4-flash");
     assertNotNull(settings, "deepseek-v4-flash model settings must resolve");
-    assertEquals(1_000_000, settings.maxInputTokens().orElseThrow());
-    assertEquals(384_000, settings.maxOutputTokens().orElseThrow());
     assertEquals(
-        Optional.of(true),
+        Optional.empty(),
         settings.separateOutputBudget(),
-        "the 384000 output is on top of the 1M input, not carved out of it — without this flag the"
-            + " shipped pair cannot boot and would cost ~40% of the diff budget if it could");
+        "this model's completion is spent out of its context window, so it must stay on the shared"
+            + " contract where the buffer is reserved and the caps are held to context-tokens");
+    assertEquals(1_048_576, settings.contextTokens().orElseThrow());
+    assertEquals(900_000, settings.maxInputTokens().orElseThrow());
+    assertEquals(8_192, settings.maxOutputTokens().orElseThrow());
+    assertTrue(
+        settings.maxInputTokens().orElseThrow() + settings.maxOutputTokens().orElseThrow()
+            <= settings.contextTokens().orElseThrow(),
+        "prompt + completion must fit the one context the provider charges them to");
+  }
+
+  @Test
+  void noShippedModelsCapsExceedItsDeclaredContextWindow() {
+    // Sibling of the buffer walk below: a shipped pair that cannot fit its own window refuses
+    // every deployment naming that model, and the validator's rule only fires for the ACTIVE one.
+    config
+        .ai()
+        .models()
+        .forEach(
+            (model, settings) -> {
+              if (settings.separateOutputBudget().orElse(false)) {
+                return; // its completion is not charged to the window
+              }
+              settings
+                  .contextTokens()
+                  .ifPresent(
+                      window ->
+                          assertTrue(
+                              settings.maxInputTokens().orElse(0)
+                                      + settings.maxOutputTokens().orElse(0)
+                                  <= window,
+                              "shipped max-input-tokens + max-output-tokens for '"
+                                  + model
+                                  + "' exceeds its context-tokens "
+                                  + window
+                                  + " — on a shared window the provider rejects every call at that"
+                                  + " budget, whatever the prompt budgeter does"));
+            });
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -232,6 +232,7 @@ class StartupConfigValidatorTest {
     lenient().when(settings.presencePenalty()).thenReturn(Optional.empty());
     lenient().when(settings.seed()).thenReturn(Optional.empty());
     lenient().when(settings.separateOutputBudget()).thenReturn(Optional.empty());
+    lenient().when(settings.contextTokens()).thenReturn(Optional.empty());
     return settings;
   }
 
@@ -541,6 +542,213 @@ class StartupConfigValidatorTest {
 
     var ex = assertFailsValidation(new ConfigBuilder().model("deepseek-chat", settings).build());
     assertTrue(ex.getMessage().contains("must be >= max-output-tokens (384000)"), ex.getMessage());
+  }
+
+  @Nested
+  class SharedContextWindow {
+
+    /**
+     * The exact shipped-default shape #562 was filed for, minus the separate-output-budget flag.
+     */
+    private ThrillhouseConfig.AiPricingConfig.ModelSettings flashCaps(int input, int output) {
+      var settings = emptyModelSettings();
+      lenient().when(settings.contextTokens()).thenReturn(Optional.of(1_048_576));
+      lenient().when(settings.maxInputTokens()).thenReturn(Optional.of(input));
+      lenient().when(settings.maxOutputTokens()).thenReturn(Optional.of(output));
+      return settings;
+    }
+
+    @Test
+    void failsFastWhenAModelsOwnCapsCannotBothFitItsContextWindow() {
+      // #562: the provider counts the completion against the same 1048576-token context as the
+      // prompt ("2062275 in the messages, 384000 in the completion"), so 1000000 in + 384000 out
+      // is a request no prompt budget can rescue — and it was retried five times at full price.
+      // Held against an INACTIVE entry here: a shipped pair that cannot boot must be rejected
+      // before some deployment switches AI_MODEL to it.
+      var ex =
+          assertFailsValidation(
+              new ConfigBuilder()
+                  .modelName("deepseek-chat")
+                  .model("deepseek-v4-flash", flashCaps(1_000_000, 384_000))
+                  .build());
+      assertTrue(
+          ex.getMessage()
+              .contains(
+                  "model 'deepseek-v4-flash' cannot fit its own caps: max-input-tokens (1000000) +"
+                      + " max-output-tokens (384000) = 1384000 exceeds context-tokens (1048576)"),
+          ex.getMessage());
+      assertTrue(
+          ex.getMessage().contains("separate-output-budget=true"),
+          "the failure must name the other contract as the way out: " + ex.getMessage());
+    }
+
+    @Test
+    void bootsWhenTheCapsFitTheContextWindow() {
+      new ConfigBuilder()
+          .modelName("deepseek-v4-flash")
+          .model("deepseek-v4-flash", flashCaps(900_000, 8_192))
+          .build()
+          .validate();
+    }
+
+    @Test
+    void bootsWhenTheCapsExactlyFillTheContextWindow() {
+      // The boundary is inclusive: a pair that exactly fills the window is sendable.
+      new ConfigBuilder()
+          .modelName("deepseek-v4-flash")
+          .model("deepseek-v4-flash", flashCaps(1_040_384, 8_192))
+          .build()
+          .validate();
+    }
+
+    @Test
+    void skipsTheWindowRuleForASeparateOutputBudgetModel() {
+      // A model that really publishes its response allowance on top of the input window does not
+      // spend the window on completions, so the sum is not the provider's arithmetic there.
+      var settings = flashCaps(1_000_000, 384_000);
+      lenient().when(settings.separateOutputBudget()).thenReturn(Optional.of(true));
+
+      new ConfigBuilder().modelName("deepseek-chat").model("separate", settings).build().validate();
+    }
+
+    @Test
+    void skipsTheWindowRuleWhenTheModelDeclaresNoWindow() {
+      // context-tokens is optional; a model with no declared window keeps the previous behaviour
+      // rather than being assumed to have one.
+      var settings = emptyModelSettings();
+      lenient().when(settings.maxInputTokens()).thenReturn(Optional.of(1_000_000));
+      lenient().when(settings.maxOutputTokens()).thenReturn(Optional.of(384_000));
+      lenient().when(settings.outputBufferTokens()).thenReturn(Optional.of(384_000));
+
+      new ConfigBuilder()
+          .modelName("undeclared")
+          .maxInputTokens(1_000_000)
+          .model("undeclared", settings)
+          .build()
+          .validate();
+    }
+
+    @Test
+    void failsFastWhenContextTokensIsNotPositive() {
+      var settings = emptyModelSettings();
+      lenient().when(settings.contextTokens()).thenReturn(Optional.of(0));
+
+      var ex = assertFailsValidation(new ConfigBuilder().model("zero-window", settings).build());
+      assertTrue(
+          ex.getMessage()
+              .contains("thrillhousebot.ai.models.\"zero-window\".context-tokens must be >= 1: 0"),
+          ex.getMessage());
+    }
+
+    @Test
+    void failsFastWhenTheEffectiveInputBudgetOverrunsAWindowSmallerThanTheDefaultCap() {
+      // A model that declares its window but no max-input-tokens falls back to the 128000 default
+      // cap, so the effective budget can exceed the real window with nothing in the entry looking
+      // wrong. Checked on the resolved values for that reason.
+      var settings = emptyModelSettings();
+      lenient().when(settings.contextTokens()).thenReturn(Optional.of(32_768));
+
+      var ex =
+          assertFailsValidation(
+              new ConfigBuilder().modelName("small").model("small", settings).build());
+      assertTrue(
+          ex.getMessage()
+              .contains(
+                  "the effective per-call budget for model 'small' (max input 48000 + response cap"
+                      + " 8192 = 56192) exceeds its context window"),
+          ex.getMessage());
+      assertTrue(ex.getMessage().contains("REVIEW_MAX_INPUT_TOKENS"), ex.getMessage());
+    }
+
+    @Test
+    void countsTheConciseCapAsTheResponseTermWhenItIsTheLargerOne() {
+      // The production shape #562 was filed from: the entry's own caps fit the window, but the
+      // summary/verifier/reply calls send REVIEW_CONCISE_MAX_OUTPUT_TOKENS against that same
+      // window, so the worst case per call is the largest cap any lane may request.
+      var settings = emptyModelSettings();
+      lenient().when(settings.contextTokens()).thenReturn(Optional.of(1_048_576));
+      lenient().when(settings.maxInputTokens()).thenReturn(Optional.of(1_000_000));
+      lenient().when(settings.outputBufferTokens()).thenReturn(Optional.of(65_536));
+
+      var ex =
+          assertFailsValidation(
+              new ConfigBuilder()
+                  .modelName("deepseek-v4-flash")
+                  .maxInputTokens(1_000_000)
+                  .conciseMaxOutputTokens(Optional.of(65_536))
+                  .model("deepseek-v4-flash", settings)
+                  .build());
+      assertTrue(
+          ex.getMessage().contains("(max input 1000000 + response cap 65536 = 1065536)"),
+          ex.getMessage());
+      assertTrue(
+          ex.getMessage().contains("REVIEW_CONCISE_MAX_OUTPUT_TOKENS"),
+          "the remedy must name the cap that actually drove the overrun: " + ex.getMessage());
+    }
+
+    @Test
+    void bootsWithTheWorkingProductionCombinationOnTheSharedWindow() {
+      // 900000 in + 96000 out = 996000 of the 1048576 window — the values a deployment is running
+      // today. The rule must accept what demonstrably works, not just refuse what does not.
+      var settings = flashCaps(900_000, 96_000);
+      lenient().when(settings.outputBufferTokens()).thenReturn(Optional.of(96_000));
+
+      new ConfigBuilder()
+          .modelName("deepseek-v4-flash")
+          .maxInputTokens(900_000)
+          .conciseMaxOutputTokens(Optional.of(65_536))
+          .model("deepseek-v4-flash", settings)
+          .build()
+          .validate();
+    }
+
+    @Test
+    void skipsTheEffectiveWindowRuleWhenTokenBudgetingIsDisabled() {
+      // With budgeting off there is no per-call input budget to bound, exactly like the other
+      // budget rules — even against a window smaller than the concise cap.
+      var settings = emptyModelSettings();
+      lenient().when(settings.contextTokens()).thenReturn(Optional.of(4_096));
+
+      new ConfigBuilder()
+          .modelName("tiny")
+          .maxInputTokens(0)
+          .model("tiny", settings)
+          .build()
+          .validate();
+    }
+
+    @Test
+    void skipsTheEffectiveWindowRuleForASeparateOutputBudgetModel() {
+      var settings = flashCaps(1_048_576, 8_192);
+      lenient().when(settings.separateOutputBudget()).thenReturn(Optional.of(true));
+
+      new ConfigBuilder()
+          .modelName("separate")
+          .maxInputTokens(1_048_576)
+          .model("separate", settings)
+          .build()
+          .validate();
+    }
+
+    @Test
+    void reportsOnlyTheRealProblemWhenTheActiveModelsWindowIsNotPositive() {
+      // A window of 0 is rejected on its own terms; treating it as a real ceiling as well would
+      // add a second, derived complaint ("48000 + 8192 exceeds 0") that tells the operator nothing
+      // and hides which key is actually wrong.
+      var settings = emptyModelSettings();
+      lenient().when(settings.contextTokens()).thenReturn(Optional.of(0));
+
+      var ex =
+          assertFailsValidation(
+              new ConfigBuilder().modelName("zero-window").model("zero-window", settings).build());
+      assertTrue(ex.getMessage().contains("context-tokens must be >= 1: 0"), ex.getMessage());
+      assertFalse(ex.getMessage().contains("exceeds its context window"), ex.getMessage());
+    }
+
+    @Test
+    void skipsTheEffectiveWindowRuleWhenTheActiveModelDeclaresNoWindow() {
+      new ConfigBuilder().modelName("deepseek-chat").maxInputTokens(1_048_576).build().validate();
+    }
   }
 
   @Test
@@ -884,6 +1092,9 @@ class StartupConfigValidatorTest {
         @WithName("max-input-tokens")
         Optional<Integer> maxInputTokens();
 
+        @WithName("context-tokens")
+        Optional<Integer> contextTokens();
+
         @WithName("max-output-tokens")
         Optional<Integer> maxOutputTokens();
 
@@ -941,6 +1152,7 @@ class StartupConfigValidatorTest {
           (name, probe) -> {
             var settings = emptyModelSettings();
             lenient().when(settings.maxInputTokens()).thenReturn(probe.maxInputTokens());
+            lenient().when(settings.contextTokens()).thenReturn(probe.contextTokens());
             lenient().when(settings.maxOutputTokens()).thenReturn(probe.maxOutputTokens());
             lenient().when(settings.outputBufferTokens()).thenReturn(probe.outputBufferTokens());
             lenient()


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [x] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

The shipped `deepseek-v4-flash` entry described a contract the model is not on. It claimed 1,000,000
input tokens with 384,000 output on a **separate** budget; the provider counts the completion against
the same 1,048,576-token context as the prompt and refuses the call:

```
This model's maximum context length is 1048576 tokens. However, you requested 2446275 tokens
(2062275 in the messages, 384000 in the completion).
```

That pair cannot fit the context even with a perfectly budgeted prompt — 1,000,000 + 384,000 is over
the limit before a single diff line is packed.

**1. The defaults now describe the provider's actual behaviour.**

```properties
thrillhousebot.ai.models.deepseek-v4-flash.context-tokens=1048576
thrillhousebot.ai.models.deepseek-v4-flash.max-input-tokens=900000
thrillhousebot.ai.models.deepseek-v4-flash.max-output-tokens=8192
```

`separate-output-budget` is gone (shared is the default and the correct contract). `max-input-tokens`
keeps 148,576 tokens of window clear for the response — the same headroom as the values a deployment
is demonstrably running today (900000 in / 96000 out = 996,000 of 1,048,576). The shipped
`max-output-tokens` matches the shipped `REVIEW_OUTPUT_BUFFER_TOKENS` reservation (8192), so the
number the budgeter holds back and the number the provider is licensed to generate agree by
construction; raising one means raising the other, which is exactly what the shared-window rules
enforce. The old 384000 response allowance is not replaced with another guess: on a shared window it
would spend 37% of every call's context on the completion.

**2. A `max-input + max-output > context` pair is now refused at boot**, following the
`StartupConfigValidator` fail-fast pattern:

- **Per entry** (`validateWindowFits`, alongside the other per-model rules): a shared-window model
  that declares `context-tokens` must fit `max-input-tokens + max-output-tokens` inside it. Checked
  for *every* configured entry, not only the active one — the #502 lesson: a bad pair in the shipped
  table is otherwise invisible until someone points `AI_MODEL` at it.
- **Per deployment** (`validateActiveModelWindow`): the same ceiling on the values that will actually
  be sent — the effective input budget (`REVIEW_MAX_INPUT_TOKENS` clamped by the model cap) plus the
  largest response cap any lane may request, i.e. `max-output-tokens` **or**
  `REVIEW_CONCISE_MAX_OUTPUT_TOKENS`, since the summary/verifier/reply calls are charged to the same
  window. This is the rule an environment can trip without touching the shipped table.

Both are skipped for a `separate-output-budget` model (its completion is not drawn from the window)
and for a model that declares no `context-tokens`, so existing configurations are unaffected. A
non-positive `context-tokens` is rejected on its own terms and does not produce a second, derived
complaint.

Worth being explicit about the limit of this: the validator closes the *shared-window* hole the issue
asks for, but it could not have caught the shipped mistake by itself. `separate-output-budget=true`
is a factual claim about the provider, and claiming it wrongly is precisely what switches every guard
off. Only a runtime signal — the provider's own length rejection — can falsify it, which is part 3.

**3. The 5x retry of a context-length rejection is deliberately NOT in this PR.** It is a different
file lane (the AI call/retry path, same class as #495 and #508 — a deterministically invalid request
that fails identically on every attempt), it has its own red/green proof, and mixing a retry-policy
change into a config correction would make both harder to review and to revert. It should be a
separate PR against the same milestone; this PR removes the misconfiguration that triggered it, not
the burn itself.

Docs: README's per-model section (inlined into the docs site), `.env.example`, and the properties
comments now state the shared-window arithmetic and warn that marking a shared-window model
`separate` turns off every guard.

## Related Issues

Fixes #562

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

Full suite: `Tests run: 2861, Failures: 0, Errors: 0, Skipped: 0` — BUILD SUCCESS.
Docs site (`cd website && npm ci && npm run build`): 66 pages built, "All internal links are valid."

### Red proof

Against the unfixed code (fix reverted, new tests kept):

Shipped defaults restored to `max-input-tokens=1000000` / `max-output-tokens=384000` /
`separate-output-budget=true`:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.config.AiPricingConfigTest.shouldShipDeepSeekV4FlashCapsThatFitItsSharedContextWindow -- Time elapsed: 0.014 s <<< FAILURE!
org.opentest4j.AssertionFailedError: this model's completion is spent out of its context window, so it must stay on the shared contract where the buffer is reserved and the caps are held to context-tokens ==> expected: <Optional.empty> but was: <Optional[true]>
	at dev.thiagogonzaga.thrillhousebot.config.AiPricingConfigTest.shouldShipDeepSeekV4FlashCapsThatFitItsSharedContextWindow(AiPricingConfigTest.java:97)
```

Validator rules removed (both call sites), shipped defaults also reverted:

```
[ERROR] Tests run: 12, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 0.037 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest$SharedContextWindow
[ERROR] dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest.failsFastWhenTheEffectiveInputBudgetOverrunsAWindowSmallerThanTheDefaultCap -- Time elapsed: 0.003 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Expected dev.thiagogonzaga.thrillhousebot.config.ConfigValidationException to be thrown, but nothing was thrown.
	at org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3234)
	at dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest.assertFailsValidation(StartupConfigValidatorTest.java:240)
	at dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest$SharedContextWindow.failsFastWhenTheEffectiveInputBudgetOverrunsAWindowSmallerThanTheDefaultCap(StartupConfigValidatorTest.java:652)

[ERROR] dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest.failsFastWhenAModelsOwnCapsCannotBothFitItsContextWindow -- Time elapsed: 0.002 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Expected dev.thiagogonzaga.thrillhousebot.config.ConfigValidationException to be thrown, but nothing was thrown.
	at org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3234)
	at dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest.assertFailsValidation(StartupConfigValidatorTest.java:240)
	at dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest$SharedContextWindow.failsFastWhenAModelsOwnCapsCannotBothFitItsContextWindow(StartupConfigValidatorTest.java:569)

[ERROR] dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest.countsTheConciseCapAsTheResponseTermWhenItIsTheLargerOne -- Time elapsed: 0.002 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Expected dev.thiagogonzaga.thrillhousebot.config.ConfigValidationException to be thrown, but nothing was thrown.
	at org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3234)
	at dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest.assertFailsValidation(StartupConfigValidatorTest.java:240)
	at dev.thiagogonzaga.thrillhousebot.config.StartupConfigValidatorTest$SharedContextWindow.countsTheConciseCapAsTheResponseTermWhenItIsTheLargerOne(StartupConfigValidatorTest.java:674)
```

"Nothing was thrown" is the defect stated exactly: a configuration that cannot possibly work booted
cleanly. Note that the existing guard test `everyShippedModelBootsUnderTheShippedConciseCap` passes
in **both** states — booting was never the problem, which is why the ceiling rule was needed.

The new `context-tokens` accessor has to exist for the new tests to compile, so "unfixed" above means
the config key present with the rules and shipped values reverted; there is no way to compile a test
for a key against a tree that does not declare it.

### Gates

- `./mvnw -B spotless:apply` → clean
- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, `Error size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` → 2861 tests, 0 failures, 0 errors
- Coverage: jacoco ∩ `git diff -U0 469539e...HEAD` over changed main code (`StartupConfigValidator`,
  `ThrillhouseConfig`) → 35 executable changed lines, **zero uncovered lines and zero uncovered
  branches**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

**Operator-facing change.** A deployment that overrode the flash caps to the old shape needs to
re-check them: with `separate-output-budget` gone, `REVIEW_OUTPUT_BUFFER_TOKENS` must cover
`max-output-tokens` again, and `REVIEW_MAX_INPUT_TOKENS` + the largest response cap must fit
1,048,576. The proven combination (900000 / 96000 / 65536, with the buffer raised to 96000) boots and
is covered by a test.

This PR does not touch defect 2 from the issue (the token estimate running ~2.2–2.3x under the
provider's count). That needs measurement first and lives in the budgeter/tokenizer lane.
