### PR TITLE
fix(deps): pin nanoid above GHSA-2v37-7h3g-55p8 in both npm trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to ThrillhouseBot.
 
 ## [Unreleased]
 
+### Dependencies
+
+- Overrode `nanoid` to `^3.3.17` in the `website/` and `frontend/` npm trees to clear GHSA-2v37-7h3g-55p8, in which a custom generator loops indefinitely when it is called with a size of zero. Every Astro and Starlight package reached the vulnerable 3.3.16 through `postcss`, which asks for `^3.3.16`, so the fixed 3.3.18 satisfies the range already declared and no direct dependency moves (#660)
+
 ## [0.6.0] — 2026-08-13
 
 On-demand commands for improving a PR and generating tests, per-repository review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to ThrillhouseBot.
 
 ## [Unreleased]
 
-### Dependencies
-
-- Overrode `nanoid` to `^3.3.17` in the `website/` and `frontend/` npm trees to clear GHSA-2v37-7h3g-55p8, in which a custom generator loops indefinitely when it is called with a size of zero. Every Astro and Starlight package reached the vulnerable 3.3.16 through `postcss`, which asks for `^3.3.16`, so the fixed 3.3.18 satisfies the range already declared and no direct dependency moves (#660)
-
 ## [0.6.0] — 2026-08-13
 
 On-demand commands for improving a PR and generating tests, per-repository review
@@ -57,6 +53,7 @@ not read.
 
 ### Dependencies
 
+- Overrode `nanoid` to `^3.3.17` in the `website/` and `frontend/` npm trees to clear GHSA-2v37-7h3g-55p8, in which a custom generator loops indefinitely when it is called with a size of zero. Every Astro and Starlight package reached the vulnerable 3.3.16 through `postcss`, which asks for `^3.3.16`, so the fixed 3.3.18 satisfies the range already declared and no direct dependency moves (#660)
 - Bumped the Quarkus platform from 3.37.4 to 3.38.0 and `quarkus-langchain4j` from 1.12.0 to 1.12.2
 - Declared `jackson-dataformat-yaml` explicitly. It was already on the classpath transitively and is version-managed by the Jackson BOM; reading a repository's own `.github/thrillhousebot.yml` uses it directly
 - Bumped the frontend `next` to 16.2.12 and the dev-only `jsdom` to 30.0.1, with `@types/node` on a patch release

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2313,9 +2313,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
   },
   "overrides": {
     "postcss": "8.5.23",
-    "sharp": "0.35.3"
+    "sharp": "0.35.3",
+    "nanoid": "^3.3.17"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^7.0.0",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6474,9 +6474,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/website/package.json
+++ b/website/package.json
@@ -26,7 +26,8 @@
     "starlight-versions": "^0.9.1"
   },
   "overrides": {
-    "postcss": "8.5.23"
+    "postcss": "8.5.23",
+    "nanoid": "^3.3.17"
   },
   "devDependencies": {
     "unist-util-visit": "^5.1.0"


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔒 Security
- [x] 📦 Dependency update

## Description

[GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (high, CVSS 5.9): a nanoid
custom generator loops indefinitely when size is zero. Anything below 3.3.17 is affected, and both
npm trees resolved 3.3.16.

Every reported top-level package — `@astrojs/starlight`, `astro`, `astro-mermaid`,
`starlight-links-validator`, `starlight-versions` — reaches it through the same edge:

```
astro@7.1.4 → vite@8.1.3 → postcss@8.5.23 (overridden) → nanoid@3.3.16
```

So none of them needs upgrading. postcss asks for `nanoid@^3.3.16`, and the fixed 3.3.18 satisfies
that range, so an override lifts the floor without moving a single direct dependency. Both
`package.json` files already override `postcss` (and `frontend/` also overrides `sharp`), so this
follows the pattern already in place. The pin is `^3.3.17` — the first fixed release — rather than an
exact version, so future 3.x patches are picked up without another PR.

`frontend/` carried the same advisory through its own tree and is fixed the same way.

Recorded in `CHANGELOG.md` under `[0.6.0]` → `### Dependencies`, first among the bumps because it is
the one clearing an advisory. It belongs in 0.6.0 rather than `[Unreleased]`: 0.6.0 is on `main` but
has no tag or GitHub Release yet, so this ships in it. `### Dependencies` is where the two earlier
advisory-clearing bumps live (the OpenTelemetry pin for GHSA-rcgg-9c38-7xpx and the `jackson-bom`
bump for GHSA-5jmj-h7xm-6q6v); `### Security` in this changelog is used for product security
behaviour such as session handling and access control, not for dependency advisories.

## Related Issues

N/A — dependency advisory.

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

- `npm audit` in `website/`: **found 0 vulnerabilities** (was 1 high)
- `npm audit` in `frontend/`: **found 0 vulnerabilities** (was 1 high)
- Resolved tree confirms the lift: `postcss@8.5.23 overridden → nanoid@3.3.18`
- `npm run build` in `website/`: 75 pages, all internal links valid
- `npm run build` in `frontend/`: succeeds
- `npm test` in `frontend/`: 22 passed

### One note on the frontend suite

`tokens/page.test.tsx` fails on a machine whose locale is not en-US. It asserts on the string
`184,320`, and `(184320).toLocaleString()` renders `184.320` under `pt_BR.UTF-8`. Confirmed unrelated
to this change: the same test fails identically on an unmodified `origin/main` worktree, and passes
with `LC_ALL=en_US.UTF-8` on both. CI runs in an en-US locale, which is why the `frontend` check has
been green throughout. Filed separately rather than fixed here.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
