### PR TITLE
test(sonar): keep only the throwing call inside assertThrows lambdas

### DIFF
--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentThrottleTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubCommentThrottleTest.java
@@ -81,8 +81,8 @@ class GitHubCommentThrottleTest {
     capture =
         new Handler() {
           @Override
-          public void publish(LogRecord record) {
-            logged.add(record);
+          public void publish(LogRecord entry) {
+            logged.add(entry);
           }
 
           @Override
@@ -110,7 +110,7 @@ class GitHubCommentThrottleTest {
 
   private String log() {
     return logged.stream()
-        .map(record -> record.getMessage() + " " + Arrays.toString(record.getParameters()))
+        .map(entry -> entry.getMessage() + " " + Arrays.toString(entry.getParameters()))
         .reduce("", (left, right) -> left + right);
   }
 
@@ -173,16 +173,11 @@ class GitHubCommentThrottleTest {
 
     // The registered logger raises nothing of its own, so callers keep the exception — and the
     // fail-soft handling built on it — that they had before #568.
+    var request = new GitHubCommentClient.CreateCommentRequest("the generated reply");
+
     assertThrows(
         WebApplicationException.class,
-        () ->
-            client.createComment(
-                "Bearer token",
-                ACCEPT,
-                "owner",
-                "repo",
-                7,
-                new GitHubCommentClient.CreateCommentRequest("the generated reply")));
+        () -> client.createComment("Bearer token", ACCEPT, "owner", "repo", 7, request));
 
     assertEquals(1, attempts.get(), "a refusal that will never succeed is not repeated");
     var log = log();

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWritesTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWritesTest.java
@@ -77,6 +77,12 @@ class GitHubLostWritesTest {
         });
   }
 
+  /** Posts on {@code target} and asserts the post is thrown away by {@code failure}. */
+  private void assertPostLost(
+      GitHubLostWrites.Target target, List<String> carried, WebApplicationException failure) {
+    assertThrows(WebApplicationException.class, () -> post(target, carried, failure));
+  }
+
   @Test
   void aPostOnAPullRequestThatLostNothingCarriesNoNotice() {
     var carried = new ArrayList<String>();
@@ -90,7 +96,7 @@ class GitHubLostWritesTest {
   void aDroppedReplyIsAnnouncedOnTheNextCommentThatLandsOnThatPullRequest() {
     var carried = new ArrayList<String>();
 
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    assertPostLost(PR, carried, throttled());
     post(PR, carried, null);
 
     // The notice cannot be posted on its own — it would be the very call being throttled — so the
@@ -105,7 +111,7 @@ class GitHubLostWritesTest {
   void theNoticeIsSaidOnceAndNotOnEveryCommentAfterwards() {
     var carried = new ArrayList<String>();
 
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    assertPostLost(PR, carried, throttled());
     post(PR, carried, null);
     post(PR, carried, null);
 
@@ -116,9 +122,9 @@ class GitHubLostWritesTest {
   void aNoticeThatCouldNotBeDeliveredIsKeptForTheNextTry() {
     var carried = new ArrayList<String>();
 
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    assertPostLost(PR, carried, throttled());
     // The post that should have carried the notice is itself thrown away.
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    assertPostLost(PR, carried, throttled());
     post(PR, carried, null);
 
     // Two losses now, and the notice was never cleared by the post that failed to deliver it.
@@ -128,7 +134,7 @@ class GitHubLostWritesTest {
   @Test
   void aLossThatArrivesWhileTheNoticeIsInFlightIsStillAnnouncedNext() {
     var carried = new ArrayList<String>();
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    assertPostLost(PR, carried, throttled());
 
     lost.carrying(
         PR,
@@ -148,7 +154,7 @@ class GitHubLostWritesTest {
   @Test
   void aLossThatLandsWhileTwoPostsCarryTheSameNoticeIsStillAnnouncedAfterwards() {
     var carried = new ArrayList<String>();
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    assertPostLost(PR, carried, throttled());
 
     // Two posts on the same pull request overlap — the inner one runs entirely between the outer
     // one's read of the pending notice and its completion, the interleaving a PR under a burst of
@@ -191,7 +197,7 @@ class GitHubLostWritesTest {
   void aNoticeIsScopedToThePullRequestThatLostThePost() {
     var carried = new ArrayList<String>();
 
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    assertPostLost(PR, carried, throttled());
     post(OTHER_PR, carried, null);
 
     assertEquals("", carried.get(1));
@@ -201,7 +207,7 @@ class GitHubLostWritesTest {
   void aRefusalThatWillNeverWorkIsNotAnnouncedOnThePullRequest() {
     var carried = new ArrayList<String>();
 
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, refusal()));
+    assertPostLost(PR, carried, refusal());
     post(PR, carried, null);
 
     // A missing permission is a defect to fix, not a command to re-run.
@@ -212,7 +218,7 @@ class GitHubLostWritesTest {
   void aNoticeGoesStaleRatherThanBeingGluedOntoAMuchLaterComment() {
     var carried = new ArrayList<String>();
 
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    assertPostLost(PR, carried, throttled());
     now.set(now.get().plus(Duration.ofHours(7)));
     post(PR, carried, null);
 
@@ -225,13 +231,13 @@ class GitHubLostWritesTest {
 
     // Both of the two slots this fixture allows are used and then settled: each pull request lost
     // a post and each was told about it on its next comment.
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    assertPostLost(PR, carried, throttled());
     post(PR, carried, null);
-    assertThrows(WebApplicationException.class, () -> post(OTHER_PR, carried, throttled()));
+    assertPostLost(OTHER_PR, carried, throttled());
     post(OTHER_PR, carried, null);
 
     var third = new GitHubLostWrites.Target("owner", "repo", 9);
-    assertThrows(WebApplicationException.class, () -> post(third, carried, throttled()));
+    assertPostLost(third, carried, throttled());
     post(third, carried, null);
 
     // Nothing is owed to either of the first two any more, so holding their slots until the TTL
@@ -249,7 +255,7 @@ class GitHubLostWritesTest {
   @Test
   void aCarrierLeftOverFromASettledEntryCannotRetireALaterLoss() {
     var carried = new ArrayList<String>();
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    assertPostLost(PR, carried, throttled());
 
     lost.carrying(
         PR,
@@ -271,13 +277,13 @@ class GitHubLostWritesTest {
   @Test
   void aFloodOfLosingPullRequestsCannotGrowTheRegistryWithoutEnd() {
     var carried = new ArrayList<String>();
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
-    assertThrows(WebApplicationException.class, () -> post(OTHER_PR, carried, throttled()));
+    assertPostLost(PR, carried, throttled());
+    assertPostLost(OTHER_PR, carried, throttled());
 
     var third = new GitHubLostWrites.Target("owner", "repo", 9);
-    assertThrows(WebApplicationException.class, () -> post(third, carried, throttled()));
+    assertPostLost(third, carried, throttled());
     // A PR already holding a notice still counts its second loss even at capacity.
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
+    assertPostLost(PR, carried, throttled());
 
     post(third, carried, null);
     post(PR, carried, null);
@@ -288,12 +294,12 @@ class GitHubLostWritesTest {
   @Test
   void anExpiredNoticeMakesRoomForANewOne() {
     var carried = new ArrayList<String>();
-    assertThrows(WebApplicationException.class, () -> post(PR, carried, throttled()));
-    assertThrows(WebApplicationException.class, () -> post(OTHER_PR, carried, throttled()));
+    assertPostLost(PR, carried, throttled());
+    assertPostLost(OTHER_PR, carried, throttled());
     now.set(now.get().plus(Duration.ofHours(7)));
 
     var third = new GitHubLostWrites.Target("owner", "repo", 9);
-    assertThrows(WebApplicationException.class, () -> post(third, carried, throttled()));
+    assertPostLost(third, carried, throttled());
     post(third, carried, null);
 
     assertTrue(carried.get(3).contains("An earlier reply"), carried.get(3));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponsesTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiResponsesTest.java
@@ -58,12 +58,12 @@ class AiResponsesTest {
   void throwsOnALengthStopRatherThanReturningTheCutBody() {
     // Returning the partial would send it to a JSON parser, which reports "not valid JSON" — the
     // exact misdiagnosis this exists to prevent.
+    var cutShort = aiTruncated("{\"docs\":[{\"file\":\"A");
+
     var thrown =
         assertThrows(
             AiResponseTruncatedException.class,
-            () ->
-                AiResponses.textOrThrowOnTruncation(
-                    aiTruncated("{\"docs\":[{\"file\":\"A"), "X", ModelLane.ACTIVE));
+            () -> AiResponses.textOrThrowOnTruncation(cutShort, "X", ModelLane.ACTIVE));
 
     assertTrue(
         thrown.getMessage().contains("max-output-tokens"),
@@ -72,12 +72,14 @@ class AiResponsesTest {
 
   @Test
   void namesTheActiveModelsCapForACallOnTheDefaultModel() {
+    var cutShort = aiTruncated("partial");
+
     var thrown =
         assertThrows(
             AiResponseTruncatedException.class,
             () ->
                 AiResponses.textOrThrowOnTruncation(
-                    aiTruncated("partial"), "/improve assistant", ModelLane.ACTIVE));
+                    cutShort, "/improve assistant", ModelLane.ACTIVE));
 
     assertTrue(
         thrown.getMessage().contains("Raise the active model's max-output-tokens"),
@@ -92,14 +94,14 @@ class AiResponsesTest {
   void namesTheConciseCapForACallOnTheConciseModel() {
     // The concise named model never receives the active model's max-output-tokens, so telling the
     // operator to raise it would send them to a setting that cannot affect this call.
+    var cutShort = aiTruncated("{\"verdicts\":[{\"id");
+
     var thrown =
         assertThrows(
             AiResponseTruncatedException.class,
             () ->
                 AiResponses.textOrThrowOnTruncation(
-                    aiTruncated("{\"verdicts\":[{\"id"),
-                    "Finding verification",
-                    ModelLane.CONCISE));
+                    cutShort, "Finding verification", ModelLane.CONCISE));
 
     assertTrue(
         thrown.getMessage().contains("raise REVIEW_CONCISE_MAX_OUTPUT_TOKENS"),
@@ -115,13 +117,14 @@ class AiResponsesTest {
     // was generated and billed. Dropping it here left every blocking lane with nothing to salvage
     // from, however much of its response had completed before the cut.
     var cut = "{\"verdicts\":[{\"id\":1,\"verdict\":\"valid\"},{\"id\":2,\"verd";
+    var cutShort = aiTruncated(cut);
 
     var thrown =
         assertThrows(
             AiResponseTruncatedException.class,
             () ->
                 AiResponses.textOrThrowOnTruncation(
-                    aiTruncated(cut), "Finding verification", ModelLane.CONCISE));
+                    cutShort, "Finding verification", ModelLane.CONCISE));
 
     assertEquals(cut, thrown.partialBody(), "the paid, cut body must travel with the failure");
   }
@@ -132,13 +135,14 @@ class AiResponsesTest {
     // salvage machinery recovers the elements that closed. Pinned end to end because a body no
     // consumer could use would be no better than the null it replaced.
     var cut = "{\"verdicts\":[{\"id\":1,\"verdict\":\"valid\"},{\"id\":2,\"verd";
+    var cutShort = aiTruncated(cut);
 
     var thrown =
         assertThrows(
             AiResponseTruncatedException.class,
             () ->
                 AiResponses.textOrThrowOnTruncation(
-                    aiTruncated(cut), "Finding verification", ModelLane.CONCISE));
+                    cutShort, "Finding verification", ModelLane.CONCISE));
 
     var salvaged =
         new TruncatedResponseSalvager(new ObjectMapper())
@@ -150,12 +154,14 @@ class AiResponsesTest {
 
   @Test
   void namesTheCallSoTheOperatorKnowsWhichCommandWasCutShort() {
+    var cutShort = aiTruncated("partial");
+
     var thrown =
         assertThrows(
             AiResponseTruncatedException.class,
             () ->
                 AiResponses.textOrThrowOnTruncation(
-                    aiTruncated("partial"), "/improve assistant", ModelLane.ACTIVE));
+                    cutShort, "/improve assistant", ModelLane.ACTIVE));
 
     assertTrue(thrown.getMessage().startsWith("/improve assistant"), thrown.getMessage());
   }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ConciseModelTruncationTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ConciseModelTruncationTest.java
@@ -70,13 +70,12 @@ class ConciseModelTruncationTest {
         .when(conciseStreamingChatModel)
         .chat(any(ChatRequest.class), any(StreamingChatResponseHandler.class));
 
+    var session = reviewSession();
+    var inputs = new AiReviewService.SummaryInputs("ctx", "[]", "files", "", "");
+
     var thrown =
         assertThrows(
-            AiResponseTruncatedException.class,
-            () ->
-                aiReviewService.summarize(
-                    reviewSession(),
-                    new AiReviewService.SummaryInputs("ctx", "[]", "files", "", "")));
+            AiResponseTruncatedException.class, () -> aiReviewService.summarize(session, inputs));
 
     assertTrue(
         thrown.getMessage().contains("max-output-tokens"),


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor
- [x] ✅ Test

## Description

Clears the SonarCloud findings raised on PR #532 in four test classes: 28 × `java:S5778` and 2 × `java:S6213`.

`S5778` fires when an `assertThrows` lambda contains more than one invocation, because the assertion can then be satisfied by a call the test never meant to exercise — a fixture builder that started throwing would be indistinguishable from the behaviour under test.

Per file:

| File | Findings | Fix |
| --- | --- | --- |
| `GitHubLostWritesTest` | 20 × S5778 | The 20 sites are all `assertThrows(WebApplicationException.class, () -> post(target, carried, throttled()))`, where the failure factory ran inside the lambda. They move behind one `assertPostLost(target, carried, failure)` helper whose lambda holds only the `post` call, so the factory is evaluated at the call site. |
| `AiResponsesTest` | 6 × S5778 | `aiTruncated(...)` moves out of each lambda into a `cutShort` local; the lambda keeps only `AiResponses.textOrThrowOnTruncation(...)`. |
| `GitHubCommentThrottleTest` | 1 × S5778, 2 × S6213 | The `CreateCommentRequest` construction moves to a `request` local, leaving `client.createComment(...)` alone in the lambda. The two `LogRecord record` variables that shadowed the restricted `record` identifier are renamed to `entry`. |
| `ConciseModelTruncationTest` | 1 × S5778 | `reviewSession()` and the `SummaryInputs` construction move to `session`/`inputs` locals, leaving `aiReviewService.summarize(...)` alone in the lambda. |

No suppression is used — no `@SuppressWarnings`, no `// NOSONAR`.

### Narrowing did not change what any test asserts

Narrowing an `assertThrows` lambda can silently change the assertion: if a test only passed because an *earlier* call in the lambda threw, the narrowed lambda fails. Each of the four classes was therefore run before and after the change:

| Class | Tests | Before | After |
| --- | --- | --- | --- |
| `GitHubLostWritesTest` | 17 | 0 failures | 0 failures |
| `AiResponsesTest` | 9 | 0 failures | 0 failures |
| `ConciseModelTruncationTest` | 3 | 0 failures | 0 failures |
| `GitHubCommentThrottleTest` | 2 | 0 failures | 0 failures |

All 31 tests keep their results, so in every one of the 28 cases the expected thrower really was the call the test names (`post`, `textOrThrowOnTruncation`, `createComment`, `summarize`) and the hoisted fixtures — `throttled()`, `refusal()`, `aiTruncated(...)`, `new CreateCommentRequest(...)`, `reviewSession()` — never threw.

## Related Issues

N/A — SonarCloud findings reported on PR #532.

## How Has This Been Tested?

- [x] Unit tests

Test-only change, so there is no red/green proof to quote and no changed main code for the coverage intersection; the standard given for pure refactors is that the suite stays green, which it does.

```
./mvnw -B spotless:apply                                   -> BUILD SUCCESS
./mvnw -B clean compile spotbugs:check spotless:check      -> BUILD SUCCESS, BugInstance size is 0
./mvnw -B clean test                                       -> Tests run: 2940, Failures: 0, Errors: 0, Skipped: 0
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Scoped to the four test files above; no main code is touched.
