### PR TITLE
docs(dev-mode): state the .env and PEM steps a fresh clone needs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,11 @@
 
 # GitHub App
 GITHUB_APP_ID=your_app_id
-GITHUB_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+# The PKCS#1 .pem GitHub downloads when you generate an App private key, on ONE line with literal
+# \n escapes and no surrounding quotes — quotes are read as part of the key and the bot refuses to
+# boot. Throwaway key for local development:
+#   openssl genrsa -traditional 2048 | awk '{printf "%s\\n", $0}'
+GITHUB_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----
 GITHUB_WEBHOOK_SECRET=your_webhook_secret
 # Optional: the bot's own GitHub login(s), comma-separated. Override when the App is deployed under a
 # different slug (its bot login is <app-slug>[bot]); keeps loop protection, /resolve, summary dedup,

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Edit `.env` with the credentials from step 1:
 | Variable | Value |
 |---|---|
 | `GITHUB_APP_ID` | From GitHub App settings → About |
-| `GITHUB_PRIVATE_KEY` | Downloaded when you generated a private key |
+| `GITHUB_PRIVATE_KEY` | The `.pem` downloaded when you generated a private key — on one line, newlines as `\n`, unquoted |
 | `GITHUB_WEBHOOK_SECRET` | The webhook secret you set |
 | `GITHUB_CLIENT_ID` | From app settings → Identifying and authorizing users |
 | `GITHUB_CLIENT_SECRET` | From app settings → Identifying and authorizing users |
