### PR TITLE
fix(review): reach the double-check surface and the finding's own wording

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -279,12 +279,21 @@ public class PrSummaryGenerator {
    * Collapsed section for low-confidence medium/low findings that were withheld from inline
    * threads. Keeps the signal visible and clearly non-blocking without opening a review thread that
    * maintainers must triage and resolve.
+   *
+   * <p>A bullet that says what an inline finding already says is cross-referenced to it. This list
+   * never passed through the deduplicator — {@code collapse} weighs the gap bullets and walkthrough
+   * rows against the findings and stops there — so one defect reported both inline and here read as
+   * two independent defects, which is exactly the repetition-reads-as-severity failure the
+   * deduplicator exists to prevent (#639). The bullet is annotated instead of dropped because it is
+   * the finding's only rendered surface: it is the one place the {@code path:line} a maintainer
+   * needs to clear it from the PR conversation is printed (#548).
    */
   private static void appendDoubleCheckFindings(StringBuilder sb, ReviewResult result) {
     var findings = result.doubleCheckFindings();
     if (findings.isEmpty()) {
       return;
     }
+    var inline = result.findings().stream().filter(Finding::postsInline).toList();
     sb.append("### Things to double-check\n");
     sb.append("<details>\n");
     sb.append("<summary>")
@@ -305,10 +314,28 @@ public class PrSummaryGenerator {
           .append(":")
           .append(f.line())
           .append("`) ")
-          .append(SuggestionFormatter.confidenceDisclaimer(Confidence.LOW))
-          .append("\n");
+          .append(SuggestionFormatter.confidenceDisclaimer(Confidence.LOW));
+      SummarySurfaceDeduplicator.restatedBy(f, inline)
+          .ifPresent(published -> sb.append(" ").append(sameIssueNote(published)));
+      sb.append("\n");
     }
     sb.append("\n</details>\n\n");
+  }
+
+  /** Opening of the cross-reference appended to a double-check bullet that restates a finding. */
+  static final String SAME_ISSUE_PREFIX = "_Same issue as the inline finding on ";
+
+  /**
+   * The cross-reference naming the inline finding a double-check bullet restates, by the locator
+   * that finding's own row and review thread carry, so a reader can see the two are one defect.
+   */
+  private static String sameIssueNote(Finding published) {
+    return SAME_ISSUE_PREFIX
+        + "`"
+        + MarkdownSafe.inlineCode(published.file())
+        + ":"
+        + published.line()
+        + "`._";
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -89,6 +89,29 @@ public class PrSummaryGenerator {
    */
   static final String NO_MODEL_SUMMARY = "Not summarized — no model summary for this file";
 
+  /** Heading of the Description vs. Implementation section when a mismatch exists. */
+  static final String GAPS_HEADING = "### ⚠️ Description vs. Implementation";
+
+  /**
+   * Heading of the same section when the check found nothing. Carries no warning emoji: a clean
+   * result is not a warning, and reusing the ⚠️ heading would make every review look flagged.
+   */
+  static final String NO_GAPS_HEADING = "### Description vs. Implementation";
+
+  /**
+   * Body for the state where the model reported gaps but #588 collapsed every one of them onto a
+   * finding that states the same thing. The claim still reaches the reader at its most specific
+   * surface, so it is not repeated here — but the check plainly ran, and saying so is what keeps a
+   * collapsed section from reading exactly like a skipped one (#637).
+   */
+  static final String GAPS_ALL_REPORTED_AS_FINDINGS =
+      "Every mismatch found between the description and the change is reported as a finding below,"
+          + " so it is not repeated here.";
+
+  /** Body for the state where the check ran over the description and found no mismatch. */
+  static final String NO_GAPS_FOUND =
+      "No mismatch found between the PR description and the change.";
+
   /**
    * One changed file in the walkthrough: its path, the diff's authoritative change type, and
    * whether it is a pure rename — renamed with no content change, hence never sent to the model and
@@ -146,12 +169,13 @@ public class PrSummaryGenerator {
     // One observation must be published once. The findings are the most specific surface, so a
     // description-gap bullet — or a walkthrough clause appended after the row's file summary —
     // that only restates one of them is collapsed away before anything is rendered (#588).
+    var reportedGaps = descriptionGaps(aiSummary);
     var surfaces =
         SummarySurfaceDeduplicator.collapse(
-            descriptionGaps(aiSummary), summariesByPath(aiSummary), result.findings());
+            reportedGaps, summariesByPath(aiSummary), result.findings());
 
     appendPrPurpose(sb, aiSummary);
-    appendDescriptionGaps(sb, surfaces.descriptionGaps());
+    appendDescriptionGaps(sb, aiSummary, reportedGaps.size(), surfaces.descriptionGaps());
     appendWalkthroughDiagram(sb, aiSummary);
 
     sb.append("### Changes Overview\n");
@@ -400,16 +424,42 @@ public class PrSummaryGenerator {
     return aiSummary.descriptionGaps().stream().filter(g -> !g.isBlank()).toList();
   }
 
-  private static void appendDescriptionGaps(StringBuilder sb, List<String> gaps) {
-    if (gaps.isEmpty()) {
+  /**
+   * Renders the Description vs. Implementation section in whichever of its three states the check
+   * actually reached, so a reader can tell a matching description from a check that never ran
+   * (#637). Silence is reserved for the one case that earns it — {@code aiSummary} is {@code null},
+   * meaning no summary came back at all, which the summary-degradation banners already disclose.
+   *
+   * <p>The states are: gaps survived, so they are listed; the model reported gaps but every one of
+   * them restated a finding and #588 collapsed them all away, which used to delete the whole
+   * section along with them (the sharpest measured case — the review found the contradicted bug and
+   * still said nothing about the description); and the model reported none, which is now stated
+   * rather than implied by an absent heading.
+   *
+   * <p>A PR with an empty body reaches the last state too, since the model reports no gaps for a
+   * description it never received and the renderer cannot tell the two apart from the response
+   * alone. The line is vacuous there rather than wrong, and that is the safe direction: the failure
+   * this fixes is a reader who cannot tell "checked, matched" from "never checked".
+   */
+  private static void appendDescriptionGaps(
+      StringBuilder sb, ReviewResponse.Summary aiSummary, int reported, List<String> gaps) {
+    if (aiSummary == null) {
       return;
     }
-    sb.append("### ⚠️ Description vs. Implementation\n");
-    sb.append("The PR description does not fully match the change:\n");
-    for (String gap : gaps) {
-      sb.append("- ").append(gap.strip()).append("\n");
+    if (!gaps.isEmpty()) {
+      sb.append(GAPS_HEADING).append("\n");
+      sb.append("The PR description does not fully match the change:\n");
+      for (String gap : gaps) {
+        sb.append("- ").append(gap.strip()).append("\n");
+      }
+      sb.append("\n");
+      return;
     }
-    sb.append("\n");
+    if (reported > 0) {
+      sb.append(GAPS_HEADING).append("\n").append(GAPS_ALL_REPORTED_AS_FINDINGS).append("\n\n");
+      return;
+    }
+    sb.append(NO_GAPS_HEADING).append("\n").append(NO_GAPS_FOUND).append("\n\n");
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -40,6 +41,16 @@ import java.util.regex.Pattern;
  *       also carries an inline finding is normal and useful — and drops only the clauses appended
  *       after it that restate an already-published claim.
  * </ul>
+ *
+ * <p>A fourth surface, the collapsed "Things to double-check" list, carries findings that never
+ * opened an inline thread. It is cross-referenced rather than collapsed ({@link #restatedBy}): a
+ * bullet there is a finding's only rendered surface, so annotating it says "this is the finding
+ * above, not a second defect" without risking the deletion of a claim on a mistaken match.
+ *
+ * <p>Two <em>inline</em> findings stating one defect from different angles are deliberately left
+ * alone. Nothing here may edit the finding list: it drives the risk counts, the review verdict, the
+ * inline threads and the resolution backstop, and a finding removed from it is removed from all of
+ * them. That duplicate is the reader's to judge.
  *
  * <p>Two texts state the same claim when they share a contiguous run of {@value #PHRASE_TOKENS}
  * content words, or when their content words overlap by {@value #OVERLAP_THRESHOLD} of the shorter
@@ -96,11 +107,67 @@ final class SummarySurfaceDeduplicator {
   private static final Pattern CONTRACTED_NEGATION =
       Pattern.compile("(?:ca|wo|sha|ai)?n['\u2019]t\\b");
 
-  /** One text reduced to what it asserts: its content words in order, and whether it negates. */
-  record Claim(List<String> words, boolean negated) {}
+  /**
+   * One text reduced to what it asserts: its content words in order, and whether it negates. {@code
+   * phraseOnly} marks a claim only the contiguous-run arm may match — the shape used for a
+   * finding's description, which is long prose where the overlap coefficient would happily fire on
+   * two different observations that merely discuss the same code (#639).
+   */
+  record Claim(List<String> words, boolean negated, boolean phraseOnly) {
+
+    /** A claim judged on both arms — a bullet, a walkthrough clause, or a finding title. */
+    Claim(List<String> words, boolean negated) {
+      this(words, negated, false);
+    }
+  }
 
   /** The description-gap bullets and per-path walkthrough notes left after collapsing. */
   record Surfaces(List<String> descriptionGaps, Map<String, String> fileSummaries) {}
+
+  /**
+   * What one finding publishes, as claims to match other surfaces against: its title on both arms,
+   * and its description on the contiguous-run arm only.
+   *
+   * <p>The title alone was too thin a target. A finding title is a terse label ("nextToken is
+   * ignored after the first request") while the surface restating it quotes the PR description at
+   * length, so the overlap coefficient — measured over the shorter side, the title — divided a
+   * handful of shared words by the title's own length and fell short, leaving the duplicate
+   * standing (#639). The wording the two genuinely share usually sits in the finding's description,
+   * which states the same defect in the same terms the restatement uses.
+   *
+   * <p>Only the phrase arm reads it. A run of {@value #PHRASE_TOKENS} adjacent content words
+   * surviving stop-word removal in both texts is specific evidence; letting a long description into
+   * the overlap arm as well would collapse claims that are merely about the same function, and a
+   * false collapse deletes a claim outright where a surviving duplicate only repeats one.
+   */
+  private static List<Claim> claimsOf(Finding finding) {
+    var description = claim(finding.description());
+    return List.of(
+        claim(finding.title()), new Claim(description.words(), description.negated(), true));
+  }
+
+  /**
+   * The published finding {@code candidate} restates, if any — the finding-to-finding comparison
+   * {@link #collapse} never makes, since it only ever weighs another surface against the findings.
+   *
+   * <p>Used to cross-reference a "Things to double-check" bullet that says what an inline finding
+   * already says (#639). The bullet is annotated rather than dropped: unlike a gap bullet, it is a
+   * finding's only rendered surface — the one place its {@code path:line} locator is printed, which
+   * is what a maintainer needs to clear it from the PR conversation (#548) — so deleting it on a
+   * mistaken match would take the claim away entirely.
+   */
+  static Optional<Finding> restatedBy(Finding candidate, List<Finding> published) {
+    // Both sides come from ReviewResult.findings(), whose List.copyOf rejects null elements, so no
+    // null guard earns its keep here. A titleless finding is the real degenerate case, and claim()
+    // reduces it to a claim with no words, which matches nothing.
+    var candidateClaim = claim(candidate.title());
+    for (Finding finding : published) {
+      if (restates(candidateClaim, claimsOf(finding))) {
+        return Optional.of(finding);
+      }
+    }
+    return Optional.empty();
+  }
 
   /**
    * Collapses {@code descriptionGaps} and {@code fileSummaries} against the findings already
@@ -108,9 +175,9 @@ final class SummarySurfaceDeduplicator {
    */
   static Surfaces collapse(
       List<String> descriptionGaps, Map<String, String> fileSummaries, List<Finding> findings) {
-    var claims = new ArrayList<Claim>(findings.size() + descriptionGaps.size());
+    var claims = new ArrayList<Claim>(2 * findings.size() + descriptionGaps.size());
     for (Finding finding : findings) {
-      claims.add(claim(finding.title()));
+      claims.addAll(claimsOf(finding));
     }
     var keptGaps = new ArrayList<String>(descriptionGaps.size());
     for (String gap : descriptionGaps) {
@@ -165,7 +232,7 @@ final class SummarySurfaceDeduplicator {
         continue;
       }
       if (sharesPhrase(candidatePhrases, claim.words())
-          || overlaps(candidateWords, claim.words())) {
+          || (!claim.phraseOnly() && overlaps(candidateWords, claim.words()))) {
         return true;
       }
     }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -133,6 +133,143 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
+  void doubleCheckBulletThatRestatesAnInlineFindingIsCrossReferenced() {
+    // ThrillhouseBot-test #39: the pagination defect was filed twice — once inline, once as a
+    // lower-confidence item — and the summary presented the pair as two independent defects.
+    var inline =
+        new Finding(
+            RiskLevel.HIGH,
+            Confidence.HIGH,
+            "collector/usage.py",
+            88,
+            "list_usage stops after the first page of usage records",
+            "The loop sends one request and returns its items; next_page_token is never followed.",
+            null,
+            null);
+    var lowConfidence =
+        new Finding(
+            RiskLevel.MEDIUM,
+            Confidence.LOW,
+            "collector/usage.py",
+            91,
+            "Only the first page of usage records reaches the aggregator",
+            "desc",
+            null,
+            null);
+    var result =
+        new ReviewResult(
+            List.of(inline, lowConfidence),
+            0,
+            1,
+            1,
+            0,
+            RiskLevel.HIGH,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
+
+    var summary = generator.generate(1, 30, 4, List.of(), null, result);
+
+    // The bullet keeps its claim and its own locator — nothing is deleted...
+    assertTrue(
+        summary.contains("Only the first page of usage records reaches the aggregator"), summary);
+    assertTrue(summary.contains("`collector/usage.py:91`"), summary);
+    // ...but it now names the inline finding it repeats, so it no longer reads as a second defect.
+    assertTrue(
+        summary.contains("_Same issue as the inline finding on `collector/usage.py:88`._"),
+        summary);
+  }
+
+  @Test
+  void doubleCheckBulletStatingSomethingElseIsNotCrossReferenced() {
+    var inline =
+        new Finding(
+            RiskLevel.HIGH,
+            Confidence.HIGH,
+            "collector/usage.py",
+            88,
+            "list_usage stops after the first page of usage records",
+            "The loop sends one request and returns its items; next_page_token is never followed.",
+            null,
+            null);
+    var unrelated =
+        new Finding(
+            RiskLevel.LOW,
+            Confidence.LOW,
+            "collector/config.py",
+            12,
+            "Timeout is hardcoded to 30 seconds",
+            "desc",
+            null,
+            null);
+    var result =
+        new ReviewResult(
+            List.of(inline, unrelated),
+            0,
+            1,
+            0,
+            1,
+            RiskLevel.HIGH,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
+
+    var summary = generator.generate(2, 30, 4, List.of(), null, result);
+
+    assertTrue(summary.contains("Timeout is hardcoded to 30 seconds"), summary);
+    assertFalse(summary.contains("Same issue as the inline finding"), summary);
+  }
+
+  @Test
+  void twoInlineFindingsOnOneDefectAreBothKept() {
+    // The same root cause filed from two angles stays as two findings: the list drives the risk
+    // counts, the verdict, the inline threads and the backstop, so nothing here may edit it.
+    var producer =
+        new Finding(
+            RiskLevel.HIGH,
+            "src/cache.js",
+            40,
+            "staleEntries is cleared before the consumer reads it",
+            "desc",
+            null,
+            null);
+    var consumer =
+        new Finding(
+            RiskLevel.HIGH,
+            "src/cache.js",
+            62,
+            "The consumer reads staleEntries after it is cleared",
+            "desc",
+            null,
+            null);
+    var result =
+        new ReviewResult(
+            List.of(producer, consumer),
+            0,
+            2,
+            0,
+            0,
+            RiskLevel.HIGH,
+            ReviewState.REQUEST_CHANGES,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
+
+    var summary = generator.generate(1, 20, 3, List.of(), null, result);
+
+    assertTrue(summary.contains("staleEntries is cleared before the consumer reads it"), summary);
+    assertTrue(summary.contains("The consumer reads staleEntries after it is cleared"), summary);
+  }
+
+  @Test
   void shouldPluralizeDoubleCheckSummaryWhenMultipleLowConfidenceFindings() {
     var findings =
         List.of(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -226,7 +226,7 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
-  void shouldOmitPurposeAndGapsSectionsWhenAbsent() {
+  void shouldOmitPurposeSectionWhenAbsentAndStillDiscloseTheGapCheck() {
     var blankSummary = new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", " ", List.of());
     var nullPurposeSummary = new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", null, null);
     var blankGapsSummary = new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", null, List.of(" ", ""));
@@ -234,15 +234,31 @@ class PrSummaryGeneratorTest {
         new ReviewResult(
             List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
 
+    // A summary came back and reported nothing to flag: the section says so rather than vanishing.
     for (var summary :
         List.of(
-            generator.generate(1, 0, 0, List.of(), null, result),
             generator.generate(1, 0, 0, List.of(), blankSummary, result),
             generator.generate(1, 0, 0, List.of(), nullPurposeSummary, result),
             generator.generate(1, 0, 0, List.of(), blankGapsSummary, result))) {
-      assertFalse(summary.contains("What this PR does"));
-      assertFalse(summary.contains("Description vs. Implementation"));
+      assertFalse(summary.contains("What this PR does"), summary);
+      assertTrue(
+          summary.contains("No mismatch found between the PR description and the change."),
+          summary);
     }
+  }
+
+  @Test
+  void shouldOmitTheGapSectionEntirelyWhenNoSummaryCameBack() {
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
+
+    // No summary at all is the one absence that is honest: nothing compared the description to the
+    // diff, and the summary-degradation banners already say why.
+    var summary = generator.generate(1, 0, 0, List.of(), null, result);
+
+    assertFalse(summary.contains("What this PR does"), summary);
+    assertFalse(summary.contains("Description vs. Implementation"), summary);
   }
 
   @Test
@@ -1331,7 +1347,7 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
-  void descriptionGapsSectionDisappearsWhenEveryBulletRestatesAFinding() {
+  void descriptionGapsSectionStatesTheCheckRanWhenEveryBulletRestatesAFinding() {
     var findings =
         List.of(
             new Finding(
@@ -1375,7 +1391,34 @@ class PrSummaryGeneratorTest {
 
     var summary = generator.generate(1, 10, 0, List.of(), aiSummary, result);
 
+    // #588 still collapses the bullet onto the finding — the claim is not stated twice...
+    assertFalse(summary.contains("no rotation logic exists"), summary);
+    // ...but the section itself survives and says the check ran, so a review that compared the
+    // description against the diff no longer reads exactly like one that skipped it (#637).
+    assertTrue(summary.contains("### ⚠️ Description vs. Implementation"), summary);
+    assertTrue(
+        summary.contains(
+            "Every mismatch found between the description and the change is reported as a finding"
+                + " below, so it is not repeated here."),
+        summary);
+    assertFalse(summary.contains("No mismatch found between the PR description"), summary);
+  }
+
+  @Test
+  void descriptionGapsSectionStatesTheCheckFoundNothingWhenTheModelReportedNoGap() {
+    var aiSummary =
+        new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", "Adds a cache wrapper.", List.of());
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
+
+    var summary = generator.generate(1, 10, 0, List.of(), aiSummary, result);
+
+    // A clean result is not a warning, so the heading drops the ⚠️ the mismatch states carry.
+    assertTrue(summary.contains("### Description vs. Implementation"), summary);
     assertFalse(summary.contains("### ⚠️ Description vs. Implementation"), summary);
+    assertTrue(
+        summary.contains("No mismatch found between the PR description and the change."), summary);
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicatorTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -256,5 +257,87 @@ class SummarySurfaceDeduplicatorTest {
         SummarySurfaceDeduplicator.claim("hardcoded failures return").words(),
         SummarySurfaceDeduplicator.claim("hardcodes failure returned").words());
     assertEquals(List.of("use", "log"), SummarySurfaceDeduplicator.claim("use logs").words());
+  }
+
+  /** The #41 shape: a terse title, with the wording a restatement shares sitting in the body. */
+  private static Finding paginationFinding() {
+    return new Finding(
+        RiskLevel.HIGH,
+        "collector/usage.js",
+        88,
+        "next_page_token is ignored after the first request",
+        "list_usage sends one request and returns its items; the response's next_page_token is"
+            + " never followed, so only the first page of usage records is returned.",
+        null,
+        null);
+  }
+
+  @Test
+  void gapCollapsesOntoTheWordingInTheFindingsDescription() {
+    var gap =
+        "The description says the collector walks every page of usage records, but only the first"
+            + " page of usage records is returned.";
+
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(List.of(gap), Map.of(), List.of(paginationFinding()));
+
+    assertTrue(surfaces.descriptionGaps().isEmpty(), surfaces.descriptionGaps().toString());
+  }
+
+  @Test
+  void gapMerelyOverlappingTheDescriptionsVocabularyIsKept() {
+    // Every content word of this gap appears in the finding's description, so the overlap
+    // coefficient would collapse it — but the two share no run of adjacent content words, and
+    // shared vocabulary alone means little across a long description. Kept, per the bias this
+    // class takes everywhere: a surviving duplicate repeats a claim, a false collapse deletes one.
+    var gap = "The PR description says the response items are returned from one request.";
+
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(List.of(gap), Map.of(), List.of(paginationFinding()));
+
+    assertEquals(List.of(gap), surfaces.descriptionGaps());
+  }
+
+  @Test
+  void doubleCheckFindingRestatingAnInlineFindingNamesIt() {
+    var inline = paginationFinding();
+    var lowConfidence =
+        new Finding(
+            RiskLevel.MEDIUM,
+            Confidence.LOW,
+            "collector/usage.js",
+            91,
+            "Only the first page of usage records reaches the aggregator",
+            "desc",
+            null,
+            null);
+
+    assertEquals(
+        Optional.of(inline), SummarySurfaceDeduplicator.restatedBy(lowConfidence, List.of(inline)));
+  }
+
+  @Test
+  void doubleCheckFindingWithNothingInCommonNamesNoFinding() {
+    var unrelated =
+        new Finding(
+            RiskLevel.LOW,
+            Confidence.LOW,
+            "collector/config.js",
+            12,
+            "Timeout is hardcoded to 30 seconds",
+            "desc",
+            null,
+            null);
+
+    assertEquals(
+        Optional.empty(),
+        SummarySurfaceDeduplicator.restatedBy(unrelated, List.of(paginationFinding())));
+    // A finding with no title reduces to a claim with no words, and matches nothing.
+    var titleless =
+        new Finding(
+            RiskLevel.LOW, Confidence.LOW, "collector/config.js", 12, null, "d", null, null);
+    assertEquals(
+        Optional.empty(),
+        SummarySurfaceDeduplicator.restatedBy(titleless, List.of(paginationFinding())));
   }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

> **Stacked on #643.** This branch is cut from `fix/637-description-gaps-disclosure`, because both
> changes edit `PrSummaryGenerator.generate` within a few lines of each other. Merge #643 first; the
> diff below against `release/v0.6.0` therefore also contains #643's commit (`a398ac9`). This PR's
> own commit is `c62a8ea`.

## Description

#639 reports three duplicate shapes. This addresses two of them and deliberately declines the third.

### Shape 1 — inline finding + "Things to double-check" bullet (#39)

**Established cause: that surface never reaches the deduplicator.** `SummarySurfaceDeduplicator.collapse`
takes the description-gap bullets and the walkthrough rows, weighs them against the findings, and
stops there. The double-check list is rendered straight from `result.doubleCheckFindings()`. One
defect filed both inline and as a lower-confidence item therefore read as two independent defects —
the repetition-reads-as-severity failure #596 exists to prevent.

Such a bullet is now cross-referenced to the inline finding it repeats:

```
- **MEDIUM:** Only the first page of usage records reaches the aggregator (`collector/usage.py:91`) _(low confidence — verify before acting)_ _Same issue as the inline finding on `collector/usage.py:88`._
```

**Annotated, not dropped.** Unlike a gap bullet, this bullet is a finding's *only* rendered surface:
it is the one place that finding's `path:line` is printed, and that locator is what a maintainer
needs to clear it from the PR conversation (#548). Deleting it on a mistaken match would take the
claim away entirely — the exact direction #596 refuses to take. The annotation removes the false
impression of two defects while a wrong match costs only a misplaced sentence.

### Shape 2 — inline finding + description-gap bullet (#45, #41)

The matcher did run on this pair; it compared the gap against the finding's **title alone**. A title
is a terse label ("next_page_token is ignored after the first request") while the bullet quotes the
PR description at length, so the overlap coefficient — measured over the shorter side, which is the
title — divided a handful of shared words by the title's own length and fell short. The wording the
two genuinely share usually sits in the finding's *description*.

The finding's description now contributes a claim too, but **on the contiguous-run arm only**: a run
of 3 adjacent content words surviving stop-word removal in both texts is specific evidence, while
letting long prose into the overlap arm would collapse claims that merely discuss the same function.
`gapMerelyOverlappingTheDescriptionsVocabularyIsKept` pins that boundary — a gap whose every content
word appears in the description but which shares no run with it is kept.

### Shape 3 — inline + inline (#50): out of scope, deliberately

Nothing in this class may edit the finding list. It drives the risk counts, the review verdict, the
inline threads and the resolution backstop, and a finding removed from it is removed from all of
them — including its review thread, which is the surface a maintainer replies on to close it. A
false collapse there does not merely delete a sentence, it deletes a tracked finding. `#596`'s
under-fire bias says leave it: two inline findings on one root cause are the reader's to judge.
`twoInlineFindingsOnOneDefectAreBothKept` pins that decision so it is not "fixed" by accident.

The walkthrough exemption (a row summarising a file that also carries an inline finding is normal,
not a duplicate) is untouched.

## Related Issues

Fixes #639

## How Has This Been Tested?

- [x] Unit tests

Red on unfixed main code — shape 1, the whole rendered summary showing the same defect twice with
nothing connecting them:

```
PrSummaryGeneratorTest.doubleCheckBulletThatRestatesAnInlineFindingIsCrossReferenced <<< FAILURE!
org.opentest4j.AssertionFailedError:
## 🤖 ThrillhouseBot PR Summary
...
### Key Findings
- **HIGH:** list_usage stops after the first page of usage records (`collector/usage.py:88`)

### Things to double-check
<details>
<summary>1 lower-confidence finding</summary>

- **MEDIUM:** Only the first page of usage records reaches the aggregator (`collector/usage.py:91`) _(low confidence — verify before acting)_

</details>
 ==> expected: <true> but was: <false>
```

Red on unfixed main code — shape 2, the gap surviving beside the finding it restates:

```
Tests run: 19, Failures: 1, Errors: 0, Skipped: 0 <<< FAILURE! -- in SummarySurfaceDeduplicatorTest
SummarySurfaceDeduplicatorTest.gapCollapsesOntoTheWordingInTheFindingsDescription <<< FAILURE!
org.opentest4j.AssertionFailedError: [The description says the collector walks every page of usage
records, but only the first page of usage records is returned.] ==> expected: <true> but was: <false>
```

The three guard tests (`doubleCheckBulletStatingSomethingElseIsNotCrossReferenced`,
`gapMerelyOverlappingTheDescriptionsVocabularyIsKept`, `twoInlineFindingsOnOneDefectAreBothKept`)
pass both before and after, by design: they pin what must not start collapsing.

Gates: `spotless:check` clean, `spotbugs:check` BugInstance size is 0, `clean test` 2958/2958 green.
Coverage: jacoco ∩ `git diff -U0 79d17eb...HEAD` (both commits) — 39 changed main lines with
bytecode, zero uncovered lines, zero uncovered branches.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors