### PR TITLE
fix(review): carve documented build-tool conventions out of the verifier's rejection ground

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPrompts.java
@@ -57,7 +57,19 @@ public final class FindingVerifierPrompts {
               triggering case (the empty collection, the out-of-range index) can reach the call.
               Requiring the diff to prove the standard library makes whole classes of real defect
               unreportable — a correct "crashes with UnsupportedOperationException on an empty
-              list" finding was deleted on exactly that ground. Keep this rejection ground for repo
+              list" finding was deleted on exactly that ground. This ground likewise does NOT cover
+              documented conventions of a build tool or framework that the provided material itself
+              configures — that a Gradle Shadow build emits <base>-all.jar and Maven emits
+              <artifactId>-<version>.jar unless a finalName or archive-name override says
+              otherwise, that a lockfile-based install step requires the lockfile to be committed,
+              that a Docker COPY of a path no earlier stage or build context produces fails the
+              build at that instruction, that a framework CLI runs only the targets its project
+              file declares. A reviewer is expected to know those exactly as it is expected to know
+              List.max throws on an empty list, and the build file that settles the produced name
+              usually sits in the same diff as the instruction naming it. Judge such a finding
+              against the build file, manifest and committed filenames the material DOES show —
+              not on whether the diff restates the tool's documentation.
+              Keep this rejection ground for repo
               state not shown (files, solution or project files, manifests), for unshown callers,
               and for unshown configuration; those genuinely are outside the material.
             - suggestion_new is functionally equivalent to suggestion_old (an alias,
@@ -226,6 +238,29 @@ public final class FindingVerifierPrompts {
             validating allow-list), when the value reaching the sink is a literal or is otherwise
             not attacker-influenced, or when the sink it names is not in the diff at all.
 
+            An artifact-reference finding — one naming a build or run instruction (a Dockerfile
+            COPY or ENTRYPOINT, a workflow step, a script line) whose path, filename or artifact
+            nothing in the provided material produces — asserts a NON-EXISTENCE, so no quoted line
+            can ever show the missing thing. Requiring one rejects the entire class, which is why
+            this carve-out exists: do NOT reject such a finding on the ground that the diff does
+            not establish what the build emits. Judge it against the producing side the material
+            DOES show — the build file in the same diff (build.gradle.kts, pom.xml, package.json, a
+            Makefile) that determines the artifact name, the earlier stages and steps, and the
+            filenames the PR actually commits. When those disagree with the name the instruction
+            uses, the mismatch is demonstrated here and keeps the risk its deterministic failure
+            carries. The possibility that some pre-existing file you were not shown supplies the
+            missing path lowers CONFIDENCE only and is never a rejection: the unshown-material
+            grounds exist to stop a FINDING from resting on material nobody can see, not to let you
+            invent unshown material that rescues the code. "Not in the diff" describes the window
+            you were given, not the world. Reject it only when the provided material shows the
+            producing step or the committed file that satisfies the reference, when the finding
+            names neither a build file nor a committed filename that the material shows and so
+            rests on nothing, or when the instruction it quotes is not in the diff at all. When you
+            genuinely cannot settle it, downgrade to confidence "low" or "medium" phrased as a
+            verification request naming the build command to run — do not delete it. Deleting this
+            class is not free: both times it happened, the deliberate near-miss beside it (an
+            unpinned base image) was left standing alone as the only issue reported on that file.
+
             A producer→consumer contract finding (dimension 9) — one tracing a value from where it
             is produced to where it is consumed — spans two locations that are in different
             enclosing units by construction: the producer and the consumer are necessarily
@@ -242,7 +277,8 @@ public final class FindingVerifierPrompts {
             rule, a privileged container, a change that weakens the safety property the PR claims
             to add — IS demonstrable here and may be "high"; do not auto-downgrade it as remembered
             framework behavior. Unverifiable framework-behavior claims are at most "medium" risk
-            with "low" confidence — but a claim resting on documented language or standard-library
+            with "low" confidence — but a claim resting on documented language, standard-library,
+            or build-tool and framework-convention
             semantics is not one of those, so that cap does not apply to it either; rate it by what
             the failure costs. An injection-sink finding whose sink and tainted value are both
             visible in the provided material is likewise demonstrable here and is not capped: keep
@@ -250,7 +286,13 @@ public final class FindingVerifierPrompts {
             sanitizing layer on confidence, never on risk. Claims about the contents or behavior of
             artifacts not shown in the diff (base images, registries, installed packages,
             remote services) are not demonstrable here: downgrade any such finding above
-            "medium". A config-key documentation-completeness claim backed by the key's quoted
+            "medium". That cap is about an artifact whose CONTENTS or BEHAVIOR you cannot see, not
+            about an artifact NAME the material's own build file determines: an artifact-reference
+            finding whose instruction and producing build file are both in the provided material is
+            demonstrable here and is not capped — a COPY, ENTRYPOINT or workflow step naming
+            something the build never produces fails deterministically, for everyone, the first
+            time it is exercised.
+            A config-key documentation-completeness claim backed by the key's quoted
             definition is demonstrable from that definition rather than remembered framework
             behavior, so that cap does not apply to it; leave it at the risk the omission carries
             — normally "low", "medium" when a plausible reading of the documentation as written

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerifierPromptsContentTest.java
@@ -114,4 +114,75 @@ class FindingVerifierPromptsContentTest {
         "visible in the provided material is likewise demonstrable here and is not capped",
         "the medium/low cap must not apply to a demonstrated injection sink (#605)");
   }
+
+  @Test
+  void verifierDoesNotTreatBuildToolConventionsAsUnestablished() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "This ground likewise does NOT cover",
+        "the verifier must not reject a finding for resting on build-tool conventions (#646)");
+    assertContains(
+        sys,
+        "documented conventions of a build tool or framework that the provided material itself",
+        "the carve-out must name the class it covers: conventions the material itself configures");
+    assertContains(
+        sys,
+        "<base>-all.jar",
+        "the kotlin #56 regression rested on Shadow's default naming, so it must be named");
+    assertContains(
+        sys,
+        "a lockfile-based install step requires the lockfile to be committed",
+        "the python #51 regression rested on lockfile requirements, so it must be named");
+    assertContains(
+        sys,
+        "a framework CLI runs only the targets its project",
+        "the angular #61 regression rested on CLI architect targets, so it must be named");
+    assertContains(
+        sys,
+        "not on whether the diff restates the tool's documentation",
+        "such a finding is judged on the build file shown, not on the diff proving the tool");
+  }
+
+  @Test
+  void verifierJudgesAnArtifactReferenceFindingOnTheProducingSideItIsShown() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "An artifact-reference finding",
+        "the verifier must judge a build/run instruction naming an unproduced path (#646)");
+    assertContains(
+        sys,
+        "asserts a NON-EXISTENCE, so no quoted line",
+        "the carve-out must name why the class cannot satisfy the quote/establish grounds");
+    assertContains(
+        sys,
+        "lowers CONFIDENCE only and is never a rejection",
+        "an unshown pre-existing file must move confidence, not delete the finding (#646)");
+    assertContains(
+        sys,
+        "invent unshown material that rescues the code",
+        "the unshown-material grounds must not be run in reverse to rescue the code (#646)");
+    assertContains(
+        sys,
+        "\"Not in the diff\" describes the window",
+        "the material window is not the world — the framing recorded on #636");
+  }
+
+  @Test
+  void artifactReferenceCarveOutKeepsItsRejectionPathsAndTheUnshownArtifactCap() {
+    String sys = FindingVerifierPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "producing step or the committed file that satisfies the reference,",
+        "a reference the material shows satisfied must stay rejectable (#646)");
+    assertContains(
+        sys,
+        "rests on nothing",
+        "a finding naming neither a build file nor a committed filename must stay rejectable");
+    assertContains(
+        sys,
+        "That cap is about an artifact whose CONTENTS or BEHAVIOR you cannot see, not",
+        "the unshown-artifact severity cap must not swallow an artifact-reference finding (#646)");
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