@@ -880,6 +880,37 @@ and a [Smee.io](https://smee.io/) channel for webhook forwarding. Use `./mvnw`
 for Maven (wrapper included).
 
 ### Dev mode
+
+Dev mode reads configuration from a `.env` file in the project root, and a fresh clone has none —
+the bot refuses to boot until `GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET` and
+`AI_API_KEY` are all set. Create the file first:
+
+```bash
+cp .env.example .env
+```
+
+Fill it in with the credentials from your GitHub App (see [GitHub App setup](#github-app-setup)).
+`GITHUB_PRIVATE_KEY` has to be a real PEM RSA key — placeholder text is rejected at boot, not on
+first use. Use the `.pem` GitHub gives you when you generate an App private key, or generate a
+throwaway one for purely local work:
+
+```bash
+openssl genrsa -traditional 2048 | awk '{printf "%s\\n", $0}'
+```
+
+`-traditional` matters: it writes the PKCS#1 (`BEGIN RSA PRIVATE KEY`) format GitHub's own keys
+use, which is the only format the bot parses — OpenSSL 3 otherwise defaults to PKCS#8. The `awk`
+step folds the key onto one line with literal `\n` escapes, which is what `.env` needs. Paste that
+line in **unquoted**:
+
+```dotenv
+GITHUB_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\nMIIEow...\n-----END RSA PRIVATE KEY-----
+```
+
+Surrounding quotes are read as part of the key and boot fails. `GITHUB_WEBHOOK_SECRET` and
+`AI_API_KEY` only need to be non-empty to boot, but must be the real values before webhooks
+verify and reviews run; dashboard OAuth (`GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`) is optional
+and its absence only disables dashboard login. Then:
 
 ```bash
 # Terminal 1: Smee proxy

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -48,6 +48,17 @@ public class StartupConfigValidator {
   private static final String PRIVATE_KEY_PROPERTY = "thrillhousebot.github.private-key";
   private static final String APP_ID_PROPERTY = "thrillhousebot.github.app-id";
 
+  /**
+   * The remedy carried by every {@code GITHUB_PRIVATE_KEY} problem. A fresh clone fails here with
+   * placeholder text copied straight out of {@code .env.example} (#593), and the refusal is where
+   * the reader actually is — so it states the accepted format, the single-line spelling {@code
+   * .env} needs, and a command that produces a usable key, rather than only naming the property.
+   */
+  private static final String PRIVATE_KEY_REMEDY =
+      "Use the PKCS#1 PEM GitHub downloads when you generate an App private key, on one line with"
+          + " \\n escapes and no surrounding quotes; for a throwaway local key run: openssl genrsa"
+          + " -traditional 2048";
+
   private final ThrillhouseConfig config;
   private final String aiApiKey;
   private final ActiveModelSettings activeModel;
@@ -305,7 +316,11 @@ public class StartupConfigValidator {
 
   private static void validatePrivateKey(List<String> problems, String privateKey) {
     if (privateKey == null || privateKey.isBlank()) {
-      problems.add("GITHUB_PRIVATE_KEY is required but is not set (" + PRIVATE_KEY_PROPERTY + ")");
+      problems.add(
+          "GITHUB_PRIVATE_KEY is required but is not set ("
+              + PRIVATE_KEY_PROPERTY
+              + "). "
+              + PRIVATE_KEY_REMEDY);
       return;
     }
     try {
@@ -315,7 +330,9 @@ public class StartupConfigValidator {
           "GITHUB_PRIVATE_KEY is set but is not a valid PEM RSA private key ("
               + PRIVATE_KEY_PROPERTY
               + "): "
-              + e.getMessage());
+              + e.getMessage()
+              + ". "
+              + PRIVATE_KEY_REMEDY);
     }
   }
 
@@ -632,8 +649,9 @@ public class StartupConfigValidator {
     }
     sb.append(System.lineSeparator())
         .append(
-            "Set the values above (see .env.example) and restart. Dashboard OAuth"
-                + " (GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET) is optional.");
+            "Copy .env.example to .env in the project root (both dev mode and docker compose read"
+                + " it), set the values above, and restart. Dashboard OAuth (GITHUB_CLIENT_ID /"
+                + " GITHUB_CLIENT_SECRET) is optional.");
     return sb.toString();
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -288,6 +288,34 @@ class StartupConfigValidatorTest {
   }
 
   @Test
+  void missingPrivateKeyNamesHowToObtainOne() {
+    // The refusal is where the reader actually is, so it has to state the remedy — which key
+    // format is accepted and the command that produces a throwaway one — not only the property.
+    var message = assertFailsValidation(new ConfigBuilder().privateKey("  ").build()).getMessage();
+    assertTrue(message.contains("openssl genrsa -traditional 2048"), message);
+    assertTrue(message.contains("no surrounding quotes"), message);
+  }
+
+  @Test
+  void malformedPrivateKeyNamesHowToObtainOne() {
+    // Placeholder text is the fresh-clone case (#593): the parser error alone does not tell the
+    // reader what a valid value looks like.
+    var message =
+        assertFailsValidation(new ConfigBuilder().privateKey("not-a-valid-key").build())
+            .getMessage();
+    assertTrue(message.contains("openssl genrsa -traditional 2048"), message);
+    assertTrue(message.contains("no surrounding quotes"), message);
+  }
+
+  @Test
+  void refusalNamesCopyingEnvExampleAsTheFirstStep() {
+    // A fresh clone has no .env at all, so the closing line has to name the copy step rather than
+    // merely point at the example file.
+    var message = assertFailsValidation(new ConfigBuilder().aiApiKey("").build()).getMessage();
+    assertTrue(message.contains("Copy .env.example to .env"), message);
+  }
+
+  @Test
   void failsFastWhenWebhookSecretMissing() {
     var ex = assertFailsValidation(new ConfigBuilder().webhookSecret(null).build());
     assertTrue(ex.getMessage().contains("GITHUB_WEBHOOK_SECRET"), ex.getMessage());

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -97,7 +97,7 @@ Edit `.env` with the credentials from step 1:
 | Variable | Value |
 |---|---|
 | `GITHUB_APP_ID` | From GitHub App settings → About |
-| `GITHUB_PRIVATE_KEY` | Downloaded when you generated a private key |
+| `GITHUB_PRIVATE_KEY` | The `.pem` downloaded when you generated a private key — on one line, newlines as `\n`, unquoted |
 | `GITHUB_WEBHOOK_SECRET` | The webhook secret you set |
 | `GITHUB_CLIENT_ID` | From app settings → Identifying and authorizing users |
 | `GITHUB_CLIENT_SECRET` | From app settings → Identifying and authorizing users |


### PR DESCRIPTION
## What type of PR is this?

- [x] 📝 Documentation
- [x] 🐛 Bug fix

## Description

`./mvnw quarkus:dev` refuses to boot on a fresh clone: `StartupConfigValidator` hard-requires
`GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET` and `AI_API_KEY`. That refusal is
correct and stays. What was missing is discoverability — the README dev-mode section never named
the `.env.example` → `.env` step, and never said the private key has to be a real generated PEM.

**README dev-mode section** now states the `cp .env.example .env` step, the PEM requirement, and a
one-line command for a throwaway key:

```bash
openssl genrsa -traditional 2048 | awk '{printf "%s\\n", $0}'
```

`-traditional` is load-bearing. `RsaPrivateKeyParser` only strips PKCS#1 armor
(`BEGIN RSA PRIVATE KEY`), and OpenSSL 3's `genrsa` writes PKCS#8 by default, so a key generated
without the flag is rejected at boot exactly like placeholder text. Verified directly against the
parser:

```
pkcs8.pem     -> REJECTED: Could not parse RSA private key: Illegal base64 character 2d
key (pkcs1)   -> OK
```

**`.env.example` shipped a value that cannot work.** The private key was double-quoted; the
surrounding quotes are read as part of the value in dev mode and boot fails with
`Illegal base64 character 22` (`"`). The example is now the unquoted single-line form with `\n`
escapes, which was verified to work on both paths — `quarkus:dev`, and the docker compose
`env_file` path (`docker compose run` shows the literal `\n` reaching the container, which the
parser handles).

**Validator message.** The refusal is where the reader actually is, so it now names the remedy:
every `GITHUB_PRIVATE_KEY` problem carries the accepted format, the single-line spelling and the
openssl command, and the closing line says to copy `.env.example` to `.env` rather than merely
pointing at the file. The real refusal now reads:

```
ThrillhouseBot cannot start — required configuration is missing or invalid:
  - GITHUB_PRIVATE_KEY is set but is not a valid PEM RSA private key (thrillhousebot.github.private-key): Could not parse RSA private key: Illegal base64 character 2e. Use the PKCS#1 PEM GitHub downloads when you generate an App private key, on one line with \n escapes and no surrounding quotes; for a throwaway local key run: openssl genrsa -traditional 2048
Copy .env.example to .env in the project root (both dev mode and docker compose read it), set the values above, and restart. Dashboard OAuth (GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET) is optional.
```

## Related Issues

Fixes #593

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

**Red/green proof.** Three new tests in `StartupConfigValidatorTest`, verbatim red output on the
unfixed validator:

```
[ERROR] StartupConfigValidatorTest.missingPrivateKeyNamesHowToObtainOne:295 ThrillhouseBot cannot start — required configuration is missing or invalid:
  - GITHUB_PRIVATE_KEY is required but is not set (thrillhousebot.github.private-key)
Set the values above (see .env.example) and restart. Dashboard OAuth (GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET) is optional. ==> expected: <true> but was: <false>
[ERROR] StartupConfigValidatorTest.malformedPrivateKeyNamesHowToObtainOne:306 ThrillhouseBot cannot start — required configuration is missing or invalid:
  - GITHUB_PRIVATE_KEY is set but is not a valid PEM RSA private key (thrillhousebot.github.private-key): Could not parse RSA private key: Illegal base64 character 2d
Set the values above (see .env.example) and restart. Dashboard OAuth (GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET) is optional. ==> expected: <true> but was: <false>
[ERROR] StartupConfigValidatorTest.refusalNamesCopyingEnvExampleAsTheFirstStep:315 ThrillhouseBot cannot start — required configuration is missing or invalid:
  - AI_API_KEY is required but is not set (quarkus.langchain4j.openai.api-key)
Set the values above (see .env.example) and restart. Dashboard OAuth (GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET) is optional. ==> expected: <true> but was: <false>
[ERROR] Tests run: 68, Failures: 3, Errors: 0, Skipped: 0
```

**End-to-end check of the instructions themselves.** Followed the new README text from scratch on a
clean worktree (JDK 25): `cp .env.example .env`, generated the key with the documented openssl
command, pasted it unquoted, filled the other three values:

```
INFO [dev.thiagogonzaga...StartupConfigValidator] Configuration validated: GitHub App id, private key, webhook secret, and AI API key are present.
INFO [io.quarkus] thrillhousebot 0.5.1-SNAPSHOT on JVM (powered by Quarkus 3.38.0) started in 9.435s. Listening on: http://localhost:8080
```

**Gates**

- `./mvnw -B spotless:apply` then `./mvnw -B clean compile spotbugs:check spotless:check` — BUILD
  SUCCESS, `BugInstance size is 0`
- `./mvnw -B clean test` — `Tests run: 2850, Failures: 0, Errors: 0, Skipped: 0`
- `cd website && npm ci && npm run build` (run from this branch's worktree) — 66 pages built,
  `All internal links are valid.` The only intra-README link added sits in the Development section,
  which no docs page inlines (`include:` covers only `#features`, `#providers`, `#commands`,
  `#configuration`, `#repository-configuration`, `#pr-labels`).
- Coverage: jacoco ∩ `git diff -U0` over changed main lines — zero uncovered lines, zero uncovered
  branches.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Behaviour is unchanged — the validator still refuses to boot on exactly the same conditions; only
its wording gained the remedy. The `.env.example` quoting fix is the one change with a functional
effect, and it makes a previously broken example work on both the dev-mode and docker compose
paths.
