### PR TITLE
refactor: clear the SonarCloud findings on the release PR's main code

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidator.java
@@ -49,6 +49,14 @@ public class StartupConfigValidator {
   private static final String APP_ID_PROPERTY = "thrillhousebot.github.app-id";
 
   /**
+   * The opening of every refusal about the reserved output buffer. Three separate rules quote the
+   * effective buffer back to the operator — the safety-margin floor, the shared-window ceiling and
+   * the concise-lane ceiling — and they are meant to read as one family, so the wording lives in
+   * one place rather than being kept in step by hand.
+   */
+  private static final String EFFECTIVE_OUTPUT_BUFFER = "the effective output buffer (";
+
+  /**
    * The remedy carried by every {@code GITHUB_PRIVATE_KEY} problem. A fresh clone fails here with
    * placeholder text copied straight out of {@code .env.example} (#593), and the refusal is where
    * the reader actually is — so it states the accepted format, the single-line spelling {@code
@@ -313,7 +321,7 @@ public class StartupConfigValidator {
         && margin <= 1.0
         && (int) (maxInputTokens * margin) - outputBuffer <= 0) {
       problems.add(
-          "the effective output buffer ("
+          EFFECTIVE_OUTPUT_BUFFER
               + outputBuffer
               + ") must be less than the effective max input tokens x safety margin ("
               + (int) (maxInputTokens * margin)
@@ -333,7 +341,7 @@ public class StartupConfigValidator {
           .ifPresent(
               maxOutput ->
                   problems.add(
-                      "the effective output buffer ("
+                      EFFECTIVE_OUTPUT_BUFFER
                           + outputBuffer
                           + ") must be >= max-output-tokens ("
                           + maxOutput
@@ -517,7 +525,7 @@ public class StartupConfigValidator {
           .ifPresent(
               v ->
                   problems.add(
-                      "the effective output buffer ("
+                      EFFECTIVE_OUTPUT_BUFFER
                           + outputBuffer
                           + ") must be >= REVIEW_CONCISE_MAX_OUTPUT_TOKENS ("
                           + v
@@ -618,15 +626,22 @@ public class StartupConfigValidator {
    * is on this line because it is the one generation parameter that no longer follows the active
    * model (#567), so an operator reading the banner would otherwise draw the wrong conclusion about
    * where the verifier's output allowance goes.
+   *
+   * <p>Behind a level check because both banner arguments are built by a call, and a parameter
+   * placeholder only defers the {@code toString} — not the work that produces the argument. The
+   * line itself is unchanged; it simply stops formatting a banner nobody will read when {@code
+   * INFO} is off.
    */
   private void logConciseModelStatus() {
-    log.info(
-        "Concise model active for summary/verifier/reply calls: max-output-tokens={}"
-            + " (REVIEW_CONCISE_MAX_OUTPUT_TOKENS), reasoning_effort={}; other generation"
-            + " parameters follow the active model '{}'.",
-        orProviderDefault(conciseMaxOutputTokens),
-        conciseReasoningEffortBanner(),
-        activeModel.modelName());
+    if (log.isInfoEnabled()) {
+      log.info(
+          "Concise model active for summary/verifier/reply calls: max-output-tokens={}"
+              + " (REVIEW_CONCISE_MAX_OUTPUT_TOKENS), reasoning_effort={}; other generation"
+              + " parameters follow the active model '{}'.",
+          orProviderDefault(conciseMaxOutputTokens),
+          conciseReasoningEffortBanner(),
+          activeModel.modelName());
+    }
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubErrorLogger.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubErrorLogger.java
@@ -62,13 +62,22 @@ public class GitHubErrorLogger implements ResponseExceptionMapper<Throwable> {
   /**
    * Logs the failure and returns {@code null} so the runtime's default mapper still builds the
    * exception the callers are written against.
+   *
+   * <p>Both lines are behind a level check because {@link GitHubApiError#diagnostics()} builds its
+   * string eagerly — a parameter placeholder defers the {@code toString}, not the call that
+   * produces the argument. The debug line is the one that pays: it runs on every optional-file
+   * probe, which is ordinary traffic, and debug is off in production. The messages themselves are
+   * unchanged; this is the diagnosis path that identified the {@code 401 Bad credentials} failure
+   * in issue 624, so what it prints when it prints must stay exactly as it was.
    */
   @Override
   public Throwable toThrowable(Response response) {
     var error = GitHubApiError.from(response);
     if (error.isSevere()) {
-      log.warn("GitHub API call failed: {}", error.diagnostics());
-    } else {
+      if (log.isWarnEnabled()) {
+        log.warn("GitHub API call failed: {}", error.diagnostics());
+      }
+    } else if (log.isDebugEnabled()) {
       log.debug("GitHub API call returned an error: {}", error.diagnostics());
     }
     return null;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -361,8 +361,8 @@ public class FollowUpAnalyzer {
     var sb = new StringBuilder();
     var id = 1;
     for (var finding : previous) {
-      // A finding a newer round already closed keeps its id slot (so the surviving ids do not
-      // shift) but is not re-shown as open for the model to re-account for (#470).
+      // A finding a newer round already closed keeps its id slot, so the surviving ids do not
+      // shift, but it is not re-shown as open for the model to re-account for. See issue 470.
       if (settledIds.contains(id)) {
         id++;
         continue;
@@ -784,8 +784,15 @@ public class FollowUpAnalyzer {
   /**
    * The shape every locator has — a path, a colon, a line number. Only ever used to prove a
    * <em>negative</em>; see {@link #namesALocator}.
+   *
+   * <p>Written as a lookbehind rather than the obvious {@code \S+:\d+}, which is the same predicate
+   * but quadratic on this input. {@code :} is itself a {@code \S}, so in the obvious form every
+   * colon gives the engine another way to split the same prefix and the body — arbitrary text from
+   * a PR comment — drives the backtracking. The two forms accept exactly the same strings: {@code
+   * \S+:\d+} matches iff some colon has a non-space character before it and a digit after it, which
+   * is what this states directly, with no quantifier to backtrack over.
    */
-  private static final Pattern LOCATOR_SHAPE = Pattern.compile("\\S+:\\d+");
+  private static final Pattern LOCATOR_SHAPE = Pattern.compile("(?<=\\S):\\d");
 
   /**
    * Whether {@code body} names anything locator-shaped at all. This is a <em>necessary</em>
@@ -873,10 +880,8 @@ public class FollowUpAnalyzer {
     }
     String locator = finding.file() + ":" + finding.line();
     for (var comment : conversationComments) {
-      if (!isMaintainerConversationComment(comment, botIdentity)) {
-        continue;
-      }
-      if (!isClearDirective(comment.body())) {
+      if (!isMaintainerConversationComment(comment, botIdentity)
+          || !isClearDirective(comment.body())) {
         continue;
       }
       // The naming may sit in backticks (the shape the summary prints); only the directive token

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LargePrNudge.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LargePrNudge.java
@@ -69,6 +69,25 @@ record LargePrNudge(boolean enabled, int minFiles, int minChangedLines) {
   /** Section heading of the rendered note; also the marker tests and callers match on. */
   static final String NUDGE_HEADING = "### ⚠️ Large PR — no inline findings";
 
+  /**
+   * Everything the note says after the size sentence: why a clean result on a change this size is
+   * worth re-checking, and what to run.
+   *
+   * <p>Two details of the literal are load-bearing. It opens with a space, because it is appended
+   * straight onto a sentence that ends in {@code .} or {@code above).}. It ends with a blank line
+   * before the closing delimiter, which is the trailing {@code \n\n} that separates this section
+   * from whatever the summary appends next.
+   */
+  private static final String CLOSING_ADVICE =
+      """
+       A change this size coming back clean is worth a second look: it may genuinely be clean, \
+      but it is also what a shallow pass looks like.
+
+      Re-run `/review` for a fresh pass, or `/improve` for a whole-PR improvement pass, before \
+      treating this as a clean bill of health. This note is advisory — it does not hold approval.
+
+      """;
+
   static LargePrNudge from(ThrillhouseConfig.LargePrNudgeConfig config) {
     return new LargePrNudge(config.enabled(), config.minFiles(), config.minChangedLines());
   }
@@ -105,13 +124,7 @@ record LargePrNudge(boolean enabled, int minFiles, int minChangedLines) {
           .append(
               " too low-confidence to post on the diff (see \"Things to double-check\" above).");
     }
-    sb.append(
-        " A change this size coming back clean is worth a second look: it may genuinely be"
-            + " clean, but it is also what a shallow pass looks like.\n\n");
-    sb.append(
-        "Re-run `/review` for a fresh pass, or `/improve` for a whole-PR improvement pass, before"
-            + " treating this as a clean bill of health. This note is advisory — it does not hold"
-            + " approval.\n\n");
+    sb.append(CLOSING_ADVICE);
     return Optional.of(sb.toString());
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/UnitTestGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/UnitTestGenerator.java
@@ -292,30 +292,10 @@ public class UnitTestGenerator extends AbstractPrSuggestionGenerator {
       }
       if (shown == MAX_PRIOR_FINDINGS) {
         overCap++;
-        continue;
+      } else {
+        appendFinding(sb, i + 1, findings.get(i));
+        shown++;
       }
-      var finding = findings.get(i);
-      sb.append(i + 1)
-          .append(". [")
-          .append(text(finding.risk()).toUpperCase(Locale.ROOT))
-          .append("] ");
-      // The location is written only when there is one. line is a primitive, so an absent line
-      // arrives as 0 — appending it would hand the model a file:0 that points nowhere and costs
-      // tokens on every finding that lacks one, which is the same noise a literal "null" would be.
-      var file = text(finding.file());
-      if (!file.isEmpty()) {
-        sb.append(file);
-        if (finding.line() > 0) {
-          sb.append(':').append(finding.line());
-        }
-        sb.append(" — ");
-      }
-      sb.append(text(finding.title())).append('\n');
-      var description = text(finding.description());
-      if (!description.isEmpty()) {
-        sb.append("   ").append(description).append('\n');
-      }
-      shown++;
     }
     if (overCap > 0) {
       sb.append("(")
@@ -323,6 +303,29 @@ public class UnitTestGenerator extends AbstractPrSuggestionGenerator {
           .append(" further finding(s) were reported but are not listed here.)\n");
     }
     return sb.toString();
+  }
+
+  /**
+   * One rendered finding: {@code id. [RISK] file:line — title}, with its description underneath.
+   */
+  private static void appendFinding(StringBuilder sb, int id, ReviewResponse.Finding finding) {
+    sb.append(id).append(". [").append(text(finding.risk()).toUpperCase(Locale.ROOT)).append("] ");
+    // The location is written only when there is one. line is a primitive, so an absent line
+    // arrives as 0 — appending it would hand the model a file:0 that points nowhere and costs
+    // tokens on every finding that lacks one, which is the same noise a literal "null" would be.
+    var file = text(finding.file());
+    if (!file.isEmpty()) {
+      sb.append(file);
+      if (finding.line() > 0) {
+        sb.append(':').append(finding.line());
+      }
+      sb.append(" — ");
+    }
+    sb.append(text(finding.title())).append('\n');
+    var description = text(finding.description());
+    if (!description.isEmpty()) {
+      sb.append("   ").append(description).append('\n');
+    }
   }
 
   /** A finding field as prompt text: absent fields are blanks, not the literal {@code null}. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/config/StartupConfigValidatorTest.java
@@ -1078,6 +1078,20 @@ class StartupConfigValidatorTest {
   }
 
   @Test
+  void bootsWithoutBuildingTheConciseBannerWhenInfoLoggingIsOff() {
+    // Both banner arguments are produced by a call, so the line sits behind a level check. With
+    // INFO off that check is false and nothing is formatted — validation must still complete.
+    var julLogger = java.util.logging.Logger.getLogger(StartupConfigValidator.class.getName());
+    var originalLevel = julLogger.getLevel();
+    julLogger.setLevel(java.util.logging.Level.WARNING);
+    try {
+      assertDoesNotThrow(() -> new ConfigBuilder().build().validate());
+    } finally {
+      julLogger.setLevel(originalLevel);
+    }
+  }
+
+  @Test
   void bootsWhenTheConciseReasoningEffortIsUnset() {
     // Unset is the shipped state: the lane resolves its own default, so there is nothing to reject.
     new ConfigBuilder()

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubErrorLoggerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubErrorLoggerTest.java
@@ -140,6 +140,19 @@ class GitHubErrorLoggerTest {
   }
 
   @Test
+  void staysSilentAndStillMapsTheResponseWhenLoggingIsOff() {
+    // Both lines sit behind a level check, because diagnostics() builds its string eagerly and a
+    // parameter placeholder only defers the toString. With the logger off neither branch may log,
+    // and the mapper must still hand the response on to the runtime's default mapper.
+    julLogger.setLevel(Level.OFF);
+
+    assertNull(mapper.toThrowable(response(403, SECONDARY_LIMIT_BODY)));
+    assertNull(mapper.toThrowable(response(404, "{\"message\":\"Not Found\"}")));
+
+    assertTrue(logged.isEmpty(), logged.toString());
+  }
+
+  @Test
   void doesNotWarnAboutAnAbsentOptionalRepositoryFile() {
     // The bot probes for .github/instructions and the settings file and reads 404 as "absent";
     // warning on those would bury the failures that matter under ordinary traffic.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -3115,4 +3115,26 @@ class FollowUpAnalyzerTest {
         FollowUpAnalyzer.namesALocator("> @thrillhousebot resolved src/A.java:10 — title"),
         "a quoted locator names nothing, matching where the clear actually looks");
   }
+
+  @Test
+  void namesALocatorShouldReadTheSameShapeOnColonHeavyText() {
+    // The shape test is written as a lookbehind so an arbitrarily long comment body cannot drive
+    // backtracking. These are the inputs where that rewrite could have drifted from the plain
+    // "non-space, colon, digit" reading it replaces.
+    assertTrue(
+        FollowUpAnalyzer.namesALocator("resolved C:/work/src/A.java:10"),
+        "a colon earlier in the token does not hide the one before the line number");
+    assertTrue(
+        FollowUpAnalyzer.namesALocator("resolved src/A.java::10"),
+        "a doubled colon still leaves a colon with a non-space before it and a digit after");
+    assertFalse(
+        FollowUpAnalyzer.namesALocator("resolved :10"),
+        "a colon opening a token has no path in front of it, so it names nothing");
+    assertFalse(
+        FollowUpAnalyzer.namesALocator("resolved src/A.java: 10"),
+        "a space between the colon and the number is not a locator");
+    assertFalse(
+        FollowUpAnalyzer.namesALocator("a:".repeat(2000)),
+        "colon-heavy text with no line number still resolves to no locator");
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [x] 🔧 Refactor
- [x] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

SonarCloud raised twelve issues against the release PR (#532) in seven main-code files. Ten are cleared here; two are left deliberately and argued below. Nothing is silenced — no `@SuppressWarnings`, no `// NOSONAR`.

Every change is a refactor. No message an operator reads and no string handed to the model differs by a byte.

### Cleared

**`FollowUpAnalyzer` — `java:S8786`, the locator-shape regex**

`LOCATOR_SHAPE` was `\S+:\d+`. That is ambiguous: `:` is itself a `\S`, so every colon in the subject gives the engine another way to split the same prefix, and the subject is an arbitrary PR comment body. Rewritten as `(?<=\S):\d` — the same predicate stated directly, "a colon with a non-space before it and a digit after it", with no quantifier to backtrack over.

The two forms accept exactly the same strings. `\S+:\d+` matches iff some colon has a non-space character before it and a digit after it, which is what the lookbehind says. Checked rather than argued: exhaustive comparison over every string up to length 6 drawn from `a`, `:`, `1`, space, `/`, `.` plus 200,000 random strings up to length 40 from the same alphabet — 255,987 subjects, zero disagreements.

The cost it removes, same JVM, same run:

```
"a:" x 20000 + " "   old 4513 ms   new 0 ms
"x" x 60000          old 5428 ms   new 1 ms
```

**`FollowUpAnalyzer` — `java:S135`, `clearedInConversation`**

Two guard clauses skipping the same comment, merged into one. No behaviour change: `||` short-circuits in the same order the two `continue`s did.

**`FollowUpAnalyzer` — `java:S125`, the id-slot comment**

Not commented-out code — a real comment, recording that a settled finding keeps its id slot so the surviving ids do not shift (#470). The intent is worth keeping, so it is kept; the parenthetical that Sonar was parsing as a call is rewritten as prose.

**`GitHubErrorLogger` — 2 × `java:S2629`**

Both lines put behind a level check. `GitHubApiError.diagnostics()` builds its string eagerly — a `{}` placeholder defers the `toString`, not the call that produces the argument. The debug line pays for that on every optional-file probe, which is ordinary traffic and is exactly why it is at debug.

This is the class that produced the `401 Bad credentials` diagnosis in production (#624), so its output is load-bearing. Both messages and both levels are unchanged; the only difference is that the argument is no longer built when nothing will consume it.

**`StartupConfigValidator` — `java:S1192`**

The three output-buffer refusals (safety-margin floor, shared-window ceiling, concise-lane ceiling) share their opening clause as `EFFECTIVE_OUTPUT_BUFFER` instead of three copies kept in step by hand. The rendered messages are unchanged.

**`StartupConfigValidator` — `java:S2629`**

Same treatment as above for the concise-model boot banner: both its arguments are produced by a call.

**`LargePrNudge` — 2 × `java:S6126`**

The two closing paragraphs become one text block. Verified byte-identical to the concatenation it replaces (`String.equals` on the old and new literals side by side, `true`). The two load-bearing details of the literal — the leading space, and the trailing blank line that is the `\n\n` — are now called out in the Javadoc, because a text block makes both of them invisible.

**`UnitTestGenerator` — `java:S135`**

The per-finding rendering moves into `appendFinding`, so the cap reads as one either/or instead of a second `continue`. Identical output.

### Left, deliberately

**`JacocoCoverageReport:202` — `java:S1075`, "Remove this hard-coded path-delimiter"**

This is not a path and not configurable. The `/` joins a JaCoCo `<package name>` to a `<sourcefile name>`. A JaCoCo package name is the JVM internal binary name, which the class-file format defines as `/`-separated on every platform, and the repository paths it is matched against are git paths, also always `/`. The code already carries a five-line comment saying exactly this, and it is right: a `File.separator` here would break every report produced on Windows. There is no knob to add — an operator setting it could only set it wrong.

**`RepoSettingsParser:268` — `java:S135`, the ignore-glob cap loop**

`sanitize` has three exits: skip blank, warn-and-skip over-long, warn-and-stop at the cap. Getting to one requires moving when the warnings fire, and each way of doing that changes observable behaviour:

- hoisting the cap check to the top of the loop makes the "more than N patterns" warning fire on a trailing blank entry, which today it does not;
- collecting first and truncating after makes the over-long warning fire for entries past the cap, which today it does not, and stops the loop short-circuiting.

Every restructure that keeps the behaviour still leaves two exits, so it would not clear the rule anyway. This is the per-repo ignore-glob parser with its own open hardening issue (#481); its parsing behaviour should change there, deliberately, not as a side effect of a rule count.

## Related Issues

N/A — SonarCloud findings on #532.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Every change here is a refactor or comment change, so there is no red/green proof to quote: the point is that behaviour is unchanged, and the existing suite is the evidence. The equivalence claims that could not be shown by the existing suite were checked directly and are quoted above (regex: 255,987 subjects, 0 disagreements; text block: `equals` → `true`).

Three tests added, for the branches the level checks introduce and for the regex rewrite's edge cases:

- `GitHubErrorLoggerTest.staysSilentAndStillMapsTheResponseWhenLoggingIsOff` — with the logger at `OFF`, neither the severe nor the non-severe path logs, and the mapper still returns `null` so the runtime's default mapper builds the exception.
- `StartupConfigValidatorTest.bootsWithoutBuildingTheConciseBannerWhenInfoLoggingIsOff` — validation completes normally with `INFO` off.
- `FollowUpAnalyzerTest.namesALocatorShouldReadTheSameShapeOnColonHeavyText` — `C:/work/src/A.java:10` and `src/A.java::10` are locators; `:10`, `src/A.java: 10` and 2,000 repetitions of `a:` are not.

Gates, on this branch:

```
./mvnw -B spotless:apply
./mvnw -B clean compile spotbugs:check spotless:check   BUILD SUCCESS, BugInstance size is 0
./mvnw -B clean test                                    Tests run: 2943, Failures: 0, Errors: 0, Skipped: 0
```

Coverage — JaCoCo ∩ `git diff -U0 6ba8eee...HEAD`, changed main lines only:

```
StartupConfigValidator.java   25 changed lines,  5 executable
GitHubErrorLogger.java        11 changed lines,  3 executable
FollowUpAnalyzer.java         12 changed lines,  3 executable
LargePrNudge.java             20 changed lines,  1 executable
UnitTestGenerator.java        26 changed lines, 14 executable

26 executable changed main lines: 0 uncovered lines, 0 uncovered branches
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Regex equivalence and cost, run against JDK 25 with the old and new patterns side by side:

```
total=255987 mismatches=0
old ms=4513 new ms=0          subject: "a:" x 20000 + " "
nocolon old ms=5428 new ms=1  subject: "x" x 60000
```

## Additional Notes

Scope is the seven assigned files plus three test files. `GitHubAuthClient`, `GitHubWriteRetry`, `GitHubApiError`, `FindingVerificationService`, `FindingPipeline`, `ReviewDiffFormatter`, `DiffBudgetPlanner`, `SummarySurfaceDeduplicator` and `TruncatedResponseSalvager` are untouched.
