### PR TITLE
fix(review): say when confidence, not severity, decided the verdict

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/BlockingStrictness.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/BlockingStrictness.java
@@ -65,17 +65,39 @@ public enum BlockingStrictness {
     };
   }
 
-  /** Whether this finding alone is enough to escalate the review to {@code REQUEST_CHANGES}. */
+  /**
+   * Whether this finding alone is enough to escalate the review to {@code REQUEST_CHANGES}. Two
+   * independent gates, kept separate on purpose (#645): {@link #severityQualifies(RiskLevel)} asks
+   * whether the defect class is severe enough for this mode, and the confidence gate asks whether
+   * the review demonstrated it. Only {@link #STRICT} drops the second one.
+   */
   public boolean isBlocking(Finding finding) {
     if (finding == null) {
       return false;
     }
-    return switch (this) {
-      case BALANCED -> isCriticalOrHigh(finding.risk()) && finding.confidence() == Confidence.HIGH;
-      case STRICT -> isCriticalOrHigh(finding.risk());
-      case LENIENT ->
-          finding.risk() == RiskLevel.CRITICAL && finding.confidence() == Confidence.HIGH;
-    };
+    return severityQualifies(finding.risk())
+        && (this == STRICT || finding.confidence() == Confidence.HIGH);
+  }
+
+  /**
+   * Whether this finding cleared the severity gate but was denied blocking eligibility by the
+   * confidence gate alone — the case where the verdict turns on a hedge rather than on the risk.
+   *
+   * <p>This is the silent demotion #645 measured: a hedge the review prompt itself mandates when a
+   * mitigation is not visible in the diff (#575) removes a HIGH finding from blocking
+   * consideration, and the published finding says only "verify before acting". Surfacing the
+   * predicate is what lets {@link VerdictBuilder} say so where the verdict is explained; the gate
+   * itself is unchanged, so no finding starts or stops blocking because of this method.
+   *
+   * <p>Always {@code false} under {@link #STRICT}, which has no confidence gate to withhold on.
+   */
+  public boolean withheldByConfidence(Finding finding) {
+    return finding != null && severityQualifies(finding.risk()) && !isBlocking(finding);
+  }
+
+  /** Whether the finding's risk alone meets this mode's bar, before confidence is considered. */
+  private boolean severityQualifies(RiskLevel risk) {
+    return this == LENIENT ? risk == RiskLevel.CRITICAL : isCriticalOrHigh(risk);
   }
 
   private static boolean isCriticalOrHigh(RiskLevel risk) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -38,7 +38,11 @@ public record ReviewResult(
     // False when the required-context set could not be resolved; rendered CI copy then drops
     // "required".
     boolean requiredContextsKnown,
-    TruncationDetail truncation) {
+    TruncationDetail truncation,
+    // How many outstanding findings were severe enough to block but were denied eligibility by
+    // their confidence alone, on a review that did not end up requesting changes — see
+    // #confidenceHoldNotice(int). Zero whenever the hedge was not what decided the verdict.
+    int blockingWithheldByConfidence) {
   public ReviewResult {
     findings = List.copyOf(findings);
     previousStatuses = List.copyOf(previousStatuses);
@@ -48,6 +52,47 @@ public record ReviewResult(
     if (reviewState == null) {
       reviewState = ReviewState.fromHighestRisk(highestRisk);
     }
+  }
+
+  /**
+   * Convenience constructor for results built before the confidence-hold count existed (and tests):
+   * nothing was withheld from blocking by confidence, so no such disclosure is rendered. The
+   * production path ({@code VerdictBuilder}) passes the real count through the canonical
+   * constructor.
+   */
+  public ReviewResult(
+      List<Finding> findings,
+      int criticalCount,
+      int highCount,
+      int mediumCount,
+      int lowCount,
+      RiskLevel highestRisk,
+      ReviewState reviewState,
+      boolean isFirstReview,
+      String summaryMarkdown,
+      List<PreviousFindingStatus> previousStatuses,
+      List<CiCheck> offendingCiChecks,
+      int omittedFiles,
+      boolean ciUnreadable,
+      boolean requiredContextsKnown,
+      TruncationDetail truncation) {
+    this(
+        findings,
+        criticalCount,
+        highCount,
+        mediumCount,
+        lowCount,
+        highestRisk,
+        reviewState,
+        isFirstReview,
+        summaryMarkdown,
+        previousStatuses,
+        offendingCiChecks,
+        omittedFiles,
+        ciUnreadable,
+        requiredContextsKnown,
+        truncation,
+        0);
   }
 
   /** Convenience constructor for results whose CI status was fully readable (the common case). */
@@ -339,6 +384,62 @@ public record ReviewResult(
        findings themselves are complete.
 
       """;
+
+  /**
+   * True when at least one outstanding finding was severe enough to block but its confidence, not
+   * its risk, is why this review is not requesting changes.
+   */
+  public boolean confidenceHeldTheVerdict() {
+    return blockingWithheldByConfidence > 0;
+  }
+
+  /**
+   * Lead-in of {@link #confidenceHoldNotice(int)}. Shared with the surfaces that render or
+   * recognize the banner so the two cannot drift, exactly like {@link #TRUNCATION_NOTICE_LEAD_IN}.
+   */
+  static final String CONFIDENCE_HOLD_LEAD_IN = "> ⚠️ **Severity did not decide this verdict.**";
+
+  /**
+   * The shared "N finding(s) … hedged" clause behind both confidence-hold surfaces, so the summary
+   * banner and the check-run summary never drift on the count or on what the hedge means.
+   */
+  private static String confidenceHoldClause(int withheld) {
+    return String.format(
+        "%d finding(s) were severe enough to block on their own, but the review hedged its"
+            + " confidence in them",
+        withheld);
+  }
+
+  /**
+   * Banner prepended to the summary when confidence, not severity, is why the review did not
+   * request changes (#645).
+   *
+   * <p>Under the default {@code balanced} mode a critical/high finding blocks only when the review
+   * is highly confident in it, and the review prompt mandates a hedge whenever a mitigation is not
+   * visible in the diff — so the very class the severity floor exists to protect (an injection sink
+   * with no visible sanitizer) is hedged by construction and quietly loses the floor's consequence.
+   * Round 6 of the dogfood corpus measured that on a stored-XSS sink and a verified build-breaking
+   * defect, both non-blocking, with nothing in the review saying why.
+   *
+   * <p>The gate itself is deliberately left alone: an operator who wants severity alone to decide
+   * already has {@code REVIEW_BLOCKING_STRICTNESS=strict}, and widening the default would collapse
+   * {@code balanced} into it, leaving no mode that means "only demonstrated findings block". What
+   * was wrong was that the choice was invisible, so this states it and names the knob.
+   */
+  static String confidenceHoldNotice(int withheld) {
+    return String.format(
+        CONFIDENCE_HOLD_LEAD_IN
+            + " %s, so this review comments instead of requesting changes. A hedge means the"
+            + " finding could not be confirmed from the diff alone — not that it was disproven —"
+            + " so read those findings before merging. Set `REVIEW_BLOCKING_STRICTNESS=strict` to"
+            + " let severity alone decide.%n%n",
+        confidenceHoldClause(withheld));
+  }
+
+  /** The one-sentence check-run form of {@link #confidenceHoldNotice(int)}. */
+  static String confidenceHoldBrief(int withheld) {
+    return "Not blocking: " + confidenceHoldClause(withheld) + ".";
+  }
 
   /**
    * The shared "N file(s) were omitted …" clause, so the review banner and the on-demand-command

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -239,7 +239,24 @@ public class VerdictBuilder {
     return CheckRunManager.CHECK_NAME;
   }
 
+  /**
+   * The check-run summary line. Every branch below explains a verdict, so the confidence-hold
+   * clause is appended once around all of them rather than woven into each: a critical/high finding
+   * kept from blocking by its confidence can be a new finding (the counts branch) or an unresolved
+   * previous one (the no-new-findings branches), and #645's whole complaint is that the effect was
+   * silent. Empty whenever confidence was not what decided the verdict, so no existing summary
+   * changes.
+   */
   static String checkSummaryForResult(ReviewResult result) {
+    if (!result.confidenceHeldTheVerdict()) {
+      return verdictSummaryFor(result);
+    }
+    return verdictSummaryFor(result)
+        + " "
+        + ReviewResult.confidenceHoldBrief(result.blockingWithheldByConfidence());
+  }
+
+  private static String verdictSummaryFor(ReviewResult result) {
     var truncationSuffix = truncationSuffixFor(result);
     if (result.hasIssues()) {
       return String.format(
@@ -488,6 +505,15 @@ public class VerdictBuilder {
     var outstanding = new ArrayList<Finding>(tally.findings());
     outstanding.addAll(unresolvedPrevious);
     ReviewState state = ReviewState.fromFindings(outstanding, blockingStrictness);
+    // #645: count the outstanding findings whose severity cleared the mode's bar but whose
+    // confidence did not, and only when the review is not requesting changes anyway — that is
+    // exactly when the hedge, not the risk, is what produced the verdict a maintainer is looking
+    // at. On a review that already blocks the same hedge changed nothing, and a banner that
+    // changes nothing is the noise a check run cannot afford.
+    var withheldByConfidence =
+        state == ReviewState.REQUEST_CHANGES
+            ? 0
+            : (int) outstanding.stream().filter(blockingStrictness::withheldByConfidence).count();
     // Backstop statuses reach the gate but never `outstanding`, keeping the hold downgrade-only
     // (APPROVE → COMMENT, never REQUEST_CHANGES). Keep the toStatuses list as-is on the common
     // no-backstop path — no ArrayList wrap/copy when there is nothing to append.
@@ -530,7 +556,8 @@ public class VerdictBuilder {
                 diffStats.omittedFiles(),
                 ciUnreadable,
                 requiredContextsKnown,
-                diffStats.truncation()));
+                diffStats.truncation(),
+                withheldByConfidence));
     if (pureRenameRollup != null && !pureRenameRollup.isBlank()) {
       summaryMarkdown =
           summaryMarkdown.replace(
@@ -539,6 +566,11 @@ public class VerdictBuilder {
                   + "\n\n> **AI review scope:** "
                   + pureRenameRollup.strip()
                   + "\n\n");
+    }
+    // Prepended before the coverage banners so those stay outermost: a diff the review never saw
+    // in full is the larger caveat, and it is the first thing a reader should meet.
+    if (withheldByConfidence > 0) {
+      summaryMarkdown = ReviewResult.confidenceHoldNotice(withheldByConfidence) + summaryMarkdown;
     }
     if (diffStats.truncated()) {
       summaryMarkdown =
@@ -571,7 +603,8 @@ public class VerdictBuilder {
         diffStats.omittedFiles(),
         ciUnreadable,
         requiredContextsKnown,
-        diffStats.truncation());
+        diffStats.truncation(),
+        withheldByConfidence);
   }
 
   /**

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/BlockingStrictnessTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/BlockingStrictnessTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * #645 — {@link BlockingStrictness#withheldByConfidence}, the predicate that names the case where a
+ * finding's severity cleared the mode's bar and only its confidence kept it from blocking. The
+ * gate's own outcomes are asserted alongside it, because the point of the predicate is that it
+ * partitions the non-blocking findings without moving any of them.
+ */
+class BlockingStrictnessTest {
+
+  private static Finding finding(RiskLevel risk, Confidence confidence) {
+    return new Finding(risk, confidence, "a.java", 1, "t", "d", null, null);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    // Hedged severity — the #645 case: would block on risk alone, confidence removes it.
+    "BALANCED, CRITICAL, MEDIUM, true",
+    "BALANCED, CRITICAL, LOW, true",
+    "BALANCED, HIGH, MEDIUM, true",
+    "BALANCED, HIGH, LOW, true",
+    "LENIENT, CRITICAL, MEDIUM, true",
+    "LENIENT, CRITICAL, LOW, true",
+    // Confident enough to block: nothing was withheld.
+    "BALANCED, CRITICAL, HIGH, false",
+    "BALANCED, HIGH, HIGH, false",
+    "LENIENT, CRITICAL, HIGH, false",
+    // Severity, not confidence, is why these do not block.
+    "BALANCED, MEDIUM, MEDIUM, false",
+    "BALANCED, LOW, LOW, false",
+    "LENIENT, HIGH, MEDIUM, false",
+    "LENIENT, HIGH, HIGH, false",
+    // STRICT has no confidence gate to withhold on.
+    "STRICT, HIGH, LOW, false",
+    "STRICT, CRITICAL, MEDIUM, false",
+    "STRICT, MEDIUM, LOW, false"
+  })
+  void withheldByConfidenceIsolatesTheHedgeAsTheReason(
+      BlockingStrictness mode, RiskLevel risk, Confidence confidence, boolean withheld) {
+    var f = finding(risk, confidence);
+    assertTrue(withheld == mode.withheldByConfidence(f), mode + " " + risk + "/" + confidence);
+    // Withheld and blocking are mutually exclusive by construction: a withheld finding is one the
+    // gate rejected, so a mode can never claim both about the same finding.
+    assertFalse(mode.withheldByConfidence(f) && mode.isBlocking(f));
+  }
+
+  /**
+   * The refactor that split the severity and confidence gates must not move any verdict: these are
+   * the same outcomes the enum produced when each mode carried its own combined expression.
+   */
+  @ParameterizedTest
+  @CsvSource({
+    "BALANCED, CRITICAL, HIGH, true",
+    "BALANCED, HIGH, HIGH, true",
+    "BALANCED, HIGH, MEDIUM, false",
+    "BALANCED, MEDIUM, HIGH, false",
+    "STRICT, HIGH, LOW, true",
+    "STRICT, CRITICAL, LOW, true",
+    "STRICT, MEDIUM, HIGH, false",
+    "LENIENT, CRITICAL, HIGH, true",
+    "LENIENT, CRITICAL, LOW, false",
+    "LENIENT, HIGH, HIGH, false"
+  })
+  void isBlockingKeepsItsPreSplitOutcomes(
+      BlockingStrictness mode, RiskLevel risk, Confidence confidence, boolean blocks) {
+    assertTrue(blocks == mode.isBlocking(finding(risk, confidence)));
+  }
+
+  @ParameterizedTest
+  @EnumSource(BlockingStrictness.class)
+  void neitherPredicateThrowsOnANullFinding(BlockingStrictness mode) {
+    assertFalse(mode.isBlocking(null));
+    assertFalse(mode.withheldByConfidence(null));
+  }
+
+  /** A finding predating the confidence field defaults to HIGH, so it still blocks (#105). */
+  @Test
+  void aPreConfidenceFindingIsNotTreatedAsWithheld() {
+    var legacy = new Finding(RiskLevel.HIGH, "a.java", 1, "t", "d", null, null);
+    assertTrue(BlockingStrictness.BALANCED.isBlocking(legacy));
+    assertFalse(BlockingStrictness.BALANCED.withheldByConfidence(legacy));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -601,4 +601,54 @@ class ReviewResultTest {
         message.contains("where one exists"),
         "the gap must be closed with a path, not admitted in a parenthetical");
   }
+
+  /**
+   * #645 — a result built without the confidence-hold count (every caller that predates it)
+   * discloses nothing, so the banner appears only where {@code VerdictBuilder} measured a hold.
+   */
+  @Test
+  void aResultBuiltWithoutTheConfidenceHoldCountDisclosesNothing() {
+    var result =
+        new ReviewResult(
+            List.of(),
+            0,
+            0,
+            0,
+            0,
+            null,
+            ReviewState.APPROVE,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0,
+            false,
+            true,
+            ReviewResult.TruncationDetail.EMPTY);
+
+    assertEquals(0, result.blockingWithheldByConfidence());
+    assertFalse(result.confidenceHeldTheVerdict());
+  }
+
+  /**
+   * #645 — the hold banner must name the count, say what a hedge does and does not mean, and point
+   * at the mode that already exists for operators who want severity alone to decide. Its check-run
+   * form carries the same clause so the two surfaces cannot drift.
+   */
+  @Test
+  void theConfidenceHoldNoticeExplainsTheHedgeAndNamesTheKnob() {
+    var notice = ReviewResult.confidenceHoldNotice(2);
+
+    assertTrue(notice.startsWith(ReviewResult.CONFIDENCE_HOLD_LEAD_IN), notice);
+    assertTrue(notice.contains("2 finding(s) were severe enough to block on their own"), notice);
+    assertTrue(notice.contains("could not be confirmed from the diff alone"), notice);
+    assertTrue(notice.contains("not that it was disproven"), notice);
+    assertTrue(notice.contains("`REVIEW_BLOCKING_STRICTNESS=strict`"), notice);
+    assertTrue(notice.endsWith(System.lineSeparator().repeat(2)), notice);
+
+    var brief = ReviewResult.confidenceHoldBrief(2);
+    assertTrue(brief.startsWith("Not blocking: "), brief);
+    assertTrue(brief.contains("2 finding(s) were severe enough to block on their own"), brief);
+    assertTrue(brief.endsWith("."), brief);
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -1319,4 +1319,163 @@ class VerdictBuilderTest {
         result.reviewState(),
         "a PR with no genuine outstanding findings must be approvable again");
   }
+
+  // ---------------------------------------------------------------------------------------------
+  // #645 — a confidence hedge silently removes blocking eligibility. The gate is unchanged; what
+  // the review must no longer do is stay silent about which gate produced the verdict.
+  // ---------------------------------------------------------------------------------------------
+
+  private static final String CONFIDENCE_HOLD_HEADLINE = "Severity did not decide this verdict";
+
+  private static final String CONFIDENCE_HOLD_CLAUSE =
+      "1 finding(s) were severe enough to block on their own, but the review hedged its confidence"
+          + " in them";
+
+  private static final VerdictBuilder.DiffStats ONE_FILE = new VerdictBuilder.DiffStats(1, 1, 0);
+
+  private static ReviewResponse.Finding aiFinding(String risk, String confidence) {
+    return new ReviewResponse.Finding(
+        risk, confidence, "a.java", 1, "sink", "reaches a sink", null, null);
+  }
+
+  private static ReviewResponse responseWithFindings(ReviewResponse.Finding... findings) {
+    return new ReviewResponse(List.of(findings), List.of(), null);
+  }
+
+  private ReviewResult verdictFor(VerdictBuilder verdictBuilder, ReviewResponse response) {
+    return verdictBuilder.buildResult(
+        response, true, ONE_FILE, List.of(), List.of(), CI_CLEAR, List.of());
+  }
+
+  private VerdictBuilder builderWith(BlockingStrictness strictness) {
+    return new VerdictBuilder(
+        summaryGenerator,
+        followUpAnalyzer,
+        BotIdentity.from(List.of("thrillhousebot[bot]")),
+        strictness);
+  }
+
+  /**
+   * The round-6 React case: a HIGH finding the model hedged to medium confidence is removed from
+   * blocking consideration entirely, so the PR gets a comment instead of a request for changes. The
+   * verdict may stand, but both surfaces that explain it must say the hedge is what produced it.
+   */
+  @Test
+  void aHedgedHighFindingSaysWhyItDidNotBlock() {
+    var result = verdictFor(builder, responseWithFindings(aiFinding("high", "medium")));
+
+    assertEquals(ReviewState.COMMENT, result.reviewState());
+    var markdown = result.summaryMarkdown();
+    assertTrue(markdown.contains(CONFIDENCE_HOLD_HEADLINE), markdown);
+    assertTrue(
+        markdown.contains(
+            CONFIDENCE_HOLD_CLAUSE + ", so this review comments instead of requesting changes"),
+        markdown);
+    assertTrue(markdown.contains("`REVIEW_BLOCKING_STRICTNESS=strict`"), markdown);
+    var checkSummary = VerdictBuilder.checkSummaryForResult(result);
+    assertTrue(
+        checkSummary.contains("Not blocking: " + CONFIDENCE_HOLD_CLAUSE + "."), checkSummary);
+  }
+
+  /**
+   * The Angular counter-case: another finding already carries the verdict, so the hedge changed
+   * nothing. Disclosing it there would put a paragraph on every blocking review explaining an
+   * outcome the review did not have — the noise a check run cannot afford.
+   */
+  @Test
+  void aReviewThatAlreadyRequestsChangesDoesNotDiscloseAHold() {
+    var result =
+        verdictFor(
+            builder, responseWithFindings(aiFinding("high", "medium"), aiFinding("high", "high")));
+
+    assertEquals(ReviewState.REQUEST_CHANGES, result.reviewState());
+    assertEquals(0, result.blockingWithheldByConfidence());
+    assertFalse(result.summaryMarkdown().contains(CONFIDENCE_HOLD_HEADLINE));
+    assertFalse(VerdictBuilder.checkSummaryForResult(result).contains("Not blocking:"));
+  }
+
+  /** Severity, not confidence, is why a hedged medium does not block — nothing to disclose. */
+  @Test
+  void aHedgedMediumFindingIsNotAConfidenceHold() {
+    var result = verdictFor(builder, responseWithFindings(aiFinding("medium", "medium")));
+
+    assertEquals(ReviewState.COMMENT, result.reviewState());
+    assertEquals(0, result.blockingWithheldByConfidence());
+    assertFalse(result.summaryMarkdown().contains(CONFIDENCE_HOLD_HEADLINE));
+  }
+
+  /** Each mode discloses the hold for exactly the severities its own severity gate would block. */
+  @Test
+  void theHoldIsReportedPerModeAgainstThatModesSeverityBar() {
+    var lenient = builderWith(BlockingStrictness.LENIENT);
+    var hedgedHigh = verdictFor(lenient, responseWithFindings(aiFinding("high", "medium")));
+    assertEquals(0, hedgedHigh.blockingWithheldByConfidence());
+    assertFalse(hedgedHigh.summaryMarkdown().contains(CONFIDENCE_HOLD_HEADLINE));
+
+    var hedgedCritical = verdictFor(lenient, responseWithFindings(aiFinding("critical", "medium")));
+    assertEquals(1, hedgedCritical.blockingWithheldByConfidence());
+    assertTrue(hedgedCritical.summaryMarkdown().contains(CONFIDENCE_HOLD_HEADLINE));
+
+    // STRICT has no confidence gate, so the same finding blocks and nothing is withheld.
+    var strict =
+        verdictFor(
+            builderWith(BlockingStrictness.STRICT),
+            responseWithFindings(aiFinding("high", "medium")));
+    assertEquals(ReviewState.REQUEST_CHANGES, strict.reviewState());
+    assertEquals(0, strict.blockingWithheldByConfidence());
+  }
+
+  /**
+   * The hedge is equally decisive on a previous finding still open, which reaches the gate through
+   * {@code outstanding} but produces no new-finding counts — so the disclosure must survive the
+   * check-run summary's no-new-findings branch too.
+   */
+  @Test
+  void anUnresolvedPreviousHedgedHighIsDisclosedWithNoNewFindings() {
+    when(followUpAnalyzer.toStatuses(any()))
+        .thenReturn(List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still open")));
+    var previous =
+        new Finding(RiskLevel.HIGH, Confidence.MEDIUM, "a.java", 7, "sink", "d", null, null);
+
+    var result =
+        builder.buildResult(
+            CLEAN_RESPONSE, false, ONE_FILE, List.of(), List.of(previous), CI_CLEAR, List.of());
+
+    assertEquals(ReviewState.COMMENT, result.reviewState());
+    assertEquals(1, result.blockingWithheldByConfidence());
+    var checkSummary = VerdictBuilder.checkSummaryForResult(result);
+    assertTrue(checkSummary.contains("previous finding(s) remain unresolved"), checkSummary);
+    assertTrue(
+        checkSummary.contains("Not blocking: " + CONFIDENCE_HOLD_CLAUSE + "."), checkSummary);
+  }
+
+  /** A diff the review never saw in full is the larger caveat and keeps the top of the summary. */
+  @Test
+  void theCoverageBannerStaysAboveTheConfidenceHold() {
+    var truncated =
+        new VerdictBuilder.DiffStats(
+            1,
+            1,
+            0,
+            1,
+            new ReviewResult.TruncationDetail(
+                List.of("f.java"), List.of(), List.of(), List.of(), SummaryDegradation.NONE));
+
+    var result =
+        builder.buildResult(
+            responseWithFindings(aiFinding("high", "medium")),
+            true,
+            truncated,
+            List.of(),
+            List.of(),
+            CI_CLEAR,
+            List.of());
+
+    var markdown = result.summaryMarkdown();
+    assertTrue(markdown.startsWith(ReviewResult.TRUNCATION_NOTICE_LEAD_IN), markdown);
+    assertTrue(
+        markdown.indexOf(ReviewResult.TRUNCATION_NOTICE_LEAD_IN)
+            < markdown.indexOf(CONFIDENCE_HOLD_HEADLINE),
+        markdown);
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔒 Security

## Description

`BlockingStrictness.isBlocking` under the default `BALANCED` mode requires severity ∈ {HIGH, CRITICAL} **and** confidence HIGH, so any hedge removes a finding from blocking consideration entirely. The finding's visible text says only "verify before acting" — neither the effect on the verdict nor the reason for it is disclosed anywhere.

Round 6 measured the consequence on React #62: a stored-XSS `dangerouslySetInnerHTML` sink and a `COPY` of an artifact the build never produces (verified build-breaking) were both hedged to medium and both non-blocking, leaving an unrelated `allowedTags` no-op as the sole reason the review requested changes. Without it the PR would have received `COMMENT` — which is what happened to round 5's React PR. The conflict runs deeper than one case: #575 puts uncertainty on confidence and never on risk, which is why #594 floors unmitigated injection sinks at HIGH — but an injection sink whose mitigation is not visible is hedged **by construction**, because the same prompt instructs it. The hedge therefore removes the consequence of the floor for exactly the class the floor exists to protect.

### Direction chosen: disclose, and separate the gates structurally — do not widen blocking

The issue lists three options. This PR takes **option 1 (disclose it)** and the structural half of **option 2 (separate the gates)**, and deliberately does not widen what blocks.

**Why not widen.** Making a medium-confidence HIGH block is already available: it is exactly what `REVIEW_BLOCKING_STRICTNESS=strict` means today. Changing the default would collapse `balanced` into `strict` — the two modes would then differ only on LOW-confidence findings — and leave no mode meaning "only demonstrated findings block", with no way back. It would also silently invalidate two documented invariants in files outside this PR's lane: `Confidence.fromString` maps unrecognized labels to MEDIUM *"so a garbled value never blocks a merge"*, and `FindingVerificationService.demoteHedgedBlockingFindings` drops hedged findings to medium so each *"can no longer request changes on its own"*. On a corpus where round 6 produced 2 false positives across 12 languages and 11 of 12 PRs already requested changes, the marginal verdict this would flip is not worth a check run teams switch off — which is the failure mode that ends with the bot disabled. What was actually broken is that the choice was **invisible**.

**What changed.**

- `BlockingStrictness` now states its two gates separately — a severity gate (`severityQualifies`) and a confidence gate — instead of folding them into one expression per mode. `isBlocking`'s outcomes are unchanged for every mode/risk/confidence combination, and a parameterized test pins the pre-split table.
- New `BlockingStrictness.withheldByConfidence(Finding)`: true when a finding cleared this mode's severity bar and only its confidence denied it blocking eligibility. It is a query, not a gate — no finding starts or stops blocking because of it. Always false under `STRICT`, which has no confidence gate.
- `VerdictBuilder` counts those among the **outstanding** findings (new plus unresolved previous), and only when the review is not requesting changes anyway. That is precisely when the hedge, rather than the risk, produced the verdict a maintainer is looking at; on a review that already blocks the same hedge changed nothing, and a banner that changes nothing is noise. The count travels on `ReviewResult` as `blockingWithheldByConfidence`, added as a new canonical component with a 15-arg convenience constructor defaulting it to 0, so every existing caller is untouched.
- Both surfaces that explain the verdict now say it. The PR summary gets a banner below the coverage banner (a diff the review never saw in full is the larger caveat and keeps the top):

  > ⚠️ **Severity did not decide this verdict.** 1 finding(s) were severe enough to block on their own, but the review hedged its confidence in them, so this review comments instead of requesting changes. A hedge means the finding could not be confirmed from the diff alone — not that it was disproven — so read those findings before merging. Set `REVIEW_BLOCKING_STRICTNESS=strict` to let severity alone decide.

  and the check-run summary gains `Not blocking: 1 finding(s) were severe enough to block on their own, but the review hedged its confidence in them.` — appended around every branch, because the decisive finding can be a new one (the counts branch) or an unresolved previous one (the no-new-findings branches).

**Option 3 (exempt classes that cannot be confirmed from the diff alone) is not implemented here**, and cannot be from this lane: nothing structural marks a finding as belonging to that class — `Finding` carries no category, and the class is defined in `PrReviewPrompts` / `FindingVerificationService`. `withheldByConfidence` is the single seam where such an exemption would land later; the blocking decision has no other branch on confidence.

Inline placement, the other half of the issue, needs no change for this class: `Finding.postsInline` already keeps CRITICAL/HIGH inline at any confidence (#407), so only medium/low-risk findings are routed to "Things to double-check" — which is the intended behavior, not the silent demotion.

## Related Issues

Fixes #645

## How Has This Been Tested?

- [x] Unit tests

### Red/green proof

With the three main files reverted to `29c6e14` and the new-API assertions removed (the string assertions below compile against the unfixed code), `./mvnw -B test -Dtest=VerdictBuilderTest`:

```
[ERROR] Tests run: 50, Failures: 4, Errors: 0, Skipped: 0, Time elapsed: 1.734 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.VerdictBuilderTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.VerdictBuilderTest.theHoldIsReportedPerModeAgainstThatModesSeverityBar -- Time elapsed: 0.009 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
	at dev.thiagogonzaga.thrillhousebot.review.VerdictBuilderTest.theHoldIsReportedPerModeAgainstThatModesSeverityBar(VerdictBuilderTest.java:1413)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.VerdictBuilderTest.theCoverageBannerStaysAboveTheConfidenceHold -- Time elapsed: 0.002 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 
> ⚠️ **Large PR — partial review.** 1 file(s) were omitted entirely (f.java) because the diff exceeded the review budget; the findings and verdict below cover only the reviewed portion.

 ==> expected: <true> but was: <false>
	at dev.thiagogonzaga.thrillhousebot.review.VerdictBuilderTest.theCoverageBannerStaysAboveTheConfidenceHold(VerdictBuilderTest.java:1470)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.VerdictBuilderTest.aHedgedHighFindingSaysWhyItDidNotBlock -- Time elapsed: 0.002 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
	at dev.thiagogonzaga.thrillhousebot.review.VerdictBuilderTest.aHedgedHighFindingSaysWhyItDidNotBlock(VerdictBuilderTest.java:1369)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.VerdictBuilderTest.anUnresolvedPreviousHedgedHighIsDisclosedWithNoNewFindings -- Time elapsed: 0.002 s <<< FAILURE!
org.opentest4j.AssertionFailedError: No new issues in this revision, but 1 previous finding(s) remain unresolved — fix them, or reply on their review thread with why they are deferred. A finding listed only under "Things to double-check" has no thread: clear it by commenting `@thrillhousebot resolved path/to/File.java:42 — <the finding's title>` on this PR. ==> expected: <true> but was: <false>
	at dev.thiagogonzaga.thrillhousebot.review.VerdictBuilderTest.anUnresolvedPreviousHedgedHighIsDisclosedWithNoNewFindings(VerdictBuilderTest.java:1442)
```

Each failure is the disclosure being absent: the summary carries no hold banner, the check-run summary carries no `Not blocking:` clause, and with a coverage gap present the truncation banner is the whole summary. The two guard tests — `aReviewThatAlreadyRequestsChangesDoesNotDiscloseAHold` and `aHedgedMediumFindingIsNotAConfidenceHold` — pass on the unfixed code by construction; they exist to pin that the fix does not over-disclose.

Green after the fix: **3002 tests, 0 failures, 0 errors**.

### Gates

| gate | result |
|---|---|
| `./mvnw -B spotless:apply` | applied |
| `./mvnw -B clean compile spotbugs:check spotless:check` | **BugInstance size is 0**, BUILD SUCCESS |
| `./mvnw -B clean test` | Tests run: 3002, Failures: 0, Errors: 0, Skipped: 0 |
| jacoco ∩ `git diff -U0 29c6e14...HEAD` | 23 executable changed main lines, **0 uncovered lines, 0 uncovered branches** |

Java 25 (`jdk-25.jdk`, `maven.compiler.release=25`).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No documentation change: no configuration key, default, or accepted value changed — `REVIEW_BLOCKING_STRICTNESS` behaves exactly as documented, and this PR only makes the mode's effect on a given verdict visible in the review output. No `README.md` or `docs/**` files are touched, so the Docs workflow is unaffected.

Lane discipline: only `BlockingStrictness`, `VerdictBuilder`, `ReviewResult` and their tests are touched (`BlockingStrictnessTest` is new — the enum previously had no test file of its own and its cases lived in `ReviewStateTest`, which is left untouched to avoid colliding with parallel work). `PrReviewPrompts` and `FindingVerificationService` were read but not edited.
