### PR TITLE
fix(review): route pr_purpose through MarkdownSafe.inline in the PR summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to ThrillhouseBot.
 
 - **Dashboard token test no longer assumes an en-US locale** (#661): the test now asserts the same `toLocaleString()` output the component renders, so it passes on machines with any runtime locale
 - **Dimension 7's mismatch rule now carries its own external-producer boundary** (#680): the "nothing in the provided material produces it" definition states that an artifact whose producer is legitimately outside the diff (a base image, a release binary) is not a mismatch but the unshown-state case, phrased as a verification request; the closing escape cross-references the same boundary, so the two sentences read as one rule
+- **PR summary hardening** (#636): the model's `pr_purpose` paragraph is now routed through `MarkdownSafe.inline` like every other model-supplied string in the summary, so a crafted purpose can no longer inject headings, HTML, fences, or table pipes into the posted comment
 
 ## [0.6.0] — 2026-08-13
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -439,7 +439,7 @@ public class PrSummaryGenerator {
       return;
     }
     sb.append("### What this PR does\n");
-    sb.append(aiSummary.prPurpose().strip()).append("\n\n");
+    sb.append(MarkdownSafe.inline(aiSummary.prPurpose())).append("\n\n");
   }
 
   /** The model's non-blank description gaps; empty when there is no summary to read them from. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -363,6 +363,24 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
+  void shouldNeutralizeHostilePrPurpose() {
+    var hostilePurpose = "Legit purpose.\n### Injected heading\n</details>\n```\n| pipe";
+    var aiSummary = new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", hostilePurpose, List.of());
+    var result =
+        new ReviewResult(
+            List.of(), 0, 0, 0, 0, null, ReviewState.APPROVE, true, "", List.of(), List.of(), 0);
+
+    var summary = generator.generate(1, 5, 0, List.of(), aiSummary, result);
+
+    // The purpose paragraph routes through the same helper as every other model field: it is
+    // flattened and neutralized, so no heading, </details>, fence, or pipe escapes the section.
+    assertTrue(summary.contains(MarkdownSafe.inline(hostilePurpose)), summary);
+    assertFalse(summary.contains("\n### Injected"), summary);
+    assertFalse(summary.contains("</details>"), summary);
+    assertFalse(summary.contains("```"), summary);
+  }
+
+  @Test
   void shouldOmitPurposeSectionWhenAbsentAndStillDiscloseTheGapCheck() {
     var blankSummary = new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", " ", List.of());
     var nullPurposeSummary = new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", null, null);


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔒 Security

## Description

`PrSummaryGenerator` spliced the model's `pr_purpose` into the posted summary raw, the only model-supplied string in the file that bypassed `MarkdownSafe`'s documented invariant. A crafted diff could steer the model into emitting markdown/HTML that landed unescaped in the bot's comment (injected headings, a `</details>` that closes the collapsible, an early-closing fence, a table-splitting pipe).

The purpose renders as a prose paragraph, so it now routes through `MarkdownSafe.inline`, the operation for block-level prose: flattened to one line with `<`, backticks, and `|` neutralized — the same treatment every other model field in the renderer already gets.

## Related Issues

Closes #636

## How Has This Been Tested?

- [x] Unit tests

`shouldNeutralizeHostilePrPurpose` pins that a hostile purpose (injected heading, `</details>`, fence, pipe) is neutralized and cannot break out of the section. `./mvnw verify` passes locally (tests, Spotless, SpotBugs, JaCoCo).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

CHANGELOG `[Unreleased]` gains a Fixed entry for #636.
