### PR TITLE
perf(review): derive claim phrase and word sets once in summary-surface dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to ThrillhouseBot.
 
 ## [Unreleased]
 
+### Changed
+
+- **Summary-surface deduplication derives each claim's phrase and word sets once** (#678): the sets are computed when a claim is built and reused across every comparison, instead of being re-derived for each (candidate, claim) pair. Deduplication decisions are unchanged
+
 ### Fixed
 
 - **Dashboard token test no longer assumes an en-US locale** (#661): the test now asserts the same `toLocaleString()` output the component renders, so it passes on machines with any runtime locale

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
@@ -111,9 +111,20 @@ final class SummarySurfaceDeduplicator {
    * One text reduced to what it asserts: its content words in order, and whether it negates. {@code
    * phraseOnly} marks a claim only the contiguous-run arm may match — the shape used for a
    * finding's description, which is long prose where the overlap coefficient would happily fire on
-   * two different observations that merely discuss the same code (#639).
+   * two different observations that merely discuss the same code (#639). The word set and phrase
+   * set are derived once here and reused across every comparison the claim takes part in (#678).
    */
-  record Claim(List<String> words, boolean negated, boolean phraseOnly) {
+  record Claim(
+      List<String> words,
+      boolean negated,
+      boolean phraseOnly,
+      Set<String> wordSet,
+      Set<String> phrases) {
+
+    Claim(List<String> words, boolean negated, boolean phraseOnly) {
+      this(
+          words, negated, phraseOnly, Set.copyOf(words), SummarySurfaceDeduplicator.phrases(words));
+    }
 
     /** A claim judged on both arms — a bullet, a walkthrough clause, or a finding title. */
     Claim(List<String> words, boolean negated) {
@@ -143,7 +154,13 @@ final class SummarySurfaceDeduplicator {
   private static List<Claim> claimsOf(Finding finding) {
     var description = claim(finding.description());
     return List.of(
-        claim(finding.title()), new Claim(description.words(), description.negated(), true));
+        claim(finding.title()),
+        new Claim(
+            description.words(),
+            description.negated(),
+            true,
+            description.wordSet(),
+            description.phrases()));
   }
 
   /**
@@ -221,18 +238,16 @@ final class SummarySurfaceDeduplicator {
   }
 
   /**
-   * True when {@code candidate} states a claim one of {@code claims} already states. The
-   * candidate's phrase and word sets are derived once and reused across every claim.
+   * True when {@code candidate} states a claim one of {@code claims} already states. Each side's
+   * phrase and word sets were derived once at construction and are reused across every pair.
    */
   private static boolean restates(Claim candidate, List<Claim> claims) {
-    Set<String> candidatePhrases = phrases(candidate.words());
-    Set<String> candidateWords = new HashSet<>(candidate.words());
     for (Claim claim : claims) {
-      if (contradicts(candidate, candidateWords, claim)) {
+      if (contradicts(candidate, claim)) {
         continue;
       }
-      if (sharesPhrase(candidatePhrases, claim.words())
-          || (!claim.phraseOnly() && overlaps(candidateWords, claim.words()))) {
+      if (sharesPhrase(candidate.phrases(), claim.phrases())
+          || (!claim.phraseOnly() && overlaps(candidate.wordSet(), claim.wordSet()))) {
         return true;
       }
     }
@@ -252,17 +267,17 @@ final class SummarySurfaceDeduplicator {
    * their content, so "the PR claims X, but the code cannot X" continues to collapse onto the
    * finding that reports X missing.
    */
-  private static boolean contradicts(Claim candidate, Set<String> candidateWords, Claim claim) {
+  private static boolean contradicts(Claim candidate, Claim claim) {
     if (candidate.negated() == claim.negated()) {
       return false;
     }
-    var claimWords = new HashSet<>(claim.words());
-    return candidateWords.containsAll(claimWords) || claimWords.containsAll(candidateWords);
+    return candidate.wordSet().containsAll(claim.wordSet())
+        || claim.wordSet().containsAll(candidate.wordSet());
   }
 
   /** True when the claim contains one of the candidate's {@value #PHRASE_TOKENS}-word runs. */
-  private static boolean sharesPhrase(Set<String> candidatePhrases, List<String> claim) {
-    return phrases(claim).stream().anyMatch(candidatePhrases::contains);
+  private static boolean sharesPhrase(Set<String> candidatePhrases, Set<String> claimPhrases) {
+    return claimPhrases.stream().anyMatch(candidatePhrases::contains);
   }
 
   private static Set<String> phrases(List<String> tokens) {
@@ -274,14 +289,13 @@ final class SummarySurfaceDeduplicator {
   }
 
   /** Overlap coefficient — shared content words over the shorter side — against the threshold. */
-  private static boolean overlaps(Set<String> candidateWords, List<String> claim) {
-    var claimWords = new HashSet<>(claim);
+  private static boolean overlaps(Set<String> candidateWords, Set<String> claimWords) {
     int shorter = Math.min(candidateWords.size(), claimWords.size());
     if (shorter < MIN_OVERLAP_TOKENS) {
       return false;
     }
-    claimWords.retainAll(candidateWords);
-    return (double) claimWords.size() / shorter >= OVERLAP_THRESHOLD;
+    long shared = claimWords.stream().filter(candidateWords::contains).count();
+    return (double) shared / shorter >= OVERLAP_THRESHOLD;
   }
 
   /**


### PR DESCRIPTION
## What type of PR is this?

- [x] 🚀 Performance

## Description

`SummarySurfaceDeduplicator` re-derived every published claim's phrase set (and word set) once per (candidate, claim) pair: `sharesPhrase` called `phrases(claim)` inside the per-candidate loop, and `contradicts`/`overlaps` rebuilt `HashSet` copies of the claim's words on each comparison.

`Claim` now carries its word set and phrase set as components, derived once when the claim is built and reused across every comparison. `restates`, `contradicts`, `sharesPhrase` and `overlaps` read the precomputed sets; `overlaps` counts the intersection without mutating a copy. The finding-description claim reuses the sets already derived for the description instead of recomputing them.

Deduplication decisions are byte-identical — same phrase-run membership test, same overlap coefficient, polarity logic untouched.

## Related Issues

Closes #678

## How Has This Been Tested?

- [x] Unit tests

Existing `SummarySurfaceDeduplicatorTest` passes unchanged; `./mvnw verify` clean.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Same quadratic-rederivation shape #647 removed from the coverage recorders. CHANGELOG updated under [Unreleased].
