### PR TITLE
refactor(review): clear the regex quality findings on the floor and the redactor

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
@@ -49,13 +49,20 @@ public final class GitHubApiError {
    * GitHub App/PAT/OAuth token prefixes and bearer/JWT shapes. GitHub does not echo credentials in
    * an error body, but a body is untrusted text on its way to a log file, so a token-shaped run of
    * characters is masked rather than trusted to be harmless.
+   *
+   * <p>Deliberately ONE alternation rather than one pattern per shape: the shapes overlap, and a
+   * single pass masks each overlap as the leftmost match, whereas masking in passes decides the
+   * overlap by pass order and leaves material the one-pass form masks. Whichever order is chosen,
+   * {@code "…ghp_<7 chars>Bearer <20 chars>"} keeps its token prefix unmasked if the bearer pass
+   * runs first, and {@code "Bearer ghp_<10 chars>.<tail>"} keeps the tail of the bearer value if
+   * the token pass does. So this stays one pattern even though it reads as four.
    */
   private static final Pattern CREDENTIAL_SHAPED =
       Pattern.compile(
-          "(?i)(gh[pousr]_[A-Za-z0-9_]{10,})"
-              + "|(github_pat_[A-Za-z0-9_]{10,})"
-              + "|(bearer\\s+[A-Za-z0-9._~+/=-]{10,})"
-              + "|(eyJ[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,})");
+          "(?i)(gh[pousr]_\\w{10,})"
+              + "|(github_pat_\\w{10,})"
+              + "|(bearer\\s+[\\w.~+/=-]{10,})"
+              + "|(eyJ[\\w-]{8,}\\.[\\w-]{8,}\\.[\\w-]{8,})");
 
   /**
    * The wording GitHub uses when it is throttling rather than refusing. A secondary rate limit and
@@ -159,9 +166,9 @@ public final class GitHubApiError {
    * window has reopened and the call can go straight back out.
    */
   public Duration retryDelay(int attempt, Instant now) {
-    var retryAfter = retryAfterSeconds();
-    if (retryAfter.isPresent()) {
-      return atLeastZero(Duration.ofSeconds(retryAfter.get()));
+    var fromHeader = retryAfterSeconds();
+    if (fromHeader.isPresent()) {
+      return atLeastZero(Duration.ofSeconds(fromHeader.get()));
     }
     var reset = parseLong(rateLimitReset);
     if (reset.isPresent()) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -95,14 +95,23 @@ public class FindingVerificationService {
           Pattern.CASE_INSENSITIVE);
 
   /**
-   * Injection sinks and vulnerability classes named explicitly, per the review prompt's dimension-2
-   * list. Matching one of these is only the first half of the floor's test.
+   * Vulnerability classes named explicitly, per the review prompt's dimension-2 list. Matching one
+   * of these is only the first half of the floor's test.
    */
   private static final Pattern INJECTION_SINK =
       Pattern.compile(
           "\\b(xss|cross[- ]site scripting|sql injection|command injection|shell injection"
-              + "|path traversal|directory traversal|(unsafe|insecure) deserializ\\w*"
-              + "|dangerouslysetinnerhtml|bypasssecuritytrusthtml|v-html|inner_?html|outerhtml"
+              + "|path traversal|directory traversal|(unsafe|insecure) deserializ\\w*)\\b",
+          Pattern.CASE_INSENSITIVE);
+
+  /**
+   * The raw-HTML sinks from the same list, named as the API rather than as a class. Read as a union
+   * with {@link #INJECTION_SINK} — a finding naming either names a sink — and kept a second pattern
+   * only because one alternation of both lists is more than the regex complexity budget allows.
+   */
+  private static final Pattern HTML_SINK_API =
+      Pattern.compile(
+          "\\b(dangerouslysetinnerhtml|bypasssecuritytrusthtml|v-html|inner_?html|outerhtml"
               + "|insertadjacenthtml|document\\.write)\\b",
           Pattern.CASE_INSENSITIVE);
 
@@ -115,15 +124,26 @@ public class FindingVerificationService {
           Pattern.CASE_INSENSITIVE);
 
   /**
-   * The finding's own statement that nothing neutralizes the tainted value. Deliberately keyed on
-   * an ABSENCE claim: it is what turns "this code uses innerHTML" into "user data reaches an
-   * injection sink unmitigated", which is the class the prompt floors at "high".
+   * The finding's own statement that nothing neutralizes the tainted value, worded as an adjective
+   * on the value itself. Deliberately keyed on an ABSENCE claim: it is what turns "this code uses
+   * innerHTML" into "user data reaches an injection sink unmitigated", which is the class the
+   * prompt floors at "high".
    */
-  private static final Pattern NO_MITIGATION =
+  private static final Pattern UNMITIGATED_ADJECTIVE =
       Pattern.compile(
-          "\\b(unsanitiz\\w*|unescaped|unvalidated|unparameteriz\\w*|non-parameteriz\\w*"
-              + "|(no|not|without|missing|never|lacks?|absent)\\s+(\\w+[\\s-]+){0,3}"
-              + "(sanitiz|escap|validat|parameteriz|encod)\\w*)",
+          "\\b(unsanitiz\\w*|unescaped|unvalidated|unparameteriz\\w*|non-parameteriz\\w*)",
+          Pattern.CASE_INSENSITIVE);
+
+  /**
+   * The same absence claim worded as a missing step ("no sanitization", "never escaped"), with room
+   * for a few words between the negator and the neutralizing verb. Read as a union with {@link
+   * #UNMITIGATED_ADJECTIVE}; the two are one claim split across two patterns only because one
+   * alternation of both wordings is more than the regex complexity budget allows.
+   */
+  private static final Pattern MITIGATION_ABSENT =
+      Pattern.compile(
+          "\\b(no|not|without|missing|never|lacks?|absent)\\s+(\\w+[\\s-]+){0,3}"
+              + "(sanitiz|escap|validat|parameteriz|encod)\\w*",
           Pattern.CASE_INSENSITIVE);
 
   /**
@@ -136,9 +156,19 @@ public class FindingVerificationService {
    */
   private static final Pattern SINK_DENIED =
       Pattern.compile(
-          "\\b(no|not|never)\\s+(\\w+[\\s-]+){0,1}"
+          "\\b(no|not|never)\\s+(\\w+[\\s-]+)?"
               + "(xss|cross[- ]site scripting|sql injection|command injection|shell injection"
-              + "|path traversal|directory traversal|vulnerab\\w*|exploitab\\w*)\\b",
+              + "|path traversal|directory traversal)\\b",
+          Pattern.CASE_INSENSITIVE);
+
+  /**
+   * The same denial worded about the exposure rather than the class ("not exploitable", "no
+   * vulnerability here"). Read as a union with {@link #SINK_DENIED}, from which it is separated
+   * only because one alternation of both wordings is more than the regex complexity budget allows.
+   */
+  private static final Pattern EXPLOITABILITY_DENIED =
+      Pattern.compile(
+          "\\b(no|not|never)\\s+(\\w+[\\s-]+)?(vulnerab|exploitab)\\w*\\b",
           Pattern.CASE_INSENSITIVE);
 
   /**
@@ -146,6 +176,11 @@ public class FindingVerificationService {
    * them"). An absence claim about one layer must not floor the class when the same text says
    * another layer neutralizes the value. Negated forms are excluded, so "is not escaped" and "was
    * never sanitized" stay absence claims instead of defeating themselves.
+   *
+   * <p>Left exactly as it stands, {@code {0,1}} and all: its complexity is over the analyzer's
+   * budget and cannot come under it without dropping a copula, a verb form or the one-word gap,
+   * each of which narrows what it matches (#594, #608). Rewriting the quantifier alone would move
+   * that unfixable finding onto this change's own lines while fixing nothing.
    */
   private static final Pattern MITIGATION_ASSERTED =
       Pattern.compile(
@@ -497,17 +532,29 @@ public class FindingVerificationService {
     // is safe, and the review prompt mandates exactly that hypothesis on this class (#608).
     String asserted = CONDITIONAL_CLAUSE.matcher(text).replaceAll(" ");
     return namesInjectionSink(text)
-        && NO_MITIGATION.matcher(text).find()
+        && claimsNothingNeutralizesIt(text)
         // Either defeater anywhere in the finding's assertions suppresses the floor. Under-firing
-        // costs a finding the lift it should have had, which is where this class already stood;
-        // over-firing escalates a non-defect and, at high confidence, blocks the merge on it.
-        && !SINK_DENIED.matcher(asserted).find()
+        // only costs a finding the lift it should have had (which is where this class already
+        // stood), while over-firing escalates a non-defect and, at high confidence, blocks the
+        // merge on it.
+        && !deniesTheSink(asserted)
         && !MITIGATION_ASSERTED.matcher(asserted).find();
   }
 
   private static boolean namesInjectionSink(String text) {
     return INJECTION_SINK.matcher(text).find()
+        || HTML_SINK_API.matcher(text).find()
         || (SQL.matcher(text).find() && STRING_BUILT.matcher(text).find());
+  }
+
+  /** The absence claim in either of its two wordings; one claim, two patterns. */
+  private static boolean claimsNothingNeutralizesIt(String text) {
+    return UNMITIGATED_ADJECTIVE.matcher(text).find() || MITIGATION_ABSENT.matcher(text).find();
+  }
+
+  /** The sink denied by class ("no SQL injection") or by exposure ("not exploitable"). */
+  private static boolean deniesTheSink(String asserted) {
+    return SINK_DENIED.matcher(asserted).find() || EXPLOITABILITY_DENIED.matcher(asserted).find();
   }
 
   private static boolean isBlockingEligible(ReviewResponse.Finding finding) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -950,6 +950,31 @@ class FindingVerificationServiceTest {
   }
 
   @Test
+  void doesNotFloorAFindingThatDeniesTheExposureRatherThanTheSinkByName() {
+    // The denial the finding words about the exposure ("not exploitable") instead of about the
+    // class ("no SQL injection"): it names no sink of its own, so it is the wording most easily
+    // lost when the denials are read as two patterns rather than one alternation.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "low",
+                "high",
+                "src/main/java/Report.java",
+                31,
+                "Unescaped title in the offline CSV export",
+                "The value reaches document.write with no escaping, but the sheet is rendered by a"
+                    + " build step and served to nobody, so this is not exploitable.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    assertEquals("low", result.findings().get(0).risk());
+  }
+
+  @Test
   void doesNotFloorAFindingThatDescribesTheMitigationAsPresent() {
     // The other half of the same defect: no negated sink here, but the finding affirmatively
     // states the value IS escaped. An absence claim about one layer ("unvalidated" at storage)


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor
- [x] ✅ Test

## Description

Clears the SonarCloud regex findings reported on `GitHubApiError` and `FindingVerificationService`, without moving what any of the patterns match.

**`GitHubApiError` — 6 × S5869, 2 × S6353, 1 × S1117 fixed.**
All six duplicate character classes are one cause, not six: the pattern carries `(?i)`, so `A-Za-z` inside `[A-Za-z0-9_]` / `[A-Za-z0-9_-]` / `[A-Za-z0-9._~+/=-]` is redundant against `a-z`. Each is now written with `\w`, which fixes S5869 and S6353 together. **None of the six was a typo for a different character** — `gh[pousr]_` covers exactly the five GitHub token prefixes (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`) with no repeat, and `[\w-]` / `[\w.~+/=-]` are the base64url and bearer-value alphabets. The local `retryAfter` in `retryDelay` that hid the field is renamed `fromHeader`.

**`FindingVerificationService` — 3 × S5843, 1 × S6353, 1 × S125 fixed.**
All four flagged patterns are read as booleans through `find()`, so "some alternative matches somewhere" is exactly the union of the halves' `find()` results — splitting a top-level alternation is an identity here, not a re-tuning:

- `INJECTION_SINK` → the named vulnerability classes + `HTML_SINK_API` (the raw-HTML sinks named as APIs), unioned in `namesInjectionSink`.
- `NO_MITIGATION` → `UNMITIGATED_ADJECTIVE` ("unsanitized") + `MITIGATION_ABSENT` ("no sanitization"), unioned in `claimsNothingNeutralizesIt`.
- `SINK_DENIED` → the denial by class ("no SQL injection") + `EXPLOITABILITY_DENIED` (the denial by exposure, "not exploitable"), unioned in `deniesTheSink`.
- `{0,1}` → `?` in `SINK_DENIED` (S6353), and the floor's comment is reworded so no line of it parses as code (S125).

## Three findings left deliberately

1. **`CREDENTIAL_SHAPED` S5843 (24)** stays one alternation. Its shapes overlap, and masking in passes decides each overlap by pass order rather than by leftmost match. A differential run over 400k generated bodies found both orders lose material the one-pass form masks: bearer-first leaves `ghp_<7 chars>` unmasked in `"…ghp_<7 chars>Bearer <20 chars>"`, and token-first leaves the `.<tail>` of a bearer value in `"Bearer ghp_<10 chars>.<tail>"`. No single-pattern form of the four shapes reaches 20 either — the cheapest equivalent rewrite (folding the two token prefixes into a nested alternation, `(?:\.[\w-]{8,}){2}` for the JWT segments) still scores 21, because the analyzer prices a flat alternative at 1 but a nested quantifier or nested alternation at 2–3. Masking less is not a trade worth making for a complexity number.
2. **`MITIGATION_ASSERTED` S5843 (49)** cannot reach 20 without dropping a copula, a verb form or the one-word gap — each narrows what it matches, and this is the defeater #594 and #608 spent four rounds getting right.
3. **`MITIGATION_ASSERTED` S6353 (`{0,1}`)**, consequently, is left too. Rewriting that one quantifier fixes nothing that matters and re-dates the pattern's lines, which pulls the 1h6min unfixable S5843 above onto this PR's own new code — the first push did exactly that and took `new_maintainability_rating` on new code from A to B. The pattern is therefore left byte-identical to `release/v0.6.0`, with a comment saying why.

## Related Issues

N/A — raised by SonarCloud on the v0.6.0 release PR (#532).

## How Has This Been Tested?

- [x] Unit tests

**Equivalence.** A differential harness compiled the old patterns and their replacements and compared them over 400 000 generated strings drawn from an alphabet of the exact tokens these patterns key on (sink names, negators, copulas, mitigation verbs, token prefixes, separators):

```
diffs: cred=0 sink=0 nomit=0 denied=0 asserted=0
```

Zero divergence. The same harness is what caught the credential-split leak described above (17 divergences, which is why that split was reverted).

**Characterisation.** The 50 existing `FindingVerificationServiceTest` cases — the injection-sink floor, the conditional-mitigation cases and the over-firing defeaters — pass unchanged, before and after.

**New test.** `doesNotFloorAFindingThatDeniesTheExposureRatherThanTheSinkByName` pins the denial wording that carries no sink name of its own ("not exploitable"), which is the one the split could silently drop. It passes against the pre-change code (it characterises behaviour that already existed), and it is red as soon as the split loses that half — dropping `EXPLOITABILITY_DENIED` from `deniesTheSink`:

```
[ERROR] Failures:
[ERROR]   FindingVerificationServiceTest.doesNotFloorAFindingThatDeniesTheExposureRatherThanTheSinkByName:973
expected: <...Finding[risk=low, ... title=Unescaped title in the offline CSV export, ...
but was: <...Finding[risk=high, ... title=Unescaped title in the offline CSV export, ...
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

**Analyzer verification.** The first push was analysed by SonarCloud on this PR: 15 of the 17 findings gone, and the two survivors reported at exactly the complexity predicted for them (`CREDENTIAL_SHAPED` "from 24 to the 20 allowed"), which is what rules out a compliant single-pattern form.

**Gates**

| Gate | Result |
| --- | --- |
| `./mvnw -B spotless:apply` + `spotless:check` | clean |
| `./mvnw -B clean compile spotbugs:check` | `BugInstance size is 0`, `Error size is 0` |
| `./mvnw -B clean test` | `Tests run: 2941, Failures: 0, Errors: 0, Skipped: 0` |
| jacoco ∩ `git diff -U0 6ba8eee...HEAD` (main) | 15 changed executable lines, 0 uncovered lines, 0 uncovered branches |

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The analyzer's complexity metric prices a flat alternative at 1, but a nested quantifier, a nested alternation or a lookaround at 2–3. Factoring common prefixes (`(sql|command|shell) injection`) therefore *raises* the score, which is why the fix here is "fewer alternatives per pattern" rather than "shorter pattern".
