### PR TITLE
refactor(github): clear the SonarCloud findings on the token-refresh path

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubAuthClient.java
@@ -191,7 +191,7 @@ public class GitHubAuthClient {
 
     log.info("Generating new installation token for installation {}", installationId);
     var jwt = generateAppJwt();
-    var authHeader = "Bearer " + jwt;
+    var authHeader = BEARER + jwt;
 
     var response =
         tokenApi.createInstallationToken(authHeader, "application/vnd.github+json", installationId);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetry.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetry.java
@@ -147,18 +147,21 @@ public final class GitHubWriteRetry {
   public <T> T call(String operation, String auth, Function<String, T> operationCall) {
     var credential = auth;
     var refreshable = true;
-    for (int attempt = 1; ; ) {
+    // The loop is unbounded and `attempt` is not what counts it round: an attempt is spent at the
+    // one point below where a wait GitHub asked for has actually been served. A credential swap
+    // repeats the call without advancing it — the "outside the attempt budget" rule above — so a
+    // counted for-loop here would change how many attempts a refreshed call gets.
+    var attempt = 1;
+    while (true) {
       try {
         pacer.acquire(operation);
         return operationCall.apply(credential);
       } catch (WebApplicationException e) {
-        if (refreshable) {
-          var fresh = credentials.replacementFor(operation, credential, e);
-          if (fresh.isPresent()) {
-            credential = fresh.get();
-            refreshable = false;
-            continue;
-          }
+        var fresh = replacementCredential(operation, credential, refreshable, e);
+        if (fresh.isPresent()) {
+          credential = fresh.get();
+          refreshable = false;
+          continue;
         }
         var delay = retryDelay(operation, e, attempt);
         if (delay.isEmpty()) {
@@ -183,10 +186,30 @@ public final class GitHubWriteRetry {
   }
 
   /**
+   * The fresher credential to repeat this failure with, or empty when there is none — either
+   * because the one swap this call is allowed has already been spent, or because {@link
+   * GitHubTokenRefresh} has nothing fresher to offer for this failure. Empty is what sends the
+   * failure on to the backoff below, so a swap that cannot happen costs the caller nothing.
+   */
+  private Optional<String> replacementCredential(
+      String operation, String credential, boolean refreshable, WebApplicationException failure) {
+    if (!refreshable) {
+      return Optional.empty();
+    }
+    return credentials.replacementFor(operation, credential, failure);
+  }
+
+  /**
    * How long to wait before repeating this failure, or empty when it must not be repeated — either
    * because GitHub is refusing rather than throttling, or because the attempts are spent. The
    * spent-attempts case is logged, because it is the one where a completed generation is discarded
    * and the operator needs the response's own words to see why.
+   *
+   * <p>That line sits behind a level check because {@link GitHubApiError#diagnostics()} builds its
+   * string eagerly — a parameter placeholder defers the {@code toString}, not the call that
+   * produces the argument. The message itself is unchanged: this is the warning that surfaced the
+   * issue-624 diagnosis in production, so what it prints when it prints must stay exactly as it
+   * was.
    */
   private Optional<Duration> retryDelay(
       String operation, WebApplicationException failure, int attempt) {
@@ -195,12 +218,14 @@ public final class GitHubWriteRetry {
       return Optional.empty();
     }
     if (attempt >= MAX_ATTEMPTS) {
-      log.warn(
-          "GitHub still throttling {} after {} attempts — the generated content is lost and the"
-              + " command has to be re-run. {}",
-          operation,
-          MAX_ATTEMPTS,
-          error.get().diagnostics());
+      if (log.isWarnEnabled()) {
+        log.warn(
+            "GitHub still throttling {} after {} attempts — the generated content is lost and the"
+                + " command has to be re-run. {}",
+            operation,
+            MAX_ATTEMPTS,
+            error.get().diagnostics());
+      }
       return Optional.empty();
     }
     return Optional.of(min(error.get().retryDelay(attempt, clock.get()), MAX_DELAY_PER_ATTEMPT));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
@@ -28,7 +28,12 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -197,6 +202,58 @@ class GitHubWriteRetryTest {
     assertSame(lastFailure, thrown);
     assertEquals(3, calls.get());
     assertEquals(List.of(Duration.ofSeconds(4), Duration.ofSeconds(4)), slept);
+  }
+
+  @Test
+  void aSpentBudgetStillGivesUpSilentlyWhenWarningsAreOff() {
+    // The give-up line sits behind a level check, because diagnostics() builds its string eagerly
+    // and a parameter placeholder only defers the toString. With the logger off nothing may be
+    // logged, and the retry must still spend the same three attempts and rethrow the same failure.
+    var julLogger = Logger.getLogger(GitHubWriteRetry.class.getName());
+    var logged = new CopyOnWriteArrayList<LogRecord>();
+    var capture =
+        new Handler() {
+          @Override
+          public void publish(LogRecord entry) {
+            logged.add(entry);
+          }
+
+          @Override
+          public void flush() {
+            // Nothing is buffered.
+          }
+
+          @Override
+          public void close() {
+            // Nothing to release.
+          }
+        };
+    var originalLevel = julLogger.getLevel();
+    julLogger.setLevel(Level.OFF);
+    julLogger.addHandler(capture);
+    var calls = new AtomicInteger();
+    var lastFailure = throttled("Retry-After", "4");
+
+    try {
+      var thrown =
+          assertThrows(
+              WebApplicationException.class,
+              () ->
+                  retry.call(
+                      "a comment on o/r #7",
+                      () -> {
+                        calls.incrementAndGet();
+                        throw lastFailure;
+                      }));
+
+      assertSame(lastFailure, thrown);
+      assertEquals(3, calls.get());
+      assertEquals(List.of(Duration.ofSeconds(4), Duration.ofSeconds(4)), slept);
+      assertTrue(logged.isEmpty(), logged.toString());
+    } finally {
+      julLogger.removeHandler(capture);
+      julLogger.setLevel(originalLevel);
+    }
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor

## Description

Four SonarCloud findings on the v0.6.0 release PR (#532), all introduced by the token-refresh work in #625/#629. This is the #624 recovery path — a review that outlives its installation token — so every change here is structural. No statement of the retry or refresh mechanism moves, no bound changes, and nothing is silenced with `@SuppressWarnings` or `// NOSONAR`.

**S1192 (CRITICAL, `GitHubAuthClient.java:194`)** — `getInstallationToken` built its JWT header from a literal `"Bearer "` while the class already declares `BEARER` with that exact value, and two other sites already use the constant. Mechanical.

**S3776 (CRITICAL, `GitHubWriteRetry.java:147`)** — cognitive complexity 16 against a limit of 15. Fixed by extraction only. The credential-swap guard and the lookup it guards move into `replacementCredential`, which returns empty when the one swap this call is allowed has already been spent. Same statements in the same order: `credentials.replacementFor` is still reached only when the swap is still available, and empty still means "fall through to the backoff". Against Sonar's own arithmetic, the `if (refreshable)` at nesting 2 (+3) disappears and the `if (fresh.isPresent())` drops from nesting 3 (+4) to nesting 2 (+3), so the method scores 12.

**S127 (MAJOR, `GitHubWriteRetry.java:180`)** — the backoff loop was `for (int attempt = 1; ; )`, a `for` with no condition and no update whose counter advanced from the body. It is not a counted loop, and the assignment does encode retry semantics: an attempt is spent at the single point where a wait GitHub asked for has actually been served, and a credential swap `continue`s without advancing it, which is the "outside the attempt budget" rule the class documents. A counted `for` rewrite would change how many attempts a refreshed call gets, so the fix is the opposite direction — the loop is written as the unbounded loop it already was, with `attempt` as ordinary loop state rather than a disguised loop counter. `int attempt = 1; while (true)` is byte-for-byte the same control flow as `for (int attempt = 1; ; )`, including where `continue` lands, so the attempt count is untouched. A comment records why it cannot be counted, so the next reader does not "fix" it into a `for`.

**S2629 (MAJOR, `GitHubWriteRetry.java:203`)** — the give-up warning passed `error.get().diagnostics()`, which builds its string eagerly; a `{}` placeholder defers the `toString`, not the call that produces the argument. It now sits behind an `isWarnEnabled` check — the same shape `GitHubErrorLogger` already uses for the same method, for the same reason. The message is unchanged to the character. `GitHubWriteRetry`'s warnings are what surfaced the #624 diagnosis in production, so what it prints when it prints had to stay exactly as it was.

## Related Issues

N/A — SonarCloud findings raised on #532. Origin of the code: #625, #629.

## How Has This Been Tested?

- [x] Unit tests

All four changes are pure refactors: no behaviour changes, so there is no red/green proof to quote. The existing `GitHubWriteRetryTest` suite is what pins the behaviour that had to survive, and it does — in particular `aRejectedCredentialIsReplacedAndTheWriteRepeatedWithIt` (a swap costs no attempt and no wait), `aCredentialIsReplacedOnlyOncePerCall` (2 calls, 1 mint — the `refreshable == false` path now inside the extracted method), `aPersistentThrottleGivesUpAfterThreeAttempts` (3 attempts, 2 waits) and `everyAttemptWaitsForItsPacingSlotIncludingTheRepeats`.

One test is added, `aSpentBudgetStillGivesUpSilentlyWhenWarningsAreOff`, for the level check S2629 required: with the logger at `OFF` the retry must still spend the same three attempts, still sleep the same two waits, still rethrow the same failure, and log nothing. It also covers the new guard's false branch, so the added branch is not left half-tested. It follows the harness `GitHubErrorLoggerTest.staysSilentAndStillMapsTheResponseWhenLoggingIsOff` already established for the identical guard.

Gates, all from a dedicated worktree on `release/v0.6.0` at `79d17eb`:

- `./mvnw -B spotless:apply` — clean
- `./mvnw -B clean compile spotbugs:check spotless:check` — BUILD SUCCESS, `BugInstance size is 0`
- `./mvnw -B clean test` — `Tests run: 2950, Failures: 0, Errors: 0, Skipped: 0`
- Coverage: jacoco ∩ `git diff -U0 79d17eb...HEAD` over changed main code — 14 executable changed lines, zero uncovered lines and zero uncovered branches. Both branches of the new `if (!refreshable)` and of the new `if (log.isWarnEnabled())` are covered.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Scope is limited to `GitHubAuthClient.java`, `GitHubWriteRetry.java` and `GitHubWriteRetryTest.java`. `"Bearer "` literals also survive in `DashboardAccessChecker` and `AuthResource`; those are outside this lane and were not flagged on this PR, so they are left alone.
