### PR TITLE
refactor(review): clear the review pipeline's SonarCloud smells

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -379,12 +379,50 @@ public class DiffBudgetPlanner {
    */
   private BoundedFindings condensePreviousFindings(String block, int capTokens) {
     var all = block.split("\n", -1);
-    var fenced =
-        all.length > 2
-            && all[0].startsWith(PromptTemplateEscaper.fencePrefix())
-            && all[0].equals(all[all.length - 1]);
+    var fenced = isFenced(all);
     var body = fenced ? List.of(all).subList(1, all.length - 1) : List.of(all);
 
+    var condensed = entryLinesOnly(body);
+
+    // The disclosure has to survive the cap that forced it, so its cost — and the fences' — comes
+    // off the top rather than being what gets dropped.
+    var reserve = tokenCounter.estimateTokens(elisionNotice(condensed.entries()));
+    if (fenced) {
+      reserve += 2 * tokenCounter.estimateTokens(all[0]);
+    }
+    var capped = longestPrefixWithin(condensed.lines(), capTokens, reserve);
+
+    var text = new StringBuilder();
+    if (fenced) {
+      text.append(all[0]).append('\n');
+    }
+    text.append(String.join("\n", capped.lines()));
+    if (fenced) {
+      text.append('\n').append(all[0]);
+    }
+    text.append('\n').append(elisionNotice(capped.dropped()));
+    return new BoundedFindings(
+        text.toString(), condensed.entries() - capped.dropped(), capped.dropped());
+  }
+
+  /**
+   * Whether the block is wrapped in the untrusted-data fence, which is only true when the first and
+   * last lines are the same fence line and there is a body between them.
+   */
+  private static boolean isFenced(String[] lines) {
+    return lines.length > 2
+        && lines[0].startsWith(PromptTemplateEscaper.fencePrefix())
+        && lines[0].equals(lines[lines.length - 1]);
+  }
+
+  /** The condensation pass's output: the surviving lines and how many entries they open. */
+  private record CondensedBody(List<String> lines, int entries) {}
+
+  /**
+   * Drops every line that continues an entry — description, quoted code, thread reply — keeping the
+   * entry lines themselves and any preamble that precedes the first entry.
+   */
+  private static CondensedBody entryLinesOnly(List<String> body) {
     var condensed = new ArrayList<String>(body.size());
     var entries = 0;
     var inEntry = false;
@@ -398,18 +436,23 @@ public class DiffBudgetPlanner {
         condensed.add(line);
       }
     }
+    return new CondensedBody(condensed, entries);
+  }
 
