### PR TITLE
fix(github): mint a fresh installation token when GitHub rejects the old one

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
@@ -132,6 +132,17 @@ public final class GitHubApiError {
   }
 
   /**
+   * Whether GitHub rejected the credential rather than the request. 401 is the only status an
+   * installation token that has expired, been revoked or been replaced can draw, and GitHub decides
+   * it before routing the request — so the call never reached the handler that would have written
+   * anything, and it is worth repeating once a fresh token has been minted. See {@link
+   * GitHubTokenRefresh}.
+   */
+  public boolean isExpiredCredential() {
+    return status == 401;
+  }
+
+  /**
    * Whether this failure is worth a warning in the log. Reads probe for optional files ({@code
    * .github/instructions}, the repo settings file) and treat 404 as "absent", so a 404 is expected
    * traffic and only clutters the log at warning level; an auth, throttle or server failure is not.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClient.java
@@ -27,9 +27,11 @@ import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.security.interfaces.RSAPrivateKey;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -41,6 +43,21 @@ public class GitHubAuthClient {
 
   private static final Logger log = LoggerFactory.getLogger(GitHubAuthClient.class);
 
+  private static final String BEARER = "Bearer ";
+
+  /**
+   * How long a minted installation token is reused before a new one is fetched.
+   *
+   * <p>GitHub expires it at 60 minutes, so whatever is left over is the longest a piece of work may
+   * take between reading the header and its final write. The 10 minutes this used to leave were
+   * chosen when reviews were short; with {@code AI_TIMEOUT=900s} a <em>single</em> model call is
+   * allowed 15 minutes and a multi-call review takes considerably more, so a review starting late
+   * in the window routinely outlived its credential (#624). Halving the token's life doubles the
+   * worst-case mint rate to two per installation per hour, which is nothing against the App's
+   * limits, and it only narrows the window — {@link GitHubTokenRefresh} is what closes it.
+   */
+  static final Duration TOKEN_TTL = Duration.ofMinutes(30);
+
   private final ThrillhouseConfig config;
   private final GitHubTokenApi tokenApi;
 