The verifier rejects correct findings that rest on **build-tool conventions**, on the same
"not established by the provided material" ground #589/#614 covered for standard-library
semantics.

### The class

An artifact-reference defect — a `COPY`/`ENTRYPOINT`/workflow step naming a jar, binary,
file or directory the build never produces — asserts a **non-existence**. No quoted line can
ever show a missing thing, so "prove it from the diff" rejects the entire class. #641 taught
the reviewer to report exactly this shape (dimension 7, "A BUILD OR RUN INSTRUCTION NAMING A
PATH, FILENAME OR ARTIFACT THAT NOTHING IN THE PROVIDED MATERIAL PRODUCES"); the verifier was
positioned to delete most of it.

Round 6 planted this defect in all twelve corpus PRs and every builder confirmed it with a real
`docker build` that failed at that step. Two were found by the reviewer and then rejected:

- **kotlin #56** — "depends on remembered Shadow plugin default naming not shown in the diff".
  `build.gradle.kts` and `settings.gradle.kts` are in the same diff and determine the produced
  name (`vulnscan-aggregator-1.0.0-all.jar` vs the copied `vulnscan-aggregator.jar`).
- **python #51** — "depends on a pre-existing requirements-lock.txt outside the diff". The
  corpus repo's `main` contains only `README.md`; no lock file exists anywhere.
- **angular #61** — a true extra rejected the same way (CLI architect targets).

Both rejections produced the #638 displacement pattern: the reviewer had the real defect **and**
the deliberate near-miss (an unpinned base image), the verifier deleted the real one, and the
near-miss stood alone. Nine of twelve round-6 PRs showed no displacement — the two that did are
exactly the two rejected. Part of what #638 recorded as a reviewer failure is a verifier failure.

### What changed in `FindingVerifierPrompts.SYSTEM`

Three edits, all following the shape #614 shipped rather than a parallel mechanism.

1. **The first rejection ground gains a second exclusion.** Alongside "documented semantics of
   the language or its own standard library" it now also excludes documented conventions of a
   build tool or framework *that the provided material itself configures*: Shadow's `-all` jar,
   Maven's `<artifactId>-<version>.jar` absent a `finalName` override, a lockfile-based install
   step requiring a committed lockfile, a Docker `COPY` of a path no earlier stage produces, a
   framework CLI running only the targets its project file declares. Such a finding is judged
   against the build file, manifest and committed filenames the material **does** show.

2. **A dedicated artifact-reference paragraph**, in the shape of the existing injection-sink and
   mock-fidelity carve-outs. It names the class, says why the quote/establish grounds cannot
   apply to it (it asserts a non-existence), says what to judge it on instead (the producing
   side: the build file in the same diff, earlier stages, the filenames the PR commits), and puts
   the residual uncertainty on **confidence, never on deletion** — "the possibility that some
   pre-existing file you were not shown supplies the missing path lowers CONFIDENCE only and is
   never a rejection: the unshown-material grounds exist to stop a FINDING from resting on
   material nobody can see, not to let you invent unshown material that rescues the code."

3. **Severity calibration** gains the matching half: the existing "artifacts not shown in the
   diff (base images, registries, installed packages, remote services)" cap is about an artifact
   whose *contents or behavior* you cannot see, not about an artifact *name* the material's own
   build file determines — mirroring the same distinction `PrReviewPrompts` already draws for the
   unshown-mitigation case. The standard-library cap exemption is extended to build-tool and
   framework-convention semantics.

### The ground is not weakened generally

Kept verbatim: repo state not shown, unshown callers, unshown configuration remain rejection
grounds, and round 6 showed the verifier making several *good* rejections on them. The new
paragraph keeps explicit rejection paths so it is not a licence to assert anything about the
environment — reject when the material shows the producing step or the committed file that
satisfies the reference, when the finding names neither a build file nor a committed filename the
material shows (it then rests on nothing), or when the quoted instruction is not in the diff.
When it genuinely cannot be settled: downgrade to a verification request naming the build command
to run, not delete.

### On the #636 framing

"Not in the diff" is a statement about the material window, not about the world. The half of that
idea which fits here is in the prompt: the unshown-material grounds must not be run in reverse to
invent material that rescues the code. The other half — *re-checking* a claim against the whole
file the reviewer could not see in full — does **not** fit this change: the verifier is a single
model call over fixed material with no way to fetch anything, so re-checking needs a material or
pipeline change (`FindingVerificationService` / the material assembly), which is another lane and
should be a separate issue.

## Related Issues

Fixes #646

## How Has This Been Tested?

- [x] Unit tests

Prompt-text change, so there is no red/green proof — nothing executable changed. Per the repo's
convention for this class, the guard is content tests in the existing style:
`FindingVerifierPromptsContentTest` gains three tests pinning the conventions carve-out (with the
kotlin/python/angular markers that each regression rested on), the artifact-reference paragraph
(non-existence rationale, confidence-not-rejection, the window-vs-world sentence), and its
rejection paths plus the severity-cap exemption. The pre-existing #589 guards still pass
unchanged, which is what keeps the repo-state/unshown-caller grounds honest.

**This cannot be verified by inspection.** Prompt changes on this exact surface have twice looked
correct and failed in measurement. The only real check is the next corpus round: re-run **kotlin
#56** and **python #51** and confirm the artifact-reference finding survives verification, re-run
**angular #61** for the true extra, and confirm displacement drops to zero across the twelve PRs
(#638's metric) rather than staying at the two PRs where the rejection happened.

Worth adding separately: a `evalcorpus` verifier case built from the kotlin #56 material, so
`PromptEvalTest` covers this class. Out of this PR's lane (`review/eval` is held by another agent).

Gates (JDK 25, `/Library/Java/JavaVirtualMachines/jdk-25.jdk`):

- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — `Tests run: 2967, Failures: 0, Errors: 0, Skipped: 0`, BUILD SUCCESS
- jacoco ∩ `git diff -U0 29c6e14...HEAD` — 45 changed main lines, 0 uncovered lines, 0 uncovered
  branches (all changed main lines are text-block content of the `SYSTEM` constant)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
