### PR TITLE
fix(review): keep an unnamed file counted instead of crashing or vanishing

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -62,6 +62,13 @@ public class DiffBudgetPlanner {
    */
   private static final Pattern NUMBERED_ENTRY = Pattern.compile("^\\d+\\. \\[");
 
+  /**
+   * Stand-in for a coverage gap on a file GitHub gave no name. It keeps the gap counted — the
+   * omitted/clipped list sizes are what hold APPROVE — while naming it as honestly as the input
+   * allows. See {@link #recordName}.
+   */
+  static final String UNNAMED_FILE = "(unnamed file)";
+
   private final ReviewDiffFormatter formatter;
   private final TokenCounter tokenCounter;
   private final ThrillhouseConfig config;
@@ -546,11 +553,17 @@ public class DiffBudgetPlanner {
   private Rendered renderAndSize(
       List<GitHubPullRequestClient.FileDiff> reviewable, int diffBudgetTokens) {
     var ordered = new ArrayList<>(reviewable);
+    // The name tie-break only fires between files of equal size, and natural ordering on a null
+    // key throws. Unnamed last: packing is impact-descending, so whatever sorts last is what the
+    // bin cap omits first, and a degenerate entry must never displace a well-formed file — a
+    // finding on a file the model cannot name has no path to anchor an inline comment to anyway.
     ordered.sort(
         Comparator.comparingInt(
                 (GitHubPullRequestClient.FileDiff f) -> f.additions() + f.deletions())
             .reversed()
-            .thenComparing(GitHubPullRequestClient.FileDiff::filename));
+            .thenComparing(
+                GitHubPullRequestClient.FileDiff::filename,
+                Comparator.nullsLast(Comparator.naturalOrder())));
 
     var reviewableNames = ReviewDiffFormatter.namesOf(reviewable);
     var rendered = new Rendered(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
@@ -601,22 +614,30 @@ public class DiffBudgetPlanner {
   }
 
   /**
+   * Records a coverage-gap filename, standing in for a null one. {@code FileDiff.filename()} is not
+   * validated at construction, and a null name reaching the plan's name lists makes the {@code
+   * List.copyOf} in the {@link BudgetPlan} constructor throw — failing the whole review at plan
+   * time for a file the disclosure could not have named anyway.
+   *
+   * <p>Dropping the entry instead would be worse than the crash it avoids, and silently: these
+   * lists are not only display text, their <em>size</em> is what {@link BudgetPlan#truncated()}
+   * gates APPROVE on. If the unnamed file were the only gap, the count would fall to zero and a
+   * file the model never read would stop withholding approval — the bot approving a PR it did not
+   * fully see. So the gap keeps a slot and the disclosure names it as best it can (#473).
+   *
+   * <p>Two unnamed gaps in different classes can collide on the placeholder and be deduplicated by
+   * the omitted/clipped disjointness filter. Both are gaps and both hold approval, so the outcome
+   * stays honest in the direction that matters.
+   */
+  private static void recordName(List<String> names, String filename) {
+    names.add(filename == null ? UNNAMED_FILE : filename);
+  }
+
+  /**
    * A reviewable file GitHub reported with real additions/deletions but no patch text (binary, or a
    * text diff too large to display). It survives {@link ReviewDiffFormatter#isPureRename} (which
    * needs a zero change count) yet has no diff to review, so it must be omitted, not packed.
    */
-  /**
-   * Records a coverage-gap filename, skipping a null one. {@code FileDiff.filename()} is not
-   * validated at construction, and a null name reaching the plan's name lists makes the {@code
-   * List.copyOf} in the {@link BudgetPlan} constructor throw — failing the whole review at plan
-   * time for a file the disclosure could not have named anyway.
-   */
-  private static void recordName(List<String> names, String filename) {
-    if (filename != null) {
-      names.add(filename);
-    }
-  }
-
   private static boolean isPatchlessWithChanges(GitHubPullRequestClient.FileDiff file) {
     var patch = file.patch();
     return (patch == null || patch.isBlank()) && file.additions() + file.deletions() > 0;
@@ -647,7 +668,7 @@ public class DiffBudgetPlanner {
         target = binSections.size() - 1;
       }
       if (target < 0) {
-        omitted.add(s.file().filename());
+        recordName(omitted, s.file().filename());
         continue;
       }
       binSections.get(target).add(s);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -854,16 +854,92 @@ class DiffBudgetPlannerTest {
   }
 
   @Test
-  void aPatchlessFileWithNoNameIsSkippedInsteadOfFailingThePlan() {
+  void aPatchlessFileWithNoNameIsCountedAsAGapInsteadOfFailingThePlan() {
     // GitHub returns a null/blank patch for binaries and oversized text diffs, and FileDiff does
     // not validate its filename. A null name reaching the plan's omitted list makes List.copyOf in
-    // the BudgetPlan constructor throw, failing the whole review at plan time — for a file the
-    // disclosure could not have named anyway.
+    // the BudgetPlan constructor throw, failing the whole review at plan time (#550). Dropping it
+    // instead would be the worse failure and a silent one: the list size is what holds APPROVE, so
+    // the only omission vanishing would let the bot approve a PR it never read (#473).
     var files = Arrays.asList(new FileDiff(null, "modified", 7, 0, 7, ""));
 
     var plan = planner.plan(files, 10000, 3);
 
-    assertTrue(plan.omittedFiles().isEmpty(), plan.omittedFiles().toString());
+    assertEquals(List.of("(unnamed file)"), plan.omittedFiles());
     assertTrue(plan.clippedFiles().isEmpty(), plan.clippedFiles().toString());
+    assertTrue(plan.truncated(), "an unreviewed file must keep withholding approval");
+  }
+
+  @Test
+  void anUnnamedFileTyingOnSizeDoesNotBlowUpTheImpactSort() {
+    // #473: the name tie-break only runs between files of equal additions+deletions, and
+    // Comparator.thenComparing's natural ordering throws on a null key. Two 7-change files, one
+    // unnamed, are exactly that tie.
+    var files =
+        Arrays.asList(
+            file("src/App.java", 7, patch(7)), new FileDiff(null, "modified", 7, 0, 7, ""));
+
+    var plan = planner.plan(files, 10_000, 3);
+
+    assertEquals(List.of("src/App.java"), coveredFilenames(plan));
+    assertEquals(List.of("(unnamed file)"), plan.omittedFiles(), "the patchless file has no diff");
+  }
+
+  @Test
+  void anUnnamedFileSortsAfterItsEquallySizedNamedPeers() {
+    // Which side of the tie the unnamed file lands on is a choice, not a mechanical detail: packing
+    // is impact-descending, so whatever sorts last is what the bin cap omits first. Unnamed last
+    // keeps a degenerate entry from displacing a well-formed file — findings on a file the model
+    // cannot name have no path to anchor an inline comment to.
+    var named = file("src/App.java", 7, patch(7));
+    var unnamed = new FileDiff(null, "modified", 7, 0, 7, patch(7));
+    var budget = sectionTokens(named) + 10; // room for exactly one of the two
+
+    var plan = planner.plan(Arrays.asList(unnamed, named), budget, 1);
+
+    assertEquals(List.of("src/App.java"), coveredFilenames(plan), "the named file keeps the bin");
+    assertEquals(List.of("(unnamed file)"), plan.omittedFiles());
+    assertTrue(plan.truncated());
+  }
+
+  @Test
+  void anUnnamedFileOverflowingEveryBinIsCountedNotDropped() {
+    // The bin-packing omission site: a file that fits its own budget but not the remaining bins.
+    // Its count is what VerdictBuilder reads for DiffStats.truncated(), so a nameless omission has
+    // to occupy a slot — otherwise the single omission disappears and APPROVE is no longer held.
+    var big = file("src/Big.java", 40, patch(8));
+    var unnamed = new FileDiff(null, "modified", 8, 0, 8, patch(8));
+    var budget = sectionTokens(big) + 10; // one file per bin, one bin
+
+    var plan = planner.plan(Arrays.asList(big, unnamed), budget, 1);
+
+    assertEquals(List.of("src/Big.java"), coveredFilenames(plan));
+    assertEquals(List.of("(unnamed file)"), plan.omittedFiles());
+    assertEquals(1, plan.omittedFiles().size(), "the gap count must stay honest");
+    assertTrue(plan.truncated(), "an unreviewed file must keep withholding approval");
+  }
+
+  @Test
+  void aCondensedPreviousFindingsContextStillLeavesAnUnnamedGapHoldingApproval() {
+    // The two accounts this class keeps are separate and must stay separate: #583 elides prompt
+    // text (findings the model is re-shown), #473 counts file coverage gaps. Run both at once — a
+    // previous-findings block far past its share, and a file GitHub named nothing — and the
+    // condensation must not absorb the coverage gap, nor the placeholder leak into the prompt.
+    budget(20_000);
+    var named = file("src/App.java", 5, patch(5));
+    var unnamed = new FileDiff(null, "modified", 7, 0, 7, "");
+    var inputs = inputsWith(PromptTemplateEscaper.fence(previousFindingsBlock(300, 6)));
+
+    var plan = planner.plan(Arrays.asList(named, unnamed), inputs);
+
+    assertEquals(List.of("src/App.java"), coveredFilenames(plan), "the named file is reviewed");
+    assertEquals(
+        List.of("(unnamed file)"), plan.omittedFiles(), "the nameless gap is still counted");
+    assertTrue(plan.truncated(), "an unreviewed file must keep withholding approval");
+    assertFalse(
+        planner
+            .boundPreviousFindings(inputs)
+            .previousFindings()
+            .contains(DiffBudgetPlanner.UNNAMED_FILE),
+        "the coverage placeholder has no business in the previous-findings prompt text");
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The two sites #473 names, both upstream of everything #471 and #551 changed. #551 fixed three
*other* null-filename sites in this class (the `recordName` recording points); neither of these was
in it, because both needed a semantic decision that #551 did not license.

### 1. The impact sort — `renderAndSize`

`thenComparing(FileDiff::filename)` uses natural ordering on the extracted key, which throws on a
null key. It only fires when two files have the same `additions + deletions`, which is why it has
never been hit.

**Decision — unnamed sorts last.** Both `nullsFirst` and `nullsLast` work mechanically; this is a
choice about output ordering. Packing is impact-descending, so whatever sorts last is what the bin
cap omits first. Sorting the unnamed file last means a degenerate entry can never displace a
well-formed one, and that is the right way round: a finding on a file the model cannot name has no
path to anchor an inline comment to, so budget spent there is the budget most likely wasted.

### 2. `omitted.add(s.file().filename())` — the approval-gating trade

`omitted` becomes `BudgetPlan.omittedFiles`, whose compact constructor runs `List.copyOf`, so a null
name throws at plan construction — on the async review thread after the 200 ack, with nothing posted
on the PR to explain it.

**Decision — placeholder, not filter.** Filtering the null out is the tempting fix and it is the
worse failure, silently: these lists are not only display text, their *size* is what
`BudgetPlan.truncated()` — and through it `VerdictBuilder.DiffStats.truncated()` — gates APPROVE on.
If the unnamed file were the only omission, the count would fall to zero, `truncated()` would flip to
`false`, and **a file that was never reviewed would stop withholding approval**: the bot approving a
PR it did not fully read. So the gap keeps a slot under `(unnamed file)`; the count stays honest and
the disclosure names it as well as the input allows.

Of the issue's three candidate resolutions this is the first. The second (track the omission *count*
separately from the omitted *names*) is cleaner in the abstract but changes the `BudgetPlan` record
and every consumer and construction site of it, which is a large blast radius for a defect that is
unreachable through today's production inputs. The third (declare `FileDiff.filename()` non-null and
delete every guard) is the reading #471 considered and rejected.

**Consistency with #551:** the same placeholder now replaces the drop at the three `recordName`
sites. The reasoning is identical — an unclippable or clipped file with no name is a coverage gap
whether or not it can be named, and it must hold approval — so the class should not treat the two
kinds of nameless gap differently. #551's NPE fix stands untouched; only the accounting changes, and
its test is updated to assert the gap is counted rather than dropped.

## Related Issues

Fixes #473

## How Has This Been Tested?

- [x] Unit tests

**Red**, against `469539e` with the four tests in place and no production change — both crash sites
reproduce exactly as the issue describes, and the third failure is the silent-drop behaviour:

```
[ERROR] Tests run: 4, Failures: 1, Errors: 3, Skipped: 0, Time elapsed: 1.024 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlannerTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlannerTest.anUnnamedFileTyingOnSizeDoesNotBlowUpTheImpactSort -- Time elapsed: 0.022 s <<< ERROR!
java.lang.NullPointerException: Cannot invoke "java.lang.Comparable.compareTo(Object)" because the return value of "java.util.function.Function.apply(Object)" is null
	at java.base/java.util.Comparator.lambda$comparing$77a9974f$1(Comparator.java:473)
	at java.base/java.util.Comparator.lambda$thenComparing$36697e65$1(Comparator.java:221)
	at java.base/java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
	at java.base/java.util.ArrayList.sort(ArrayList.java:1810)
	at dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlanner.renderAndSize(DiffBudgetPlanner.java:353)
	at dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlanner.plan(DiffBudgetPlanner.java:332)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlannerTest.anUnnamedFileOverflowingEveryBinIsCountedNotDropped -- Time elapsed: 0.012 s <<< ERROR!
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:220)
	at java.base/java.util.List.copyOf(List.java:1191)
	at dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlanner$BudgetPlan.<init>(DiffBudgetPlanner.java:100)
	at dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlanner.pack(DiffBudgetPlanner.java:469)
	at dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlanner.plan(DiffBudgetPlanner.java:338)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlannerTest.anUnnamedFileSortsAfterItsEquallySizedNamedPeers -- Time elapsed: 0.002 s <<< ERROR!
java.lang.NullPointerException: Cannot read field "value" because "anotherString" is null
	at java.base/java.lang.String.compareTo(String.java:2105)
	at java.base/java.util.Comparator.lambda$thenComparing$36697e65$1(Comparator.java:221)
	at dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlanner.renderAndSize(DiffBudgetPlanner.java:353)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.DiffBudgetPlannerTest.aPatchlessFileWithNoNameIsCountedAsAGapInsteadOfFailingThePlan -- Time elapsed: 0.007 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <[(unnamed file)]> but was: <[]>
```

Green with the fix. The fourth test pins the ordering decision itself (the named file keeps the only
bin; the unnamed one is the omission), so a later flip to `nullsFirst` cannot pass silently.

Gates on `603bbae` (rebased onto `c20a1d8`), all run inside this worktree:

- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` → `Tests run: 2916, Failures: 0, Errors: 0, Skipped: 0`
- jacoco (`fix-473/target/site/jacoco/jacoco.xml`) ∩ `git diff -U0 c20a1d8...HEAD` → 4 trackable
  changed main lines, zero uncovered lines, zero uncovered branches

### Rebase onto `c20a1d8`, and how the resolution was verified

#615 (the previous-findings bound) merged first and lands in this same class, so this branch was
rebased onto `c20a1d8` and one conflict resolved: both PRs had added a constant block immediately
below the class declaration — pure adjacency, no overlapping logic. Both sides are kept
(`PREVIOUS_FINDINGS_BUDGET_SHARE` / `NUMBERED_ENTRY` from #615, `UNNAMED_FILE` from this PR).
Everything else auto-merged: the two sides touch disjoint methods (`boundPreviousFindings` /
`condensePreviousFindings` vs. `renderAndSize` / `recordName` / `pack`).

Because a resolution that silently drops one side would still compile and still pass most tests,
each side was then broken deliberately in the working tree and the suite re-run:

| mutation | result |
|---|---|
| `recordName` placeholder → the old silent filter | **5 red**, all with the silent-drop signature `expected: <[(unnamed file)]> but was: <[]>` (`aPatchlessFileWithNoName…`, `anUnnamedFileTyingOnSize…`, `anUnnamedFileSortsAfter…`, `anUnnamedFileOverflowingEveryBin…`, `aCondensedPreviousFindingsContext…`). Every #615 condensation test stayed green. |
| `nullsLast` → natural ordering | **2 red**, both `NullPointerException` out of `TimSort` (`Cannot invoke "java.lang.Comparable.compareTo(Object)"…` and `Cannot read field "value" because "anotherString" is null`). Nothing else moved. |
| `boundPreviousFindings` → a no-op | **9 red**, every condensation/fence/idempotence test plus the interaction test's *first* assertion (unbounded context starves the diff budget, so even the named file goes unreviewed). The placeholder-accounting tests stayed green. |
| the cap's cut condition → never cut | **2 red**, exactly the tail-drop pair (`entriesThatStillDoNotFitAreDropped…`, `aBlockTooSmallToHoldItsOwnDisclosure…`). |

So the two sides are separable, not overlapping, and each is independently pinned by tests.

**The interaction that matters.** Both changes touch something that gets *counted*, so the new test
`aCondensedPreviousFindingsContextStillLeavesAnUnnamedGapHoldingApproval` runs them together — a
previous-findings block far past its share *and* a file GitHub named nothing — and asserts the named
file is reviewed, the nameless gap is still `(unnamed file)` in `omittedFiles`, `truncated()` still
holds APPROVE, and the coverage placeholder never leaks into the prompt text. The two accounts are
structurally separate: #615 elides *prompt text* (which findings the model is re-shown) and never
touches `omittedFiles` / `clippedFiles` / `truncated()`; this PR touches only *file coverage* and
never touches the previous-findings block. An unreviewed file cannot stop withholding approval on
either path.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Both defects predate v0.6.0 and are unreachable through today's production inputs — GitHub always
sends a filename. What v0.6.0 changed is the exposure: `/improve`, `/describe`, `/changelog`,
`/generate-tests` and `/add-docs` all route through this planner now.

While touching the area, a stray javadoc block left over from #551 (the `isPatchlessWithChanges`
doc had ended up above `recordName`, leaving the predicate undocumented) is put back on its method.

