### PR TITLE
fix(review): disclose the description-gap check instead of vanishing

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -89,6 +89,29 @@ public class PrSummaryGenerator {
    */
   static final String NO_MODEL_SUMMARY = "Not summarized — no model summary for this file";
 
+  /** Heading of the Description vs. Implementation section when a mismatch exists. */
+  static final String GAPS_HEADING = "### ⚠️ Description vs. Implementation";
+
+  /**
+   * Heading of the same section when the check found nothing. Carries no warning emoji: a clean
+   * result is not a warning, and reusing the ⚠️ heading would make every review look flagged.
+   */
+  static final String NO_GAPS_HEADING = "### Description vs. Implementation";
+
+  /**
+   * Body for the state where the model reported gaps but #588 collapsed every one of them onto a
+   * finding that states the same thing. The claim still reaches the reader at its most specific
+   * surface, so it is not repeated here — but the check plainly ran, and saying so is what keeps a
+   * collapsed section from reading exactly like a skipped one (#637).
+   */
+  static final String GAPS_ALL_REPORTED_AS_FINDINGS =
+      "Every mismatch found between the description and the change is reported as a finding below,"
+          + " so it is not repeated here.";
+
+  /** Body for the state where the check ran over the description and found no mismatch. */
+  static final String NO_GAPS_FOUND =
+      "No mismatch found between the PR description and the change.";
+
   /**
    * One changed file in the walkthrough: its path, the diff's authoritative change type, and
    * whether it is a pure rename — renamed with no content change, hence never sent to the model and
@@ -146,12 +169,13 @@ public class PrSummaryGenerator {
     // One observation must be published once. The findings are the most specific surface, so a
     // description-gap bullet — or a walkthrough clause appended after the row's file summary —
     // that only restates one of them is collapsed away before anything is rendered (#588).
+    var reportedGaps = descriptionGaps(aiSummary);
     var surfaces =
         SummarySurfaceDeduplicator.collapse(
-            descriptionGaps(aiSummary), summariesByPath(aiSummary), result.findings());
+            reportedGaps, summariesByPath(aiSummary), result.findings());
 
     appendPrPurpose(sb, aiSummary);
-    appendDescriptionGaps(sb, surfaces.descriptionGaps());
+    appendDescriptionGaps(sb, aiSummary, reportedGaps.size(), surfaces.descriptionGaps());
     appendWalkthroughDiagram(sb, aiSummary);
 
     sb.append("### Changes Overview\n");
@@ -400,16 +424,42 @@ public class PrSummaryGenerator {
     return aiSummary.descriptionGaps().stream().filter(g -> !g.isBlank()).toList();
   }
 
-  private static void appendDescriptionGaps(StringBuilder sb, List<String> gaps) {
-    if (gaps.isEmpty()) {
+  /**
+   * Renders the Description vs. Implementation section in whichever of its three states the check
+   * actually reached, so a reader can tell a matching description from a check that never ran
+   * (#637). Silence is reserved for the one case that earns it — {@code aiSummary} is {@code null},
+   * meaning no summary came back at all, which the summary-degradation banners already disclose.
+   *
+   * <p>The states are: gaps survived, so they are listed; the model reported gaps but every one of
+   * them restated a finding and #588 collapsed them all away, which used to delete the whole
+   * section along with them (the sharpest measured case — the review found the contradicted bug and
+   * still said nothing about the description); and the model reported none, which is now stated
+   * rather than implied by an absent heading.
+   *
+   * <p>A PR with an empty body reaches the last state too, since the model reports no gaps for a
+   * description it never received and the renderer cannot tell the two apart from the response
+   * alone. The line is vacuous there rather than wrong, and that is the safe direction: the failure
+   * this fixes is a reader who cannot tell "checked, matched" from "never checked".
+   */
+  private static void appendDescriptionGaps(
+      StringBuilder sb, ReviewResponse.Summary aiSummary, int reported, List<String> gaps) {
+    if (aiSummary == null) {
       return;
     }
-    sb.append("### ⚠️ Description vs. Implementation\n");
-    sb.append("The PR description does not fully match the change:\n");
-    for (String gap : gaps) {
-      sb.append("- ").append(gap.strip()).append("\n");
+    if (!gaps.isEmpty()) {
+      sb.append(GAPS_HEADING).append("\n");
+      sb.append("The PR description does not fully match the change:\n");
+      for (String gap : gaps) {
+        sb.append("- ").append(gap.strip()).append("\n");
+      }
+      sb.append("\n");
+      return;
     }
-    sb.append("\n");
+    if (reported > 0) {
+      sb.append(GAPS_HEADING).append("\n").append(GAPS_ALL_REPORTED_AS_FINDINGS).append("\n\n");
+      return;
+    }
+    sb.append(NO_GAPS_HEADING).append("\n").append(NO_GAPS_FOUND).append("\n\n");
   }
 
   /**

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -226,7 +226,7 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
-  void shouldOmitPurposeAndGapsSectionsWhenAbsent() {
+  void shouldOmitPurposeSectionWhenAbsentAndStillDiscloseTheGapCheck() {
     var blankSummary = new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", " ", List.of());
     var nullPurposeSummary = new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", null, null);
     var blankGapsSummary = new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", null, List.of(" ", ""));
@@ -234,15 +234,31 @@ class PrSummaryGeneratorTest {
         new ReviewResult(
             List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
+    // A summary came back and reported nothing to flag: the section says so rather than vanishing.
     for (var summary :
         List.of(
-            generator.generate(1, 0, 0, List.of(), null, result),
             generator.generate(1, 0, 0, List.of(), blankSummary, result),
             generator.generate(1, 0, 0, List.of(), nullPurposeSummary, result),
             generator.generate(1, 0, 0, List.of(), blankGapsSummary, result))) {
-      assertFalse(summary.contains("What this PR does"));
-      assertFalse(summary.contains("Description vs. Implementation"));
+      assertFalse(summary.contains("What this PR does"), summary);
+      assertTrue(
+          summary.contains("No mismatch found between the PR description and the change."),
+          summary);
     }
+  }
+
+  @Test
+  void shouldOmitTheGapSectionEntirelyWhenNoSummaryCameBack() {
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
+
+    // No summary at all is the one absence that is honest: nothing compared the description to the
+    // diff, and the summary-degradation banners already say why.
+    var summary = generator.generate(1, 0, 0, List.of(), null, result);
+
+    assertFalse(summary.contains("What this PR does"), summary);
+    assertFalse(summary.contains("Description vs. Implementation"), summary);
   }
 
   @Test
@@ -1331,7 +1347,7 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
-  void descriptionGapsSectionDisappearsWhenEveryBulletRestatesAFinding() {
+  void descriptionGapsSectionStatesTheCheckRanWhenEveryBulletRestatesAFinding() {
     var findings =
         List.of(
             new Finding(
@@ -1375,7 +1391,34 @@ class PrSummaryGeneratorTest {
 
     var summary = generator.generate(1, 10, 0, List.of(), aiSummary, result);
 
+    // #588 still collapses the bullet onto the finding — the claim is not stated twice...
+    assertFalse(summary.contains("no rotation logic exists"), summary);
+    // ...but the section itself survives and says the check ran, so a review that compared the
+    // description against the diff no longer reads exactly like one that skipped it (#637).
+    assertTrue(summary.contains("### ⚠️ Description vs. Implementation"), summary);
+    assertTrue(
+        summary.contains(
+            "Every mismatch found between the description and the change is reported as a finding"
+                + " below, so it is not repeated here."),
+        summary);
+    assertFalse(summary.contains("No mismatch found between the PR description"), summary);
+  }
+
+  @Test
+  void descriptionGapsSectionStatesTheCheckFoundNothingWhenTheModelReportedNoGap() {
+    var aiSummary =
+        new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", "Adds a cache wrapper.", List.of());
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
+
+    var summary = generator.generate(1, 10, 0, List.of(), aiSummary, result);
+
+    // A clean result is not a warning, so the heading drops the ⚠️ the mismatch states carry.
+    assertTrue(summary.contains("### Description vs. Implementation"), summary);
     assertFalse(summary.contains("### ⚠️ Description vs. Implementation"), summary);
+    assertTrue(
+        summary.contains("No mismatch found between the PR description and the change."), summary);
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The "Description vs. Implementation" section was rendered only when at least one description gap
survived, so a review that compared the PR description against the diff and found nothing looked
exactly like one that never ran the check.

**The cause is render-side, not model-side.** Two render paths drop the section:

1. `appendDescriptionGaps` returns early on an empty list, so "no gaps" and "check never ran" are
   the same output.
2. #588's `SummarySurfaceDeduplicator.collapse` runs *before* rendering and drops a gap bullet that
   merely restates an inline finding. When every gap the model reported collapsed that way, the
   whole section disappeared with them. That is exactly the sharpest measured case in #637 (the C
   PR, tbtest #46): the review found the pagination bug the description contradicted, filed it as
   `finding=3` — and the gap bullet restating it was collapsed onto that finding, taking the section
   with it. The existing test `descriptionGapsSectionDisappearsWhenEveryBulletRestatesAFinding`
   asserted precisely this disappearance.

The section now renders in whichever of its three states the check reached:

| state | rendered |
|---|---|
| gaps survived | ⚠️ heading + the bullets, unchanged |
| gaps reported, all collapsed onto findings | ⚠️ heading + "Every mismatch found between the description and the change is reported as a finding below, so it is not repeated here." |
| no gap reported | plain heading + "No mismatch found between the PR description and the change." |

Absence is reserved for the one case that earns it: `aiSummary == null`, meaning no summary came
back at all, which the `SUMMARY_CUT_NOTICE` / `SUMMARY_SKIPPED_NOTICE` banners already disclose.

#588's collapse is untouched — the claim is still stated once, at the finding, and the section no
longer pretends the check did not happen. Same argument as #623 (verification) and #607 (dropped
findings): absence must be distinguishable from silence.

**Known limitation.** A PR with an empty body also reaches the third state, because the model
reports no gaps for a description it never received and the renderer cannot tell the two apart from
the response alone. The line is vacuous there rather than wrong. Distinguishing them needs the PR
description plumbed into `VerdictBuilder.build`, which is `ReviewOrchestrator`'s call site — out of
this change's scope.

## Related Issues

Fixes #637

## How Has This Been Tested?

- [x] Unit tests

Red on unfixed main code (`PrSummaryGeneratorTest`, 3 failures):

```
Tests run: 62, Failures: 3, Errors: 0, Skipped: 0 <<< FAILURE! -- in PrSummaryGeneratorTest
  descriptionGapsSectionStatesTheCheckFoundNothingWhenTheModelReportedNoGap <<< FAILURE!
  descriptionGapsSectionStatesTheCheckRanWhenEveryBulletRestatesAFinding <<< FAILURE!
  shouldOmitPurposeSectionWhenAbsentAndStillDiscloseTheGapCheck <<< FAILURE!

[ERROR]   PrSummaryGeneratorTest.descriptionGapsSectionStatesTheCheckRanWhenEveryBulletRestatesAFinding:1398 ## 🤖 ThrillhouseBot PR Summary

### Changes Overview
- **Files changed:** 1
- **Lines added:** +10
- **Lines removed:** 0

### Risk Assessment
| Risk | Count |
|------|-------|
| 🔴 Critical | 0 |
| 🟠 High | 1 |
| 🟡 Medium | 0 |
| 🔵 Low | 0 |

### Key Findings
- **HIGH:** LOGD_MAX_FILE_SIZE never enforced; no rotation despite docs (`src/rotator.c:45`)

---
*Automated review by ThrillhouseBot. Reply with `/review` to re-run.*
 ==> expected: <true> but was: <false>
```

The model reported a gap and the review filed the finding it contradicts — and the rendered summary
contains no Description vs. Implementation section at all. That is #637's C case reproduced.

Gates: `spotless:check` clean, `spotbugs:check` BugInstance size is 0, `clean test` 2951/2951 green.
Coverage: jacoco ∩ `git diff -U0 79d17eb...HEAD` — 16 changed main lines with bytecode, zero
uncovered lines, zero uncovered branches.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Every review that produces a summary now carries this section. That is the point of the change: the
reader can tell "checked, matched" from "never checked".