-    // The disclosure has to survive the cap that forced it, so its cost — and the fences' — comes
-    // off the top rather than being what gets dropped.
-    var reserve = tokenCounter.estimateTokens(elisionNotice(entries));
-    if (fenced) {
-      reserve += 2 * tokenCounter.estimateTokens(all[0]);
-    }
-    var kept = new ArrayList<String>(condensed.size());
+  /** The capping pass's output: the lines that fit and how many entries the cut dropped. */
+  private record CappedBody(List<String> lines, int dropped) {}
+
+  /**
+   * The longest leading run of {@code lines} whose estimated cost, on top of {@code reserve}, stays
+   * within {@code capTokens}. Cutting is one-way: once a line does not fit, nothing after it is
+   * reconsidered, so the kept entries are a prefix and their ids never shift.
+   */
+  private CappedBody longestPrefixWithin(List<String> lines, int capTokens, int reserve) {
+    var kept = new ArrayList<String>(lines.size());
     var used = reserve;
     var dropped = 0;
     var cutting = false;
-    for (var line : condensed) {
+    for (var line : lines) {
       if (!cutting) {
         var cost = tokenCounter.estimateTokens(line);
         if (used + cost <= capTokens) {
@@ -423,17 +466,7 @@ public class DiffBudgetPlanner {
         dropped++;
       }
     }
-
-    var text = new StringBuilder();
-    if (fenced) {
-      text.append(all[0]).append('\n');
-    }
-    text.append(String.join("\n", kept));
-    if (fenced) {
-      text.append('\n').append(all[0]);
-    }
-    text.append('\n').append(elisionNotice(dropped));
-    return new BoundedFindings(text.toString(), entries - dropped, dropped);
+    return new CappedBody(kept, dropped);
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -68,6 +68,21 @@ public class FindingPipeline {
       List<ReviewResponse.Finding> findings,
       List<ReviewResponse.PreviousFindingStatus> statuses) {}
 
+  /**
+   * Everything one multi-call review's batch lane needs beyond the index of the batch being worked
+   * on: the planned batches, the session the calls are billed to, the shared prompt template, the
+   * plan the coverage disclosures are recorded on, and the previous-finding file index the statuses
+   * are scoped against. One value because these five are fixed for the whole lane and travel
+   * together through every step of it — the parallel pass, the join, the sequential retry and the
+   * truncation salvage — so the step a batch is in is the only thing its signature has to say.
+   */
+  private record BatchRun(
+      List<DiffBudgetPlanner.DiffBatch> batches,
+      ReviewSession session,
+      BatchPrompts prompts,
+      DiffBudgetPlanner.BudgetPlan plan,
+      Map<Integer, String> previousFilesById) {}
+
   /** The rendered file-section header {@link ReviewDiffFormatter#formatFileSection} emits. */
   private static final String SECTION_HEADER_PREFIX = "### ";
 
@@ -92,6 +107,25 @@ public class FindingPipeline {
           baseComparison,
           ReviewPromptAssembler.combineSections(
               template.repoInstructions(), heuristicFailureModesFor(batch)));
+    }
+
+    /**
+     * Copies the shared prompt context, swapping the diff, base-comparison and trailing-guidance
+     * slots.
+     */
+    private static AiReviewService.PromptInputs withDiff(
+        AiReviewService.PromptInputs base,
+        String diff,
+        String baseComparison,
+        String repoInstructions) {
+      return new AiReviewService.PromptInputs(
+          diff,
+          base.prContext(),
+          baseComparison,
+          base.projectStack(),
+          base.relatedTests(),
+          base.previousFindings(),
+          repoInstructions);
     }
   }
 
@@ -321,29 +355,21 @@ public class FindingPipeline {
     // findings; a batch may only close a prior finding whose file its own diff slice contained.
     var previousFilesById = followUpAnalyzer.previousFindingFilesById(ctx.previousFindingsList());
 
-    var batchPrompts = new BatchPrompts(promptInputs, withheldMaterialNotice(ctx, plan));
+    var run =
+        new BatchRun(
+            batches,
+            session,
+            new BatchPrompts(promptInputs, withheldMaterialNotice(ctx, plan)),
+            plan,
+            previousFilesById);
     var outcomesByIndex = new BatchOutcome[batches.size()];
     var failedIndices = new ArrayList<Integer>();
     try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
       var futures =
           IntStream.range(0, batches.size())
-              .mapToObj(
-                  i ->
-                      CompletableFuture.supplyAsync(
-                          () ->
-                              processBatch(
-                                  i, batches, session, batchPrompts, plan, previousFilesById),
-                          executor))
+              .mapToObj(i -> CompletableFuture.supplyAsync(() -> processBatch(i, run), executor))
               .toList();
-      joinBatchOutcomes(
-          futures,
-          batches,
-          batchPrompts,
-          plan,
-          session,
-          previousFilesById,
-          outcomesByIndex,
-          failedIndices);
+      joinBatchOutcomes(futures, run, outcomesByIndex, failedIndices);
     }
 
     for (int index : failedIndices) {
@@ -360,7 +386,7 @@ public class FindingPipeline {
         plan.recordSpendCeilingSkippedFiles(filenamesOf(batches.get(index).files()));
         continue;
       }
-      retryBatch(index, batches, session, batchPrompts, plan, previousFilesById, outcomesByIndex);
+      retryBatch(index, run, outcomesByIndex);
     }
 
     var outcomes =
@@ -501,17 +527,11 @@ public class FindingPipeline {
    * parallel pass — a mid-retry ceiling refusal or a truncation goes to disclosure (the truncation
    * salvaging first), anything else soft-fails the batch as not reviewed.
    */
-  private void retryBatch(
-      int index,
-      List<DiffBudgetPlanner.DiffBatch> batches,
-      ReviewSession session,
-      BatchPrompts prompts,
-      DiffBudgetPlanner.BudgetPlan plan,
-      Map<Integer, String> previousFilesById,
-      BatchOutcome[] outcomesByIndex) {
+  private void retryBatch(int index, BatchRun run, BatchOutcome[] outcomesByIndex) {
+    var batches = run.batches();
+    var plan = run.plan();
     try {
-      outcomesByIndex[index] =
-          processBatch(index, batches, session, prompts, plan, previousFilesById);
+      outcomesByIndex[index] = processBatch(index, run);
       Log.infof("Batch %d/%d succeeded on retry", index + 1, batches.size());
     } catch (TokenSpendCeilingExceededException e) {
       // The gate above passed but a concurrent late callback (e.g. a timed-out attempt's usage)
@@ -526,9 +546,7 @@ public class FindingPipeline {
       if (truncation.isPresent()) {
         // The parallel attempt failed transiently and the retry hit the length cap: same
         // salvage-or-disclose step as a parallel-pass truncation, and no further retry (#495).
-        outcomesByIndex[index] =
-            salvageTruncatedBatch(
-                session, index, batches, prompts, plan, previousFilesById, truncation.get());
+        outcomesByIndex[index] = salvageTruncatedBatch(index, run, truncation.get());
         return;
       }
       // Soft-fail like the on-request generators (DocGenerationService / PrImprovementService):
@@ -556,13 +574,12 @@ public class FindingPipeline {
    */
   private void joinBatchOutcomes(
       List<CompletableFuture<BatchOutcome>> futures,
-      List<DiffBudgetPlanner.DiffBatch> batches,
-      BatchPrompts prompts,
-      DiffBudgetPlanner.BudgetPlan plan,
-      ReviewSession session,
-      Map<Integer, String> previousFilesById,
+      BatchRun run,
       BatchOutcome[] outcomesByIndex,
       List<Integer> failedIndices) {
+    var batches = run.batches();
+    var plan = run.plan();
+    var session = run.session();
     for (int i = 0; i < futures.size(); i++) {
       try {
         outcomesByIndex[i] = futures.get(i).join();
@@ -572,9 +589,7 @@ public class FindingPipeline {
           // The batch's own retry below would re-send the identical prompt against the identical
           // cap (#495), so the failure goes straight to the disclose step — which now salvages
           // the complete leading findings out of the buffered partial body first (#500).
-          outcomesByIndex[i] =
-              salvageTruncatedBatch(
-                  session, i, batches, prompts, plan, previousFilesById, truncation.get());
+          outcomesByIndex[i] = salvageTruncatedBatch(i, run, truncation.get());
         } else if (isSpendCeilingBlocked(e)) {
           // Deterministic like a truncation: the ledger is monotonic within a review, so a retry
           // would be refused identically. Degrade like the budgeter — disclose, with the ceiling
@@ -599,19 +614,13 @@ public class FindingPipeline {
     }
   }
 
-  private BatchOutcome processBatch(
-      int index,
-      List<DiffBudgetPlanner.DiffBatch> batches,
-      ReviewSession session,
-      BatchPrompts prompts,
-      DiffBudgetPlanner.BudgetPlan plan,
-      Map<Integer, String> previousFilesById) {
+  private BatchOutcome processBatch(int index, BatchRun run) {
+    var batches = run.batches();
     var batch = batches.get(index);
-    var batchInputs = prompts.forBatch(batch, "");
+    var batchInputs = run.prompts().forBatch(batch, "");
     var batchResponse =
-        aiReviewService.reviewBatch(session, batchInputs, index + 1, batches.size());
-    return refineBatchOutcome(
-        session, index, batch, batchInputs, batchResponse, plan, previousFilesById);
+        aiReviewService.reviewBatch(run.session(), batchInputs, index + 1, batches.size());
+    return refineBatchOutcome(index, batch, batchInputs, batchResponse, run);
   }
 
   /**
@@ -622,18 +631,16 @@ public class FindingPipeline {
    * is metered and ceiling-gated inside {@link FindingVerificationService}.
    */
   private BatchOutcome refineBatchOutcome(
-      ReviewSession session,
       int index,
       DiffBudgetPlanner.DiffBatch batch,
       AiReviewService.PromptInputs batchInputs,
       ReviewResponse batchResponse,
-      DiffBudgetPlanner.BudgetPlan plan,
-      Map<Integer, String> previousFilesById) {
+      BatchRun run) {
     var validated = quoteValidator.validate(batchResponse, batch.text());
     validated = frameworkFilter.filter(validated, batch.text());
     var verified =
         findingVerificationService.verify(
-            ledgerSessionId(session),
+            ledgerSessionId(run.session()),
             validated,
             batchInputs.diff(),
             batchInputs.projectStack(),
@@ -642,7 +649,7 @@ public class FindingPipeline {
         index,
         verified.findings(),
         scopeStatusesToBatch(
-            batchResponse.previousFindingsStatus(), batch, plan, previousFilesById));
+            batchResponse.previousFindingsStatus(), batch, run.plan(), run.previousFilesById()));
   }
 
   /**
@@ -657,13 +664,9 @@ public class FindingPipeline {
    * ceiling-gated like any other, so #509's ceiling accounting is untouched.
    */
   private BatchOutcome salvageTruncatedBatch(
-      ReviewSession session,
-      int index,
-      List<DiffBudgetPlanner.DiffBatch> batches,
-      BatchPrompts prompts,
-      DiffBudgetPlanner.BudgetPlan plan,
-      Map<Integer, String> previousFilesById,
-      AiResponseTruncatedException truncation) {
+      int index, BatchRun run, AiResponseTruncatedException truncation) {
+    var batches = run.batches();
+    var plan = run.plan();
     var batch = batches.get(index);
     var salvaged = salvager.salvage(truncation.partialBody());
     if (!salvaged.hasFindingsOrStatuses()) {
@@ -683,11 +686,10 @@ public class FindingPipeline {
         salvaged.findings().size(),
         salvaged.previousFindingsStatus().size());
     plan.recordResponseCutFiles(filenamesOf(batch.files()));
-    var batchInputs = prompts.forBatch(batch, "");
+    var batchInputs = run.prompts().forBatch(batch, "");
     var partialResponse =
         new ReviewResponse(salvaged.findings(), salvaged.previousFindingsStatus(), null);
-    return refineBatchOutcome(
-        session, index, batch, batchInputs, partialResponse, plan, previousFilesById);
+    return refineBatchOutcome(index, batch, batchInputs, partialResponse, run);
   }
 
   private static List<String> filenamesOf(List<GitHubPullRequestClient.FileDiff> files) {
@@ -1013,10 +1015,11 @@ public class FindingPipeline {
     }
     var sb =
         new StringBuilder(
-            "## Changed files omitted from AI review\n"
-                + "Each path below IS changed by this pull request. Its content was withheld from"
-                + " the diff below, so nothing about it can appear in the material you were"
-                + " given.\n");
+            """
+            ## Changed files omitted from AI review
+            Each path below IS changed by this pull request. Its content was withheld from \
+            the diff below, so nothing about it can appear in the material you were given.
+            """);
     for (var row : rows.subList(0, Math.min(rows.size(), MAX_WITHHELD_PATHS))) {
       sb.append("- ").append(row).append('\n');
     }
@@ -1054,6 +1057,11 @@ public class FindingPipeline {
    * before it existed. That mirrors the {@linkplain #withheldMaterialNotice withheld-material
    * notice} this class already adds after planning, and it is what the token safety margin (10% of
    * the input cap by default, ~4800 tokens against this section's ~700) is held back for.
+   *
+   * <p>Deliberately <em>not</em> moved into {@link BatchPrompts}, its only caller: {@code Log}
+   * binds its category to the enclosing class at build time, so relocating the warning below would
+   * relabel an operator-facing WARN from this class to {@code FindingPipeline$BatchPrompts} and
+   * silently break any log filter keyed on the category.
    */
   private static String heuristicFailureModesFor(DiffBudgetPlanner.DiffBatch batch) {
     var scanned = heuristicScanSource(batch.text());
@@ -1103,25 +1111,6 @@ public class FindingPipeline {
     var name = headerLine.substring(SECTION_HEADER_PREFIX.length());
     var suffix = name.lastIndexOf(" (");
     return (suffix > 0 ? name.substring(0, suffix) : name).strip();
-  }
-
-  /**
-   * Copies the shared prompt context, swapping the diff, base-comparison and trailing-guidance
-   * slots.
-   */
-  private static AiReviewService.PromptInputs withDiff(
-      AiReviewService.PromptInputs base,
-      String diff,
-      String baseComparison,
-      String repoInstructions) {
-    return new AiReviewService.PromptInputs(
-        diff,
-        base.prContext(),
-        baseComparison,
-        base.projectStack(),
-        base.relatedTests(),
-        base.previousFindings(),
-        repoInstructions);
   }
 
   private String findingsJson(List<ReviewResponse.Finding> findings) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewDiffFormatter.java
@@ -96,6 +96,23 @@ public class ReviewDiffFormatter {
       }
       return false;
     }
+
+    /** Matches `**`-prefixed patterns against the file name and every sub-path of the file. */
+    private static boolean matchesSuffix(PathMatcher suffix, Path path) {
+      if (suffix == null) {
+        return false;
+      }
+      var fileName = path.getFileName();
+      if (fileName != null && suffix.matches(fileName)) {
+        return true;
+      }
+      for (var i = 0; i < path.getNameCount(); i++) {
+        if (suffix.matches(path.subpath(i, path.getNameCount()))) {
+          return true;
+        }
+      }
+      return false;
+    }
   }
 
   /** A formatted diff plus the number of files the line budget dropped (0 when nothing omitted). */
@@ -135,6 +152,12 @@ public class ReviewDiffFormatter {
     return globalGlobs.union(IgnoreGlobs.compile(perRepoPatterns));
   }
 
+  /**
+   * Deliberately <em>not</em> moved into {@link IgnoreGlobs}, its only caller: {@code Log} binds
+   * its category to the enclosing class at build time, so relocating the warning below would
+   * relabel an operator-facing WARN from this class to {@code ReviewDiffFormatter$IgnoreGlobs} and
+   * silently break any log filter keyed on the category.
+   */
   private static List<GlobMatcher> compileGlobMatchers(List<String> patterns) {
     if (patterns == null || patterns.isEmpty()) {
       return List.of();
@@ -173,23 +196,6 @@ public class ReviewDiffFormatter {
    */
   static boolean namesContain(Set<String> names, String filename) {
     return filename != null && names.contains(filename);
-  }
-
-  /** Matches `**`-prefixed patterns against the file name and every sub-path of the file. */
-  private static boolean matchesSuffix(PathMatcher suffix, Path path) {
-    if (suffix == null) {
-      return false;
-    }
-    var fileName = path.getFileName();
-    if (fileName != null && suffix.matches(fileName)) {
-      return true;
-    }
-    for (var i = 0; i < path.getNameCount(); i++) {
-      if (suffix.matches(path.subpath(i, path.getNameCount()))) {
-        return true;
-      }
-    }
-    return false;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
@@ -120,7 +120,7 @@ final class SummarySurfaceDeduplicator {
         claims.add(candidate);
       }
     }
-    var trimmed = new HashMap<String, String>(fileSummaries.size());
+    var trimmed = HashMap.<String, String>newHashMap(fileSummaries.size());
     for (var entry : fileSummaries.entrySet()) {
       trimmed.put(entry.getKey(), trimRestatedClauses(entry.getValue(), claims));
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvager.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/TruncatedResponseSalvager.java
@@ -211,12 +211,6 @@ public class TruncatedResponseSalvager {
   }
 
   /**
-   * Reads the value at the current token completely and maps it onto {@code type}; {@code null} for
-   * a non-object value or one that does not map. Reading always consumes the whole value, so the
-   * parser stays element-aligned — and a value the cut split throws, ending the pass with the
-   * partial value dropped.
-   */
-  /**
    * Closes the parser without letting a close-time failure mask the salvage result. A string-backed
    * parser cannot fail to close in practice — the null guard and the swallow exist for the
    * contract, and are exercised directly by tests because no production input reaches them.
@@ -232,6 +226,12 @@ public class TruncatedResponseSalvager {
     }
   }
 
+  /**
+   * Reads the value at the current token completely and maps it onto {@code type}; {@code null} for
+   * a non-object value or one that does not map. Reading always consumes the whole value, so the
+   * parser stays element-aligned — and a value the cut split throws, ending the pass with the
+   * partial value dropped.
+   */
   private <T> T objectOrNull(JsonParser parser, JsonToken token, Class<T> type) throws IOException {
     JsonNode node = parser.readValueAsTree();
     if (token != JsonToken.START_OBJECT) {


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor

## Description

Clears the open SonarCloud issues in the five core review-pipeline main files. Pure refactor — no behaviour change anywhere.

**Fixed (7):**

| Rule | File | Fix |
|---|---|---|
| `java:S6126` | `FindingPipeline` | The withheld-material notice becomes a text block. Verified byte-identical to the concatenation it replaces. |
| `java:S3398` | `FindingPipeline` | `withDiff` moves into `BatchPrompts`, its only caller. |
| `java:S107` | `FindingPipeline` | `joinBatchOutcomes` had 8 parameters. The batch lane's five fixed inputs (batches, session, prompts, plan, previous-finding index) become one `BatchRun` value; the join drops to 4 parameters and its four sibling steps shrink with it. |
| `java:S3776` | `DiffBudgetPlanner` | `condensePreviousFindings` splits its fence test and its two passes into `isFenced`, `entryLinesOnly` and `longestPrefixWithin`. Cognitive complexity 19 → 4. |
| `java:S3398` | `ReviewDiffFormatter` | `matchesSuffix` moves into `IgnoreGlobs`, its only caller. |
| `java:S6485` | `SummarySurfaceDeduplicator` | `HashMap.newHashMap(n)` for the walkthrough map. |
| `java:S8491` | `TruncatedResponseSalvager` | The orphaned Javadoc above `closeQuietly` moves back onto `objectOrNull`, the method it actually documents. |

### On `S3776` in `DiffBudgetPlanner`

The method carries the #583 previous-findings bound, so the extraction is deliberately code motion only: the three helpers hold the same statements in the same order, and the fence handling, the reserve arithmetic and the one-way cut are untouched. The two passes already had clean seams — a condensation pass that drops entry-continuation lines, and a capping pass that keeps the longest prefix that fits — and each is now named for what it does.

### On `S6485` in `SummarySurfaceDeduplicator`

`HashMap.newHashMap(n)` can pick a different table size than `new HashMap<>(n)`, which can change iteration order. Checked that no consumer observes it: the map's only reader is `PrSummaryGenerator.appendChangedFiles`, which iterates the changed-file list and looks each row up with `getOrDefault`.

**Deliberately left (2), both `java:S3398`:**

- `FindingPipeline.heuristicFailureModesFor` (line 1058)
- `ReviewDiffFormatter.compileGlobMatchers` (line 138)

Both hold an operator-facing `Log.warnf`. Quarkus binds a `Log` category to the **enclosing class** at build time, so moving either into its inner class relabels a WARN from `dev...FindingPipeline` to `dev...FindingPipeline$BatchPrompts` (and likewise `ReviewDiffFormatter` → `ReviewDiffFormatter$IgnoreGlobs`), silently breaking any log filter keyed on the category. `FindingPipelineTest.aBatchWithNoTextSaysTheHeuristicDimensionCouldNotBeEvaluated` attaches a JUL handler by top-level class name and fails on the move:

```
[ERROR] FindingPipelineTest.aBatchWithNoTextSaysTheHeuristicDimensionCouldNotBeEvaluated:2086
        the skipped dimension must be stated, not silent: [] ==> expected: <true> but was: <false>
[ERROR] Tests run: 2940, Failures: 1, Errors: 0, Skipped: 0
```

Re-pointing the handler at `FindingPipeline$BatchPrompts` makes it pass, confirming the category — not the warning — is what changed. Three of the repository's log-assertion tests key on the top-level class name, so the category is treated as contract here. A comment on each method records why it stays put; neither is suppressed.

## Related Issues

N/A

## How Has This Been Tested?

- [x] Unit tests

Existing suite only — a pure refactor has no behaviour to prove red/green, and the standard exempts it provided the suite stays green.

- `./mvnw -B clean compile spotbugs:check spotless:check` → **BUILD SUCCESS**, `BugInstance size is 0`
- `./mvnw -B clean test` → **BUILD SUCCESS**, `Tests run: 2940, Failures: 0, Errors: 0, Skipped: 0`
- Coverage: jacoco ∩ `git diff -U0 6ba8eee...HEAD` over changed main lines → **0 uncovered lines, 0 uncovered branches** across all 5 files

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- N/A: pure refactor, covered by the existing suite -->
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly <!-- N/A -->
- [x] My changes generate no new warnings or errors

## Additional Notes

Base is `release/v0.6.0` at `6ba8eee`. Scope is the five assigned main files only; no test file is modified.
