### PR TITLE
test: clear SonarCloud smells in nine review and github test classes

### DIFF
--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -1136,10 +1136,10 @@ class StartupConfigValidatorTest {
 
     @Test
     void theShippedConciseEffortResolvesToUnset() throws Exception {
-      // The shipped line is
-      // thrillhousebot.ai.reasoning.concise-effort=${AI_REASONING_EFFORT_CONCISE:}
-      // — an empty default, so with no env var set the lane must see "unset" (and resolve its own
-      // default) rather than an empty string the provider would reject as a reasoning tier.
+      // The shipped property thrillhousebot.ai.reasoning.concise-effort takes its value from the
+      // AI_REASONING_EFFORT_CONCISE env var with an empty default, so with no env var set the lane
+      // must see "unset" (and resolve its own default) rather than an empty string the provider
+      // would reject as a reasoning tier.
       var shipped =
           new SmallRyeConfigBuilder()
               .addDefaultInterceptors()

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
@@ -259,7 +260,7 @@ class GitHubApiErrorTest {
 
       assertEquals(SECONDARY_LIMIT_BODY, loggedBody(response));
       // Buffered first, so the exception the caller receives can still be read.
-      org.mockito.Mockito.verify(response).bufferEntity();
+      verify(response).bufferEntity();
     }
 
     @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubErrorLoggerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubErrorLoggerTest.java
@@ -58,8 +58,8 @@ class GitHubErrorLoggerTest {
     capture =
         new Handler() {
           @Override
-          public void publish(LogRecord record) {
-            logged.add(record);
+          public void publish(LogRecord entry) {
+            logged.add(entry);
           }
 
           @Override
@@ -83,8 +83,8 @@ class GitHubErrorLoggerTest {
 
   private String warnings() {
     return logged.stream()
-        .filter(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
-        .map(record -> record.getMessage() + " " + Arrays.toString(record.getParameters()))
+        .filter(entry -> entry.getLevel().intValue() >= Level.WARNING.intValue())
+        .map(entry -> entry.getMessage() + " " + Arrays.toString(entry.getParameters()))
         .reduce("", (left, right) -> left + right);
   }
 
@@ -147,7 +147,7 @@ class GitHubErrorLoggerTest {
 
     assertEquals("", warnings());
     assertTrue(
-        logged.stream().anyMatch(record -> record.getLevel().intValue() < Level.INFO.intValue()),
+        logged.stream().anyMatch(entry -> entry.getLevel().intValue() < Level.INFO.intValue()),
         "still recorded, just at debug");
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -2060,15 +2060,19 @@ class FindingPipelineTest {
     var handler =
         new java.util.logging.Handler() {
           @Override
-          public void publish(java.util.logging.LogRecord record) {
-            logged.add(String.valueOf(record.getMessage()));
+          public void publish(java.util.logging.LogRecord entry) {
+            logged.add(String.valueOf(entry.getMessage()));
           }
 
           @Override
-          public void flush() {}
+          public void flush() {
+            // Records land straight in the list; nothing is buffered.
+          }
 
           @Override
-          public void close() {}
+          public void close() {
+            // The list outlives the handler; nothing to release.
+          }
         };
     logger.addHandler(handler);
     try {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -343,9 +343,12 @@ class RebuttalContradictionTest {
     // The dispatch is mentioned only in a // comment on an added line — commented-out or
     // explanatory text, not live code — so it must not refute the decline (F3).
     var commentedDispatch =
-        "diff --git a/Worker.java\n@@ -1,2 +1,3 @@\n"
-            + "+    // executor.submit(() -> run(ctx)); removed, now synchronous\n"
-            + "+    run(ctx);\n";
+        """
+        diff --git a/Worker.java
+        @@ -1,2 +1,3 @@
+        +    // executor.submit(() -> run(ctx)); removed, now synchronous
+        +    run(ctx);
+        """;
 
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "It runs serially.", commentedDispatch).isEmpty(),
@@ -357,9 +360,12 @@ class RebuttalContradictionTest {
     // A "://" URL scheme must not be mistaken for a // line-comment start when stripping comments
     // from right-side code, so a dispatch on a later line is still seen as live evidence (F3).
     var codeWithUrl =
-        "diff --git a/Worker.java\n@@ -1,2 +1,3 @@\n"
-            + "+    var docs = \"http://example.com/submit\";\n"
-            + "+    executor.submit(() -> run(ctx));\n";
+        """
+        diff --git a/Worker.java
+        @@ -1,2 +1,3 @@
+        +    var docs = "http://example.com/submit";
+        +    executor.submit(() -> run(ctx));
+        """;
 
     var contradiction = RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeWithUrl);
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewContextLoaderTest.java
@@ -989,9 +989,9 @@ class ReviewContextLoaderTest {
     @Test
     void shouldNameTheCeilingAsTheFullPagedWalk() {
       assertEquals(
-          GitHubCommentClient.COMMENTS_PER_PAGE * GitHubCommentClient.MAX_COMMENT_PAGES,
           ReviewContextLoader.MAX_CONVERSATION_COMMENTS,
-          "the documented ceiling must be the walk the client actually performs");
+          GitHubCommentClient.COMMENTS_PER_PAGE * GitHubCommentClient.MAX_COMMENT_PAGES,
+          "the walk the client actually performs must reach the documented ceiling");
     }
 
     @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicatorTest.java
@@ -19,10 +19,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class SummarySurfaceDeduplicatorTest {
 
@@ -30,17 +35,33 @@ class SummarySurfaceDeduplicatorTest {
     return new Finding(RiskLevel.HIGH, "src/A.java", 1, title, "desc", null, null);
   }
 
-  @Test
-  void keepsAGapThatStatesSomethingNoFindingStates() {
-    var gaps =
-        List.of("The PR promises a health check before dispatch, but no health field is present.");
-    var surfaces =
-        SummarySurfaceDeduplicator.collapse(
-            gaps,
-            Map.of(),
-            List.of(finding("Worker registry pagination not followed; only first page returned")));
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("gapsNoFindingRestates")
+  void keepsAGapNoFindingRestates(String label, String gap, String findingTitle) {
+    var gaps = List.of(gap);
 
-    assertEquals(gaps, surfaces.descriptionGaps());
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(gaps, Map.of(), List.of(finding(findingTitle)));
+
+    assertEquals(gaps, surfaces.descriptionGaps(), label);
+  }
+
+  static Stream<Arguments> gapsNoFindingRestates() {
+    return Stream.of(
+        arguments(
+            "a gap that states something no finding states",
+            "The PR promises a health check before dispatch, but no health field is present.",
+            "Worker registry pagination not followed; only first page returned"),
+        arguments(
+            "a finding with no title matches nothing",
+            "The PR description omits the new retry budget entirely.",
+            null),
+        // Identical but for the negation: "does"/"not" used to be stop words, so both sides
+        // tokenized the same and the gap was deleted as a duplicate of the claim it contradicts.
+        arguments(
+            "a negated paraphrase contradicts the finding instead of restating it",
+            "Path traversal: unvalidated client source does not reach fopen path",
+            "Path traversal: unvalidated client source reaches fopen path"));
   }
 
   @Test
@@ -58,15 +79,6 @@ class SummarySurfaceDeduplicatorTest {
 
     assertEquals(1, surfaces.descriptionGaps().size());
     assertTrue(surfaces.descriptionGaps().get(0).startsWith("RunSummary.degraded"));
-  }
-
-  @Test
-  void aFindingWithNoTitleMatchesNothing() {
-    var gaps = List.of("The PR description omits the new retry budget entirely.");
-
-    var surfaces = SummarySurfaceDeduplicator.collapse(gaps, Map.of(), List.of(finding(null)));
-
-    assertEquals(gaps, surfaces.descriptionGaps());
   }
 
   @Test
@@ -135,20 +147,6 @@ class SummarySurfaceDeduplicatorTest {
 
     assertEquals(
         "Added HTTP client for worker registry", surfaces.fileSummaries().get("src/A.java"));
-  }
-
-  @Test
-  void aNegatedParaphraseContradictsTheFindingInsteadOfRestatingIt() {
-    // Identical but for the negation: "does"/"not" used to be stop words, so both sides tokenized
-    // the same and the gap was deleted as a duplicate of the claim it contradicts.
-    var gaps = List.of("Path traversal: unvalidated client source does not reach fopen path");
-    var surfaces =
-        SummarySurfaceDeduplicator.collapse(
-            gaps,
-            Map.of(),
-            List.of(finding("Path traversal: unvalidated client source reaches fopen path")));
-
-    assertEquals(gaps, surfaces.descriptionGaps());
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/StreamingChatModelListenerOrderingTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/StreamingChatModelListenerOrderingTest.java
@@ -16,6 +16,8 @@
 package dev.thiagogonzaga.thrillhousebot.review.ai;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.UserMessage;
@@ -26,6 +28,7 @@ import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -127,13 +130,10 @@ class StreamingChatModelListenerOrderingTest {
     // that ordering guarantee gives the gate: usage a ChatModelListener records into the
     // ReviewTokenLedger is already observable at the moment the user-level completion handler
     // runs — so the next gate can never read a ledger that has not seen the prior billed attempt.
-    var config =
-        org.mockito.Mockito.mock(dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig.class);
-    var review =
-        org.mockito.Mockito.mock(
-            dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig.ReviewConfig.class);
-    org.mockito.Mockito.when(config.review()).thenReturn(review);
-    org.mockito.Mockito.when(review.maxTokensPerReview()).thenReturn(100_000L);
+    var config = mock(ThrillhouseConfig.class);
+    var review = mock(ThrillhouseConfig.ReviewConfig.class);
+    when(config.review()).thenReturn(review);
+    when(review.maxTokensPerReview()).thenReturn(100_000L);
     var ledger = new ReviewTokenLedger(config);
     ledger.open(7L);
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvagerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvagerTest.java
@@ -21,8 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -323,10 +328,10 @@ class TruncatedResponseSalvagerTest {
   void closeQuietlySwallowsACloseFailure() throws Exception {
     // A string-backed parser cannot fail to close; the swallow is contract, tested directly so
     // the finally block can never mask a salvage result with a close-time surprise.
-    var parser = org.mockito.Mockito.mock(com.fasterxml.jackson.core.JsonParser.class);
-    org.mockito.Mockito.doThrow(new java.io.IOException("boom")).when(parser).close();
+    var parser = mock(JsonParser.class);
+    doThrow(new IOException("boom")).when(parser).close();
 
     assertDoesNotThrow(() -> TruncatedResponseSalvager.closeQuietly(parser));
-    org.mockito.Mockito.verify(parser).close();
+    verify(parser).close();
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor
- [x] ✅ Test

## Description

Clears the SonarCloud issues reported on PR #532 that live in test sources. Nine
test classes, no production code, no `@SuppressWarnings` and no `// NOSONAR`.

| File | Rules cleared |
| --- | --- |
| `GitHubErrorLoggerTest` | 4 × S6213 |
| `StreamingChatModelListenerOrderingTest` | 4 × S8924 |
| `TruncatedResponseSalvagerTest` | 3 × S8924 |
| `FindingPipelineTest` | 1 × S6213, 2 × S1186 |
| `RebuttalContradictionTest` | 2 × S6126 |
| `GitHubApiErrorTest` | 1 × S8924 |
| `SummarySurfaceDeduplicatorTest` | 1 × S5976 |
| `StartupConfigValidatorTest` | 1 × S125 |
| `ReviewContextLoaderTest` | 1 × S3415 |

Three of these needed a judgement call rather than a mechanical edit:

**S1186 (`FindingPipelineTest`)** — the two empty methods are `flush()` and
`close()` on an anonymous `java.util.logging.Handler` used to capture log
records, not unwritten test methods. There is genuinely nothing to do in either:
records land straight in the list, and the list outlives the handler. They now
say so, matching the capture handler already written that way in
`GitHubErrorLoggerTest`. No test case is missing here.

**S5976 (`SummarySurfaceDeduplicatorTest`)** — the three flagged tests share one
shape (a description gap survives collapse because the finding beside it does not
restate it) and differ only in why. Merged into a
`@ParameterizedTest(name = "{0}")` over a labelled `MethodSource`, the same
pattern `PatchCoverageResolverTest` already uses. Each case stays individually
named in the failure output; the label is also the assertion message, so a
failure reads:

```
[ERROR] SummarySurfaceDeduplicatorTest.keepsAGapNoFindingRestates(String, String, String)[2]
org.opentest4j.AssertionFailedError: a finding with no title matches nothing ==> expected: ...
```

The regression note on the negated-paraphrase case (`"does"`/`"not"` used to be
stop words, so both sides tokenized alike and the gap was deleted as a duplicate
of the claim it contradicts) is kept on that case in the method source.

**S3415 (`ReviewContextLoaderTest`)** — `assertEquals` had the client's paged-walk
product as expected and the documented ceiling constant as actual. Swapped so the
published constant `MAX_CONVERSATION_COMMENTS` is the expected value and the
walk the client actually performs (`COMMENTS_PER_PAGE * MAX_COMMENT_PAGES`) is
the actual one, which is the direction that produces a readable message when the
implementation drifts from the documented ceiling. The assertion message is
reworded to match. The test still passes, so it was not asserting the wrong pair
— only reporting them the wrong way round.

**S125 (`StartupConfigValidatorTest`)** — the flagged block was a comment quoting
the shipped property line `thrillhousebot.ai.reasoning.concise-effort=${AI_REASONING_EFFORT_CONCISE:}`.
The intent is worth keeping, so rather than deleting it the comment is reworded
as prose that names the property and its empty default without being shaped like
code.

## Related Issues

N/A — SonarCloud findings on #532.

## How Has This Been Tested?

- [x] Unit tests

Behaviour-preserving throughout, so there is no red/green pair to quote. The
parameterized merge was verified by deliberately breaking its assertion once and
confirming all three cases fail under their own names (output above), then
reverting.

Gates run on the head commit:

- `./mvnw -B spotless:apply` — clean
- `./mvnw -B clean compile spotbugs:check spotless:check` — BUILD SUCCESS,
  `BugInstance size is 0`
- `./mvnw -B clean test` — BUILD SUCCESS, `Tests run: 2940, Failures: 0, Errors: 0, Skipped: 0`

Test count is unchanged at 2940: the three merged tests become three
parameterized invocations.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Test-only change, so there is no changed main code for the coverage
intersection to cover. No files outside the nine listed are touched.