### PR TITLE
fix(review): stop over-clearing findings, keep quoted dispatch evidence, honest clear acks, and de-quadratic the coverage recorders

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -189,25 +189,28 @@ public class DiffBudgetPlanner {
      * Appends every non-null name of {@code filenames} that {@code into} does not already hold,
      * preserving first-seen order.
      *
-     * <p>Membership is tested against a {@link HashSet} snapshot taken once per call rather than
-     * with {@code into.contains(name)} per name. Both accumulators are {@link CopyOnWriteArrayList
-     * copy-on-write} lists, whose {@code contains} <em>and</em> {@code add} are linear, so the
-     * per-name scan made one recording pass quadratic in the batch's file count — a count nothing
-     * bounds, since a token-budgeted batch can hold hundreds of small files, and every failed or
-     * refused batch runs another pass.
+     * <p>Both accumulators are {@link CopyOnWriteArrayList copy-on-write} lists, whose {@code
+     * contains} <em>and</em> {@code add} are linear, so a scan-then-append-per-name pass was
+     * quadratic twice over in the batch's file count — a count nothing bounds, since a
+     * token-budgeted batch can hold hundreds of small files, and every failed or refused batch runs
+     * another pass. Both halves are removed here: membership is tested against a {@link HashSet}
+     * snapshot taken once per call, and the new names are appended in one {@code addAll}, which
+     * copies the backing array once rather than once per appended name.
      *
-     * <p>The snapshot does not weaken the existing concurrency contract: {@code
-     * contains}-then-{@code add} was never atomic either, so two threads recording the same name
-     * concurrently could already both append it. The snapshot only widens that same window within a
-     * single call; the next call re-reads the live list.
+     * <p>Neither change weakens the existing concurrency contract: {@code contains}-then-{@code
+     * add} was never atomic either, so two threads recording the same name concurrently could
+     * already both append it. The snapshot only widens that same window within a single call, and
+     * the batched append narrows it back; the next call re-reads the live list regardless.
      */
     private static void recordDistinct(List<String> into, List<String> filenames) {
       var known = new HashSet<>(into);
+      var added = new ArrayList<String>();
       for (var name : filenames) {
         if (name != null && known.add(name)) {
-          into.add(name);
+          added.add(name);
         }
       }
+      into.addAll(added);
     }
 
     /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -182,9 +182,30 @@ public class DiffBudgetPlanner {
 
     /** Records files a batch left unreviewed at runtime, ignoring nulls and duplicates. */
     void recordUncoveredFiles(List<String> filenames) {
+      recordDistinct(runtimeUncoveredFiles, filenames);
+    }
+
+    /**
+     * Appends every non-null name of {@code filenames} that {@code into} does not already hold,
+     * preserving first-seen order.
+     *
+     * <p>Membership is tested against a {@link HashSet} snapshot taken once per call rather than
+     * with {@code into.contains(name)} per name. Both accumulators are {@link CopyOnWriteArrayList
+     * copy-on-write} lists, whose {@code contains} <em>and</em> {@code add} are linear, so the
+     * per-name scan made one recording pass quadratic in the batch's file count — a count nothing
+     * bounds, since a token-budgeted batch can hold hundreds of small files, and every failed or
+     * refused batch runs another pass.
+     *
+     * <p>The snapshot does not weaken the existing concurrency contract: {@code
+     * contains}-then-{@code add} was never atomic either, so two threads recording the same name
+     * concurrently could already both append it. The snapshot only widens that same window within a
+     * single call; the next call re-reads the live list.
+     */
+    private static void recordDistinct(List<String> into, List<String> filenames) {
+      var known = new HashSet<>(into);
       for (var name : filenames) {
-        if (name != null && !runtimeUncoveredFiles.contains(name)) {
-          runtimeUncoveredFiles.add(name);
+        if (name != null && known.add(name)) {
+          into.add(name);
         }
       }
     }
@@ -198,11 +219,7 @@ public class DiffBudgetPlanner {
      */
     void recordSpendCeilingSkippedFiles(List<String> filenames) {
       recordUncoveredFiles(filenames);
-      for (var name : filenames) {
-        if (name != null && !spendCeilingSkippedFiles.contains(name)) {
-          spendCeilingSkippedFiles.add(name);
-        }
-      }
+      recordDistinct(spendCeilingSkippedFiles, filenames);
     }
 
     /**
@@ -214,11 +231,7 @@ public class DiffBudgetPlanner {
      * findings; only approval is withheld ({@link #truncated()}).
      */
     void recordResponseCutFiles(List<String> filenames) {
-      for (var name : filenames) {
-        if (name != null && !responseCutFiles.contains(name)) {
-          responseCutFiles.add(name);
-        }
-      }
+      recordDistinct(responseCutFiles, filenames);
     }
 
     public boolean truncated() {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -902,16 +902,33 @@ public class FollowUpAnalyzer {
    * Whether {@code body} names {@code path:line} as a whole locator. A bare {@code contains} would
    * let a comment about {@code src/A.java:10} clear the distinct finding at {@code src/A.java:1},
    * whose locator is a prefix of it — an over-clear, and the direction that must never happen — so
-   * a match followed by another digit is skipped and the scan continues.
+   * a match the following character continues is skipped and the scan continues.
+   *
+   * <p>Rejecting only a following <em>digit</em> was too narrow: it left every other continuation
+   * of the line-number token reading as a whole match. {@code src/A.java:10-12} (a maintainer
+   * naming a range) and {@code src/A.java:10x} both cleared the finding at line 10, and a locator
+   * whose printed form the summary never emits is not a naming this hatch may act on. The summary
+   * prints {@code path:line} followed by a space, a backtick or an em dash, and the documented
+   * directive form ({@code @thrillhousebot resolved path/to/File.java:42 — <title>}) is spelled the
+   * same way, so no legitimate naming ends in one of these characters — under-clearing here only
+   * leaves the finding held for one more round, which is the safe direction.
    */
   private static boolean namesLocator(String body, String locator) {
     for (var at = body.indexOf(locator); at >= 0; at = body.indexOf(locator, at + 1)) {
       var after = at + locator.length();
-      if (after >= body.length() || !Character.isDigit(body.charAt(after))) {
+      if (after >= body.length() || !continuesLocator(body.charAt(after))) {
         return true;
       }
     }
     return false;
+  }
+
+  /**
+   * Whether {@code c} extends the locator's line-number token rather than ending it: any letter or
+   * digit, or the {@code _}/{@code -} an identifier or a line range continues with.
+   */
+  private static boolean continuesLocator(char c) {
+    return Character.isLetterOrDigit(c) || c == '_' || c == '-';
   }
 
   /** A non-bot conversation comment with a body and a write-capable author association. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -803,6 +803,16 @@ public class FollowUpAnalyzer {
   private static final Pattern LOCATOR_SHAPE = Pattern.compile("(?<=\\S):\\d");
 
   /**
+   * A line range's separator and its end line, matched immediately after a locator: optional space,
+   * a dash of any spelling or a {@code ..}, optional space, then the digit that makes it a range
+   * rather than the documented {@code path:line — <title>} separator. Anchored by {@code lookingAt}
+   * at the position after the locator, so it never scans the whole body. See {@link
+   * #startsSpacedRange}.
+   */
+  private static final Pattern SPACED_LINE_RANGE =
+      Pattern.compile("[ \\t]*(?:[-\\u2010-\\u2015\\u2212]|\\.\\.)[ \\t]*\\d");
+
+  /**
    * Whether {@code body} names anything locator-shaped at all. This is a <em>necessary</em>
    * condition of {@link #clearedInConversation}, never a sufficient one: clearing a finding
    * requires its exact {@code path:line}, so a comment carrying no {@code path:line} token
@@ -924,11 +934,30 @@ public class FollowUpAnalyzer {
   private static boolean namesLocator(String body, String locator) {
     for (var at = body.indexOf(locator); at >= 0; at = body.indexOf(locator, at + 1)) {
       var after = at + locator.length();
-      if (after >= body.length() || !continuesLocator(body.charAt(after))) {
+      if (after >= body.length()) {
+        return true;
+      }
+      if (!continuesLocator(body.charAt(after)) && !startsSpacedRange(body, after)) {
         return true;
       }
     }
     return false;
+  }
+
+  /**
+   * A line range whose separator is not adjacent to the line number: {@code :1 - 3}, {@code :1 –
+   * 3}, {@code :1..3}. {@link #continuesLocator} catches only the adjacent spellings, and a range
+   * is written both ways about equally often.
+   *
+   * <p>The trailing digit is what tells a range apart from the documented {@code path:line —
+   * <title>} separator, which is spelled identically up to that point, so it is required rather
+   * than optional: {@code :1 — SQL injection} still clears the finding. The cost is a title that
+   * opens with a digit ({@code :1 — 2 call sites}) reading as a range, which under-clears — the
+   * finding is held one more round and the maintainer can name it again, whereas an over-clear
+   * drops it silently.
+   */
+  private static boolean startsSpacedRange(String body, int after) {
+    return SPACED_LINE_RANGE.matcher(body).region(after, body.length()).lookingAt();
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -803,9 +803,10 @@ public class FollowUpAnalyzer {
   private static final Pattern LOCATOR_SHAPE = Pattern.compile("(?<=\\S):\\d");
 
   /**
-   * How much whitespace may sit either side of a range's separator before the text stops reading as
-   * one range. A separator is spaced off its operands by a character or two at most; a longer run
-   * is two separate thoughts, and the bound keeps the scan over untrusted comment prose linear.
+   * How much horizontal space may sit either side of a range's separator before the text stops
+   * reading as one range. A separator is spaced off its operands by a character or two at most; a
+   * longer run is two separate thoughts, and the bound keeps the scan over untrusted comment prose
+   * linear.
    */
   private static final int MAX_RANGE_SPACING = 16;
 
@@ -972,14 +973,28 @@ public class FollowUpAnalyzer {
     return at < body.length() && Character.isDigit(body.charAt(at));
   }
 
-  /** Index of the first character at or after {@code from} that is not range spacing. */
+  /**
+   * Index of the first character at or after {@code from} that is not range spacing.
+   *
+   * <p>Spacing is every horizontal space, not just the ASCII one: a no-break space or a narrow
+   * no-break space reaches comment text through copy-paste and locale-aware autocorrect, and a
+   * separator this does not step over stops reading as a range and clears a finding the comment
+   * only named the start of. Line terminators are deliberately excluded even though {@link
+   * Character#isWhitespace} counts them — a {@code - 3} on the next line is a markdown list item,
+   * and reading it as a range would under-clear on ordinary prose rather than on a range.
+   */
   private static int skipSpacing(String body, int from) {
     var at = from;
     var limit = Math.min(body.length(), from + MAX_RANGE_SPACING);
-    while (at < limit && (body.charAt(at) == ' ' || body.charAt(at) == '\t')) {
+    while (at < limit && isHorizontalSpace(body.charAt(at))) {
       at++;
     }
     return at;
+  }
+
+  /** Whether {@code c} spaces text apart on one line. {@code isSpaceChar} misses only the tab. */
+  private static boolean isHorizontalSpace(char c) {
+    return Character.isSpaceChar(c) || c == '\t';
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -838,9 +838,12 @@ public class FollowUpAnalyzer {
     var text = namingText(body);
     var shapes = LOCATOR_SHAPE.matcher(text);
     while (shapes.find()) {
-      // The match starts at the ':'; the line number is the digit run after it.
+      // The match starts at the ':'; the line number is the digit run after it. ASCII only, to
+      // match the shape pattern's own \d and the clearing side: Character.isDigit accepts the
+      // full-width digits, which continuesLocator reads as continuing the token rather than as the
+      // line number, and a locator the two sides parse differently is one they disagree about.
       var after = shapes.start() + 1;
-      while (after < text.length() && Character.isDigit(text.charAt(after))) {
+      while (after < text.length() && text.charAt(after) >= '0' && text.charAt(after) <= '9') {
         after++;
       }
       if (after >= text.length()

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -725,7 +725,15 @@ public class FollowUpAnalyzer {
   private static final Set<String> WRITE_CAPABLE_ASSOCIATIONS =
       Set.of("OWNER", "MEMBER", "COLLABORATOR");
 
-  private static boolean mayHoldWriteAccess(String authorAssociation) {
+  /**
+   * Package-private rather than private so {@link MaintainerReplyService} can acknowledge a clear
+   * directive against the very gate that will decide it. The acknowledgment is written before any
+   * review runs, and the two used to disagree: the mention path admits a login on the
+   * manual-trigger allowlist whatever its association, while {@link #clearedInConversation}
+   * requires a write-capable one, so an allowlist-only commenter was promised a closure that never
+   * came.
+   */
+  static boolean mayHoldWriteAccess(String authorAssociation) {
     return authorAssociation != null
         && WRITE_CAPABLE_ASSOCIATIONS.contains(authorAssociation.strip().toUpperCase(Locale.ROOT));
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -933,10 +933,19 @@ public class FollowUpAnalyzer {
 
   /**
    * Whether {@code c} extends the locator's line-number token rather than ending it: any letter or
-   * digit, or the {@code _}/{@code -} an identifier or a line range continues with.
+   * digit, the {@code _} an identifier continues with, or any dash a line range continues with.
+   *
+   * <p>Every dash counts, not just the ASCII hyphen: smart-punctuation autocorrect rewrites a typed
+   * {@code 1-3} to an en dash, and a range copied out of prose can carry an em dash or a minus
+   * sign. Missing one of those clears a finding the comment only named the start of, which is the
+   * over-clear direction this guard exists to stop; treating a dash that turns out not to be a
+   * range as a continuation only under-clears, and the maintainer can say so again.
    */
   private static boolean continuesLocator(char c) {
-    return Character.isLetterOrDigit(c) || c == '_' || c == '-';
+    return Character.isLetterOrDigit(c)
+        || c == '_'
+        || Character.getType(c) == Character.DASH_PUNCTUATION
+        || c == '−';
   }
 
   /** A non-bot conversation comment with a body and a write-capable author association. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -823,9 +823,32 @@ public class FollowUpAnalyzer {
    * state the one thing derivable from the comment alone: that a directive naming no locator will
    * clear nothing, so a maintainer who wrote the directive but forgot (or mistyped away) the
    * locator is told immediately rather than after the next review quietly changes nothing.
+   *
+   * <p>"Locator-shaped" has to mean the same thing here as it does at clearing time. Shape alone —
+   * any {@code :<digit>} anywhere — counts {@code src/A.java:1-3} as a naming, and {@link
+   * #namesLocator} then refuses to clear it, so the maintainer is promised a closure that never
+   * comes. That is the promise-without-delivery this service exists to avoid, arrived at from the
+   * other side, so the guards {@link #continuesLocator} and {@link #startsSpacedRange} apply here
+   * too: a body names a locator when at least one locator-shaped token in it is whole.
    */
   static boolean namesALocator(String body) {
-    return body != null && LOCATOR_SHAPE.matcher(namingText(body)).find();
+    if (body == null) {
+      return false;
+    }
+    var text = namingText(body);
+    var shapes = LOCATOR_SHAPE.matcher(text);
+    while (shapes.find()) {
+      // The match starts at the ':'; the line number is the digit run after it.
+      var after = shapes.start() + 1;
+      while (after < text.length() && Character.isDigit(text.charAt(after))) {
+        after++;
+      }
+      if (after >= text.length()
+          || (!continuesLocator(text.charAt(after)) && !startsSpacedRange(text, after))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -965,7 +988,11 @@ public class FollowUpAnalyzer {
     if (at < body.length() && isDash(body.charAt(at))) {
       at++;
     } else if (at + 1 < body.length() && body.charAt(at) == '.' && body.charAt(at + 1) == '.') {
-      at += 2;
+      // The whole run, not two: 1...3 is git's own triple-dot range, and stopping at two would
+      // leave the third dot where the end line is expected and read the range as a whole locator.
+      while (at < body.length() && body.charAt(at) == '.') {
+        at++;
+      }
     } else {
       return false;
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -803,14 +803,11 @@ public class FollowUpAnalyzer {
   private static final Pattern LOCATOR_SHAPE = Pattern.compile("(?<=\\S):\\d");
 
   /**
-   * A line range's separator and its end line, matched immediately after a locator: optional space,
-   * a dash of any spelling or a {@code ..}, optional space, then the digit that makes it a range
-   * rather than the documented {@code path:line — <title>} separator. Anchored by {@code lookingAt}
-   * at the position after the locator, so it never scans the whole body. See {@link
-   * #startsSpacedRange}.
+   * How much whitespace may sit either side of a range's separator before the text stops reading as
+   * one range. A separator is spaced off its operands by a character or two at most; a longer run
+   * is two separate thoughts, and the bound keeps the scan over untrusted comment prose linear.
    */
-  private static final Pattern SPACED_LINE_RANGE =
-      Pattern.compile("[ \\t]*(?:[-\\u2010-\\u2015\\u2212]|\\.\\.)[ \\t]*\\d");
+  private static final int MAX_RANGE_SPACING = 16;
 
   /**
    * Whether {@code body} names anything locator-shaped at all. This is a <em>necessary</em>
@@ -955,9 +952,34 @@ public class FollowUpAnalyzer {
    * opens with a digit ({@code :1 — 2 call sites}) reading as a range, which under-clears — the
    * finding is held one more round and the maintainer can name it again, whereas an over-clear
    * drops it silently.
+   *
+   * <p>Written as a scan rather than a pattern so the separator test is literally {@link #isDash},
+   * the one {@link #continuesLocator} applies to the adjacent spelling. An enumerated character
+   * class drifts from the category test the moment either is edited, and the two guards disagreeing
+   * about the same character means a dash rejected adjacent is accepted spaced — the over-clear
+   * this exists to stop, arrived at through the fix for it.
    */
   private static boolean startsSpacedRange(String body, int after) {
-    return SPACED_LINE_RANGE.matcher(body).region(after, body.length()).lookingAt();
+    var at = skipSpacing(body, after);
+    if (at < body.length() && isDash(body.charAt(at))) {
+      at++;
+    } else if (at + 1 < body.length() && body.charAt(at) == '.' && body.charAt(at + 1) == '.') {
+      at += 2;
+    } else {
+      return false;
+    }
+    at = skipSpacing(body, at);
+    return at < body.length() && Character.isDigit(body.charAt(at));
+  }
+
+  /** Index of the first character at or after {@code from} that is not range spacing. */
+  private static int skipSpacing(String body, int from) {
+    var at = from;
+    var limit = Math.min(body.length(), from + MAX_RANGE_SPACING);
+    while (at < limit && (body.charAt(at) == ' ' || body.charAt(at) == '\t')) {
+      at++;
+    }
+    return at;
   }
 
   /**
@@ -971,10 +993,21 @@ public class FollowUpAnalyzer {
    * range as a continuation only under-clears, and the maintainer can say so again.
    */
   private static boolean continuesLocator(char c) {
-    return Character.isLetterOrDigit(c)
-        || c == '_'
-        || Character.getType(c) == Character.DASH_PUNCTUATION
-        || c == '−';
+    return Character.isLetterOrDigit(c) || c == '_' || isDash(c);
+  }
+
+  /**
+   * Whether {@code c} is a dash a line range may be written with — the whole {@code Pd} category
+   * plus the minus sign, which Unicode files under {@code Sm} but readers and autocorrect treat as
+   * a hyphen.
+   *
+   * <p>The category test rather than an enumeration: {@code Pd} holds a fullwidth hyphen-minus and
+   * a wave dash as well as the four dashes anyone lists from memory, and a range typed on a CJK
+   * keyboard is not a rarer input than one carrying an en dash from smart punctuation. Both places
+   * that ask this question call here, so neither can drift into accepting a dash the other rejects.
+   */
+  private static boolean isDash(char c) {
+    return Character.getType(c) == Character.DASH_PUNCTUATION || c == '−';
   }
 
   /** A non-bot conversation comment with a body and a write-capable author association. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyService.java
@@ -217,20 +217,42 @@ public class MaintainerReplyService {
           + " and title exactly as the summary prints it — for example `@thrillhousebot resolved"
           + " src/main/java/com/example/Widget.java:42 — Missing null check`.";
 
+  /**
+   * Acknowledgement for a directive whose author the clearing path will not honour. Reaching this
+   * method already means the commenter is authorized to address the bot, but {@link
+   * ManualReviewAuthorizer} admits a login on the manual-trigger allowlist whatever its {@code
+   * author_association}, while the clear itself requires a write-capable one ({@link
+   * FollowUpAnalyzer#mayHoldWriteAccess}) — the README says the allowlist "does not extend" to the
+   * directive. Without this branch such a commenter was told the next review would close what they
+   * named, and then nothing was cleared. Like the no-locator case the outcome is knowable from the
+   * comment alone, so the reply states it rather than leaving it to be discovered.
+   */
+  static final String CLEAR_DIRECTIVE_UNAUTHORIZED_ACK =
+      "Clearing a finding takes write access on this repository, so nothing will be cleared by that"
+          + " comment. Ask someone with write access to post the same `@thrillhousebot resolved"
+          + " path/to/File.java:42 — <title>` directive.";
+
   private void handleMention(String auth, ReplyTask task) {
     if (FollowUpAnalyzer.isClearDirective(task.question())) {
+      boolean mayClear = FollowUpAnalyzer.mayHoldWriteAccess(task.authorAssociation());
       boolean named = FollowUpAnalyzer.namesALocator(task.question());
+      String ack;
+      if (!mayClear) {
+        ack = CLEAR_DIRECTIVE_UNAUTHORIZED_ACK;
+      } else {
+        ack = named ? CLEAR_DIRECTIVE_ACK : CLEAR_DIRECTIVE_NO_LOCATOR_ACK;
+      }
       commentClient.createComment(
           auth,
           ACCEPT,
           task.owner(),
           task.repo(),
           task.prNumber(),
-          new GitHubCommentClient.CreateCommentRequest(
-              named ? CLEAR_DIRECTIVE_ACK : CLEAR_DIRECTIVE_NO_LOCATOR_ACK));
+          new GitHubCommentClient.CreateCommentRequest(ack));
       Log.infof(
-          "Acknowledged a maintainer clear directive on %s/%s #%d (names a locator: %b)",
-          task.owner(), task.repo(), task.prNumber(), named);
+          "Acknowledged a maintainer clear directive on %s/%s #%d (names a locator: %b, may clear:"
+              + " %b)",
+          task.owner(), task.repo(), task.prNumber(), named, mayClear);
       return;
     }
     var diff = fetchDiff(auth, task);

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -231,6 +231,14 @@ final class RebuttalContradiction {
    * quote that never closes costs only a kept trailing comment, which feeds the scan text of the
    * kind it already sees on every line carrying no {@code //} at all.
    *
+   * <p>The one escaping rule it does keep is where the escape applies: inside a {@code "} or {@code
+   * '} literal, never inside a backtick one and never outside a literal at all. A Go raw string is
+   * backtick-delimited and holds a backslash literally, so honouring the escape there stepped over
+   * the closing backtick of a Windows path ({@code `C:\`}), left the state open for the rest of the
+   * line, and kept a real trailing comment as live code. That is the false positive — a decline
+   * overruled by text the code does not run — which is the worse direction, and the plain
+   * first-{@code //} cut this carve-out replaced did not have it.
+   *
    * <p>A <em>multi-character</em> delimiter is the case this shallowness does not cover, and it
    * fails the other way. A Java text block or a C++ raw string whose content holds an interior
    * quote ({@code """<a href="//host">x</a>"""}, {@code R"(a"b//c)"}) closes the scanner's
@@ -243,10 +251,10 @@ final class RebuttalContradiction {
     var quote = '\0';
     for (var i = 0; i < line.length(); i++) {
       var c = line.charAt(i);
-      if (c == '\\') {
-        i++;
-      } else if (quote != '\0') {
-        if (c == quote) {
+      if (quote != '\0') {
+        if (c == '\\' && quote != '`') {
+          i++;
+        } else if (c == quote) {
           quote = '\0';
         }
       } else if (c == '"' || c == '\'' || c == '`') {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -194,14 +194,44 @@ final class RebuttalContradiction {
 
   /**
    * Drops a trailing {@code //} line comment, leaving any code before it intact. A {@code ://}
-   * sequence (a URL scheme) is not treated as a comment start.
+   * sequence (a URL scheme) is not treated as a comment start, and neither is a {@code //} that
+   * sits inside a string literal.
+   *
+   * <p>The string-literal carve-out matters because cutting at the wrong {@code //} silently throws
+   * away the rest of the line — including any dispatch construct on it. A line such as {@code
+   * String base = "//cdn.example.com"; executor.submit(task);}, a Go or C++ raw string ({@code
+   * `a//b`}, {@code R"(a//b)"}), or any quoted path holding a doubled slash used to be truncated at
+   * the quoted slashes, so the {@code executor.submit(} after them never reached {@link
+   * #CONCURRENT_DISPATCHES}. A maintainer's "it runs serially" decline then stood unchallenged over
+   * code that does dispatch concurrently — the false-negative direction this class exists to close.
+   *
+   * <p>Quote tracking is deliberately shallow: it toggles on an unescaped {@code "}, {@code '} or
+   * {@code `} and nothing else. It cannot know a language's escaping rules and does not try to; the
+   * worst an unbalanced quote costs is that a real trailing comment is kept, which only feeds the
+   * scan text of the kind it already sees on every line that carries no {@code //} at all.
    */
   private static String stripLineComment(String line) {
-    var idx = line.indexOf("//");
-    while (idx > 0 && line.charAt(idx - 1) == ':') {
-      idx = line.indexOf("//", idx + 2);
+    var quote = '\0';
+    for (var i = 0; i < line.length(); i++) {
+      var c = line.charAt(i);
+      if (c == '\\') {
+        i++;
+      } else if (quote != '\0') {
+        if (c == quote) {
+          quote = '\0';
+        }
+      } else if (c == '"' || c == '\'' || c == '`') {
+        quote = c;
+      } else if (c == '/' && i + 1 < line.length() && line.charAt(i + 1) == '/') {
+        // A URL scheme's "://" is not a comment start; step past it and keep scanning.
+        if (i > 0 && line.charAt(i - 1) == ':') {
+          i++;
+          continue;
+        }
+        return line.substring(0, i);
+      }
     }
-    return idx < 0 ? line : line.substring(0, idx);
+    return line;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -135,7 +135,7 @@ final class RebuttalContradiction {
           // only overrule a decline on what the code plainly shows, and it cannot evaluate.
           Pattern.compile(
               "newFixedThreadPool\\s{0,16}\\((?:\\s|/\\*[\\s\\S]{0,1024}?\\*/){0,16}+"
-                  + "(?!1(?:\\s|/\\*[\\s\\S]{0,1024}?\\*/){0,16}(?:,|\\)))"),
+                  + "(?!1(?:\\s|/\\*[\\s\\S]{0,1024}?\\*/){0,16}[,)])"),
           // handing the work to an executor
           Pattern.compile("\\.(?:submit|execute)\\s{0,16}\\("),
           // an asynchronous future
@@ -259,40 +259,77 @@ final class RebuttalContradiction {
    * rather than a toggle; tracked in #651.
    */
   private static String stripLineComment(String line) {
-    var quote = '\0';
-    var slashInQuote = -1;
-    for (var i = 0; i < line.length(); i++) {
+    var at = commentStart(line);
+    return at < 0 ? line : line.substring(0, at);
+  }
+
+  /**
+   * Index where a real {@code //} comment opens on {@code line}, or {@code -1} when none does.
+   * Literals are stepped over whole, so a {@code //} they hold is not a comment start.
+   */
+  private static int commentStart(String line) {
+    var i = 0;
+    while (i < line.length()) {
       var c = line.charAt(i);
-      if (quote != '\0') {
-        if (c == '\\' && quote != '`') {
-          i++;
-        } else if (c == quote) {
-          quote = '\0';
-          // The literal closed, so anything it held was quoted text after all.
-          slashInQuote = -1;
-        } else if (c == '/' && i + 1 < line.length() && line.charAt(i + 1) == '/') {
-          // No i > 0 guard: reaching here means an opener was seen at some earlier index.
-          if (line.charAt(i - 1) == ':') {
-            i++;
-            continue;
-          }
-          if (slashInQuote < 0) {
-            slashInQuote = i;
-          }
+      if (c == '"' || c == '\'' || c == '`') {
+        var close = endOfLiteral(line, i);
+        if (close < 0) {
+          // Never closed, so the opener was not one — fall back to what it swallowed.
+          return firstDoubleSlash(line, i + 1);
         }
-      } else if (c == '"' || c == '\'' || c == '`') {
-        quote = c;
-      } else if (c == '/' && i + 1 < line.length() && line.charAt(i + 1) == '/') {
-        // A URL scheme's "://" is not a comment start; step past it and keep scanning.
+        i = close + 1;
+      } else if (isDoubleSlash(line, i)) {
         if (i > 0 && line.charAt(i - 1) == ':') {
-          i++;
-          continue;
+          i += 2;
+        } else {
+          return i;
         }
-        return line.substring(0, i);
+      } else {
+        i++;
       }
     }
-    // An unclosed literal means the opener was not one — fall back to the first // it swallowed.
-    return quote == '\0' || slashInQuote < 0 ? line : line.substring(0, slashInQuote);
+    return -1;
+  }
+
+  /**
+   * Index of the quote closing the literal opened at {@code open}, or {@code -1} when the line ends
+   * first. A backslash escapes the next character in a {@code "} or {@code '} literal and not in a
+   * backtick one, which is a Go raw string and holds the backslash literally.
+   */
+  private static int endOfLiteral(String line, int open) {
+    var quote = line.charAt(open);
+    var i = open + 1;
+    while (i < line.length()) {
+      var c = line.charAt(i);
+      if (c == '\\' && quote != '`') {
+        i += 2;
+      } else if (c == quote) {
+        return i;
+      } else {
+        i++;
+      }
+    }
+    return -1;
+  }
+
+  /** First {@code //} at or after {@code from} that is not a URL scheme's, or {@code -1}. */
+  private static int firstDoubleSlash(String line, int from) {
+    var i = from;
+    while (i < line.length()) {
+      if (!isDoubleSlash(line, i)) {
+        i++;
+      } else if (i > 0 && line.charAt(i - 1) == ':') {
+        i += 2;
+      } else {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /** Whether a doubled slash sits at {@code at}. */
+  private static boolean isDoubleSlash(String line, int at) {
+    return line.charAt(at) == '/' && at + 1 < line.length() && line.charAt(at + 1) == '/';
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -312,13 +312,16 @@ final class RebuttalContradiction {
     return -1;
   }
 
-  /** First {@code //} at or after {@code from} that is not a URL scheme's, or {@code -1}. */
+  /**
+   * First {@code //} at or after {@code from} that is not a URL scheme's, or {@code -1}. Only ever
+   * called with {@code from} inside a literal, so the character before {@code i} always exists.
+   */
   private static int firstDoubleSlash(String line, int from) {
     var i = from;
     while (i < line.length()) {
       if (!isDoubleSlash(line, i)) {
         i++;
-      } else if (i > 0 && line.charAt(i - 1) == ':') {
+      } else if (line.charAt(i - 1) == ':') {
         i += 2;
       } else {
         return i;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -121,16 +121,21 @@ final class RebuttalContradiction {
           // The skip before the count is possessive because a greedy run backtracks to zero width
           // and re-matches past its own lookahead, which let newFixedThreadPool( 1 ) escape.
           //
-          // Both bounds are real: a comment longer than 256 characters, or a seventeenth run of
-          // them, reads as concurrent. They keep the scan over untrusted diff text linear, and they
-          // sit far above any real annotation of a thread count.
+          // Both bounds are real: a comment longer than 1024 characters, or a seventeenth run of
+          // them, reads as concurrent — a false positive, since the pool is serial. They exist to
+          // keep the scan over untrusted diff text linear, and nothing more should be read into
+          // them. Successive rounds found a justification comment that wrapped, then one that ran
+          // past 64 characters, then one carrying a long URL past 256, each time because the bound
+          // was asserted to sit above "any real" annotation. It does not: a comment is prose and
+          // prose has no bound. Raising this constant again is not the fix — parsing the argument
+          // list instead of pattern-matching it is (#651).
           //
           // A count that is not a literal 1 — a variable, or an expression like 1 + 0 — reads as
           // concurrent. That is deliberate and matches newFixedThreadPool(workers): the class may
           // only overrule a decline on what the code plainly shows, and it cannot evaluate.
           Pattern.compile(
-              "newFixedThreadPool\\s{0,16}\\((?:\\s|/\\*[\\s\\S]{0,256}?\\*/){0,16}+"
-                  + "(?!1(?:\\s|/\\*[\\s\\S]{0,256}?\\*/){0,16}(?:,|\\)))"),
+              "newFixedThreadPool\\s{0,16}\\((?:\\s|/\\*[\\s\\S]{0,1024}?\\*/){0,16}+"
+                  + "(?!1(?:\\s|/\\*[\\s\\S]{0,1024}?\\*/){0,16}(?:,|\\)))"),
           // handing the work to an executor
           Pattern.compile("\\.(?:submit|execute)\\s{0,16}\\("),
           // an asynchronous future

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -108,23 +108,29 @@ final class RebuttalContradiction {
           Pattern.compile(
               "newVirtualThreadPerTaskExecutor|newCachedThreadPool|newScheduledThreadPool"
                   + "|newWorkStealingPool"),
-          // A fixed pool of more than one thread. A literal count of 1 is excluded, whatever space
-          // or block comment surrounds it, up to the end of the argument — a closing paren, or the
-          // comma of the ThreadFactory overload, which is the standard way to name a single worker.
-          // Every spelling this misses reports a serial pool as concurrent dispatch and overrules a
-          // decline that was right, so the exclusion is written to be hard to spell around: the
-          // paren alone let newFixedThreadPool(1, factory) through, and tolerating only whitespace
-          // let a /* one worker */ next to the count through.
+          // A fixed pool of more than one thread. A literal count of 1 is excluded, along with the
+          // whitespace and block comments around it, up to the end of the argument — a closing
+          // paren, or the comma of the ThreadFactory overload, which is the standard way to name a
+          // single worker. Every spelling this misses reports a serial pool as concurrent dispatch
+          // and overrules a decline that was right, so the exclusion is written to be hard to spell
+          // around: the paren alone let newFixedThreadPool(1, factory) through, tolerating only
+          // whitespace let a /* one worker */ next to the count through, and a dot that stops at a
+          // line break let that same comment through again once it wrapped. The evidence text is
+          // one string of rejoined lines, so a comment does span line breaks here.
           //
           // The skip before the count is possessive because a greedy run backtracks to zero width
           // and re-matches past its own lookahead, which let newFixedThreadPool( 1 ) escape.
+          //
+          // Both bounds are real: a comment longer than 256 characters, or a seventeenth run of
+          // them, reads as concurrent. They keep the scan over untrusted diff text linear, and they
+          // sit far above any real annotation of a thread count.
           //
           // A count that is not a literal 1 — a variable, or an expression like 1 + 0 — reads as
           // concurrent. That is deliberate and matches newFixedThreadPool(workers): the class may
           // only overrule a decline on what the code plainly shows, and it cannot evaluate.
           Pattern.compile(
-              "newFixedThreadPool\\s{0,16}\\((?:\\s|/\\*.{0,64}?\\*/){0,16}+"
-                  + "(?!1(?:\\s|/\\*.{0,64}?\\*/){0,16}(?:,|\\)))"),
+              "newFixedThreadPool\\s{0,16}\\((?:\\s|/\\*[\\s\\S]{0,256}?\\*/){0,16}+"
+                  + "(?!1(?:\\s|/\\*[\\s\\S]{0,256}?\\*/){0,16}(?:,|\\)))"),
           // handing the work to an executor
           Pattern.compile("\\.(?:submit|execute)\\s{0,16}\\("),
           // an asynchronous future

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -232,9 +232,15 @@ final class RebuttalContradiction {
    * code that does dispatch concurrently — the false-negative direction this class exists to close.
    *
    * <p>Quote tracking is deliberately shallow: it toggles on an unescaped {@code "}, {@code '} or
-   * {@code `} and nothing else. It cannot know a language's escaping rules and does not try to. A
-   * quote that never closes costs only a kept trailing comment, which feeds the scan text of the
-   * kind it already sees on every line carrying no {@code //} at all.
+   * {@code `} and nothing else. It cannot know a language's escaping rules and does not try to.
+   *
+   * <p>An opener with no closer on the line is therefore assumed to have been something else — a
+   * Rust lifetime ({@code &'a ctx}), an apostrophe in prose — and the scan falls back to the first
+   * {@code //} that literal swallowed. Without that fallback a single stray apostrophe kept the
+   * whole trailing comment as scan text, and a dispatch named only inside a comment could overrule
+   * a decline. Comment text is precisely what this method exists to remove, so keeping it is not a
+   * mild degradation: it is the false-positive direction, and the plain first-{@code //} cut this
+   * carve-out replaced did not have it.
    *
    * <p>The one escaping rule it does keep is where the escape applies: inside a {@code "} or {@code
    * '} literal, never inside a backtick one and never outside a literal at all. A Go raw string is
@@ -254,6 +260,7 @@ final class RebuttalContradiction {
    */
   private static String stripLineComment(String line) {
     var quote = '\0';
+    var slashInQuote = -1;
     for (var i = 0; i < line.length(); i++) {
       var c = line.charAt(i);
       if (quote != '\0') {
@@ -261,6 +268,17 @@ final class RebuttalContradiction {
           i++;
         } else if (c == quote) {
           quote = '\0';
+          // The literal closed, so anything it held was quoted text after all.
+          slashInQuote = -1;
+        } else if (c == '/' && i + 1 < line.length() && line.charAt(i + 1) == '/') {
+          // No i > 0 guard: reaching here means an opener was seen at some earlier index.
+          if (line.charAt(i - 1) == ':') {
+            i++;
+            continue;
+          }
+          if (slashInQuote < 0) {
+            slashInQuote = i;
+          }
         }
       } else if (c == '"' || c == '\'' || c == '`') {
         quote = c;
@@ -273,7 +291,8 @@ final class RebuttalContradiction {
         return line.substring(0, i);
       }
     }
-    return line;
+    // An unclosed literal means the opener was not one — fall back to the first // it swallowed.
+    return quote == '\0' || slashInQuote < 0 ? line : line.substring(0, slashInQuote);
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -108,8 +108,13 @@ final class RebuttalContradiction {
           Pattern.compile(
               "newVirtualThreadPerTaskExecutor|newCachedThreadPool|newScheduledThreadPool"
                   + "|newWorkStealingPool"),
-          // a fixed pool of more than one thread
-          Pattern.compile("newFixedThreadPool\\s{0,16}\\(\\s{0,16}(?!1\\s{0,16}\\))"),
+          // A fixed pool of more than one thread. The count is excluded when it is 1 followed by
+          // the end of the argument — a closing paren, or the comma of the ThreadFactory overload,
+          // which is the standard way to name a single worker. Requiring the paren alone let
+          // newFixedThreadPool(1, factory) read as concurrent dispatch, which overrules a decline
+          // that was right. The leading whitespace is possessive: a greedy run would backtrack to
+          // zero width and re-match past its own lookahead, so newFixedThreadPool( 1 ) escaped too.
+          Pattern.compile("newFixedThreadPool\\s{0,16}\\(\\s{0,16}+(?!1\\s{0,16}(?:,|\\)))"),
           // handing the work to an executor
           Pattern.compile("\\.(?:submit|execute)\\s{0,16}\\("),
           // an asynchronous future

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -206,9 +206,17 @@ final class RebuttalContradiction {
    * code that does dispatch concurrently — the false-negative direction this class exists to close.
    *
    * <p>Quote tracking is deliberately shallow: it toggles on an unescaped {@code "}, {@code '} or
-   * {@code `} and nothing else. It cannot know a language's escaping rules and does not try to; the
-   * worst an unbalanced quote costs is that a real trailing comment is kept, which only feeds the
-   * scan text of the kind it already sees on every line that carries no {@code //} at all.
+   * {@code `} and nothing else. It cannot know a language's escaping rules and does not try to. A
+   * quote that never closes costs only a kept trailing comment, which feeds the scan text of the
+   * kind it already sees on every line carrying no {@code //} at all.
+   *
+   * <p>A <em>multi-character</em> delimiter is the case this shallowness does not cover, and it
+   * fails the other way. A Java text block or a C++ raw string whose content holds an interior
+   * quote ({@code """<a href="//host">x</a>"""}, {@code R"(a"b//c)"}) closes the scanner's
+   * single-quote state early, so a {@code //} still inside the literal truncates the line and drops
+   * any dispatch after it — the same false negative the carve-out above exists to close, one legal
+   * interior quote away from the shapes that are covered. Closing it needs delimiter-aware openers
+   * rather than a toggle; tracked in #651.
    */
   private static String stripLineComment(String line) {
     var quote = '\0';

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -108,13 +108,23 @@ final class RebuttalContradiction {
           Pattern.compile(
               "newVirtualThreadPerTaskExecutor|newCachedThreadPool|newScheduledThreadPool"
                   + "|newWorkStealingPool"),
-          // A fixed pool of more than one thread. The count is excluded when it is 1 followed by
-          // the end of the argument — a closing paren, or the comma of the ThreadFactory overload,
-          // which is the standard way to name a single worker. Requiring the paren alone let
-          // newFixedThreadPool(1, factory) read as concurrent dispatch, which overrules a decline
-          // that was right. The leading whitespace is possessive: a greedy run would backtrack to
-          // zero width and re-match past its own lookahead, so newFixedThreadPool( 1 ) escaped too.
-          Pattern.compile("newFixedThreadPool\\s{0,16}\\(\\s{0,16}+(?!1\\s{0,16}(?:,|\\)))"),
+          // A fixed pool of more than one thread. A literal count of 1 is excluded, whatever space
+          // or block comment surrounds it, up to the end of the argument — a closing paren, or the
+          // comma of the ThreadFactory overload, which is the standard way to name a single worker.
+          // Every spelling this misses reports a serial pool as concurrent dispatch and overrules a
+          // decline that was right, so the exclusion is written to be hard to spell around: the
+          // paren alone let newFixedThreadPool(1, factory) through, and tolerating only whitespace
+          // let a /* one worker */ next to the count through.
+          //
+          // The skip before the count is possessive because a greedy run backtracks to zero width
+          // and re-matches past its own lookahead, which let newFixedThreadPool( 1 ) escape.
+          //
+          // A count that is not a literal 1 — a variable, or an expression like 1 + 0 — reads as
+          // concurrent. That is deliberate and matches newFixedThreadPool(workers): the class may
+          // only overrule a decline on what the code plainly shows, and it cannot evaluate.
+          Pattern.compile(
+              "newFixedThreadPool\\s{0,16}\\((?:\\s|/\\*.{0,64}?\\*/){0,16}+"
+                  + "(?!1(?:\\s|/\\*.{0,64}?\\*/){0,16}(?:,|\\)))"),
           // handing the work to an executor
           Pattern.compile("\\.(?:submit|execute)\\s{0,16}\\("),
           // an asynchronous future

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -2961,6 +2961,21 @@ class FollowUpAnalyzerTest {
             "a tab-spaced line range must not clear it",
             "@thrillhousebot resolved `src/A.java:1\t-\t3` — SQL injection",
             false),
+        // Copy-paste and locale-aware autocorrect put these in comment text; a separator the scan
+        // will not step over stops reading as a range.
+        arguments(
+            "a no-break-space-spaced line range must not clear it",
+            "@thrillhousebot resolved `src/A.java:1 - 3` — SQL injection",
+            false),
+        arguments(
+            "a narrow-no-break-space-spaced line range must not clear it",
+            "@thrillhousebot resolved `src/A.java:1 - 3` — SQL injection",
+            false),
+        // A list item on the next line is prose, not a range: newlines must not space a separator.
+        arguments(
+            "a dash opening the next line is not a range and still clears",
+            "@thrillhousebot resolved src/A.java:1\n- 3 of these are SQL injection",
+            true),
         // Everything a range scan must not swallow: prose that merely continues after the locator,
         // and a separator too far away or with nothing after it to be one.
         arguments(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -2912,6 +2912,21 @@ class FollowUpAnalyzerTest {
             "an underscore continuing the line number must not clear it",
             "@thrillhousebot resolved `src/A.java:1_2` — SQL injection",
             false),
+        // Typographic ranges reach the guard as often as the ASCII hyphen does: smart-punctuation
+        // autocorrect rewrites a typed 1-3 to an en dash, and a range copied out of prose can carry
+        // an em dash or a minus sign. Each one adjacent to the line number is still a range.
+        arguments(
+            "an en-dash line range must not clear it",
+            "@thrillhousebot resolved `src/A.java:1–3` — SQL injection",
+            false),
+        arguments(
+            "an em-dash line range must not clear it",
+            "@thrillhousebot resolved `src/A.java:1—3` — SQL injection",
+            false),
+        arguments(
+            "a minus-sign line range must not clear it",
+            "@thrillhousebot resolved `src/A.java:1−3` — SQL injection",
+            false),
         arguments(
             "the documented em-dash form still clears",
             "@thrillhousebot resolved src/A.java:1 — SQL injection",

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -2897,6 +2897,24 @@ class FollowUpAnalyzerTest {
         arguments(
             "a match ending the comment counts",
             "@thrillhousebot resolved SQL injection at src/A.java:1",
+            true),
+        // A following digit used to be the only continuation the guard rejected, so every other
+        // way of continuing the line-number token still read as a whole locator and over-cleared.
+        arguments(
+            "a line range starting at the finding's line must not clear it",
+            "@thrillhousebot resolved `src/A.java:1-3` — SQL injection",
+            false),
+        arguments(
+            "a letter continuing the line number must not clear it",
+            "@thrillhousebot resolved `src/A.java:1x` — SQL injection",
+            false),
+        arguments(
+            "an underscore continuing the line number must not clear it",
+            "@thrillhousebot resolved `src/A.java:1_2` — SQL injection",
+            false),
+        arguments(
+            "the documented em-dash form still clears",
+            "@thrillhousebot resolved src/A.java:1 — SQL injection",
             true));
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -2927,6 +2927,26 @@ class FollowUpAnalyzerTest {
             "a minus-sign line range must not clear it",
             "@thrillhousebot resolved `src/A.java:1−3` — SQL injection",
             false),
+        // A range is written with the separator spaced off the line number about as often as
+        // adjacent to it, and the adjacent-character guard cannot see those spellings at all.
+        arguments(
+            "a spaced hyphen line range must not clear it",
+            "@thrillhousebot resolved `src/A.java:1 - 3` — SQL injection",
+            false),
+        arguments(
+            "a spaced en-dash line range must not clear it",
+            "@thrillhousebot resolved `src/A.java:1 – 3` — SQL injection",
+            false),
+        arguments(
+            "a dotted line range must not clear it",
+            "@thrillhousebot resolved `src/A.java:1..3` — SQL injection",
+            false),
+        // The accepted cost of requiring a digit: a title opening with one reads as a range and
+        // under-clears, which holds the finding a round rather than dropping it.
+        arguments(
+            "a title opening with a digit under-clears rather than risking the separator",
+            "@thrillhousebot resolved src/A.java:1 — 2 call sites of this SQL injection",
+            false),
         arguments(
             "the documented em-dash form still clears",
             "@thrillhousebot resolved src/A.java:1 — SQL injection",

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -3268,5 +3268,8 @@ class FollowUpAnalyzerTest {
     assertTrue(
         FollowUpAnalyzer.namesALocator("@thrillhousebot resolved SQL injection at src/A.java:10"),
         "a locator ending the comment names it");
+    assertFalse(
+        FollowUpAnalyzer.namesALocator("@thrillhousebot resolved src/A.java:1２"),
+        "a full-width digit continues the token on the clearing side, so it must here too");
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -2941,6 +2941,10 @@ class FollowUpAnalyzerTest {
             "a dotted line range must not clear it",
             "@thrillhousebot resolved `src/A.java:1..3` — SQL injection",
             false),
+        arguments(
+            "a triple-dot line range must not clear it",
+            "@thrillhousebot resolved `src/A.java:1...3` — SQL injection",
+            false),
         // Both guards ask isDash, so a dash either rejects in both spellings or neither. A
         // fullwidth hyphen-minus and a wave dash are Pd but appear in nobody's enumeration.
         arguments(
@@ -2989,6 +2993,10 @@ class FollowUpAnalyzerTest {
         arguments(
             "a dash ending the comment is not a range and still clears",
             "@thrillhousebot resolved SQL injection at src/A.java:1 -",
+            true),
+        arguments(
+            "dots running to the end of the comment are not a range and still clear",
+            "@thrillhousebot resolved SQL injection at src/A.java:1..",
             true),
         arguments(
             "a separator spaced further than a range is written still clears",
@@ -3236,5 +3244,29 @@ class FollowUpAnalyzerTest {
     assertFalse(
         FollowUpAnalyzer.namesALocator("a:".repeat(2000)),
         "colon-heavy text with no line number still resolves to no locator");
+  }
+
+  /**
+   * The ack this feeds must not promise a closure the clearing path refuses, so the forms the
+   * whole-locator guard rejects have to read as naming nothing here too.
+   */
+  @Test
+  void namesALocatorShouldRejectTheFormsTheClearingPathRefuses() {
+    assertFalse(
+        FollowUpAnalyzer.namesALocator("@thrillhousebot resolved `src/A.java:1-3` — title"),
+        "a range names no single finding, and the clearing path will not clear it");
+    assertFalse(
+        FollowUpAnalyzer.namesALocator("@thrillhousebot resolved `src/A.java:1 - 3` — title"),
+        "the spaced range is the same naming act as the adjacent one");
+    assertFalse(
+        FollowUpAnalyzer.namesALocator("@thrillhousebot resolved `src/A.java:1x` — title"),
+        "a continued line number is not a locator the clear will match");
+    assertTrue(
+        FollowUpAnalyzer.namesALocator(
+            "@thrillhousebot resolved `src/A.java:1-3` and `src/B.java:7`"),
+        "one whole locator among rejected forms is still a naming");
+    assertTrue(
+        FollowUpAnalyzer.namesALocator("@thrillhousebot resolved SQL injection at src/A.java:10"),
+        "a locator ending the comment names it");
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -2941,12 +2941,44 @@ class FollowUpAnalyzerTest {
             "a dotted line range must not clear it",
             "@thrillhousebot resolved `src/A.java:1..3` — SQL injection",
             false),
+        // Both guards ask isDash, so a dash either rejects in both spellings or neither. A
+        // fullwidth hyphen-minus and a wave dash are Pd but appear in nobody's enumeration.
+        arguments(
+            "a spaced fullwidth-hyphen line range must not clear it",
+            "@thrillhousebot resolved `src/A.java:1 － 3` — SQL injection",
+            false),
+        arguments(
+            "a spaced wave-dash line range must not clear it",
+            "@thrillhousebot resolved `src/A.java:1 〜 3` — SQL injection",
+            false),
         // The accepted cost of requiring a digit: a title opening with one reads as a range and
         // under-clears, which holds the finding a round rather than dropping it.
         arguments(
             "a title opening with a digit under-clears rather than risking the separator",
             "@thrillhousebot resolved src/A.java:1 — 2 call sites of this SQL injection",
             false),
+        arguments(
+            "a tab-spaced line range must not clear it",
+            "@thrillhousebot resolved `src/A.java:1\t-\t3` — SQL injection",
+            false),
+        // Everything a range scan must not swallow: prose that merely continues after the locator,
+        // and a separator too far away or with nothing after it to be one.
+        arguments(
+            "a sentence-ending period is not a range and still clears",
+            "@thrillhousebot resolved src/A.java:1. SQL injection is gone",
+            true),
+        arguments(
+            "a locator trailed by spaces to the end still clears",
+            "@thrillhousebot resolved SQL injection at src/A.java:1   ",
+            true),
+        arguments(
+            "a dash ending the comment is not a range and still clears",
+            "@thrillhousebot resolved SQL injection at src/A.java:1 -",
+            true),
+        arguments(
+            "a separator spaced further than a range is written still clears",
+            "@thrillhousebot resolved src/A.java:1                    - 3 SQL injection",
+            true),
         arguments(
             "the documented em-dash form still clears",
             "@thrillhousebot resolved src/A.java:1 — SQL injection",

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/MaintainerReplyServiceTest.java
@@ -622,13 +622,17 @@ class MaintainerReplyServiceTest {
   }
 
   private MaintainerReplyService.ReplyTask mentionTask(String question) {
+    return mentionTask(question, "OWNER");
+  }
+
+  private MaintainerReplyService.ReplyTask mentionTask(String question, String authorAssociation) {
     return new MaintainerReplyService.ReplyTask(
         "owner",
         "repo",
         42,
         12345L,
         "octocat",
-        "OWNER",
+        authorAssociation,
         question,
         "PR Title",
         "PR body",
@@ -675,6 +679,28 @@ class MaintainerReplyServiceTest {
     verifyNoInteractions(replyAssistant, prClient);
   }
 
+  /**
+   * The manual-trigger allowlist admits a commenter to the mention path whatever their {@code
+   * author_association}, but the clearing path requires a write-capable one. The ack must not
+   * promise a closure that gate will refuse.
+   */
+  @Test
+  void clearDirectiveFromACommenterWhoCannotClearSaysNothingWillBeCleared() {
+    authorize();
+
+    service.handle(
+        mentionTask("@thrillhousebot resolved `src/A.java:10` — SQL injection", "CONTRIBUTOR"));
+
+    var body = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+    verify(commentClient)
+        .createComment(eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(42), body.capture());
+    assertEquals(MaintainerReplyService.CLEAR_DIRECTIVE_UNAUTHORIZED_ACK, body.getValue().body());
+    assertTrue(
+        body.getValue().body().contains("nothing will be cleared"),
+        "the commenter must not read this as a promise the finding closes");
+    verifyNoInteractions(replyAssistant, prClient);
+  }
+
   @Test
   void clearDirectiveAckNeverClaimsAClearingAlreadyHappened() {
     // The ack states what the next review will evaluate; it must not report an outcome it cannot
@@ -682,7 +708,8 @@ class MaintainerReplyServiceTest {
     for (var ack :
         List.of(
             MaintainerReplyService.CLEAR_DIRECTIVE_ACK,
-            MaintainerReplyService.CLEAR_DIRECTIVE_NO_LOCATOR_ACK)) {
+            MaintainerReplyService.CLEAR_DIRECTIVE_NO_LOCATOR_ACK,
+            MaintainerReplyService.CLEAR_DIRECTIVE_UNAUTHORIZED_ACK)) {
       assertFalse(ack.startsWith("Noted"), ack);
       assertFalse(ack.contains("has been cleared"), ack);
       assertFalse(ack.contains("is cleared"), ack);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -253,6 +253,8 @@ class RebuttalContradictionTest {
         // The scheme carve-out still applies inside the unclosed literal, so the fallback lands on
         // the real comment rather than on the URL's slashes.
         "+    let u = &'a; see http://example.com // executor.submit(() -> run(ctx));",
+        // A second // inside the same unclosed literal must not move the fallback past the first.
+        "+    let f = &'a ctx; // note // executor.submit(() -> run(ctx));",
       })
   void shouldNotReadACommentAsDispatchEvidenceAfterABackslash(String codeLine) {
     assertTrue(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -170,6 +170,15 @@ class RebuttalContradictionTest {
             + "+        store is not safe for parallel writes */);",
         "+    var pool = Executors.newFixedThreadPool(1 /* exactly one worker, because the queue"
             + " must stay ordered for the replay to be deterministic */);",
+        // A justification that cites its source: one URL is enough to run a comment past 256
+        // characters, which is where the previous bound sat.
+        "+    var pool = Executors.newFixedThreadPool(1 /* one worker per"
+            + " https://github.com/org/repo/issues/12345#issuecomment-1234567890 and the four"
+            + " incidents linked from it, all of which came from parallel writes to the same"
+            + " ledger row while the nightly replay was running; the ordering guarantee the"
+            + " downstream reconciler depends on is only worth having if exactly one thread"
+            + " appends here, so please do not widen this pool without reading that thread"
+            + " first */);",
       })
   void shouldNotTreatASingleThreadedFixedPoolAsConcurrentDispatch(String codeLine) {
     assertTrue(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -213,11 +213,32 @@ class RebuttalContradictionTest {
         "+    auto path = R\"(prefix//rest)\"; executor.submit([]{ run(ctx); });",
         // A single-quoted literal.
         "+    var sep = '//'; executor.submit(() -> run(ctx));",
+        // An escaped backslash closes its literal, so the escape still applies where it exists.
+        "+    var dir = \"C:\\\\\"; executor.submit(() -> run(ctx));",
       })
   void shouldKeepDispatchEvidenceThatFollowsAQuotedDoubleSlash(String codeLine) {
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine).isPresent(),
         "the // sits inside a string literal, so the dispatch after it is live code: " + codeLine);
+  }
+
+  /**
+   * The mirror of the case above: a real trailing comment must stay stripped. Honouring a backslash
+   * escape inside a Go raw string — where a backslash is literal — stepped over the closing
+   * backtick, left the quote state open, and let the comment's own text pose as live code.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // A Windows path in a Go raw string, then a real comment naming a dispatch.
+        "+    path := `C:\\`; // executor.submit(() -> run(ctx));",
+        // The same shape with no literal involved at all.
+        "+    var n = count; // executor.submit(() -> run(ctx));",
+      })
+  void shouldNotReadACommentAsDispatchEvidenceAfterABackslash(String codeLine) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine).isEmpty(),
+        "a dispatch named only in a comment is not live code, so the decline stands: " + codeLine);
   }
 
   static Stream<Arguments> commentScanEdgeCases() {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -16,10 +16,14 @@
 package dev.thiagogonzaga.thrillhousebot.review;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class RebuttalContradictionTest {
@@ -148,6 +152,67 @@ class RebuttalContradictionTest {
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "It runs serially.", oneThread).isEmpty(),
         "a one-thread pool genuinely serializes, so it does not refute the decline");
+  }
+
+  /**
+   * A {@code //} inside a string literal is not a comment start. Cutting the line there threw away
+   * the dispatch that followed it, so the decline stood over code that does dispatch concurrently.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // A protocol-relative URL in a Java/JS string literal.
+        "+    var base = \"//cdn.example.com\"; executor.submit(() -> run(ctx));",
+        // A Go raw string literal.
+        "+    raw := `a//b`; executor.submit(func() { run(ctx) })",
+        // A C++ raw string literal, whose R\"( opener the scan must not read as a comment either.
+        "+    auto path = R\"(prefix//rest)\"; executor.submit([]{ run(ctx); });",
+        // A single-quoted literal.
+        "+    var sep = '//'; executor.submit(() -> run(ctx));",
+      })
+  void shouldKeepDispatchEvidenceThatFollowsAQuotedDoubleSlash(String codeLine) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine).isPresent(),
+        "the // sits inside a string literal, so the dispatch after it is live code: " + codeLine);
+  }
+
+  static Stream<Arguments> commentScanEdgeCases() {
+    return Stream.of(
+        arguments(
+            "an escaped quote does not close the literal, so the // after it is still quoted",
+            "+    var s = \"a\\\"//b\"; executor.submit(() -> run(ctx));",
+            true),
+        arguments(
+            "a URL scheme's :// is not a comment start",
+            "+    var u = http://example.com; executor.submit(() -> run(ctx));",
+            true),
+        arguments(
+            "a line opening with // is comment from its very first character",
+            "// executor.submit(() -> run(ctx));",
+            false),
+        arguments(
+            "a lone / is division, and a trailing / ends the line without opening a comment",
+            "+    var half = total / 2; executor.submit(() -> run(ctx)); /",
+            true));
+  }
+
+  /** Edge shapes of the comment scan, each turning on one decision the scan makes alone. */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("commentScanEdgeCases")
+  void shouldFindTheCommentStartOutsideStringLiterals(String name, String code, boolean refuted) {
+    assertEquals(
+        refuted,
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", code).isPresent(),
+        name);
+  }
+
+  @Test
+  void shouldStillStripARealTrailingLineCommentAfterAStringLiteral() {
+    var commented = "+    var base = \"//cdn.example.com\"; // executor.submit(() -> run(ctx));\n";
+
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", commented).isEmpty(),
+        "a dispatch that only appears in a line comment is not live code");
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -243,11 +243,36 @@ class RebuttalContradictionTest {
         "+    path := `C:\\`; // executor.submit(() -> run(ctx));",
         // The same shape with no literal involved at all.
         "+    var n = count; // executor.submit(() -> run(ctx));",
+        // An opener with no closer is not a literal: a Rust lifetime, and an apostrophe in prose.
+        "+    let f = handler(&'a ctx); // executor.submit(() -> run(ctx));",
+        "+    var n = count; // don't let this executor.submit(task) come back",
+        // A closed literal earlier on the line must not consume the fallback.
+        "+    var a = \"//x\"; let f = &'a ctx; // executor.submit(() -> run(ctx));",
+        // A file URL keeps its three slashes rather than reading as a comment.
+        "+    var u = \"file:///etc/hosts\"; // executor.submit(() -> run(ctx));",
+        // The scheme carve-out still applies inside the unclosed literal, so the fallback lands on
+        // the real comment rather than on the URL's slashes.
+        "+    let u = &'a; see http://example.com // executor.submit(() -> run(ctx));",
       })
   void shouldNotReadACommentAsDispatchEvidenceAfterABackslash(String codeLine) {
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine).isEmpty(),
         "a dispatch named only in a comment is not live code, so the decline stands: " + codeLine);
+  }
+
+  /** The fallback for an unclosed literal must cut at the comment, not before the code. */
+  @Test
+  void shouldKeepDispatchBeforeACommentOnALineWithAnUnclosedQuote() {
+    var codeLine = "+    let f = &'a ctx; executor.submit(() -> run(ctx)); // one per request\n";
+
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine).isPresent(),
+        "the dispatch is live code before the comment, so it still refutes the decline");
+
+    var loneSlash = "+    let f = &'a ctx; executor.submit(() -> run(ctx)); /\n";
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", loneSlash).isPresent(),
+        "a single trailing slash opens no comment, so there is nothing to fall back to");
   }
 
   static Stream<Arguments> commentScanEdgeCases() {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -160,6 +160,10 @@ class RebuttalContradictionTest {
         "+    var pool = Executors.newFixedThreadPool( 1 );",
         "+    var pool = Executors.newFixedThreadPool( 1 , factory);",
         "+    var pool = Executors.newFixedThreadPool(\t1\t);",
+        // A block comment naming the count is the natural place to explain a pool of one.
+        "+    var pool = Executors.newFixedThreadPool(1 /* one worker */);",
+        "+    var pool = Executors.newFixedThreadPool(/* only one */ 1);",
+        "+    var pool = Executors.newFixedThreadPool(1 /* worker */, factory);",
       })
   void shouldNotTreatASingleThreadedFixedPoolAsConcurrentDispatch(String codeLine) {
     assertTrue(
@@ -177,6 +181,9 @@ class RebuttalContradictionTest {
         "+    var pool = Executors.newFixedThreadPool( 10 );",
         "+    var pool = Executors.newFixedThreadPool(8, factory);",
         "+    var pool = Executors.newFixedThreadPool(workers);",
+        // A comment does not make a count knowable, and the class cannot evaluate an expression.
+        "+    var pool = Executors.newFixedThreadPool(2 /* two */);",
+        "+    var pool = Executors.newFixedThreadPool(1 + 0);",
       })
   void shouldTreatAMultiThreadedFixedPoolAsConcurrentDispatch(String codeLine) {
     assertTrue(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -164,6 +164,12 @@ class RebuttalContradictionTest {
         "+    var pool = Executors.newFixedThreadPool(1 /* one worker */);",
         "+    var pool = Executors.newFixedThreadPool(/* only one */ 1);",
         "+    var pool = Executors.newFixedThreadPool(1 /* worker */, factory);",
+        // The evidence text is rejoined lines, so an explanation long enough to wrap is one the
+        // scan really sees across the break.
+        "+    var pool = Executors.newFixedThreadPool(1 /* one worker: the downstream\n"
+            + "+        store is not safe for parallel writes */);",
+        "+    var pool = Executors.newFixedThreadPool(1 /* exactly one worker, because the queue"
+            + " must stay ordered for the replay to be deterministic */);",
       })
   void shouldNotTreatASingleThreadedFixedPoolAsConcurrentDispatch(String codeLine) {
     assertTrue(
@@ -184,6 +190,7 @@ class RebuttalContradictionTest {
         // A comment does not make a count knowable, and the class cannot evaluate an expression.
         "+    var pool = Executors.newFixedThreadPool(2 /* two */);",
         "+    var pool = Executors.newFixedThreadPool(1 + 0);",
+        "+    var pool = Executors.newFixedThreadPool(2 /* two\n+        threads */);",
       })
   void shouldTreatAMultiThreadedFixedPoolAsConcurrentDispatch(String codeLine) {
     assertTrue(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -145,13 +145,43 @@ class RebuttalContradictionTest {
         "this construct dispatches concurrently: " + codeLine);
   }
 
-  @Test
-  void shouldNotTreatASingleThreadedFixedPoolAsConcurrentDispatch() {
-    var oneThread = "+    var pool = Executors.newFixedThreadPool(1);\n";
-
+  /**
+   * A one-thread pool genuinely serializes, so it refutes nothing — and this is the direction that
+   * matters most, since a match here overrules a maintainer whose decline was correct. The thread
+   * count is what decides it, not how the call is spelled around it.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "+    var pool = Executors.newFixedThreadPool(1);",
+        // The two-argument overload is the standard way to name a single worker.
+        "+    var pool = Executors.newFixedThreadPool(1, new WorkerThreadFactory());",
+        // Spacing inside the call must not let the count slip past the guard.
+        "+    var pool = Executors.newFixedThreadPool( 1 );",
+        "+    var pool = Executors.newFixedThreadPool( 1 , factory);",
+        "+    var pool = Executors.newFixedThreadPool(\t1\t);",
+      })
+  void shouldNotTreatASingleThreadedFixedPoolAsConcurrentDispatch(String codeLine) {
     assertTrue(
-        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", oneThread).isEmpty(),
-        "a one-thread pool genuinely serializes, so it does not refute the decline");
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine + "\n").isEmpty(),
+        "a one-thread pool genuinely serializes, so it does not refute the decline: " + codeLine);
+  }
+
+  /** The counterpart: any count above one does dispatch concurrently, however it is spelled. */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "+    var pool = Executors.newFixedThreadPool(10);",
+        // 11 starts with the same digit as 1 and must not be excluded with it.
+        "+    var pool = Executors.newFixedThreadPool(11);",
+        "+    var pool = Executors.newFixedThreadPool( 10 );",
+        "+    var pool = Executors.newFixedThreadPool(8, factory);",
+        "+    var pool = Executors.newFixedThreadPool(workers);",
+      })
+  void shouldTreatAMultiThreadedFixedPoolAsConcurrentDispatch(String codeLine) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine + "\n").isPresent(),
+        "a pool of more than one thread dispatches concurrently: " + codeLine);
   }
 
   /**


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🚀 Performance

## Description

Four fixes from the review triage of #532.

**1. `FollowUpAnalyzer.namesLocator` over-cleared findings (correctness).**
The whole-locator guard rejected only a following *digit*, so every other way of
continuing the line-number token still read as a whole match. A maintainer
commenting `@thrillhousebot resolved src/A.java:1-3 — <title>` (a line range) or
`src/A.java:1x` cleared the distinct finding at `src/A.java:1`. That is the
over-clear direction `clearedInConversation`'s own contract says must never
happen: it silently closes a finding the maintainer never resolved. Now any
letter, digit, `_` or `-` after the locator rejects the match. The summary prints
`path:line` followed by a space, a backtick or an em dash, and the documented
directive form is spelled the same way, so no legitimate naming loses its match —
and under-clearing only holds the finding one more round, the safe direction.

**2. `RebuttalContradiction.stripLineComment` dropped live dispatch evidence.**
It cut the line at the first `//` it found, even when that `//` was inside a
string literal — a protocol-relative URL, a Go raw string, a C++ `R"(...)"` raw
string, any quoted path with a doubled slash. Everything after the cut was
discarded, so a dispatch construct on the same line never reached
`CONCURRENT_DISPATCHES` and a maintainer's "it runs serially" decline stood
unchallenged over code that does dispatch concurrently — the false-negative
direction this class exists to close. The scan now tracks unescaped quote state
and keeps the existing `://` carve-out for a URL scheme outside a literal.

**3. The clear-directive acknowledgement promised a closure it could not deliver.**
`ManualReviewAuthorizer` admits a login on the manual-trigger allowlist whatever
its `author_association`, but `FollowUpAnalyzer.clearedInConversation` only
honours a write-capable one — the README says the allowlist "does not extend" to
the directive. An allowlist-only commenter (a fork-PR author, say) was therefore
told "the next review will close every previous finding this comment names", and
then nothing was cleared. `mayHoldWriteAccess` becomes package-private so the ack
and the clear read the same rule, and a commenter who cannot clear is told so
plainly.

**4. `BudgetPlan` coverage recorders were quadratic (performance).**
`recordUncoveredFiles`, `recordSpendCeilingSkippedFiles` and
`recordResponseCutFiles` each tested membership with the accumulator's own
`contains()` per name. Every accumulator is a `CopyOnWriteArrayList`, whose
`contains` **and** `add` are linear, so one recording pass was quadratic in the
batch's file count — a count nothing bounds, since a token-budgeted batch can
hold hundreds of small files, and every failed or refused batch runs another
pass. The shared shape is folded into `recordDistinct`, which snapshots the list
into a `HashSet` once per call. Behaviour is unchanged: non-null names only,
first-seen order, no duplicates. `contains`-then-`add` was never atomic, so the
snapshot does not weaken the existing concurrency contract.

## Related Issues

N/A — raised as inline review threads on #532.

## How Has This Been Tested?

- [x] Unit tests

Red/green proof. Each behavioural fix was reverted with its new tests in place;
verbatim red output.

Fixes 1 and 2:

```
[ERROR] Tests run: 177, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 1.395 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.FollowUpAnalyzerTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.FollowUpAnalyzerTest.backstopShouldMatchWholeLocatorsOnly(String, String, boolean)[4] -- Time elapsed: 0.006 s <<< FAILURE!
org.opentest4j.AssertionFailedError: a line range starting at the finding's line must not clear it ==> expected: <[1]> but was: <[]>
	at dev.thiagogonzaga.thrillhousebot.review.FollowUpAnalyzerTest.backstopShouldMatchWholeLocatorsOnly(FollowUpAnalyzerTest.java:2935)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.FollowUpAnalyzerTest.backstopShouldMatchWholeLocatorsOnly(String, String, boolean)[5] -- Time elapsed: 0.003 s <<< FAILURE!
org.opentest4j.AssertionFailedError: a letter continuing the line number must not clear it ==> expected: <[1]> but was: <[]>

[ERROR] dev.thiagogonzaga.thrillhousebot.review.FollowUpAnalyzerTest.backstopShouldMatchWholeLocatorsOnly(String, String, boolean)[6] -- Time elapsed: 0.003 s <<< FAILURE!
org.opentest4j.AssertionFailedError: an underscore continuing the line number must not clear it ==> expected: <[1]> but was: <[]>

[ERROR] Tests run: 62, Failures: 4, Errors: 0, Skipped: 0, Time elapsed: 0.034 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.RebuttalContradictionTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.RebuttalContradictionTest.shouldKeepDispatchEvidenceThatFollowsAQuotedDoubleSlash(String)[1] -- Time elapsed: 0 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the // sits inside a string literal, so the dispatch after it is live code: +    var base = "//cdn.example.com"; executor.submit(() -> run(ctx)); ==> expected: <true> but was: <false>

[ERROR] dev.thiagogonzaga.thrillhousebot.review.RebuttalContradictionTest.shouldKeepDispatchEvidenceThatFollowsAQuotedDoubleSlash(String)[2] -- Time elapsed: 0 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the // sits inside a string literal, so the dispatch after it is live code: +    raw := `a//b`; executor.submit(func() { run(ctx) }) ==> expected: <true> but was: <false>

[ERROR] dev.thiagogonzaga.thrillhousebot.review.RebuttalContradictionTest.shouldKeepDispatchEvidenceThatFollowsAQuotedDoubleSlash(String)[3] -- Time elapsed: 0.001 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the // sits inside a string literal, so the dispatch after it is live code: +    auto path = R"(prefix//rest)"; executor.submit([]{ run(ctx); }); ==> expected: <true> but was: <false>

[ERROR] dev.thiagogonzaga.thrillhousebot.review.RebuttalContradictionTest.shouldKeepDispatchEvidenceThatFollowsAQuotedDoubleSlash(String)[4] -- Time elapsed: 0.001 s <<< FAILURE!
org.opentest4j.AssertionFailedError: the // sits inside a string literal, so the dispatch after it is live code: +    var sep = '//'; executor.submit(() -> run(ctx)); ==> expected: <true> but was: <false>

[ERROR] Tests run: 239, Failures: 7, Errors: 0, Skipped: 0
```

Fix 3:

```
[ERROR] Tests run: 27, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.175 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyServiceTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.MaintainerReplyServiceTest.clearDirectiveFromACommenterWhoCannotClearSaysNothingWillBeCleared -- Time elapsed: 0.011 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <Clearing a finding takes write access on this repository, so nothing will be cleared by that comment. Ask someone with write access to post the same `@thrillhousebot resolved path/to/File.java:42 — <title>` directive.> but was: <The next review will close every previous finding this comment names by its `path:line` and title; anything it does not name stays open.>
[ERROR] Tests run: 27, Failures: 1, Errors: 0, Skipped: 0
```

The recorder change is a pure refactor with no behavioural difference, so it
carries no red proof; the existing recorder tests keep it honest.

Gates on the final tree:

- `./mvnw -B spotless:apply` then `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, `BUILD SUCCESS`
- `./mvnw -B clean test` — `Tests run: 2978, Failures: 0, Errors: 0, Skipped: 0`
- JaCoCo ∩ `git diff -U0 29c6e14...HEAD` — 30 trackable changed main lines, **0 uncovered lines and 0 uncovered branches**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No user-facing configuration or documentation changes, so README/`.env.example`
are untouched and the Docs workflow is unaffected.
