### PR TITLE
fix(review): fold the external-producer carve-out into dimension 7's mismatch definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to ThrillhouseBot.
 ### Fixed
 
 - **Dashboard token test no longer assumes an en-US locale** (#661): the test now asserts the same `toLocaleString()` output the component renders, so it passes on machines with any runtime locale
+- **Dimension 7's mismatch rule now carries its own external-producer boundary** (#680): the "nothing in the provided material produces it" definition states that an artifact whose producer is legitimately outside the diff (a base image, a release binary) is not a mismatch but the unshown-state case, phrased as a verification request; the closing escape cross-references the same boundary, so the two sentences read as one rule
 
 ## [0.6.0] — 2026-08-13
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -143,13 +143,20 @@ public final class PrReviewPrompts {
                output, a workflow that will not parse, or a value that contradicts a constraint
                stated elsewhere in the same file. One shape belongs on this list and is the one
                most often passed over: a BUILD OR RUN INSTRUCTION NAMING A PATH, FILENAME OR
-               ARTIFACT THAT NOTHING IN THE PROVIDED MATERIAL PRODUCES. A Dockerfile COPY of
+               ARTIFACT THAT NOTHING IN THE PROVIDED MATERIAL PRODUCES — where the provided
+               material is where the producer would have to be. When the artifact's producer is
+               legitimately outside the diff (an external base image, a release binary another
+               workflow builds, a file a registry or provider supplies), the reference does not
+               satisfy this definition: that is the unshown-state case covered by this
+               dimension's closing escape, and it is phrased as a verification request, never
+               floored as a mismatch. A Dockerfile COPY of
                target/<name>.jar when the build file's artifactId and version — with no finalName
                or output-name override — make the produced artifact a different filename; a COPY of
                requirement.txt when the file the PR commits is requirements.txt; a workflow step
                consuming an artifact no earlier step uploads; an ENTRYPOINT naming a binary no
                stage builds. Check every path a declarative file names against the names the rest
-               of the provided material actually shows, and treat a mismatch as "high": it fails
+               of the provided material actually shows, and when the provided material contains
+               the producer and it produces a different name, treat the mismatch as "high": it fails
                deterministically the first time it is exercised, for everyone — at build time for a
                COPY or a workflow step, at CONTAINER START for an ENTRYPOINT or CMD naming a binary
                no stage produces. Both are deterministic and both are demonstrable from the diff;
@@ -160,7 +167,9 @@ public final class PrReviewPrompts {
                schema/lint/CI validation, or that breaks the safety property the PR itself claims to
                add, is high; a cosmetic or stylistic config nitpick is low. Not a finding when a
                comment or adjacent value justifies the choice, or when correctness depends on
-               cluster/provider state not shown in the diff — phrase that as a verification request.
+               cluster/provider state or an artifact producer not shown in the diff — the
+               external-producer boundary drawn in the mismatch definition above — phrase that
+               as a verification request.
             8. MOCK FIDELITY: When a test in the provided material stubs or mocks a collaborator
                (`when(x.m(...)).thenReturn(...)`, `doThrow(...).when(x).m(...)`, `doReturn(...)`,
                equivalent fakes), compare the stubbed behavior against the real method's contract

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -156,7 +156,9 @@ public final class PrReviewPrompts {
                consuming an artifact no earlier step uploads; an ENTRYPOINT naming a binary no
                stage builds. Check every path a declarative file names against the names the rest
                of the provided material actually shows, and when the provided material contains
-               the producer and it produces a different name, treat the mismatch as "high": it fails
+               the producing side — the build file, workflow, or stage that would have to create
+               the artifact — and it produces a different name or no matching artifact at all,
+               treat the mismatch as "high": it fails
                deterministically the first time it is exercised, for everyone — at build time for a
                COPY or a workflow step, at CONTAINER START for an ENTRYPOINT or CMD naming a binary
                no stage produces. Both are deterministic and both are demonstrable from the diff;


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

In the review system prompt's dimension 7 (config/IaC correctness), the mismatch rule was defined against "NOTHING IN THE PROVIDED MATERIAL PRODUCES ..." while the escape for artifacts produced outside the diff (base image, release binary) sat two sentences below, unreconciled. Read literally, the definition floored a "high" mismatch on exactly the case the escape routes to a verification request.

This folds the external-producer carve-out into the mismatch definition itself: an artifact whose producer is legitimately outside the diff does not satisfy the definition and is handled as the unshown-state case, phrased as a verification request. The "treat as high" instruction now applies only when the provided material contains the producer and it produces a different name, and the closing escape cross-references the same boundary so the two sentences read as one rule. Genuine unproduced-artifact mismatches still rate high.

Prompt-only change; no behavior change elsewhere. CHANGELOG updated under [Unreleased].

## Related Issues

Closes #680

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

`./mvnw verify` clean locally (JDK 25), including `AiServicePromptRenderingTest`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

No new tests: the change is prompt wording only; existing prompt-rendering tests cover the service.