@@ -49,12 +66,32 @@ public class GitHubAuthClient {
 
   private final Map<Long, CachedToken> tokenCache = new ConcurrentHashMap<>();
 
+  /**
+   * Which installation a token this process minted belongs to, so a write GitHub answered with 401
+   * can be traced back to the installation whose token has to be replaced.
+   *
+   * <p>Bounded to the current and the immediately superseded token per installation. The superseded
+   * one has to stay resolvable: a dead token does not fail one write, it fails every write still
+   * holding it — five within five seconds in #624 — and each of those after the first is presenting
+   * a token the cache has already replaced. Forgetting it would leave every write but the first
+   * unable to name its own installation.
+   */
+  private final Map<String, Long> tokenOwners = new ConcurrentHashMap<>();
+
+  /**
+   * The token each installation replaced most recently, the only one {@link #tokenOwners} keeps.
+   */
+  private final Map<Long, String> supersededTokens = new ConcurrentHashMap<>();
+
   private final AtomicReference<RSAPrivateKey> cachedPrivateKey = new AtomicReference<>();
 
   @Inject
   public GitHubAuthClient(ThrillhouseConfig config, @RestClient GitHubTokenApi tokenApi) {
     this.config = config;
     this.tokenApi = tokenApi;
+    // Minting is the one thing only this bean can do, and the GitHub writes that need a dead token
+    // replaced are interface default methods with nowhere to inject it. See GitHubTokenRefresh.
+    GitHubTokenRefresh.SHARED.bind(this::mintedReplacementFor);
   }
 
   /**
@@ -104,18 +141,60 @@ public class GitHubAuthClient {
     var response =
         tokenApi.createInstallationToken(authHeader, "application/vnd.github+json", installationId);
 
-    // 50-minute TTL: tokens expire at 60 min, keep a safety margin.
-    var newToken =
-        new CachedToken(
-            response.token(), Instant.now().plus(50, ChronoUnit.MINUTES), installationId);
-    tokenCache.put(installationId, newToken);
+    var newToken = new CachedToken(response.token(), Instant.now().plus(TOKEN_TTL), installationId);
+    var previous = tokenCache.put(installationId, newToken);
+    tokenOwners.put(newToken.token(), installationId);
+    if (previous != null) {
+      // Keep the token just superseded resolvable for the writes still holding it, and forget the
+      // one before it so the index cannot grow with the process's uptime.
+      var forgotten = supersededTokens.put(installationId, previous.token());
+      Optional.ofNullable(forgotten).ifPresent(tokenOwners::remove);
+    }
 
     return newToken.token();
   }
 
   /** Returns an Authorization header value for GitHub API calls. */
   public String getAuthHeader(long installationId) {
-    return "Bearer " + getInstallationToken(installationId);
+    return BEARER + getInstallationToken(installationId);
+  }
+
+  /**
+   * The header to repeat a call with after GitHub answered it {@code 401 Bad credentials}, or empty
+   * when {@code deadAuthHeader} is not one this process issued and so names no installation.
+   *
+   * <p>Bound into {@link GitHubTokenRefresh} at construction; see that class for why a 401 is worth
+   * repeating at all. The cache entry is dropped only while it still holds the dead token, because
+   * a 401 arrives from every in-flight write at once: the first one through mints the replacement,
+   * and the rest must be handed <em>that</em> replacement rather than each evicting it and minting
+   * another, which would leave every write chasing a token the next one has already thrown away.
+   *
+   * <p>Kept separate from the method the constructor binds only because a constructor must not hand
+   * out a reference to an overridable method — CDI subclasses this bean.
+   */
+  Optional<String> refreshedAuthHeader(String deadAuthHeader) {
+    return mintedReplacementFor(deadAuthHeader);
+  }
+
+  private Optional<String> mintedReplacementFor(String deadAuthHeader) {
+    if (deadAuthHeader == null || !deadAuthHeader.startsWith(BEARER)) {
+      return Optional.empty();
+    }
+    var dead = deadAuthHeader.substring(BEARER.length());
+    var installationId = tokenOwners.get(dead);
+    if (installationId == null) {
+      return Optional.empty();
+    }
+    log.info(
+        "Installation token for installation {} was rejected — minting a replacement",
+        installationId);
+    // Expired in place rather than removed, so the replacement travels the same path a token that
+    // simply aged out does and supersedes this one through the bookkeeping in the mint above.
+    tokenCache.computeIfPresent(
+        installationId,
+        (id, cached) ->
+            cached.token().equals(dead) ? new CachedToken(dead, Instant.EPOCH, id) : cached);
+    return Optional.of(getAuthHeader(installationId));
   }
 
   private RSAPrivateKey privateKey() {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClient.java
@@ -44,17 +44,47 @@ public interface GitHubCheckRunClient {
       @PathParam("repo") String repo,
       CreateCheckRunRequest request);
 
+  /** One HTTP attempt at updating a check run. Callers want {@link #updateCheckRun} instead. */
   @PATCH
   @Path("/repos/{owner}/{repo}/check-runs/{checkRunId}")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  void updateCheckRun(
+  void updateCheckRunOnce(
       @HeaderParam("Authorization") String auth,
       @HeaderParam("Accept") String accept,
       @PathParam("owner") String owner,
       @PathParam("repo") String repo,
       @PathParam("checkRunId") long checkRunId,
       UpdateCheckRunRequest request);
+
+  /**
+   * Updates a check run, minting a fresh installation token and repeating the PATCH once when
+   * GitHub rejects the credential (#624).
+   *
+   * <p>This is the call that decides whether a review's merge gate ends up green, red, or stuck in
+   * neither. It runs after the model work and after the review has been posted, which is exactly
+   * where a token read at the top of a long review has expired — in the incident this fixes, the
+   * completion update, its conclusion-only fallback and the mark-as-failed update all drew 401 in
+   * the same second, leaving the check run permanently in progress on a PR whose review had already
+   * finished. A PATCH against a known check-run id is also the least ambiguous write there is:
+   * repeating it either applies the same state or nothing, never a duplicate. See {@link
+   * GitHubTokenRefresh}.
+   */
+  default void updateCheckRun(
+      String auth,
+      String accept,
+      String owner,
+      String repo,
+      long checkRunId,
+      UpdateCheckRunRequest request) {
+    GitHubTokenRefresh.SHARED.retrying(
+        "check run " + checkRunId + " on " + owner + "/" + repo,
+        auth,
+        credential -> {
+          updateCheckRunOnce(credential, accept, owner, repo, checkRunId, request);
+          return null;
+        });
+  }
 
   @GET
   @Path("/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks")

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentClient.java
@@ -65,9 +65,10 @@ public interface GitHubCommentClient {
         notice ->
             GitHubWriteRetry.DEFAULT.call(
                 "a comment on " + owner + "/" + repo + " #" + issueNumber,
-                () ->
+                auth,
+                credential ->
                     createCommentOnce(
-                        auth,
+                        credential,
                         accept,
                         owner,
                         repo,
@@ -151,7 +152,8 @@ public interface GitHubCommentClient {
       CreateCommentRequest request) {
     return GitHubWriteRetry.DEFAULT.call(
         "an edit of comment " + commentId + " on " + owner + "/" + repo,
-        () -> updateCommentOnce(auth, accept, owner, repo, commentId, request));
+        auth,
+        credential -> updateCommentOnce(credential, accept, owner, repo, commentId, request));
   }
 
   record CreateCommentRequest(String body) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -62,9 +62,10 @@ public interface GitHubReviewClient {
         notice ->
             GitHubWriteRetry.DEFAULT.call(
                 "a review on " + owner + "/" + repo + " #" + pullNumber,
-                () ->
+                auth,
+                credential ->
                     createReviewOnce(
-                        auth,
+                        credential,
                         accept,
                         owner,
                         repo,
@@ -197,8 +198,10 @@ public interface GitHubReviewClient {
         () ->
             GitHubWriteRetry.DEFAULT.call(
                 "an inline comment on " + owner + "/" + repo + " #" + pullNumber,
-                () ->
-                    createPullRequestCommentOnce(auth, accept, owner, repo, pullNumber, request)));
+                auth,
+                credential ->
+                    createPullRequestCommentOnce(
+                        credential, accept, owner, repo, pullNumber, request)));
   }
 
   /** One HTTP attempt at a thread reply. Callers want {@link #replyToReviewComment} instead. */
@@ -233,9 +236,10 @@ public interface GitHubReviewClient {
         () ->
             GitHubWriteRetry.DEFAULT.call(
                 "a reply to comment " + commentId + " on " + owner + "/" + repo + " #" + pullNumber,
-                () ->
+                auth,
+                credential ->
                     replyToReviewCommentOnce(
-                        auth, accept, owner, repo, pullNumber, commentId, request)));
+                        credential, accept, owner, repo, pullNumber, commentId, request)));
   }
 
   @DELETE

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubTokenRefresh.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubTokenRefresh.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.github;
+
+import jakarta.ws.rs.WebApplicationException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Swaps an installation token GitHub has stopped accepting for a freshly minted one, so a call that
+ * outlived its credential can be repeated instead of discarded.
+ *
+ * <p>#624: an installation token is read once, at the top of a review, and every write at the end
+ * of that review reuses the string. A review on {@code AI_TIMEOUT=900s} runs longer than the margin
+ * the cache leaves, so the token is dead by the time the findings are ready — and the review post,
+ * the check-run conclusion, the mark-as-failed and the failure comment all drew {@code 401 Bad
+ * credentials} off the same corpse. {@link GitHubWriteRetry} was already backing off and repeating
+ * those calls, but a repeat that re-sends the dead token can only draw the same 401: a credential
+ * fault is the one class of failure where retrying without refreshing first is guaranteed useless.
+ *
+ * <h2>Why a 401 cannot be a duplicate post</h2>
+ *
+ * GitHub authenticates before it routes, so a request it answers with 401 never reached the handler
+ * that would have created the comment, the review or the check-run update. The response is the
+ * rejection itself, not a report about a write that happened — the same argument {@link
+ * GitHubWriteRetry} makes for a throttle, and a stronger one, because 401 leaves no room for the
+ * request to have been partially applied. That is what makes repeating it safe when the ambiguous
+ * failures (a reset connection, a read timeout, a 5xx) deliberately are not repeated.
+ *
+ * <h2>Why the seam is a process-wide binding</h2>
+ *
+ * The calls that need this are {@code default} methods on the REST-client interfaces, which have no
+ * injection point — the same reason {@link GitHubWritePacer#DEFAULT} and {@link
+ * GitHubLostWrites#SHARED} are process-wide. {@link GitHubAuthClient} is the only thing that can
+ * mint a token, and it binds itself here when CDI constructs it; until then, and in any unit test
+ * that never builds one, {@link #NONE} makes every refusal behave exactly as it did before.
+ */
+final class GitHubTokenRefresh {
+
+  private static final Logger log = LoggerFactory.getLogger(GitHubTokenRefresh.class);
+
+  /** Mints a replacement for an {@code Authorization} header GitHub has stopped accepting. */
+  @FunctionalInterface
+  interface Source {
+
+    /**
+     * The current header for whichever installation minted {@code deadAuthHeader}, or empty when
+     * the header is not one this process issued and so cannot be traced to an installation.
+     */
+    Optional<String> replace(String deadAuthHeader);
+  }
+
+  /** Nothing can be replaced — the state before {@link GitHubAuthClient} binds itself. */
+  static final Source NONE = _ -> Optional.empty();
+
+  /** The process-wide seam: one binding, shared by every GitHub write in the instance. */
+  static final GitHubTokenRefresh SHARED = new GitHubTokenRefresh();
+
+  private final AtomicReference<Source> source = new AtomicReference<>(NONE);
+
+  GitHubTokenRefresh() {}
+
+  /** Points this seam at whatever can mint tokens; {@code null} restores {@link #NONE}. */
+  void bind(Source replacement) {
+    source.set(replacement == null ? NONE : replacement);
+  }
+
+  /**
+   * The header {@code auth} should be repeated with after {@code failure}, or empty when the call
+   * must not be repeated: the failure was not a rejected credential, the caller carries no
+   * credential at all, or nothing fresher than the one that just failed can be minted.
+   *
+   * <p>A replacement equal to the header that failed is refused rather than returned. That is the
+   * shape a genuinely revoked installation takes — the cache is already holding the newest token
+   * GitHub will issue and it is still being turned away — and repeating the call with it would only
+   * spend another request to be told the same thing.
+   *
+   * <p>Minting is a network call of its own, so a failure inside it is swallowed: the caller is
+   * already handling {@code failure}, and replacing that with a token-endpoint error would hide the
+   * 401 that actually explains the loss.
+   */
+  Optional<String> replacementFor(String operation, String auth, WebApplicationException failure) {
+    if (auth == null
+        || GitHubApiError.of(failure).filter(GitHubApiError::isExpiredCredential).isEmpty()) {
+      return Optional.empty();
+    }
+    var fresh = mint(auth);
+    if (fresh.isEmpty() || fresh.get().equals(auth)) {
+      log.warn(
+          "GitHub rejected the credential on {} and no fresher installation token is available —"
+              + " the payload is lost",
+          operation);
+      return Optional.empty();
+    }
+    log.warn(
+        "GitHub rejected the credential on {} — the installation token has expired, retrying once"
+            + " with a freshly minted one",
+        operation);
+    return fresh;
+  }
+
+  private Optional<String> mint(String auth) {
+    try {
+      return source.get().replace(auth);
+    } catch (RuntimeException e) {
+      log.warn("Failed to mint a replacement installation token", e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Runs a GitHub call with {@code auth} and, when GitHub rejects the credential, runs it exactly
+   * once more with a fresh one. For the writes that have no backoff loop of their own — {@link
+   * GitHubWriteRetry} folds the same refresh into its attempt loop instead, so one call there can
+   * still both refresh and back off.
+   */
+  <T> T retrying(String operation, String auth, Function<String, T> call) {
+    try {
+      return call.apply(auth);
+    } catch (WebApplicationException e) {
+      var fresh = replacementFor(operation, auth, e);
+      if (fresh.isEmpty()) {
+        throw e;
+      }
+      return call.apply(fresh.get());
+    }
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetry.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetry.java
@@ -19,6 +19,7 @@ import jakarta.ws.rs.WebApplicationException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,12 +36,23 @@ import org.slf4j.LoggerFactory;
  *
  * A retry is attempted only when {@link GitHubApiError#isThrottled()} holds — a 429, or a 403 that
  * carries a {@code Retry-After}, an exhausted {@code x-ratelimit-remaining}, or GitHub's rate-limit
- * wording in the body. GitHub rejects a throttled content-creating request at the edge, before the
- * comment exists; the response is the rejection itself, not a report about a write that happened.
- * The ambiguous failures — a connection reset, a read timeout, a 5xx — are the ones where a write
- * may well have landed, and those are deliberately <em>not</em> retried here: they propagate on the
- * first attempt exactly as they did before. That is the whole duplicate-suppression argument, and
- * it is why the throttle test is a positive signal rather than "not a success".
+ * wording in the body — or when {@link GitHubApiError#isExpiredCredential()} holds and a fresher
+ * installation token can be minted. GitHub rejects a throttled content-creating request at the
+ * edge, before the comment exists, and rejects an unauthenticated one earlier still; the response
+ * is the rejection itself, not a report about a write that happened. The ambiguous failures — a
+ * connection reset, a read timeout, a 5xx — are the ones where a write may well have landed, and
+ * those are deliberately <em>not</em> retried here: they propagate on the first attempt exactly as
+ * they did before. That is the whole duplicate-suppression argument, and it is why the throttle
+ * test is a positive signal rather than "not a success".
+ *
+ * <h2>Why a repeat alone was not enough</h2>
+ *
+ * #624: the backoff below re-read the same {@code Authorization} header on every attempt, so a
+ * review whose installation token expired mid-run drew {@code 401 Bad credentials} three times over
+ * and threw the generation away anyway. A dead credential is the one failure a repeat cannot fix on
+ * its own, so an attempt that draws a 401 swaps the credential through {@link GitHubTokenRefresh}
+ * before repeating. That happens at most once per call and does not spend a backoff attempt — the
+ * refreshed request has not been throttled, it has not been sent.
  *
  * <h2>Why this cannot stall the pipeline</h2>
  *
@@ -69,24 +81,37 @@ public final class GitHubWriteRetry {
     void sleep(Duration delay) throws InterruptedException;
   }
 
-  /** The instance production uses: real sleeping, real clock, the shared write pacer. */
+  /** The instance production uses: real sleeping, real clock, the shared pacer and token seam. */
   static final GitHubWriteRetry DEFAULT =
       new GitHubWriteRetry(
-          delay -> Thread.sleep(delay.toMillis()), Instant::now, GitHubWritePacer.DEFAULT);
+          delay -> Thread.sleep(delay.toMillis()),
+          Instant::now,
+          GitHubWritePacer.DEFAULT,
+          GitHubTokenRefresh.SHARED);
 
   private final Sleeper sleeper;
   private final Supplier<Instant> clock;
   private final GitHubWritePacer pacer;
+  private final GitHubTokenRefresh credentials;
 
   /** A retry that only backs off, for the tests that pin the backoff rather than the pacing. */
   GitHubWriteRetry(Sleeper sleeper, Supplier<Instant> clock) {
-    this(sleeper, clock, GitHubWritePacer.NONE);
+    this(sleeper, clock, GitHubWritePacer.NONE, new GitHubTokenRefresh());
   }
 
   GitHubWriteRetry(Sleeper sleeper, Supplier<Instant> clock, GitHubWritePacer pacer) {
+    this(sleeper, clock, pacer, new GitHubTokenRefresh());
+  }
+
+  GitHubWriteRetry(
+      Sleeper sleeper,
+      Supplier<Instant> clock,
+      GitHubWritePacer pacer,
+      GitHubTokenRefresh credentials) {
     this.sleeper = sleeper;
     this.clock = clock;
     this.pacer = pacer;
+    this.credentials = credentials;
   }
 
   /**
@@ -102,11 +127,39 @@ public final class GitHubWriteRetry {
    * @param operation what is being posted, for the log — never credentials or comment text
    */
   public <T> T call(String operation, Supplier<T> operationCall) {
-    for (int attempt = 1; ; attempt++) {
+    return call(operation, null, _ -> operationCall.get());
+  }
+
+  /**
+   * The same, for a call that presents an installation token. {@code operationCall} is handed the
+   * credential to use rather than closing over one, so an attempt GitHub answers with 401 can be
+   * repeated with a freshly minted token instead of re-sending the dead one (#624).
+   *
+   * <p>The refresh happens at most once per call and outside the attempt budget: a request that was
+   * turned away for its credential was never throttled, so charging it a backoff attempt would
+   * spend the budget that exists for the throttling this cannot prevent. Once the credential has
+   * been swapped a second 401 is final — the installation itself is refusing, and nothing fresher
+   * exists to try.
+   *
+   * @param auth the {@code Authorization} header to start with, or {@code null} for a call that
+   *     carries no credential of its own and so has nothing to refresh
+   */
+  public <T> T call(String operation, String auth, Function<String, T> operationCall) {
+    var credential = auth;
+    var refreshable = true;
+    for (int attempt = 1; ; ) {
       try {
         pacer.acquire(operation);
-        return operationCall.get();
+        return operationCall.apply(credential);
       } catch (WebApplicationException e) {
+        if (refreshable) {
+          var fresh = credentials.replacementFor(operation, credential, e);
+          if (fresh.isPresent()) {
+            credential = fresh.get();
+            refreshable = false;
+            continue;
+          }
+        }
         var delay = retryDelay(operation, e, attempt);
         if (delay.isEmpty()) {
           throw e;
@@ -124,6 +177,7 @@ public final class GitHubWriteRetry {
           log.warn("Interrupted while backing off {} — the payload is lost", operation);
           throw e;
         }
+        attempt++;
       }
     }
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -526,13 +526,27 @@ public class ReviewOrchestrator {
         });
   }
 
-  /** Applies failure fields to the in-memory session and persisted entity together. */
+  /**
+   * Applies failure fields to the in-memory session and persisted entity together, carrying the
+   * model's response with them when the run got far enough to have one.
+   *
+   * <p>#624: a review that dies while publishing has already paid for every model call it made, and
+   * the response was written to the database only on the success path — so the one failure mode
+   * where the findings are still worth something was the one that discarded them. Persisting it
+   * here leaves the finished work on the session and on its dashboard page instead of only in a log
+   * line. It stays out of the follow-up history either way: {@code findPreviousAiResponseJson} and
+   * {@code findAllPriorAiResponseJsons} both select on {@code STATUS_COMPLETED}, so a failed round
+   * cannot make the next one treat findings it never posted as already raised.
+   */
   void applyReviewFailure(ReviewSession session, String errorMessage) {
     applySessionState(
         session,
         s -> {
           s.setStatus(ReviewSession.STATUS_FAILED);
           s.setErrorMessage(errorMessage);
+          if (session.getAiResponseJson() != null) {
+            s.setAiResponseJson(session.getAiResponseJson());
+          }
         });
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClientTest.java
@@ -16,6 +16,9 @@
 package dev.thiagogonzaga.thrillhousebot.github;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -200,5 +203,144 @@ class GitHubAuthClientTest {
     when(githubConfig.privateKey()).thenReturn("");
 
     assertThrows(RuntimeException.class, () -> authClient.generateAppJwt());
+  }
+
+  /**
+   * #624: the margin the TTL leaves against GitHub's 60-minute expiry is the whole budget a review
+   * has between reading its header and its last write. With {@code AI_TIMEOUT=900s} a single model
+   * call may take 15 minutes on its own, and a review makes several — the old 50-minute TTL left 10
+   * minutes, so a review acquiring a token late in the window could not finish one call inside it.
+   */
+  @Test
+  void theCacheMustLeaveRoomForAWholeModelCallBeforeTheTokenExpires() {
+    var githubExpiry = java.time.Duration.ofMinutes(60);
+    var longestSingleModelCall = java.time.Duration.ofMinutes(15);
+
+    var margin = githubExpiry.minus(GitHubAuthClient.TOKEN_TTL);
+
+    assertTrue(
+        margin.compareTo(longestSingleModelCall) >= 0,
+        "a cached token must outlive one full-length model call, but only " + margin + " is left");
+  }
+
+  private static GitHubTokenApi.InstallationTokenResponse token(String value) {
+    return new GitHubTokenApi.InstallationTokenResponse(value, "2026-01-01T00:00:00Z");
+  }
+
+  /** What GitHub answers a write with once the installation token behind it has expired. */
+  private static jakarta.ws.rs.WebApplicationException badCredentials() {
+    return new jakarta.ws.rs.WebApplicationException(
+        jakarta.ws.rs.core.Response.status(401)
+            .entity("{\"message\":\"Bad credentials\",\"status\":\"401\"}")
+            .build());
+  }
+
+  /**
+   * The regression #624 is about, end to end and with nothing stubbed between the two halves: a
+   * review reads its {@code Authorization} header when it starts, spends fourteen minutes on the
+   * model, and posts with a token GitHub has since stopped accepting. Before the fix the 401
+   * propagated and the finished, paid-for review was discarded; now the rejection mints a
+   * replacement and the same generation is posted with it.
+   */
+  @Test
+  void aReviewPostThatOutlivedItsInstallationTokenIsRepostedWithAFreshToken() {
+    var installationId = 532L;
+    when(tokenApi.createInstallationToken(anyString(), anyString(), eq(installationId)))
+        .thenReturn(token("expired-token"), token("minted-token"));
+    var auth = authClient.getAuthHeader(installationId);
+    assertEquals("Bearer expired-token", auth);
+
+    var reviewClient = mock(GitHubReviewClient.class);
+    when(reviewClient.createReview(
+            anyString(), anyString(), anyString(), anyString(), anyInt(), any()))
+        .thenCallRealMethod();
+    var request =
+        new GitHubReviewClient.CreateReviewRequest(
+            "a532aff", "the generated review", "COMMENT", java.util.List.of());
+    var posted =
+        new GitHubReviewClient.ReviewResponse(
+            94131141478L, "the generated review", "COMMENTED", "a532aff", null);
+    when(reviewClient.createReviewOnce("Bearer expired-token", "json", "o", "r", 532, request))
+        .thenThrow(badCredentials());
+    when(reviewClient.createReviewOnce("Bearer minted-token", "json", "o", "r", 532, request))
+        .thenReturn(posted);
+
+    var result = reviewClient.createReview(auth, "json", "o", "r", 532, request);
+
+    assertSame(posted, result, "the review the model already produced must survive the 401");
+    verify(reviewClient).createReviewOnce("Bearer minted-token", "json", "o", "r", 532, request);
+  }
+
+  @Test
+  void refreshingReplacesTheRejectedTokenSoLaterCallersGetTheNewOne() {
+    var installationId = 42L;
+    when(tokenApi.createInstallationToken(anyString(), anyString(), eq(installationId)))
+        .thenReturn(token("expired-token"), token("minted-token"));
+    var dead = authClient.getAuthHeader(installationId);
+
+    var fresh = authClient.refreshedAuthHeader(dead);
+
+    assertEquals(java.util.Optional.of("Bearer minted-token"), fresh);
+    assertEquals(
+        "Bearer minted-token",
+        authClient.getAuthHeader(installationId),
+        "the replacement must be cached, not minted again for every later call");
+    verify(tokenApi, times(2))
+        .createInstallationToken(anyString(), anyString(), eq(installationId));
+  }
+
+  /**
+   * A dead token does not fail one write, it fails every write still holding it — the #624 log has
+   * five 401s in five seconds. The second one through must be handed the replacement the first one
+   * minted rather than evicting it and minting a third.
+   */
+  @Test
+  void aSecondWriteHoldingTheSameDeadTokenGetsTheReplacementAlreadyMinted() {
+    var installationId = 42L;
+    when(tokenApi.createInstallationToken(anyString(), anyString(), eq(installationId)))
+        .thenReturn(token("expired-token"), token("minted-token"));
+    var dead = authClient.getAuthHeader(installationId);
+    authClient.refreshedAuthHeader(dead);
+
+    var second = authClient.refreshedAuthHeader(dead);
+
+    assertEquals(java.util.Optional.of("Bearer minted-token"), second);
+    verify(tokenApi, times(2))
+        .createInstallationToken(anyString(), anyString(), eq(installationId));
+  }
+
+  /**
+   * The index that maps a token back to its installation keeps the current one and the one it
+   * replaced, and nothing older — otherwise it would grow with the process's uptime, one entry per
+   * TTL per installation.
+   */
+  @Test
+  void aTokenTwoGenerationsOldIsForgottenSoTheIndexCannotGrowWithUptime() {
+    var installationId = 42L;
+    when(tokenApi.createInstallationToken(anyString(), anyString(), eq(installationId)))
+        .thenReturn(token("first"), token("second"), token("third"));
+    var first = authClient.getAuthHeader(installationId);
+    var second = authClient.refreshedAuthHeader(first).orElseThrow();
+
+    var third = authClient.refreshedAuthHeader(second).orElseThrow();
+
+    assertEquals("Bearer third", third);
+    assertEquals(
+        java.util.Optional.of("Bearer third"),
+        authClient.refreshedAuthHeader(second),
+        "the token just superseded still names its installation");
+    assertEquals(
+        java.util.Optional.empty(),
+        authClient.refreshedAuthHeader(first),
+        "the generation before that is forgotten");
+  }
+
+  @Test
+  void aHeaderThisProcessNeverIssuedNamesNoInstallationAndIsNotReplaced() {
+    assertEquals(
+        java.util.Optional.empty(), authClient.refreshedAuthHeader("Bearer someone-elses"));
+    assertEquals(java.util.Optional.empty(), authClient.refreshedAuthHeader("Basic dXNlcjpwdw=="));
+    assertEquals(java.util.Optional.empty(), authClient.refreshedAuthHeader(null));
+    verify(tokenApi, never()).createInstallationToken(anyString(), anyString(), anyLong());
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCheckRunClientTest.java
@@ -16,8 +16,17 @@
 package dev.thiagogonzaga.thrillhousebot.github;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class GitHubCheckRunClientTest {
@@ -177,5 +186,69 @@ class GitHubCheckRunClientTest {
     assertNull(out.title());
     assertNull(out.summary());
     assertNull(out.text());
+  }
+
+  /**
+   * #624: the check-run conclusion is written after the model work and after the review has been
+   * posted — exactly where a token read at the top of a long review has already expired. Three of
+   * that incident's 401s landed here, leaving the merge gate stuck in progress on a pull request
+   * whose review had actually finished.
+   */
+  @Nested
+  class ExpiredCredentials {
+
+    private static final String DEAD = "Bearer expired-token";
+    private static final String FRESH = "Bearer minted-token";
+    private static final GitHubCheckRunClient.UpdateCheckRunRequest CONCLUSION =
+        new GitHubCheckRunClient.UpdateCheckRunRequest(null, "success", null, null, null);
+
+    @AfterEach
+    void unbind() {
+      GitHubTokenRefresh.SHARED.bind(null);
+    }
+
+    private GitHubCheckRunClient updatingClient() {
+      var client = mock(GitHubCheckRunClient.class);
+      doCallRealMethod()
+          .when(client)
+          .updateCheckRun(anyString(), anyString(), anyString(), anyString(), anyLong(), any());
+      return client;
+    }
+
+    private static WebApplicationException badCredentials() {
+      return new WebApplicationException(
+          Response.status(401).entity("{\"message\":\"Bad credentials\"}").build());
+    }
+
+    @Test
+    void aConclusionRejectedForItsCredentialIsWrittenWithAFreshOne() {
+      GitHubTokenRefresh.SHARED.bind(_ -> Optional.of(FRESH));
+      var client = updatingClient();
+      doThrow(badCredentials())
+          .when(client)
+          .updateCheckRunOnce(DEAD, "json", "o", "r", 94131141478L, CONCLUSION);
+
+      client.updateCheckRun(DEAD, "json", "o", "r", 94131141478L, CONCLUSION);
+
+      // The gate ends up green instead of stuck in progress for good.
+      verify(client).updateCheckRunOnce(FRESH, "json", "o", "r", 94131141478L, CONCLUSION);
+    }
+
+    @Test
+    void aRejectionThatNoFreshTokenCanFixStillPropagates() {
+      var client = updatingClient();
+      var rejection = badCredentials();
+      doThrow(rejection).when(client).updateCheckRunOnce(DEAD, "json", "o", "r", 1L, CONCLUSION);
+
+      var thrown =
+          assertThrows(
+              WebApplicationException.class,
+              () -> client.updateCheckRun(DEAD, "json", "o", "r", 1L, CONCLUSION));
+
+      // CheckRunManager's own fail-soft handling is left exactly as it was.
+      assertSame(rejection, thrown);
+      verify(client, times(1))
+          .updateCheckRunOnce(anyString(), anyString(), anyString(), anyString(), anyLong(), any());
+    }
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
@@ -27,7 +27,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -286,5 +288,257 @@ class GitHubWriteRetryTest {
     // The flag is restored so the shutdown the interrupt announced is not swallowed here.
     assertTrue(Thread.interrupted(), "interrupt status restored");
     assertFalse(Thread.currentThread().isInterrupted());
+  }
+
+  /**
+   * The #624 half: the one failure the backoff above cannot fix by repeating, because every repeat
+   * presents the same dead installation token. The seam here belongs to this retry instance, so
+   * nothing in these tests touches the process-wide binding.
+   */
+  @Nested
+  class ExpiredCredentials {
+
+    private static final String DEAD = "Bearer expired-token";
+    private static final String FRESH = "Bearer minted-token";
+
+    private final GitHubTokenRefresh credentials = new GitHubTokenRefresh();
+
+    private final GitHubWriteRetry refreshing =
+        new GitHubWriteRetry(
+            slept::add,
+            () -> Instant.ofEpochSecond(1_800_000_000L),
+            GitHubWritePacer.NONE,
+            credentials);
+
+    private final AtomicInteger mints = new AtomicInteger();
+
+    private WebApplicationException badCredentials() {
+      return failure(401, "{\"message\":\"Bad credentials\",\"status\":\"401\"}");
+    }
+
+    private void minting(String replacement) {
+      credentials.bind(
+          _ -> {
+            mints.incrementAndGet();
+            return Optional.ofNullable(replacement);
+          });
+    }
+
+    @Test
+    void aRejectedCredentialIsReplacedAndTheWriteRepeatedWithIt() {
+      minting(FRESH);
+      var presented = new ArrayList<String>();
+
+      var result =
+          refreshing.call(
+              "a review on o/r #532",
+              DEAD,
+              credential -> {
+                presented.add(credential);
+                if (DEAD.equals(credential)) {
+                  throw badCredentials();
+                }
+                return "posted";
+              });
+
+      // The generation was already paid for; a fresh token is the only thing that can save it.
+      assertEquals("posted", result);
+      assertEquals(List.of(DEAD, FRESH), presented);
+      // A rejected credential was never throttled, so the repeat costs no wait and no attempt.
+      assertEquals(List.of(), slept);
+    }
+
+    @Test
+    void aCredentialIsReplacedOnlyOncePerCall() {
+      minting(FRESH);
+      var calls = new AtomicInteger();
+
+      assertThrows(
+          WebApplicationException.class,
+          () ->
+              refreshing.call(
+                  "a review on o/r #532",
+                  DEAD,
+                  _ -> {
+                    calls.incrementAndGet();
+                    throw badCredentials();
+                  }));
+
+      // The installation itself is refusing; a third token would be no fresher than the second.
+      assertEquals(2, calls.get());
+      assertEquals(1, mints.get());
+    }
+
+    @Test
+    void aThrottleIsNotMistakenForADeadCredential() {
+      minting(FRESH);
+      var calls = new AtomicInteger();
+
+      var result =
+          refreshing.call(
+              "a comment on o/r #7",
+              DEAD,
+              credential -> {
+                if (calls.incrementAndGet() == 1) {
+                  throw throttled("Retry-After", "3");
+                }
+                return "posted with " + credential;
+              });
+
+      assertEquals("posted with " + DEAD, result);
+      assertEquals(0, mints.get(), "a 403 says nothing about the credential");
+      assertEquals(List.of(Duration.ofSeconds(3)), slept);
+    }
+
+    @Test
+    void aCredentialThatCannotBeReplacedFailsOnTheFirstAttempt() {
+      minting(null);
+      var calls = new AtomicInteger();
+      var rejection = badCredentials();
+
+      var thrown =
+          assertThrows(
+              WebApplicationException.class,
+              () ->
+                  refreshing.call(
+                      "a review on o/r #532",
+                      DEAD,
+                      _ -> {
+                        calls.incrementAndGet();
+                        throw rejection;
+                      }));
+
+      assertSame(rejection, thrown);
+      assertEquals(1, calls.get());
+    }
+
+    @Test
+    void aReplacementIdenticalToTheRejectedCredentialIsNotWorthRepeating() {
+      minting(DEAD);
+      var calls = new AtomicInteger();
+
+      assertThrows(
+          WebApplicationException.class,
+          () ->
+              refreshing.call(
+                  "a review on o/r #532",
+                  DEAD,
+                  _ -> {
+                    calls.incrementAndGet();
+                    throw badCredentials();
+                  }));
+
+      // The cache is already holding the newest token GitHub will issue and it is still refused.
+      assertEquals(1, calls.get());
+    }
+
+    @Test
+    void aFailureWhileMintingLeavesTheRejectionThatExplainsTheLoss() {
+      credentials.bind(
+          _ -> {
+            throw new IllegalStateException("the token endpoint is down too");
+          });
+      var rejection = badCredentials();
+
+      var thrown =
+          assertThrows(
+              WebApplicationException.class,
+              () ->
+                  refreshing.call(
+                      "a review on o/r #532",
+                      DEAD,
+                      _ -> {
+                        throw rejection;
+                      }));
+
+      assertSame(rejection, thrown, "the 401 is what the operator needs to see, not a mint error");
+    }
+
+    @Test
+    void aCallCarryingNoCredentialHasNothingToReplace() {
+      minting(FRESH);
+      var rejection = badCredentials();
+
+      assertThrows(
+          WebApplicationException.class,
+          () ->
+              refreshing.call(
+                  "a check of o/r",
+                  () -> {
+                    throw rejection;
+                  }));
+
+      assertEquals(0, mints.get());
+    }
+
+    @Test
+    void theOneShotFormLeavesAWriteThatSucceedsAlone() {
+      minting(FRESH);
+
+      var result = credentials.retrying("check run 1 on o/r", DEAD, credential -> credential);
+
+      assertEquals(DEAD, result);
+      assertEquals(0, mints.get(), "a credential GitHub accepted is never replaced");
+    }
+
+    /** The one-shot form, for the writes that have no backoff loop of their own. */
+    @Test
+    void theOneShotFormReplacesAndRepeatsExactlyOnce() {
+      minting(FRESH);
+      var presented = new ArrayList<String>();
+
+      var result =
+          credentials.retrying(
+              "check run 94131141478 on o/r",
+              DEAD,
+              credential -> {
+                presented.add(credential);
+                if (DEAD.equals(credential)) {
+                  throw badCredentials();
+                }
+                return "updated";
+              });
+
+      assertEquals("updated", result);
+      assertEquals(List.of(DEAD, FRESH), presented);
+    }
+
+    @Test
+    void theOneShotFormRethrowsWhenNothingCanBeMinted() {
+      minting(null);
+      var rejection = badCredentials();
+
+      var thrown =
+          assertThrows(
+              WebApplicationException.class,
+              () ->
+                  credentials.retrying(
+                      "check run 1 on o/r",
+                      DEAD,
+                      _ -> {
+                        throw rejection;
+                      }));
+
+      assertSame(rejection, thrown);
+    }
+
+    @Test
+    void anUnboundSeamLeavesEveryRefusalExactlyAsItWas() {
+      credentials.bind(null);
+      var rejection = badCredentials();
+
+      var thrown =
+          assertThrows(
+              WebApplicationException.class,
+              () ->
+                  credentials.retrying(
+                      "check run 1 on o/r",
+                      DEAD,
+                      _ -> {
+                        throw rejection;
+                      }));
+
+      assertSame(rejection, thrown);
+    }
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -4361,6 +4361,51 @@ class ReviewOrchestratorTest {
   }
 
   @Nested
+  class ApplyReviewFailure {
+
+    /**
+     * #624: a review that dies while publishing has already paid for every model call it made. The
+     * response was written to the database only on the success path, so the one failure mode where
+     * the findings are still worth something was the one that discarded them.
+     */
+    @Test
+    void shouldKeepTheModelResponseOfAReviewThatDiedWhilePublishing() {
+      var session = new ReviewSession();
+      session.id = 9L;
+      session.setAiResponseJson("{\"findings\":[{\"title\":\"paid for\"}]}");
+
+      orchestrator.applyReviewFailure(session, "GitHub review rejected: 401");
+
+      assertEquals(ReviewSession.STATUS_FAILED, session.getStatus());
+      var updater = ArgumentCaptor.forClass(java.util.function.Consumer.class);
+      verify(sessionPersistence).update(eq(9L), updater.capture());
+      var managed = new ReviewSession();
+      updater.getValue().accept(managed);
+      assertEquals(ReviewSession.STATUS_FAILED, managed.getStatus());
+      assertEquals("GitHub review rejected: 401", managed.getErrorMessage());
+      assertEquals(
+          "{\"findings\":[{\"title\":\"paid for\"}]}",
+          managed.getAiResponseJson(),
+          "the completed AI work must survive the failed post");
+    }
+
+    @Test
+    void shouldSkipAiResponseJsonWhenTheRunNeverGotOne() {
+      var session = new ReviewSession();
+      session.id = 10L;
+
+      orchestrator.applyReviewFailure(session, "context load failed");
+
+      var updater = ArgumentCaptor.forClass(java.util.function.Consumer.class);
+      verify(sessionPersistence).update(eq(10L), updater.capture());
+      var managed = new ReviewSession();
+      updater.getValue().accept(managed);
+      assertEquals(ReviewSession.STATUS_FAILED, managed.getStatus());
+      assertNull(managed.getAiResponseJson());
+    }
+  }
+
+  @Nested
   class PersistAiResponse {
 
     @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

A review reads its installation token **once**, at the top of the run, and every write at the end
of that review reuses the same string. The cache left 10 minutes of headroom against GitHub's
60-minute expiry, but `AI_TIMEOUT=900s` allows a *single* model call 15 minutes and a review makes
several — so a review acquiring a token late in its cache window routinely outlived it. The review
post, the check-run conclusion, the mark-as-failed update and the failure comment then all drew
`401 Bad credentials` off the same dead token. The completed, paid-for generation was discarded,
the merge gate was left neither green nor red, and the comment that would have reported the failure
was itself a content-creating call on the credential that had just failed.

### Layer 1 — refresh and retry

`GitHubWriteRetry` (#577) already backed off and repeated these calls, but every attempt re-read the
same `Authorization` header, so a repeat could only draw the same 401. A rejected credential is now
swapped for a freshly minted one and the call repeated — at most once per call.

**Where the refresh lives, and why.** In `GitHubWriteRetry`, folded into its attempt loop:

- It already owns the "is this failure worth repeating" policy and the loop that repeats it, and it
  is already the single seam every content-creating write passes through. A second, parallel retry
  mechanism next to it would have two budgets and two duplicate-suppression arguments.
- **Not in the REST-client filter**: a JAX-RS `ClientResponseFilter` cannot re-issue the request it
  is inspecting, and it could not name the installation to refresh for without the same reverse
  lookup this adds anyway.
- **Not in `GitHubAuthClient`**: it never sees the failing call. By the time a write happens the
  header string was resolved fourteen minutes earlier and the auth client is not on the path.

The one structural obstacle was that the retry received a `Supplier` that had already closed over
the header, so it could not change the credential between attempts. The five call sites now pass
`auth` plus a `Function<String, T>`, so each attempt is handed the credential to use. The old
`Supplier` overload is kept for the calls that carry no credential of their own.

Minting requires `GitHubAuthClient`, and the calls that need it are `default` methods on the
REST-client interfaces with nowhere to inject it — the same constraint that made
`GitHubWritePacer.DEFAULT` and `GitHubLostWrites.SHARED` process-wide. `GitHubTokenRefresh.SHARED`
follows that existing pattern; `GitHubAuthClient` binds itself into it when CDI constructs it, and
until then every refusal behaves exactly as it did before.

**Why this cannot double-post.** GitHub authenticates before it routes, so a request answered with
401 never reached the handler that would have created the comment, the review or the check-run
update. That is the same argument `GitHubWriteRetry` already makes for a throttle, and a stronger
one — a 401 leaves no room for the write to have been partially applied. The ambiguous failures (a
reset connection, a read timeout, a 5xx) remain deliberately un-repeated.

**Check runs.** Three of the incident's 401s were check-run writes, which did not pass through
`GitHubWriteRetry` at all. `updateCheckRun` is now a `*Once` + default-wrapper pair, the same shape
`createComment`/`createReview` already use, so `CheckRunManager` and its 422 conclusion-only
fallback are untouched and both attempts get the refresh. It deliberately does **not** gain throttle
backoff or pacing — that is not what #624 is about.

**Cache TTL: 50 → 30 minutes.** Secondary, as the issue says: it narrows the window without closing
it. 30 minutes leaves 30 minutes of headroom, which fits a full-length model call with room to
spare, and doubles the worst-case mint rate to two per installation per hour — nothing against the
App's limits.

**Cascade safety** — revised after review; the first version of this was wrong. A dead token does not
fail one write, it fails every write still holding it (five within five seconds in the incident), and
those writes are on different threads: `ReviewDispatcher` serializes per **pull request**, not per
installation, and runs each PR's review on its own virtual thread, so two reviews sharing an
installation cross the token's expiry together and refresh at the same moment.

The index therefore retires entries by **age** — GitHub's own 60-minute token expiry, past which no
write can still hold a usable token — rather than keeping "the current and the one it replaced". The
one-deep version assumed serialized refreshes: two concurrent mints roll the superseded slot forward
twice and the second evicts the *original* token while a third write is still about to present it,
so that write's 401 finds no owner, gets no replacement and is lost. An age cannot be raced.

Concurrent mints do still happen, and they are harmless: GitHub does not invalidate one installation
token by issuing another, so both writes proceed on independently valid credentials and the only
cost is one extra token request. Deduplicating them would need a lock held across the token
endpoint's round trip (or a per-installation `CompletableFuture`), and it would buy nothing but that
saved request — so there is no coordination here at all. The cache entry is expired in place only
while it still holds the dead token, so a refresher arriving after another has already replaced it
reads the replacement instead of minting again.

### Layer 2 — recovery from the database: answered, deliberately not built

The maintainer asked directly whether the stored session can be re-rendered and reposted. Having
gone through it: **no, not as an automatic repost** — and the investigation turned up three things
worth reporting, one of which is a real bug that this PR does fix.

**1. `aiResponseJson` is not actually there on a failed session.** `FindingPipeline` sets it on the
*in-memory* session; only `applyReviewResult` (the success path) writes it to the database.
`applyReviewFailure` wrote status and `errorMessage` and nothing else — so the exact scenario Layer 2
would recover from is the one where the response was never persisted. **Fixed here**: the failure
path now carries the response with it, so the paid-for findings survive on the session and on its
dashboard page instead of only in a log line. Both `findPreviousAiResponseJson` and
`findAllPriorAiResponseJsons` select on `STATUS_COMPLETED`, so a failed round still cannot make the
next one treat findings it never posted as already raised. This is the cheap half of Layer 2 and it
is the precondition for any future repost.

**2. There is no good trigger, and that is what kills it.** Of the three options:

- *Next webhook for the PR* — the most common next event after a failed review is a push, which
  moves the head SHA and fails the staleness gate. Useless in the common case.
- *Startup sweep of failed sessions* — exactly the "fires on a long-dead PR" case the brief calls
  worse than no recovery.
- *Explicit command* — a new `/repost` surface next to `/review`, which the user can already run.

The only genuinely good moment to recover is **immediately, in-process, while the review is still in
memory** — which is precisely what Layer 1 does. A DB-backed repost is a strictly worse in-process
retry gated behind a trigger that in practice never fires usefully.

**3. The stored session is nowhere near enough to repost from.** `postReview` takes a `ReviewResult`,
not a `ReviewResponse`: building one needs the full `ReviewContext` (files, diff, prior reviews,
inline comments), the CI evaluation and the budget plan, plus a `DiffLineResolver` to anchor inline
comments — none of it persisted. `ReviewSession` also carries no `installationId`, so a repost
cannot even authenticate without resolving the installation from the repository first. Recovery
would mean re-fetching the diff and re-running the verdict build; it is a re-render, not a replay,
and it would be a large change across the orchestrator, the publisher and the schema for a narrow
window (post failed for a *non-credential* reason, head SHA unchanged, someone triggers it).

**On idempotency — worth flagging.** `createCommentOnce` is **not** an idempotency mechanism. The
`Once` suffix means "one HTTP attempt", the un-retried primitive that exists so the retry policy
lives in exactly one place (`createComment`); it says nothing about at-most-once delivery, and the
same pattern now applies to `updateCheckRunOnce`. Nothing in the codebase deduplicates a repost
against a review already on the PR. That removes the "just use the existing mechanism" shortcut for
Layer 2 and would have to be built. It does not affect Layer 1, whose no-duplicate argument rests on
401 being an edge rejection rather than on any dedup.

**Staleness**, for the record, had a clean answer if it had been built: gate on
`session.commitSha` still equalling the PR head, and on mismatch write `STATUS_FAILED` with an
`errorMessage` recording that the head had moved past the reviewed SHA — never a silent drop. It is
the trigger and the missing context, not staleness, that make the repost not worth its complexity.

## Related Issues

Fixes #624

## How Has This Been Tested?

- [x] Unit tests

### Red/green proof

Both of these compile against unfixed `a532aff` and fail there for the reason claimed.

**1. The review post — the exact regression.** A real `GitHubAuthClient` mints the header, the review
posts with it fourteen minutes later, GitHub rejects it. On `a532aff`:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClientTest.aReviewPostThatOutlivedItsInstallationTokenIsRepostedWithAFreshToken -- Time elapsed: 0.945 s <<< ERROR!
jakarta.ws.rs.WebApplicationException: HTTP 401 Unauthorized
	at dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.lambda$createReview$1(GitHubReviewClient.java:66)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubWriteRetry.call(GitHubWriteRetry.java:108)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.lambda$createReview$0(GitHubReviewClient.java:63)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubLostWrites.lambda$carrying$0(GitHubLostWrites.java:133)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubLostWrites.recording(GitHubLostWrites.java:144)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubLostWrites.carrying(GitHubLostWrites.java:133)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.createReview(GitHubReviewClient.java:60)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClientTest.aReviewPostThatOutlivedItsInstallationTokenIsRepostedWithAFreshToken(GitHubAuthClientTest.java:241)
```

The generation is lost. With the fix the same test posts it under the minted token.

**2. The work discarded on the failure path.** On `a532aff`:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestratorTest.shouldKeepTheModelResponseOfAReviewThatDiedWhilePublishing -- Time elapsed: 1.671 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the completed AI work must survive the failed post ==> expected: <{"findings":[{"title":"paid for"}]}> but was: <null>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1210)
	at dev.thiagogonzaga.thrillhousebot.review.ReviewOrchestratorTest$ApplyReviewFailure.shouldKeepTheModelResponseOfAReviewThatDiedWhilePublishing(ReviewOrchestratorTest.java:4381)
```

**3. The concurrent-refresh race** (raised in review against `94fb5d1`, and real). Two threads
refreshing the same dead token, held inside the mint together by a gate so the interleaving is
deterministic. Against the one-deep index:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClientTest.concurrentRefreshesOfOneDeadTokenLeaveALaterHolderAbleToResolveIt -- Time elapsed: 0.774 s <<< FAILURE!
org.opentest4j.AssertionFailedError: a write still holding the dead token must not be stranded by a concurrent refresh ==> expected: <true> but was: <false>
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:232)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClientTest.concurrentRefreshesOfOneDeadTokenLeaveALaterHolderAbleToResolveIt(GitHubAuthClientTest.java:413)
```

It uses a hand-written `GitHubTokenApi` rather than a mock, because answer sequencing under
concurrent invocation is exactly what a mock does not promise, and the gate has a bounded wait so
the test still passes if minting is ever serialized. Ran 5× clean.

The remaining tests pin the refusals — a 403 throttle is not mistaken for a dead credential, a
credential is replaced at most once per call, a replacement identical to the rejected one is not
worth a request, a failure while minting leaves the 401 that explains the loss, and a call carrying
no credential has nothing to replace — plus the cascade case (a second write holding the same dead
token gets the replacement already minted rather than a third one) and the index bound.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Gates on `32ab457`:

- `./mvnw -B spotless:apply` then `./mvnw -B clean compile spotbugs:check spotless:check` — **BugInstance size is 0**, BUILD SUCCESS
- `./mvnw -B clean test` — **2939 tests, 0 failures, 0 errors**
- jacoco ∩ `git diff -U0 a532aff...HEAD` — 8 changed main files, 79 trackable changed lines,
  **0 uncovered lines and 0 uncovered branches**

**The refresh does not run on the Vert.x event loop**, so it introduces no #535-class blocking fault.
Established from the call graph rather than the log line:

- `orchestrator.review(...)` has exactly one caller — `ReviewDispatcher:146`, reached via
  `reviewExecutor.execute(...)` on `Executors.newVirtualThreadPerTaskExecutor()`. Every write in a
  review, and therefore every 401 catch and every mint, runs on that virtual thread.
- The GitHub REST clients declare synchronous return types under `quarkus-rest-client-jackson`.
  Invoking one from the event loop throws `BlockingOperationNotAllowedException` rather than
  returning 401 — so the incident's 401s are themselves proof the writes were not on the event loop.
- The `vert.x-eventloop-thread-0` line is `GitHubErrorLogger`, a `ResponseExceptionMapper`, which the
  reactive client runs on the I/O thread while processing the response. Its output is
  `GitHub API call failed: status=401 … body={"message": "Bad credentials", "status": "401"}` — the
  body quoted in #624. It records where the response was *observed*, not where the caller is.

The mint therefore inherits exactly the blocking-on-a-virtual-thread posture every other GitHub call
in a review already has.

Not covered by this PR, and worth its own issue: the refresh heals the *writes*, because those are
the calls that pass through the retry seam. The orchestrator's `auth` local is still resolved once
per review, so a read (or a GraphQL thread resolution) that outlives the token still fails — the
shorter TTL narrows that but does not close it. Closing it properly means threading a credential
that resolves per call rather than a header string captured at the top of the run, which touches
every `auth` parameter in the codebase and is well outside this lane.