### PR TITLE
test(dashboard): assert locale-formatted token total via toLocaleString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to ThrillhouseBot.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dashboard token test no longer assumes an en-US locale** (#661): the test now asserts the same `toLocaleString()` output the component renders, so it passes on machines with any runtime locale
+
 ## [0.6.0] — 2026-08-13
 
 On-demand commands for improving a PR and generating tests, per-repository review

--- a/frontend/app/(dashboard)/tokens/page.test.tsx
+++ b/frontend/app/(dashboard)/tokens/page.test.tsx
@@ -29,7 +29,7 @@ describe('TokensPage', () => {
       expect(screen.getByRole('heading', { name: 'Token Analytics' })).toBeInTheDocument();
     });
 
-    expect(screen.getByText('184,320')).toBeInTheDocument();
+    expect(screen.getByText(mockTokenData.totalTokens.toLocaleString())).toBeInTheDocument();
     expect(screen.getByText('deepseek-chat')).toBeInTheDocument();
     expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
   });


### PR DESCRIPTION
## What type of PR is this?

- [x] ✅ Test

## Description

`frontend/app/(dashboard)/tokens/page.test.tsx` asserted the hard-coded en-US grouping `184,320`, while the component renders the value with `toLocaleString()`, which follows the runtime locale. On a pt-BR machine the component renders `184.320` and the test fails, even on an unmodified `main`.

The expectation now asserts `mockTokenData.totalTokens.toLocaleString()`, so it follows the same formatting rule as the component and passes in any locale. This is option 1 from the issue — the least invasive fix; it makes no product decision about pinning the dashboard to a single locale. No other locale-sensitive assertions exist in the frontend test suite (checked for grouped-number literals across `app` and `lib`).

Also adds a CHANGELOG entry under `[Unreleased]`.

## Related Issues

Closes #661

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

Ran `npx vitest run` in `frontend/` twice: default locale and `LC_ALL=pt_BR.UTF-8 LANG=pt_BR.UTF-8`. Both: 6 files, 22 tests passed.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

None.