### PR TITLE
fix(review): stop a lesser finding from displacing the config-doc and IaC one

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -141,7 +141,17 @@ public final class PrReviewPrompts {
                will not pass schema validation (a missing required field, a mistyped value, an
                invalid apiVersion/kind pairing), a Helm/template expression that renders to invalid
                output, a workflow that will not parse, or a value that contradicts a constraint
-               stated elsewhere in the same file. These fail at apply/validation/CI time, not at
+               stated elsewhere in the same file. One shape belongs on this list and is the one
+               most often passed over: a BUILD OR RUN INSTRUCTION NAMING A PATH, FILENAME OR
+               ARTIFACT THAT NOTHING IN THE PROVIDED MATERIAL PRODUCES. A Dockerfile COPY of
+               target/<name>.jar when the build file's artifactId and version — with no finalName
+               or output-name override — make the produced artifact a different filename; a COPY of
+               requirement.txt when the file the PR commits is requirements.txt; a workflow step
+               consuming an artifact no earlier step uploads; an ENTRYPOINT naming a binary no
+               stage builds. Check every path a declarative file names against the names the rest
+               of the provided material actually shows, and treat a mismatch as "high": it breaks
+               the build deterministically, on the first run, for everyone.
+               These fail at apply/validation/CI time, not at
                "runtime", so judge them on whether the breakage is visible here — not on whether they
                map to a code exception. Scale severity by impact: a change that will fail
                schema/lint/CI validation, or that breaks the safety property the PR itself claims to
@@ -194,9 +204,9 @@ public final class PrReviewPrompts {
                producer and consumer agree, or when the consumer is not in the provided material —
                say nothing rather than narrating the data flow of an ordinary local change.
             10. CONFIG KEY DOCUMENTATION COMPLETENESS: when the diff documents a configuration key
-               — an environment variable or property named in a .md, .env* or config table — AND a
-               "Config key definitions from the repository" section supplies that key's definition,
-               read the documented description against that definition and flag it when the
+               — an environment variable or property named in a .md, .env* or config table — AND
+               the provided material anywhere establishes that key's DEFINITION, read the
+               documented description against that definition and flag it when the
                description omits a FORMAT-CRITICAL fact an operator needs to set the value
                correctly: the value TYPE, LIST/SEPARATOR semantics (a List-typed binding is
                comma-separated in SmallRye/Quarkus config, so documentation that shows one value
@@ -211,10 +221,22 @@ public final class PrReviewPrompts {
                missing example, and any fact the definition does not establish are not findings.
                The starkest form of the same gap counts too — a key the diff ADDS while also
                changing a documentation/config file that lists sibling keys without listing the new
-               one is undocumented; report that here. Say nothing when the definition is not in the
-               provided material, when the documentation already states the fact anywhere in the
-               changed material, or when the diff changes no documentation/config file at all (you
-               cannot see whether documentation for the key exists elsewhere).
+               one is undocumented; report that here.
+               The definition can reach you two ways, and the SECOND is the ordinary one. A
+               "Config key definitions from the repository" section is supplied only when the
+               repository's key is defined in a file that section's resolver can find; most
+               projects define theirs somewhere it does not look. So the definition is equally the
+               CODE IN THIS SAME DIFF THAT READS, PARSES OR BINDS THE KEY: strings.Split(raw, ","),
+               .split(","), raw.Split(',', …), a List<String> / string[] / Vec<String> / list-typed
+               binding, Duration.ofMillis(parsed), os.environ.get(KEY, DEFAULT), a parse with a
+               fallback constant. That line does not merely hint at the format — it IS the format,
+               and it establishes the omitted fact exactly as a rendered definition would. Read the
+               diff's own parsing line against the diff's own documentation line; do not wait for a
+               section that will usually be absent. Say nothing when NEITHER the section nor the
+               provided material shows how the key is read, parsed or bound, when the documentation
+               already states the fact anywhere in the changed material, or when the diff changes no
+               documentation/config file at all (you cannot see whether documentation for the key
+               exists elsewhere).
 
             For each finding, provide:
             - risk: "critical" | "high" | "medium" | "low"
@@ -307,6 +329,34 @@ public final class PrReviewPrompts {
               pass which lookup it uses. "Grows without bound" and "is scanned linearly per item"
               are two different defects on two different dimensions; naming either one does not
               report the other, and a finding about the accumulator's scope covers neither.
+            - Finding a defect on a config key or a declarative file does not finish that key or
+              that file. Here the displacement is the ordinary outcome, not the exception: the
+              finding you already have is precisely what makes the artifact feel read, and the
+              dimension-specific question then never gets asked. Two artifacts carry such a
+              question, and a real finding on the same artifact does not answer it:
+              (a) A CONFIG KEY you touched for any reason — the diff parses it, or you filed a
+                  finding on how the code applies it (parsed and never used, applied to the wrong
+                  branch, defaulted wrongly, read at the wrong scope) — still has dimension 10's
+                  question open: does the documentation this diff changes state its type, list
+                  separator, unit or duration format, allowed values and default? "This variable is
+                  parsed and never applied" and "this variable's documentation never says it is
+                  comma-separated" are two defects on two dimensions; the more serious one does not
+                  contain the other, and finding the more serious one is the usual reason the
+                  documentation gap is lost.
+              (b) A DOCKERFILE, WORKFLOW, MANIFEST OR TERRAFORM FILE you filed one finding on — an
+                  unpinned base image, a missing lockfile, a broad permission — still has two
+                  questions open before you leave it: does every path, filename and artifact it
+                  names exist in the material (dimension 7), and does it drop privilege before
+                  running the application — a USER directive in a Dockerfile, runAsNonRoot in a
+                  manifest (dimension 2)? The hardening nit and the build-breaking reference are
+                  not alternatives to each other, and the one that is easier to see is not the one
+                  the file most needs reported. File each.
+              This asks an already-open question of an artifact you are already reviewing; it does
+              NOT lower either dimension's evidence bar. A key whose documentation already states
+              every format-critical fact, or one whose parsing you cannot see, yields no second
+              finding; neither does a file whose references all resolve and which already switches
+              user. Say nothing rather than file a weaker finding to satisfy the check — asking the
+              question and answering "no gap" is the check working.
             - Before you finish, re-read what you have written — each finding's description, each
               file_summaries line, each description_gaps entry — for any statement that describes
               a defect no finding in your list covers, and promote each one into its own finding

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -149,11 +149,14 @@ public final class PrReviewPrompts {
                requirement.txt when the file the PR commits is requirements.txt; a workflow step
                consuming an artifact no earlier step uploads; an ENTRYPOINT naming a binary no
                stage builds. Check every path a declarative file names against the names the rest
-               of the provided material actually shows, and treat a mismatch as "high": it breaks
-               the build deterministically, on the first run, for everyone.
-               These fail at apply/validation/CI time, not at
-               "runtime", so judge them on whether the breakage is visible here — not on whether they
-               map to a code exception. Scale severity by impact: a change that will fail
+               of the provided material actually shows, and treat a mismatch as "high": it fails
+               deterministically the first time it is exercised, for everyone — at build time for a
+               COPY or a workflow step, at CONTAINER START for an ENTRYPOINT or CMD naming a binary
+               no stage produces. Both are deterministic and both are demonstrable from the diff;
+               do not downgrade the second because its failure is later than the first.
+               These fail at apply/validation/CI time or when the container starts, not on an
+               application code path, so judge them on whether the breakage is visible here — not on
+               whether they map to a code exception. Scale severity by impact: a change that will fail
                schema/lint/CI validation, or that breaks the safety property the PR itself claims to
                add, is high; a cosmetic or stylistic config nitpick is low. Not a finding when a
                comment or adjacent value justifies the choice, or when correctness depends on

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -800,11 +800,17 @@ class PrReviewPromptsContentTest {
   }
 
   /**
-   * #638 rounds 4/5 — the same shape as #537 above, on two more dimensions. In go #40 the review
-   * read {@code WEBHOOKRELAY_ALLOWED_TOPICS}, filed a better bug (parsed but never applied) and
-   * never returned to the documentation question; in node #41 and java #43 it filed the deliberate
-   * unpinned-base-image bait on the Dockerfile and not the planted defect on the same file. Every
-   * miss was clean, so this is displacement while the artifact is in hand, not suppression.
+   * #638 rounds 4/5 — the same shape as #537 above, on two more dimensions: config-key
+   * documentation and config/IaC correctness, numbered 10 and 7 in this prompt. Issue #638 and the
+   * corpus briefs call the same two 9 and 6, numbering the corpus's own dimensions rather than the
+   * prompt's, so the tests below name each dimension and give both numbers where it matters — a
+   * bare "dimension 9" in this file already means the producer→consumer contract dimension.
+   *
+   * <p>In go #40 the review read {@code WEBHOOKRELAY_ALLOWED_TOPICS}, filed a better bug (parsed
+   * but never applied) and never returned to the documentation question; in node #41 and java #43
+   * it filed the deliberate unpinned-base-image bait on the Dockerfile and not the planted defect
+   * on the same file. Every miss was clean, so this is displacement while the artifact is in hand,
+   * not suppression.
    */
   @Test
   void aFindingOnAConfigKeyOrDeclarativeFileMustNotEndTheExaminationOfIt() {
@@ -865,9 +871,11 @@ class PrReviewPromptsContentTest {
   }
 
   /**
-   * #638 dimension 9 — the misses on python #39, angular #49, csharp #47, rust #42 and go #40 all
-   * define their key somewhere {@code ConfigKeyContextResolver} cannot reach ({@code Program.cs} is
-   * not even a supported extension; {@code main.go}, {@code main.py}, {@code Main.java} and {@code
+   * The config-key documentation dimension — 10 in this prompt, 9 in #638 and the corpus briefs.
+   *
+   * <p>Its misses on python #39, angular #49, csharp #47, rust #42 and go #40 all define their key
+   * somewhere {@code ConfigKeyContextResolver} cannot reach ({@code Program.cs} is not even a
+   * supported extension; {@code main.go}, {@code main.py}, {@code Main.java} and {@code
    * app-config.service.ts} are not config stems), so the section never renders and the dimension's
    * old {@code AND a "Config key definitions…" section supplies} gate closed it outright. The
    * self-check below already accepted a definition quoted from the diff; the dimension did not.
@@ -898,10 +906,12 @@ class PrReviewPromptsContentTest {
   }
 
   /**
-   * #638 dimension 6 — java #43 planted a {@code COPY} of a jar Maven never produces and round 4's
-   * python PR planted {@code COPY requirement.txt} against a committed {@code requirements.txt}.
-   * Both break {@code docker build} deterministically, and neither was among the defect shapes
-   * dimension 7 enumerated, which listed only schema/parse/constraint failures.
+   * The config/IaC correctness dimension — 7 in this prompt, 6 in #638 and the corpus briefs.
+   *
+   * <p>java #43 planted a {@code COPY} of a jar Maven never produces and round 4's python PR
+   * planted {@code COPY requirement.txt} against a committed {@code requirements.txt}. Both break
+   * {@code docker build} deterministically, and neither was among the defect shapes dimension 7
+   * enumerated, which listed only schema/parse/constraint failures.
    */
   @Test
   void configIacDimensionEnumeratesTheUnproducedArtifactReferenceShape() {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -930,8 +930,38 @@ class PrReviewPromptsContentTest {
         "the round-4 python missing-file COPY must be named too (#638)");
     assertContains(
         sys,
-        "the build deterministically, on the first run",
-        "an unresolvable reference must be graded on its deterministic build failure (#638)");
+        "deterministically the first time it is exercised, for everyone",
+        "an unresolvable reference must be graded on its deterministic failure (#638)");
+  }
+
+  /**
+   * The shapes in that list do not all fail at the same moment: a {@code COPY} of a missing file
+   * breaks {@code docker build}, while an {@code ENTRYPOINT} naming a binary no stage produces
+   * builds fine and fails when the container starts. The dimension's framing sentence predates #638
+   * and said these defects fail "not at runtime", which the ENTRYPOINT shape contradicts — and a
+   * prompt that teaches the comment-contradicts-code class (dimension 4) is a poor instructor for
+   * it while its own text disagrees with the list it introduces. The grade attaches to the reason,
+   * so a build-time-only framing would invite skipping or misgrading the start-time shapes.
+   */
+  @Test
+  void configIacFramingCoversStartTimeFailureNotOnlyBuildTime() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "at CONTAINER START for an ENTRYPOINT or CMD naming a binary",
+        "the grading reason must cover the shape that fails when the container starts (#638)");
+    assertContains(
+        sys,
+        "do not downgrade the second because its failure is later than the first",
+        "a start-time failure must not be graded below a build-time one (#638)");
+    assertContains(
+        sys,
+        "apply/validation/CI time or when the container starts",
+        "the framing sentence must not claim these defects never fail at run time (#638)");
+    assertContains(
+        sys,
+        "application code path, so judge them on whether the breakage is visible here",
+        "the framing must still refuse to demand a code-exception trace (#638)");
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -799,6 +799,131 @@ class PrReviewPromptsContentTest {
         "unbounded growth and a linear per-item lookup must not collapse into one (#537)");
   }
 
+  /**
+   * #638 rounds 4/5 — the same shape as #537 above, on two more dimensions. In go #40 the review
+   * read {@code WEBHOOKRELAY_ALLOWED_TOPICS}, filed a better bug (parsed but never applied) and
+   * never returned to the documentation question; in node #41 and java #43 it filed the deliberate
+   * unpinned-base-image bait on the Dockerfile and not the planted defect on the same file. Every
+   * miss was clean, so this is displacement while the artifact is in hand, not suppression.
+   */
+  @Test
+  void aFindingOnAConfigKeyOrDeclarativeFileMustNotEndTheExaminationOfIt() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "Finding a defect on a config key or a declarative file does not finish that key or",
+        "one filed defect must not close a config key or an IaC file to a second one (#638)");
+    assertContains(
+        sys,
+        "finding you already have is precisely what makes the artifact feel read",
+        "the miss must be framed as displacement by a real finding, not inattention (#638)");
+    assertContains(
+        sys,
+        "question open: does the documentation this diff changes state its type, list",
+        "a code-level finding on a key must still trigger the documentation question (#638)");
+    assertContains(
+        sys,
+        "parsed and never applied",
+        "the go #40 shape — a better bug on the same key — must be named (#638)");
+    assertContains(
+        sys,
+        "unpinned base image, a missing lockfile, a broad permission",
+        "the near-miss findings that displaced the planted IaC defect must be named (#638)");
+    assertContains(
+        sys,
+        "does every path, filename and artifact it",
+        "a filed IaC finding must still trigger the reference-resolution question (#638)");
+    assertContains(
+        sys,
+        "a USER directive in a Dockerfile, runAsNonRoot in a",
+        "a filed IaC finding must still trigger the drop-privilege question (#638)");
+    assertContains(
+        sys,
+        "not alternatives to each other",
+        "the hardening nit must sit beside the planted defect, not replace it (#638)");
+  }
+
+  /**
+   * The recall trigger above must not become a licence to report every key and file it looks at:
+   * round 5 produced only four false positives across twelve languages.
+   */
+  @Test
+  void theConfigAndIacTriggerDoesNotLowerEitherDimensionsEvidenceBar() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "NOT lower either dimension's evidence bar",
+        "asking the dimension's question must not relax its evidence requirement (#638)");
+    assertContains(
+        sys,
+        "neither does a file whose references all resolve",
+        "a complete doc entry or a resolving reference must produce nothing (#638)");
+    assertContains(
+        sys,
+        "Say nothing rather than file a weaker finding to satisfy the check",
+        "the trigger must not manufacture a finding to answer itself (#638)");
+  }
+
+  /**
+   * #638 dimension 9 — the misses on python #39, angular #49, csharp #47, rust #42 and go #40 all
+   * define their key somewhere {@code ConfigKeyContextResolver} cannot reach ({@code Program.cs} is
+   * not even a supported extension; {@code main.go}, {@code main.py}, {@code Main.java} and {@code
+   * app-config.service.ts} are not config stems), so the section never renders and the dimension's
+   * old {@code AND a "Config key definitions…" section supplies} gate closed it outright. The
+   * self-check below already accepted a definition quoted from the diff; the dimension did not.
+   */
+  @Test
+  void theConfigDocDimensionAcceptsTheDiffsOwnParsingLineAsTheDefinition() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "the provided material anywhere establishes that key's DEFINITION",
+        "the dimension must not gate on the resolver section alone (#638)");
+    assertContains(
+        sys,
+        "CODE IN THIS SAME DIFF THAT READS, PARSES OR BINDS THE KEY",
+        "the diff's own parsing line must count as the key's definition (#638)");
+    assertContains(
+        sys,
+        "strings.Split(raw, \",\")",
+        "the parsing forms the corpus actually plants must be named (#638)");
+    assertContains(
+        sys,
+        "section that will usually be absent",
+        "the prompt must say the definitions section is normally missing (#638)");
+    assertContains(
+        sys,
+        "Say nothing when NEITHER the section nor the",
+        "an unparseable, undefined key must still yield no finding (#638)");
+  }
+
+  /**
+   * #638 dimension 6 — java #43 planted a {@code COPY} of a jar Maven never produces and round 4's
+   * python PR planted {@code COPY requirement.txt} against a committed {@code requirements.txt}.
+   * Both break {@code docker build} deterministically, and neither was among the defect shapes
+   * dimension 7 enumerated, which listed only schema/parse/constraint failures.
+   */
+  @Test
+  void configIacDimensionEnumeratesTheUnproducedArtifactReferenceShape() {
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "BUILD OR RUN INSTRUCTION NAMING A PATH, FILENAME OR",
+        "the unresolvable-reference shape must be an enumerated dimension-7 defect (#638)");
+    assertContains(
+        sys,
+        "or output-name override — make the produced artifact a different filename",
+        "the java #43 jar-name mismatch must be named as the shape's canonical case (#638)");
+    assertContains(
+        sys,
+        "requirement.txt when the file the PR commits is requirements.txt",
+        "the round-4 python missing-file COPY must be named too (#638)");
+    assertContains(
+        sys,
+        "the build deterministically, on the first run",
+        "an unresolvable reference must be graded on its deterministic build failure (#638)");
+  }
+
   @Test
   void mockFidelityIsReportableFromTheSignatureAndLandsAtMedium() {
     assertContains(


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Dimensions 7 (config/IaC) and 10 (config-key documentation) are under-reported across corpus
rounds 4 and 5 — 6 and 8 misses across 24 PRs — and the failure mode is not inattention. A finding
*is* emitted, it *is* real, and it crowds out the planted one:

- **go #40**: `WEBHOOKRELAY_ALLOWED_TOPICS` was read, reasoned about, and reported as *parsed but
  never applied to filter events* — a worse bug than the planted one. The documentation question
  was never revisited.
- **node #41 / java #43**: the corpus's deliberate unpinned-base-image bait was reported instead of
  the planted defect on the same Dockerfile (missing `USER`; a `COPY` naming a jar Maven never
  produces).

Every miss was clean — marker sequences unbroken, Risk Assessment counts reconciling with published
findings — so nothing was found-then-suppressed. These are genuine non-reports.

Three changes to `PrReviewPrompts.SYSTEM`, following the shape of the trigger #612 added for
dimension 5 rather than inventing a parallel mechanism.

**1. A displacement trigger, placed beside its dimension-5 sibling.** "Finding a defect on a config
key or a declarative file does not finish that key or that file." It names the mechanism the way
#612 does — the finding you already have is precisely what makes the artifact feel read — and then
asks the dimension's own question of each artifact: for a config key, does the documentation this
diff changes state its type, separator, unit, allowed values and default; for a Dockerfile,
workflow, manifest or Terraform file, do every path and artifact name it references resolve
(dimension 7), and does it drop privilege before running the app (dimension 2).

**2. Dimension 10 no longer hard-gates on the resolver-built definitions section.** This is the
part most likely to explain the dimension-9 misses, and it is a structural gate rather than an
attention one. The dimension read:

> AND a "Config key definitions from the repository" section supplies that key's definition

That section is built by `ConfigKeyContextResolver`, whose candidate set is `application*` resources
plus source files whose *stem* ends in config/configuration/settings/properties/env with a
java/kt/py/ts/js/go/rb/rs extension. None of the missed PRs qualify:

| PR | key defined in | why the resolver cannot reach it |
|---|---|---|
| go #40 | `cmd/dispatcher/main.go` | stem `main` |
| python #39 | `main.py` | stem `main` |
| angular #49 | `app-config.service.ts` | stem ends `service` |
| csharp #47 | `Program.cs` | `.cs` is not a supported extension |
| rust #42 | `src/main.rs` | stem `main` |
| java #43 | `Main.java` | stem `main` |

So the section never rendered, and "Say nothing when the definition is not in the provided material"
closed the dimension outright. The evidence the answer keys actually call for is a comparison of two
lines *both in the diff* — the doc row and `strings.Split(raw, ",")` / `.split(',')` /
`Duration.ofMillis(...)`. The dimension now names the diff's own parsing line as the definition and
says plainly that the section is normally absent. This is not a widening of the claim: the
self-check at "A config-key documentation-completeness claim (dimension 10) must quote … from the
diff or from the config-key definitions section" already accepted a diff-sourced definition, so the
dimension statement and its self-check disagreed. `FindingVerifierPrompts` also already tolerates it
("do not reject it for quoting a definition line the diff does not contain"), so no change is needed
outside this lane.

**3. Dimension 7 enumerates the unproduced-artifact reference shape.** The dimension listed only
schema, parse and same-file-constraint failures. It now names a build or run instruction referencing
a path, filename or artifact that nothing in the material produces — java #43's `COPY` of
`target/suppression-sync.jar` against a pom with no `finalName`, and round 4's `COPY requirement.txt`
against a committed `requirements.txt`. Both fail `docker build` deterministically, and both were
displaced by a hardening nit on the same file.

**Precision is deliberately not relaxed.** Round 5 produced only 4 false positives across 12
languages, three of which were the corpus's own bait working as intended. The trigger therefore
closes by stating that it asks an already-open question of an artifact under review and does NOT
lower either dimension's evidence bar; a key whose documentation is complete, a key whose parsing is
not visible, and a file whose references all resolve each yield no second finding — "say nothing
rather than file a weaker finding to satisfy the check". Dimension 10's "stay inside that list"
exclusion and its "say nothing when neither the section nor the material shows how the key is read"
escape are both intact.

**This cannot be verified by inspection.** Prompt changes in this project have twice looked correct
and failed in measurement — #575 for severity and #545 for performance. The only real verification
is a corpus round. The PRs a future round should re-check specifically: **go #40**, **node #41**,
**java #43** for the displacement shape, and the dimension-9 misses on **python #39**, **angular
#49**, **csharp #47** and **rust #42** for the definition-source gate. The false-positive count
should be re-checked in the same round, since the direction of the change is toward recall.

## Related Issues

Fixes #638

## How Has This Been Tested?

- [x] Unit tests

Prompt-text changes are exempt from red/green, but the four new content tests were run against the
base prompt to confirm they pin the new text rather than something already present. With
`PrReviewPrompts.java` reverted to `79d17eb` and the new tests in place:

```
[ERROR] Tests run: 57, Failures: 4, Errors: 0, Skipped: 0, Time elapsed: 0.115 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.ai.PrReviewPromptsContentTest
org.opentest4j.AssertionFailedError: the dimension must not gate on the resolver section alone (#638) — missing marker: "the provided material anywhere establishes that key's DEFINITION" ==> expected: <true> but was: <false>
org.opentest4j.AssertionFailedError: one filed defect must not close a config key or an IaC file to a second one (#638) — missing marker: "Finding a defect on a config key or a declarative file does not finish that key or" ==> expected: <true> but was: <false>
org.opentest4j.AssertionFailedError: asking the dimension's question must not relax its evidence requirement (#638) — missing marker: "NOT lower either dimension's evidence bar" ==> expected: <true> but was: <false>
org.opentest4j.AssertionFailedError: the unresolvable-reference shape must be an enumerated dimension-7 defect (#638) — missing marker: "BUILD OR RUN INSTRUCTION NAMING A PATH, FILENAME OR" ==> expected: <true> but was: <false>
```

Gates on the branch head:

- `./mvnw -B spotless:apply` — clean
- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, `Error size is 0`, Spotless keeping 324 files clean, BUILD SUCCESS
- `./mvnw -B clean test` — `Tests run: 2953, Failures: 0, Errors: 0, Skipped: 0`, BUILD SUCCESS
  (`PrReviewPromptsContentTest` 53 → 57)
- Coverage, jacoco ∩ `git diff -U0 79d17eb...HEAD` over changed main lines (144-154, 207-209,
  224-239, 332-359): zero instrumented lines in the intersection, therefore zero uncovered lines and
  zero uncovered branches. Every changed main line is prose inside the `SYSTEM` text block, which
  jacoco attributes to the field's first line; no branch was added.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Scope is `PrReviewPrompts.java` and `PrReviewPromptsContentTest.java` only. Two adjacent
observations found while tracing the gate, both left alone deliberately:

- `ConfigKeyContextResolver`'s candidate set is narrow enough that it cannot resolve keys for most
  non-Java repositories (`.cs`, `.php`, `.rb` stems aside, `main.*` and `*.service.ts` are simply not
  candidates). Broadening it would raise the quality of the rendered evidence, but it is outside this
  lane and the prompt fix does not depend on it.
- `FindingVerifierPrompts`'s config-doc clause is permissive about where the definition came from, so
  it needs no matching change; if the resolver is ever broadened, the two should be re-read together.
