### PR TITLE
fix(github): retire the token index by age so a concurrent refresh cannot strand a write

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClient.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +45,12 @@ public class GitHubAuthClient {
   private static final Logger log = LoggerFactory.getLogger(GitHubAuthClient.class);
 
   private static final String BEARER = "Bearer ";
+
+  /**
+   * How long GitHub itself honours an installation token. Not ours to choose — every duration below
+   * is reasoned against it, so it is written down once rather than repeated as a literal.
+   */
+  static final Duration GITHUB_TOKEN_LIFETIME = Duration.ofMinutes(60);
 
   /**
    * How long a minted installation token is reused before a new one is fetched.
@@ -67,11 +74,33 @@ public class GitHubAuthClient {
   private final Map<Long, CachedToken> tokenCache = new ConcurrentHashMap<>();
 
   /**
-   * How long a token this process minted stays traceable back to its installation. GitHub expires
-   * an installation token 60 minutes after issuing it, so past that no write can still be holding a
-   * usable one and the entry is dead weight.
+   * The longest a write can still be holding a token it read from the cache. The cache hands one
+   * out for up to {@link #TOKEN_TTL}, and the holder then runs for as long as its work takes — a
+   * review's model calls, its retries and its backoff. Two hours is far past any review this bot
+   * has run; it is the term that decides how long the index below has to remember a token, so it is
+   * stated rather than folded into a single opaque number.
    */
-  static final Duration OWNER_RETENTION = Duration.ofMinutes(60);
+  static final Duration LONGEST_WRITE_IN_FLIGHT = Duration.ofHours(2);
+
+  /**
+   * How long a token this process minted stays traceable back to its installation.
+   *
+   * <p>This has to <em>outlive</em> the token, not match it, and getting that wrong is subtle
+   * enough to be worth spelling out. An entry is consulted only when a write is holding a token
+   * GitHub has just refused, and the ordinary reason for that refusal is that the token has passed
+   * {@link #GITHUB_TOKEN_LIFETIME}. Every lookup that matters therefore happens when the entry is
+   * <em>already older than the token's whole life</em>. Retaining for exactly that life puts the
+   * sweep boundary precisely on the trigger condition: the refresh mints at {@code issued + 60min +
+   * something}, sweeps everything older than {@code now - 60min}, and deletes the entry for the
+   * very token whose 401 provoked it — so the first write of a cascade is rescued and every later
+   * holder of the same token finds nothing and is stranded, which is #624 again.
+   *
+   * <p>Retention is therefore the token's whole life plus how late the last write holding it can
+   * still fail ({@link #TOKEN_TTL} + {@link #LONGEST_WRITE_IN_FLIGHT}), with room to spare. At two
+   * mints per installation per hour the index holds a dozen entries per installation, which is
+   * nothing; the sweep is the cheaper side of this trade by a wide margin.
+   */
+  static final Duration OWNER_RETENTION = Duration.ofHours(6);
 
   /** A token this process minted: the installation it belongs to, and when it was issued. */
   private record TokenOwner(long installationId, Instant issuedAt) {}
@@ -99,10 +128,22 @@ public class GitHubAuthClient {
 
   private final AtomicReference<RSAPrivateKey> cachedPrivateKey = new AtomicReference<>();
 
+  private final Supplier<Instant> clock;
+
   @Inject
   public GitHubAuthClient(ThrillhouseConfig config, @RestClient GitHubTokenApi tokenApi) {
+    this(config, tokenApi, Instant::now);
+  }
+
+  /**
+   * Everything here turns on durations measured in hours — how long a token is cached, how long its
+   * owner stays resolvable — so the tests need a clock they can move rather than one they must
+   * outwait. Nothing else in this class reads the time directly.
+   */
+  GitHubAuthClient(ThrillhouseConfig config, GitHubTokenApi tokenApi, Supplier<Instant> clock) {
     this.config = config;
     this.tokenApi = tokenApi;
+    this.clock = clock;
     // Minting is the one thing only this bean can do, and the GitHub writes that need a dead token
     // replaced are interface default methods with nowhere to inject it. See GitHubTokenRefresh.
     GitHubTokenRefresh.SHARED.bind(this::mintedReplacementFor);
@@ -114,7 +155,7 @@ public class GitHubAuthClient {
    */
   public String generateAppJwt() {
     try {
-      Instant now = Instant.now();
+      Instant now = clock.get();
       var privateKey = privateKey();
 
       var claims =
@@ -143,7 +184,7 @@ public class GitHubAuthClient {
    */
   public String getInstallationToken(long installationId) {
     var cached = tokenCache.get(installationId);
-    if (cached != null && Instant.now().isBefore(cached.expiresAt())) {
+    if (cached != null && clock.get().isBefore(cached.expiresAt())) {
       log.debug("Using cached installation token (expires at {})", cached.expiresAt());
       return cached.token();
     }
@@ -155,23 +196,29 @@ public class GitHubAuthClient {
     var response =
         tokenApi.createInstallationToken(authHeader, "application/vnd.github+json", installationId);
 
-    var issuedAt = Instant.now();
+    // Read after the round trip, so the recorded instant is no earlier than GitHub's own issue
+    // time and the entry below is never retired sooner than the token it names.
+    var issuedAt = clock.get();
     var newToken = new CachedToken(response.token(), issuedAt.plus(TOKEN_TTL), installationId);
     tokenCache.put(installationId, newToken);
-    // Every token this process hands out stays traceable until GitHub's own expiry, so a write
+    // Every token this process hands out stays traceable well past GitHub's expiry, so a write
     // still holding an older one can always name the installation that has to replace it.
     tokenOwners.put(newToken.token(), new TokenOwner(installationId, issuedAt));
-    forgetTokensIssuedBefore(issuedAt.minus(OWNER_RETENTION));
+    forgetOwnersOlderThanRetention(issuedAt);
 
     return newToken.token();
   }
 
   /**
-   * Drops index entries for tokens issued before {@code cutoff} — GitHub has expired them, so no
-   * write can still present one and no replacement for one is worth minting. Swept on every mint,
-   * which bounds the index at the tokens issued in the last {@link #OWNER_RETENTION}.
+   * Drops index entries for tokens issued more than {@link #OWNER_RETENTION} before {@code now} —
+   * long past the point where any write could still be presenting one. Swept on every mint, which
+   * bounds the index at the tokens issued in that window.
+   *
+   * <p>The cutoff is absolute, so sweeping on behalf of one installation only ever retires entries
+   * that are genuinely that old, whichever installation they belong to.
    */
-  void forgetTokensIssuedBefore(Instant cutoff) {
+  private void forgetOwnersOlderThanRetention(Instant now) {
+    var cutoff = now.minus(OWNER_RETENTION);
     tokenOwners.values().removeIf(owner -> owner.issuedAt().isBefore(cutoff));
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClient.java
@@ -67,21 +67,35 @@ public class GitHubAuthClient {
   private final Map<Long, CachedToken> tokenCache = new ConcurrentHashMap<>();
 
   /**
+   * How long a token this process minted stays traceable back to its installation. GitHub expires
+   * an installation token 60 minutes after issuing it, so past that no write can still be holding a
+   * usable one and the entry is dead weight.
+   */
+  static final Duration OWNER_RETENTION = Duration.ofMinutes(60);
+
+  /** A token this process minted: the installation it belongs to, and when it was issued. */
+  private record TokenOwner(long installationId, Instant issuedAt) {}
+
+  /**
    * Which installation a token this process minted belongs to, so a write GitHub answered with 401
    * can be traced back to the installation whose token has to be replaced.
    *
-   * <p>Bounded to the current and the immediately superseded token per installation. The superseded
-   * one has to stay resolvable: a dead token does not fail one write, it fails every write still
-   * holding it — five within five seconds in #624 — and each of those after the first is presenting
-   * a token the cache has already replaced. Forgetting it would leave every write but the first
-   * unable to name its own installation.
+   * <p>Entries are retired by <em>age</em>, not by generation, and that distinction is the whole
+   * correctness argument. Refreshes of one installation are not serialized: {@code
+   * ReviewDispatcher} serializes per pull request, not per installation, and runs each PR's review
+   * on its own virtual thread — so two reviews in the same installation share one cached token,
+   * cross its expiry together, and refresh concurrently. Both mint, which costs an extra token
+   * request and no more, because GitHub does not invalidate one installation token by issuing
+   * another.
+   *
+   * <p>Keeping only "the current and the one it replaced" would not survive that. Two concurrent
+   * mints roll a one-deep superseded slot forward twice, and the second one's bookkeeping evicts
+   * the <em>original</em> token while a third write is still about to present it. That write's 401
+   * then finds no owner, gets no replacement, and is lost — precisely the failure this class exists
+   * to prevent, reintroduced by the bookkeeping meant to bound the index. An age cannot be raced: a
+   * token minted seconds ago is resolvable no matter how many refreshes have happened since.
    */
-  private final Map<String, Long> tokenOwners = new ConcurrentHashMap<>();
-
-  /**
-   * The token each installation replaced most recently, the only one {@link #tokenOwners} keeps.
-   */
-  private final Map<Long, String> supersededTokens = new ConcurrentHashMap<>();
+  private final Map<String, TokenOwner> tokenOwners = new ConcurrentHashMap<>();
 
   private final AtomicReference<RSAPrivateKey> cachedPrivateKey = new AtomicReference<>();
 
@@ -141,17 +155,24 @@ public class GitHubAuthClient {
     var response =
         tokenApi.createInstallationToken(authHeader, "application/vnd.github+json", installationId);
 
-    var newToken = new CachedToken(response.token(), Instant.now().plus(TOKEN_TTL), installationId);
-    var previous = tokenCache.put(installationId, newToken);
-    tokenOwners.put(newToken.token(), installationId);
-    if (previous != null) {
-      // Keep the token just superseded resolvable for the writes still holding it, and forget the
-      // one before it so the index cannot grow with the process's uptime.
-      var forgotten = supersededTokens.put(installationId, previous.token());
-      Optional.ofNullable(forgotten).ifPresent(tokenOwners::remove);
-    }
+    var issuedAt = Instant.now();
+    var newToken = new CachedToken(response.token(), issuedAt.plus(TOKEN_TTL), installationId);
+    tokenCache.put(installationId, newToken);
+    // Every token this process hands out stays traceable until GitHub's own expiry, so a write
+    // still holding an older one can always name the installation that has to replace it.
+    tokenOwners.put(newToken.token(), new TokenOwner(installationId, issuedAt));
+    forgetTokensIssuedBefore(issuedAt.minus(OWNER_RETENTION));
 
     return newToken.token();
+  }
+
+  /**
+   * Drops index entries for tokens issued before {@code cutoff} — GitHub has expired them, so no
+   * write can still present one and no replacement for one is worth minting. Swept on every mint,
+   * which bounds the index at the tokens issued in the last {@link #OWNER_RETENTION}.
+   */
+  void forgetTokensIssuedBefore(Instant cutoff) {
+    tokenOwners.values().removeIf(owner -> owner.issuedAt().isBefore(cutoff));
   }
 
   /** Returns an Authorization header value for GitHub API calls. */
@@ -164,10 +185,17 @@ public class GitHubAuthClient {
    * when {@code deadAuthHeader} is not one this process issued and so names no installation.
    *
    * <p>Bound into {@link GitHubTokenRefresh} at construction; see that class for why a 401 is worth
-   * repeating at all. The cache entry is dropped only while it still holds the dead token, because
-   * a 401 arrives from every in-flight write at once: the first one through mints the replacement,
-   * and the rest must be handed <em>that</em> replacement rather than each evicting it and minting
-   * another, which would leave every write chasing a token the next one has already thrown away.
+   * repeating at all.
+   *
+   * <p>A dead token does not fail one write, it fails every write still holding it — five within
+   * five seconds in #624 — and those writes are on different threads. Nothing here coordinates
+   * them, and nothing needs to: the cache entry is expired only while it still holds the dead
+   * token, so a refresher arriving after another has already replaced it reads the replacement
+   * instead of minting again; two that arrive together both mint, and two valid installation tokens
+   * are as good as one, since GitHub does not invalidate either. What must not happen is a holder
+   * losing the ability to name its installation, and {@link #tokenOwners} retires by age precisely
+   * so that cannot be raced. A lock across the token endpoint's round trip would buy only the saved
+   * request.
    *
    * <p>Kept separate from the method the constructor binds only because a constructor must not hand
    * out a reference to an overridable method — CDI subclasses this bean.
@@ -181,10 +209,11 @@ public class GitHubAuthClient {
       return Optional.empty();
     }
     var dead = deadAuthHeader.substring(BEARER.length());
-    var installationId = tokenOwners.get(dead);
-    if (installationId == null) {
+    var owner = tokenOwners.get(dead);
+    if (owner == null) {
       return Optional.empty();
     }
+    var installationId = owner.installationId();
     log.info(
         "Installation token for installation {} was rejected — minting a replacement",
         installationId);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClientTest.java
@@ -24,6 +24,16 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -256,7 +266,7 @@ class GitHubAuthClientTest {
         .thenCallRealMethod();
     var request =
         new GitHubReviewClient.CreateReviewRequest(
-            "a532aff", "the generated review", "COMMENT", java.util.List.of());
+            "a532aff", "the generated review", "COMMENT", List.of());
     var posted =
         new GitHubReviewClient.ReviewResponse(
             94131141478L, "the generated review", "COMMENTED", "a532aff", null);
@@ -280,7 +290,7 @@ class GitHubAuthClientTest {
 
     var fresh = authClient.refreshedAuthHeader(dead);
 
-    assertEquals(java.util.Optional.of("Bearer minted-token"), fresh);
+    assertEquals(Optional.of("Bearer minted-token"), fresh);
     assertEquals(
         "Bearer minted-token",
         authClient.getAuthHeader(installationId),
@@ -304,18 +314,18 @@ class GitHubAuthClientTest {
 
     var second = authClient.refreshedAuthHeader(dead);
 
-    assertEquals(java.util.Optional.of("Bearer minted-token"), second);
+    assertEquals(Optional.of("Bearer minted-token"), second);
     verify(tokenApi, times(2))
         .createInstallationToken(anyString(), anyString(), eq(installationId));
   }
 
   /**
-   * The index that maps a token back to its installation keeps the current one and the one it
-   * replaced, and nothing older — otherwise it would grow with the process's uptime, one entry per
-   * TTL per installation.
+   * Every token stays resolvable while GitHub would still accept it, however many refreshes have
+   * happened since — retention is by age, so no number of newer tokens can strand a holder of an
+   * older one.
    */
   @Test
-  void aTokenTwoGenerationsOldIsForgottenSoTheIndexCannotGrowWithUptime() {
+  void everyTokenStillWithinGitHubsExpiryKeepsNamingItsInstallation() {
     var installationId = 42L;
     when(tokenApi.createInstallationToken(anyString(), anyString(), eq(installationId)))
         .thenReturn(token("first"), token("second"), token("third"));
@@ -326,21 +336,107 @@ class GitHubAuthClientTest {
 
     assertEquals("Bearer third", third);
     assertEquals(
-        java.util.Optional.of("Bearer third"),
+        Optional.of("Bearer third"),
         authClient.refreshedAuthHeader(second),
         "the token just superseded still names its installation");
     assertEquals(
-        java.util.Optional.empty(),
+        Optional.of("Bearer third"),
         authClient.refreshedAuthHeader(first),
-        "the generation before that is forgotten");
+        "and so does the generation before that, which GitHub would still have accepted");
+  }
+
+  /** Past GitHub's own 60-minute expiry the entry is dead weight and is swept on the next mint. */
+  @Test
+  void aTokenGitHubHasExpiredIsForgottenSoTheIndexCannotGrowWithUptime() {
+    var installationId = 42L;
+    when(tokenApi.createInstallationToken(anyString(), anyString(), eq(installationId)))
+        .thenReturn(token("first"));
+    var first = authClient.getAuthHeader(installationId);
+
+    authClient.forgetTokensIssuedBefore(Instant.now().plus(Duration.ofMinutes(1)));
+
+    assertEquals(Optional.empty(), authClient.refreshedAuthHeader(first));
+    verify(tokenApi, times(1))
+        .createInstallationToken(anyString(), anyString(), eq(installationId));
+  }
+
+  /**
+   * A hand-written token API rather than a mock: this test drives two threads through the mint at
+   * once, and answer sequencing under concurrent invocation is exactly what a mock does not
+   * promise. The gate holds each mint until the other has arrived, or a bounded wait elapses — so
+   * the test still passes if minting is ever serialized, while today it makes the overlap
+   * deterministic.
+   */
+  private static final class GatedTokenApi implements GitHubTokenApi {
+
+    private final AtomicInteger minted = new AtomicInteger();
+    private final CountDownLatch overlap;
+
+    GatedTokenApi(int gatedMints) {
+      this.overlap = new CountDownLatch(gatedMints);
+    }
+
+    @Override
+    public InstallationTokenResponse createInstallationToken(
+        String authorization, String accept, long installationId) {
+      var n = minted.incrementAndGet();
+      if (n > 1) {
+        overlap.countDown();
+        try {
+          overlap.await(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IllegalStateException(e);
+        }
+      }
+      return token("token-" + n);
+    }
+  }
+
+  /**
+   * #624's cascade with the threads it actually has. {@code ReviewDispatcher} serializes per pull
+   * request, not per installation, and runs each review on its own virtual thread — so two reviews
+   * sharing an installation hold the same cached token, cross its expiry together, and refresh at
+   * the same moment.
+   *
+   * <p>With a one-deep superseded slot their two mints rolled it forward twice and evicted the
+   * original token, so a third write still holding it could name no installation, got no
+   * replacement, and was lost exactly as in the incident. No sequential test reaches that
+   * interleaving.
+   */
+  @Test
+  void concurrentRefreshesOfOneDeadTokenLeaveALaterHolderAbleToResolveIt() throws Exception {
+    var installationId = 42L;
+    var client = new GitHubAuthClient(config, new GatedTokenApi(2));
+    var dead = client.getAuthHeader(installationId);
+    assertEquals("Bearer token-1", dead);
+
+    try (var threads = Executors.newVirtualThreadPerTaskExecutor()) {
+      var both =
+          Stream.of(1, 2)
+              .map(
+                  _ ->
+                      CompletableFuture.supplyAsync(
+                          () -> client.refreshedAuthHeader(dead), threads))
+              .toList();
+      for (var refresh : both) {
+        var replacement = refresh.get(30, TimeUnit.SECONDS);
+        assertTrue(replacement.isPresent(), "both concurrent refreshes must get a live token");
+        assertNotEquals(dead, replacement.orElseThrow(), "and never the token GitHub just refused");
+      }
+    }
+
+    // The straggler: a third write that read the same header before any of this and 401s now.
+    assertTrue(
+        client.refreshedAuthHeader(dead).isPresent(),
+        "a write still holding the dead token must not be stranded by a concurrent refresh");
   }
 
   @Test
   void aHeaderThisProcessNeverIssuedNamesNoInstallationAndIsNotReplaced() {
-    assertEquals(
-        java.util.Optional.empty(), authClient.refreshedAuthHeader("Bearer someone-elses"));
-    assertEquals(java.util.Optional.empty(), authClient.refreshedAuthHeader("Basic dXNlcjpwdw=="));
-    assertEquals(java.util.Optional.empty(), authClient.refreshedAuthHeader(null));
+    assertEquals(Optional.empty(), authClient.refreshedAuthHeader("Bearer someone-elses"));
+    assertEquals(Optional.empty(), authClient.refreshedAuthHeader("Basic dXNlcjpwdw=="));
+    assertEquals(Optional.empty(), authClient.refreshedAuthHeader(null));
     verify(tokenApi, never()).createInstallationToken(anyString(), anyString(), anyLong());
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClientTest.java
@@ -355,10 +355,22 @@ class GitHubAuthClientTest {
   }
 
   /**
-   * The bug this replaced: retention was set to GitHub's 60-minute token lifetime, which is exactly
-   * the age at which a token starts drawing 401s. The refresh's own sweep therefore deleted the
-   * entry whose 401 provoked it, and every later write in the same cascade — the second of the five
-   * in five seconds — looked up a token the first refresh had just erased and got nothing back.
+   * A refresh must not retire the entry the rest of its own cascade is still resolving against.
+   *
+   * <p>This is the boundary {@link GitHubAuthClient#OWNER_RETENTION} has to clear, and it fails in
+   * the direction that looks safe. An entry is consulted only because a write is holding a token
+   * GitHub has just refused, and the ordinary reason for that refusal is that the token has passed
+   * {@link GitHubAuthClient#GITHUB_TOKEN_LIFETIME} — so every lookup that matters happens when the
+   * entry is <em>already older than the token's whole life</em>. Size the window at that lifetime,
+   * which reads as generous, and the refresh mints at {@code issued + 60min + ε}, sweeps everything
+   * older than {@code now - 60min}, and deletes the entry for the very token whose 401 provoked it.
+   * The first write of the cascade is rescued and every later holder of that token is stranded.
+   *
+   * <p>Hence a window of {@link GitHubAuthClient#TOKEN_TTL} plus {@link
+   * GitHubAuthClient#LONGEST_WRITE_IN_FLIGHT} rather than the token lifetime, and hence {@link
+   * #theOwnerIndexMustOutliveEveryTokenItNames} pinning the relationship. Anything that shortens
+   * the window back towards the lifetime brings this failure back, and brings it back quietly: the
+   * refresh that triggers the sweep still succeeds, so only the writes behind it are lost.
    */
   @Test
   void aRefreshDoesNotSweepAwayTheEntryTheRestOfItsCascadeStillNeeds() {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClientTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClientTest.java
@@ -33,10 +33,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -78,7 +78,15 @@ class GitHubAuthClientTest {
 
   @Mock private ThrillhouseConfig.GitHubConfig githubConfig;
 
-  @InjectMocks private GitHubAuthClient authClient;
+  private GitHubAuthClient authClient;
+
+  /** A clock the tests move by hand; retention is measured in hours and cannot be outwaited. */
+  private final AtomicReference<Instant> now =
+      new AtomicReference<>(Instant.parse("2026-08-12T13:32:03Z"));
+
+  private void advance(Duration by) {
+    now.updateAndGet(instant -> instant.plus(by));
+  }
 
   @BeforeEach
   void setUp() {
@@ -86,6 +94,7 @@ class GitHubAuthClientTest {
     when(config.github()).thenReturn(githubConfig);
     when(githubConfig.appId()).thenReturn("123456");
     when(githubConfig.privateKey()).thenReturn(TEST_PRIVATE_KEY);
+    authClient = new GitHubAuthClient(config, tokenApi, now::get);
   }
 
   @Test
@@ -345,19 +354,78 @@ class GitHubAuthClientTest {
         "and so does the generation before that, which GitHub would still have accepted");
   }
 
-  /** Past GitHub's own 60-minute expiry the entry is dead weight and is swept on the next mint. */
+  /**
+   * The bug this replaced: retention was set to GitHub's 60-minute token lifetime, which is exactly
+   * the age at which a token starts drawing 401s. The refresh's own sweep therefore deleted the
+   * entry whose 401 provoked it, and every later write in the same cascade — the second of the five
+   * in five seconds — looked up a token the first refresh had just erased and got nothing back.
+   */
   @Test
-  void aTokenGitHubHasExpiredIsForgottenSoTheIndexCannotGrowWithUptime() {
+  void aRefreshDoesNotSweepAwayTheEntryTheRestOfItsCascadeStillNeeds() {
     var installationId = 42L;
     when(tokenApi.createInstallationToken(anyString(), anyString(), eq(installationId)))
-        .thenReturn(token("first"));
-    var first = authClient.getAuthHeader(installationId);
+        .thenReturn(token("first"), token("second"));
+    var dead = authClient.getAuthHeader(installationId);
 
-    authClient.forgetTokensIssuedBefore(Instant.now().plus(Duration.ofMinutes(1)));
+    // The only reason a write holding this token draws 401 at all: GitHub has expired it.
+    advance(GitHubAuthClient.GITHUB_TOKEN_LIFETIME.plusMinutes(1));
+    assertEquals(Optional.of("Bearer second"), authClient.refreshedAuthHeader(dead));
 
-    assertEquals(Optional.empty(), authClient.refreshedAuthHeader(first));
+    // The straggler, a few seconds behind the first write of the cascade.
+    advance(Duration.ofSeconds(4));
+    assertEquals(
+        Optional.of("Bearer second"),
+        authClient.refreshedAuthHeader(dead),
+        "the refresh must not retire the entry its own cascade is still resolving against");
+  }
+
+  /** The constructor CDI uses: same behaviour, on the real clock rather than a movable one. */
+  @Test
+  void theInjectedConstructorMintsOnTheSystemClock() {
+    var installationId = 7L;
+    when(tokenApi.createInstallationToken(anyString(), anyString(), eq(installationId)))
+        .thenReturn(token("wall-clock"));
+    var client = new GitHubAuthClient(config, tokenApi);
+
+    assertEquals("Bearer wall-clock", client.getAuthHeader(installationId));
+    assertEquals(
+        "Bearer wall-clock",
+        client.getAuthHeader(installationId),
+        "and caches it, so the TTL is measured against a clock that actually advances");
     verify(tokenApi, times(1))
         .createInstallationToken(anyString(), anyString(), eq(installationId));
+  }
+
+  /**
+   * The invariant the constant has to satisfy, stated so it cannot silently drift back onto the
+   * trigger condition: an entry is only ever consulted after GitHub has stopped honouring the token
+   * it names, by a write that may have been holding it since the cache last handed it out.
+   */
+  @Test
+  void theOwnerIndexMustOutliveEveryTokenItNames() {
+    var latestPossibleLookup =
+        GitHubAuthClient.TOKEN_TTL.plus(GitHubAuthClient.LONGEST_WRITE_IN_FLIGHT);
+
+    assertTrue(
+        GitHubAuthClient.OWNER_RETENTION.compareTo(GitHubAuthClient.GITHUB_TOKEN_LIFETIME) > 0,
+        "retention that only matches the token lifetime sweeps on exactly the 401 it must survive");
+    assertTrue(
+        GitHubAuthClient.OWNER_RETENTION.compareTo(latestPossibleLookup) > 0,
+        "retention must cover a write that read the token at the end of the cache window");
+  }
+
+  /** Past retention the entry really is dead weight, and the next mint sweeps it. */
+  @Test
+  void aTokenPastRetentionIsForgottenSoTheIndexCannotGrowWithUptime() {
+    var installationId = 42L;
+    when(tokenApi.createInstallationToken(anyString(), anyString(), eq(installationId)))
+        .thenReturn(token("first"), token("second"));
+    var first = authClient.getAuthHeader(installationId);
+
+    advance(GitHubAuthClient.OWNER_RETENTION.plusMinutes(1));
+    authClient.getAuthHeader(installationId);
+
+    assertEquals(Optional.empty(), authClient.refreshedAuthHeader(first));
   }
 
   /**
@@ -407,9 +475,14 @@ class GitHubAuthClientTest {
   @Test
   void concurrentRefreshesOfOneDeadTokenLeaveALaterHolderAbleToResolveIt() throws Exception {
     var installationId = 42L;
-    var client = new GitHubAuthClient(config, new GatedTokenApi(2));
+    var client = new GitHubAuthClient(config, new GatedTokenApi(2), now::get);
     var dead = client.getAuthHeader(installationId);
     assertEquals("Bearer token-1", dead);
+
+    // Aged past GitHub's expiry first, because that is the only state a refresh ever runs in — and
+    // it is what makes each mint's retention sweep a real sweep rather than a no-op on a token
+    // minted microseconds ago.
+    advance(GitHubAuthClient.GITHUB_TOKEN_LIFETIME.plusMinutes(1));
 
     try (var threads = Executors.newVirtualThreadPerTaskExecutor()) {
       var both =


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Follow-up to #625, which was merged while this was in review. The refresh it added is sound; the
index that makes it work is not, under the concurrency the code actually has.

`GitHubAuthClient` maps a token back to its installation so a write GitHub answered with 401 can name
the installation whose token must be replaced. #625 bounded that index to the current token and the
one it replaced — a bound that quietly assumes refreshes of one installation are **serialized**.

They are not. `ReviewDispatcher` serializes per **pull request**, not per installation, and runs each
PR's review on its own virtual thread (`Executors.newVirtualThreadPerTaskExecutor()`). Two reviews
sharing an installation hold the same cached token, cross its expiry together, and refresh at the
same moment.

Both then mint. That part is harmless — GitHub does not invalidate one installation token by issuing
another, so both writes proceed on independently valid credentials and the only cost is one extra
token request. The damage is one line later: two mints roll a one-deep superseded slot forward
twice, and the second one evicts the **original** token while a third write is still about to
present it. That write's 401 finds no owner, gets no replacement, and is lost — exactly the failure
#624 exists to prevent, reintroduced by the bookkeeping meant to bound the index.

### The fix

Entries are retired by **age** instead of by generation. An age cannot be raced, so the guarantee
holds under any interleaving.

The window has to be chosen carefully, and the first version of this PR got it wrong — see the
review finding below, which was right. Retention now covers the token's whole life plus how late the
last write holding it can still fail (`TOKEN_TTL` + `LONGEST_WRITE_IN_FLIGHT`), with room to spare,
and an invariant test pins that relationship so it cannot silently drift back.

**No coordination is added, deliberately.** The only thing a per-installation lock (or a
`CompletableFuture` the other refreshers join) would buy is the saved token request, and it would
hold that lock across the token endpoint's round trip. `compute()`/`computeIfAbsent()` around the
mint would be worse still: it serializes per key by holding a `ConcurrentHashMap` bin across a
blocking HTTP call. The cache entry is already expired *in place* only while it still holds the dead
token, so a refresher arriving after another has replaced it reads the replacement rather than
minting again; only genuinely simultaneous refreshers both mint, and that is fine.

### Not an event-loop regression

Worth recording, since the incident's 401 lines were logged on `vert.x-eventloop-thread-0` and a
synchronous `createInstallationToken` there would be a #535-class fault. Established from the call
graph, not the log line:

- `orchestrator.review(...)` has exactly one caller — `ReviewDispatcher:146`, reached via
  `reviewExecutor.execute(...)` on a virtual-thread-per-task executor. Every write in a review, and
  therefore every 401 catch and every mint, runs on that virtual thread.
- The GitHub REST clients declare synchronous return types under `quarkus-rest-client-jackson`.
  Invoking one from the event loop throws `BlockingOperationNotAllowedException` rather than
  returning 401 — so the incident's 401s are themselves proof the writes were not on the event loop.
- The `vert.x-eventloop-thread-0` line is `GitHubErrorLogger`, a `ResponseExceptionMapper`, which the
  reactive client runs on the I/O thread while processing the response. Its output is
  `GitHub API call failed: status=401 … body={"message": "Bad credentials", "status": "401"}` — the
  body quoted in #624. It records where the response was *observed*, not where the caller is.

The mint inherits exactly the blocking-on-a-virtual-thread posture every other GitHub call in a
review already has.

## Related Issues

Follow-up to #625. Relates to #624.

## How Has This Been Tested?

- [x] Unit tests

### Review finding, and why it was right

The first push of this PR set retention to 60 minutes — GitHub's token lifetime. That is exactly
the age at which a token starts drawing 401s, and the index is consulted *only* because a token has
drawn one, so every lookup that matters happens when the entry is already older than the window. The
boundary and the trigger condition coincided:

```
token issued at            T
GitHub stops honouring it  T + 60min          <- the only reason a 401 happens at all
so the refresh mints at    T + 60min + ε
and swept everything older than (T + 60min + ε) − 60min  =  T + ε   >   T
                                                             ^ the dead token's own entry
```

So the first write of a cascade was rescued and every later holder of that token was stranded — not
"at best partial", but *guaranteed* to strand, in the ordinary expiry case that is the whole of
#624. Retention now covers `TOKEN_TTL + LONGEST_WRITE_IN_FLIGHT` with room to spare, both named
constants, and `theOwnerIndexMustOutliveEveryTokenItNames` pins the relationship.

Two sub-claims in the finding do not hold, for the record, and neither changes the conclusion:

- **`issuedAt` is already recorded after the mint returns** (it was on the line following the
  `createInstallationToken` call), not before. That direction is also the safe one: GitHub issued the
  token *during* the round trip, so a timestamp taken after it is no earlier than GitHub's own issue
  instant and the entry is never retired sooner than the token it names. Kept, with a comment saying
  why.
- **The global sweep is not itself a regression.** The cutoff is absolute wall-clock, so an entry is
  judged against its own age whichever installation triggered the sweep. It was only harmful in
  combination with the too-short window; with retention correct, a mint by another installation can
  only retire entries that are genuinely six hours old.

### Red/green proof

The class now takes its time from an injected clock, because the previous test could not reach a
60-minute boundary and quietly proved nothing about it (see below).

**1. The sweep eating its own cascade.** A token aged past GitHub's expiry — the only state a
refresh ever runs in — is refreshed, then a straggler a few seconds behind asks for the same
replacement. Against the previous 60-minute retention:

```
[ERROR] GitHubAuthClientTest.aRefreshDoesNotSweepAwayTheEntryTheRestOfItsCascadeStillNeeds <<< FAILURE!
org.opentest4j.AssertionFailedError: the refresh must not retire the entry its own cascade is still resolving against ==> expected: <Optional[Bearer second]> but was: <Optional.empty>
```

**2. The invariant.**

```
[ERROR] GitHubAuthClientTest.theOwnerIndexMustOutliveEveryTokenItNames <<< FAILURE!
org.opentest4j.AssertionFailedError: retention that only matches the token lifetime sweeps on exactly the 401 it must survive ==> expected: <true> but was: <false>
```

**3. The concurrency test was vacuous, and is not any more.** As first written it ran entirely
within microseconds of the mint, so the cutoff could never reach the token, no entry was ever swept,
and the straggler assertion passed for that reason rather than the intended one — it pinned only the
interleaving where every lookup precedes every sweep. It now advances the clock past GitHub's expiry
before the concurrent refreshes, so each mint's sweep is a real sweep. That alone turns it red
against the previous retention:

```
[ERROR] GitHubAuthClientTest.concurrentRefreshesOfOneDeadTokenLeaveALaterHolderAbleToResolveIt <<< FAILURE!
org.opentest4j.AssertionFailedError: a write still holding the dead token must not be stranded by a concurrent refresh ==> expected: <true> but was: <false>
```

It still drives two threads through the mint together, held inside it by a gate so the interleaving
is deterministic, and still uses a hand-written `GitHubTokenApi` rather than a Mockito mock. Against
the original one-deep superseded index it fails the same way:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClientTest.concurrentRefreshesOfOneDeadTokenLeaveALaterHolderAbleToResolveIt -- Time elapsed: 0.774 s <<< FAILURE!
org.opentest4j.AssertionFailedError: a write still holding the dead token must not be stranded by a concurrent refresh ==> expected: <true> but was: <false>
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:232)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClientTest.concurrentRefreshesOfOneDeadTokenLeaveALaterHolderAbleToResolveIt(GitHubAuthClientTest.java:413)
```

(answer sequencing under concurrent invocation is precisely what a mock does not promise, and the
gate's wait is bounded so the test still passes if minting is ever serialized in future).

`everyTokenStillWithinGitHubsExpiryKeepsNamingItsInstallation` replaces the merged test that asserted
the opposite — that a two-generations-old token is forgotten immediately — because that assertion
encoded the bug. `aTokenPastRetentionIsForgottenSoTheIndexCannotGrowWithUptime` pins the bound that
is actually wanted, now driven by the clock rather than by a package-private sweep seam that only
existed for want of one.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Gates on `1361cbb`, base `91edefe`:

- `./mvnw -B spotless:apply` then `./mvnw -B clean compile spotbugs:check spotless:check` — **BugInstance size is 0**, BUILD SUCCESS
- `./mvnw -B clean test` — **2942 tests, 0 failures, 0 errors**
- jacoco ∩ `git diff -U0 91edefe...HEAD` — 22 trackable changed main lines, **0 uncovered lines and 0 uncovered branches**

The last commit is comment-only: the javadoc on
`aRefreshDoesNotSweepAwayTheEntryTheRestOfItsCascadeStillNeeds` said "the bug this replaced" and then
described the 60-minute window, which never existed in this PR's base — only in this branch's first
commit. It now states the hazard as a standing property of the bound instead, names the constants it
is built from and points at the invariant test, since that is what a future reader tempted to shrink
the window actually needs.