### PR TITLE
fix(review): close three under-fire gaps in the injection-sink floor's defeaters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to ThrillhouseBot.
 ### Fixed
 
 - **Dashboard token test no longer assumes an en-US locale** (#661): the test now asserts the same `toLocaleString()` output the component renders, so it passes on machines with any runtime locale
+- **Injection-sink floor no longer under-fires on three defeater-pattern gaps** (#676): "Nothing sanitizes ..." now registers as an absence claim, "does not prevent SQL injection" is no longer read as a denial of the sink, and a parenthetical coordinator inside a conditional ("If, however, ...") no longer truncates the hypothetical span and leaves its mitigation verb read as asserted
 
 ## [0.6.0] — 2026-08-13
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -185,11 +185,18 @@ public class FindingVerificationService {
   /**
    * A bridge verb filling {@link #SINK_DENIED}'s one-word gap ("does not <i>prevent</i> SQL
    * injection"): the negation then targets the missing defense, not the sink, so the sentence
-   * asserts the defect and must not read as a denial. Matched against the gap group whole, so a
-   * bridge verb elsewhere in the finding changes nothing.
+   * asserts the defect and must not read as a denial. The stems are the defense verbs a finding
+   * puts between a negation and a sink name — warding it off (prevent, stop, block, guard, protect,
+   * defend), removing it (mitigate, eliminate, avoid, fix, address, handle) or neutralizing the
+   * value (sanitize, escape, validate, filter, neutralize); an adjective or quantifier gap ("no
+   * possible SQL injection") stays a denial. Matched against the gap group whole, so a bridge verb
+   * elsewhere in the finding changes nothing.
    */
   private static final Pattern BRIDGE_VERB_GAP =
-      Pattern.compile("(prevent|stop|block|guard|protect)\\w*[\\s-]+", Pattern.CASE_INSENSITIVE);
+      Pattern.compile(
+          "(prevent|stop|block|guard|protect|defend|mitigat|eliminat|avoid|fix|address|handle"
+              + "|sanitiz|escap|validat|filter|neutraliz)\\w*[\\s-]+",
+          Pattern.CASE_INSENSITIVE);
 
   /**
    * The same denial worded about the exposure rather than the class ("not exploitable", "no

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -190,17 +190,28 @@ public class FindingVerificationService {
   /**
    * A bridge verb filling {@link #SINK_DENIED}'s one-word gap ("does not <i>prevent</i> SQL
    * injection"): the negation then targets the missing defense, not the sink, so the sentence
-   * asserts the defect and must not read as a denial. The stems are the defense verbs a finding
-   * puts between a negation and a sink name — warding it off (prevent, stop, block, guard, protect,
-   * defend), removing it (mitigate, eliminate, avoid, fix, address, handle) or neutralizing the
-   * value (sanitize, escape, validate, filter, neutralize); an adjective or quantifier gap ("no
-   * possible SQL injection") stays a denial. Matched against the gap group whole, so a bridge verb
-   * elsewhere in the finding changes nothing.
+   * asserts the defect and must not read as a denial. The stems are the warding-off family
+   * (prevent, stop, block, guard, protect, defend, prohibit, forbid, disallow, preclude, thwart,
+   * hinder, impede); an adjective or quantifier gap ("no possible SQL injection") stays a denial.
+   * Matched against the gap group whole, so a bridge verb elsewhere in the finding changes nothing.
+   * Read as a union with {@link #NEUTRALIZING_VERB_GAP}; one family per pattern only because one
+   * alternation of both is more than the regex complexity budget allows.
    */
   private static final Pattern BRIDGE_VERB_GAP =
       Pattern.compile(
-          "(prevent|stop|block|guard|protect|defend|mitigat|eliminat|avoid|fix|address|handle"
-              + "|sanitiz|escap|validat|filter|neutraliz)\\w*[\\s-]+",
+          "(prevent|stop|block|guard|protect|defend|prohibit|forbid|disallow|preclude|thwart"
+              + "|hinder|impede)\\w*[\\s-]+",
+          Pattern.CASE_INSENSITIVE);
+
+  /**
+   * The bridge verbs that remove the defect (mitigate, eliminate, avoid, fix, address, handle) or
+   * neutralize the value (sanitize, escape, validate, filter, neutralize); the second half of
+   * {@link #BRIDGE_VERB_GAP}'s union.
+   */
+  private static final Pattern NEUTRALIZING_VERB_GAP =
+      Pattern.compile(
+          "(mitigat|eliminat|avoid|fix|address|handle|sanitiz|escap|validat|filter|neutraliz)"
+              + "\\w*[\\s-]+",
           Pattern.CASE_INSENSITIVE);
 
   /**
@@ -244,6 +255,19 @@ public class FindingVerificationService {
    */
   private static final Pattern NEGATING_SUBJECT =
       Pattern.compile("\\b(nothing|nobody)\\s*$", Pattern.CASE_INSENSITIVE);
+
+  /**
+   * The mitigation asserted with do-support ("the framework does escape the value", "React did
+   * sanitize it"): emphatic, but still a statement of fact, and invisible to {@link
+   * #MITIGATION_ASSERTED}'s copula and subject-slot alternatives. The verb must follow the
+   * auxiliary directly, so the negated "does not escape" stays an absence claim; modals are
+   * deliberately absent — "should escape" is a recommendation, not an assertion. Kept a separate
+   * pattern because {@link #MITIGATION_ASSERTED} is already over the regex complexity budget.
+   */
+  private static final Pattern MITIGATION_DO_SUPPORTED =
+      Pattern.compile(
+          "\\b(do|does|did)\\s+(sanitiz|escap|validat|parameteriz|encod)es?\\b",
+          Pattern.CASE_INSENSITIVE);
 
   /**
    * A conditional clause — a hypothesis the finding raises, not a fact it states. Matches from the
@@ -602,12 +626,18 @@ public class FindingVerificationService {
   }
 
   /**
-   * A {@link #MITIGATION_ASSERTED} hit, unless the match opens with a negating pronoun subject:
-   * "Nothing is sanitized" is the absence claim in auxiliary order, and the pattern's first
-   * alternative starts at the auxiliary so it never sees the subject.
+   * A {@link #MITIGATION_ASSERTED} or {@link #MITIGATION_DO_SUPPORTED} hit, unless the match opens
+   * with a negating pronoun subject: "Nothing is sanitized" is the absence claim in auxiliary
+   * order, and {@link #MITIGATION_ASSERTED}'s first alternative starts at the auxiliary so it never
+   * sees the subject.
    */
   private static boolean assertsMitigation(String asserted) {
-    Matcher asserts = MITIGATION_ASSERTED.matcher(asserted);
+    return hasUnnegatedMatch(MITIGATION_ASSERTED, asserted)
+        || hasUnnegatedMatch(MITIGATION_DO_SUPPORTED, asserted);
+  }
+
+  private static boolean hasUnnegatedMatch(Pattern mitigation, String asserted) {
+    Matcher asserts = mitigation.matcher(asserted);
     while (asserts.find()) {
       if (!NEGATING_SUBJECT.matcher(asserted.substring(0, asserts.start())).find()) {
         return true;
@@ -638,7 +668,9 @@ public class FindingVerificationService {
     Matcher denial = SINK_DENIED.matcher(asserted);
     while (denial.find()) {
       String gap = denial.group(2);
-      if (gap == null || !BRIDGE_VERB_GAP.matcher(gap).matches()) {
+      if (gap == null
+          || !(BRIDGE_VERB_GAP.matcher(gap).matches()
+              || NEUTRALIZING_VERB_GAP.matcher(gap).matches())) {
         return true;
       }
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -151,9 +151,11 @@ public class FindingVerificationService {
   /**
    * The absence claim worded with a pronoun subject ("Nothing sanitizes the value", "nobody escapes
    * it before render"), so a subject-worded absence registers just like the step-worded one; {@link
-   * #MITIGATION_ASSERTED} excludes the same pronouns from its subject slot so the two never read
-   * one sentence both ways. Kept a separate pattern only because folding the pronouns into {@link
-   * #MITIGATION_ABSENT}'s negator alternation puts that pattern over the regex complexity budget.
+   * #MITIGATION_ASSERTED} excludes the same pronouns from its subject slot, and {@link
+   * #assertsMitigation} drops an auxiliary-order match they precede ("Nothing is sanitized"), so
+   * the two never read one sentence both ways. Kept a separate pattern only because folding the
+   * pronouns into {@link #MITIGATION_ABSENT}'s negator alternation puts that pattern over the regex
+   * complexity budget.
    */
   private static final Pattern MITIGATION_ABSENT_SUBJECT =
       Pattern.compile(
@@ -203,7 +205,11 @@ public class FindingVerificationService {
    * A finding that states the mitigation IS present ("it is escaped on render", "React escapes
    * them"). An absence claim about one layer must not floor the class when the same text says
    * another layer neutralizes the value. Negated forms are excluded, so "is not escaped" and "was
-   * never sanitized" stay absence claims instead of defeating themselves.
+   * never sanitized" stay absence claims instead of defeating themselves. The auxiliary-order
+   * alternative cannot see its own subject, so a pronoun-negated subject ("Nothing is sanitized")
+   * is excluded in {@link #assertsMitigation}, which drops a match directly preceded by a {@link
+   * #NEGATING_SUBJECT} — folding that into this pattern as lookbehinds would push it further over
+   * the regex complexity budget.
    *
    * <p>Left exactly as it stands, {@code {0,1}} and all: its complexity is over the analyzer's
    * budget and cannot come under it without dropping a copula, a verb form or the one-word gap,
@@ -217,6 +223,15 @@ public class FindingVerificationService {
               + "|\\b(?!(no|not|never|nothing|nobody)\\b)\\w+\\s+"
               + "(sanitizes|escapes|validates|parameterizes|encodes)\\b",
           Pattern.CASE_INSENSITIVE);
+
+  /**
+   * A pronoun subject that negates the clause it opens: a {@link #MITIGATION_ASSERTED} match
+   * starting right after one ("Nothing <i>is sanitized</i> before render") is the absence claim in
+   * auxiliary order, not a mitigation. Anchored to the end of the text before the match, so a
+   * pronoun elsewhere in the finding changes nothing.
+   */
+  private static final Pattern NEGATING_SUBJECT =
+      Pattern.compile("\\b(nothing|nobody)\\s*$", Pattern.CASE_INSENSITIVE);
 
   /**
    * A conditional clause — a hypothesis the finding raises, not a fact it states. Matches from the
@@ -571,7 +586,22 @@ public class FindingVerificationService {
         // stood), while over-firing escalates a non-defect and, at high confidence, blocks the
         // merge on it.
         && !deniesTheSink(asserted)
-        && !MITIGATION_ASSERTED.matcher(asserted).find();
+        && !assertsMitigation(asserted);
+  }
+
+  /**
+   * A {@link #MITIGATION_ASSERTED} hit, unless the match opens with a negating pronoun subject:
+   * "Nothing is sanitized" is the absence claim in auxiliary order, and the pattern's first
+   * alternative starts at the auxiliary so it never sees the subject.
+   */
+  private static boolean assertsMitigation(String asserted) {
+    Matcher asserts = MITIGATION_ASSERTED.matcher(asserted);
+    while (asserts.find()) {
+      if (!NEGATING_SUBJECT.matcher(asserted.substring(0, asserts.start())).find()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static boolean namesInjectionSink(String text) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -153,13 +153,18 @@ public class FindingVerificationService {
    * it before render"), so a subject-worded absence registers just like the step-worded one; {@link
    * #MITIGATION_ASSERTED} excludes the same pronouns from its subject slot, and {@link
    * #assertsMitigation} drops an auxiliary-order match they precede ("Nothing is sanitized"), so
-   * the two never read one sentence both ways. Kept a separate pattern only because folding the
-   * pronouns into {@link #MITIGATION_ABSENT}'s negator alternation puts that pattern over the regex
-   * complexity budget.
+   * the two never read one sentence both ways. A defense noun as the verb's direct object flips the
+   * sentence's meaning — "Nothing escapes validation" says every value IS validated — so the verb
+   * is held to its finite and participle forms (the noun could otherwise re-match as the verb
+   * through the word gap) and the trailing lookahead rejects a defense-noun object, keeping the
+   * over-fire direction closed (#594) while "nothing escapes the value" stays an absence claim.
+   * Kept a separate pattern only because folding the pronouns into {@link #MITIGATION_ABSENT}'s
+   * negator alternation puts that pattern over the regex complexity budget.
    */
   private static final Pattern MITIGATION_ABSENT_SUBJECT =
       Pattern.compile(
-          "\\b(nothing|nobody)\\s+(\\w+[\\s-]+){0,3}(sanitiz|escap|validat|parameteriz|encod)\\w*",
+          "\\b(nothing|nobody)\\s+(\\w+[\\s-]+){0,3}(sanitiz|escap|validat|parameteriz|encod)"
+              + "(es|ed|ing)\\b(?!\\s+(validation|sanitization|escaping|encoding|filtering)\\b)",
           Pattern.CASE_INSENSITIVE);
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -135,19 +136,28 @@ public class FindingVerificationService {
           Pattern.CASE_INSENSITIVE);
 
   /**
-   * The same absence claim worded as a missing step ("no sanitization", "never escaped", "nothing
-   * sanitizes it"), with room for a few words between the negator and the neutralizing verb. The
-   * negators include the pronoun forms ("nothing", "nobody") so a subject-worded absence ("Nothing
-   * sanitizes the value") registers just like the step-worded one; {@link #MITIGATION_ASSERTED}
-   * excludes the same pronouns from its subject slot so the two never read one sentence both ways.
-   * Read as a union with {@link #UNMITIGATED_ADJECTIVE}; the two are one claim split across two
-   * patterns only because one alternation of both wordings is more than the regex complexity budget
-   * allows.
+   * The same absence claim worded as a missing step ("no sanitization", "never escaped"), with room
+   * for a few words between the negator and the neutralizing verb. Read as a union with {@link
+   * #UNMITIGATED_ADJECTIVE} and {@link #MITIGATION_ABSENT_SUBJECT}; the three are one claim split
+   * across three patterns only because one alternation of every wording is more than the regex
+   * complexity budget allows.
    */
   private static final Pattern MITIGATION_ABSENT =
       Pattern.compile(
-          "\\b(no|not|nothing|nobody|without|missing|never|lacks?|absent)\\s+(\\w+[\\s-]+){0,3}"
+          "\\b(no|not|without|missing|never|lacks?|absent)\\s+(\\w+[\\s-]+){0,3}"
               + "(sanitiz|escap|validat|parameteriz|encod)\\w*",
+          Pattern.CASE_INSENSITIVE);
+
+  /**
+   * The absence claim worded with a pronoun subject ("Nothing sanitizes the value", "nobody escapes
+   * it before render"), so a subject-worded absence registers just like the step-worded one; {@link
+   * #MITIGATION_ASSERTED} excludes the same pronouns from its subject slot so the two never read
+   * one sentence both ways. Kept a separate pattern only because folding the pronouns into {@link
+   * #MITIGATION_ABSENT}'s negator alternation puts that pattern over the regex complexity budget.
+   */
+  private static final Pattern MITIGATION_ABSENT_SUBJECT =
+      Pattern.compile(
+          "\\b(nothing|nobody)\\s+(\\w+[\\s-]+){0,3}(sanitiz|escap|validat|parameteriz|encod)\\w*",
           Pattern.CASE_INSENSITIVE);
 
   /**
@@ -158,15 +168,26 @@ public class FindingVerificationService {
    * The gap is one word, so an assertion of the defect that merely contains a negation ("no
    * protection against SQL injection") is not mistaken for a denial — and the one word it does
    * admit must not be a bridge verb ("does not prevent SQL injection", "never blocks XSS"), which
-   * asserts the defect rather than denying the sink; the lookahead excludes
-   * prevent/stop/block/guard/protect forms while leaving "no SQL injection here" a denial.
+   * asserts the defect rather than denying the sink. That exclusion lives in {@link
+   * #deniesTheSink}, which drops a match whose gap word is a {@link #BRIDGE_VERB_GAP} — folding it
+   * into this pattern as a lookahead puts it over the regex complexity budget — while "no SQL
+   * injection here" stays a denial.
    */
   private static final Pattern SINK_DENIED =
       Pattern.compile(
-          "\\b(no|not|never)\\s+(?!(prevent|stop|block|guard|protect))(\\w+[\\s-]+)?"
+          "\\b(no|not|never)\\s+(\\w+[\\s-]+)?"
               + "(xss|cross[- ]site scripting|sql injection|command injection|shell injection"
               + "|path traversal|directory traversal)\\b",
           Pattern.CASE_INSENSITIVE);
+
+  /**
+   * A bridge verb filling {@link #SINK_DENIED}'s one-word gap ("does not <i>prevent</i> SQL
+   * injection"): the negation then targets the missing defense, not the sink, so the sentence
+   * asserts the defect and must not read as a denial. Matched against the gap group whole, so a
+   * bridge verb elsewhere in the finding changes nothing.
+   */
+  private static final Pattern BRIDGE_VERB_GAP =
+      Pattern.compile("(prevent|stop|block|guard|protect)\\w*[\\s-]+", Pattern.CASE_INSENSITIVE);
 
   /**
    * The same denial worded about the exposure rather than the class ("not exploitable", "no
@@ -559,14 +580,27 @@ public class FindingVerificationService {
         || (SQL.matcher(text).find() && STRING_BUILT.matcher(text).find());
   }
 
-  /** The absence claim in either of its two wordings; one claim, two patterns. */
+  /** The absence claim in any of its three wordings; one claim, three patterns. */
   private static boolean claimsNothingNeutralizesIt(String text) {
-    return UNMITIGATED_ADJECTIVE.matcher(text).find() || MITIGATION_ABSENT.matcher(text).find();
+    return UNMITIGATED_ADJECTIVE.matcher(text).find()
+        || MITIGATION_ABSENT.matcher(text).find()
+        || MITIGATION_ABSENT_SUBJECT.matcher(text).find();
   }
 
-  /** The sink denied by class ("no SQL injection") or by exposure ("not exploitable"). */
+  /**
+   * The sink denied by class ("no SQL injection") or by exposure ("not exploitable"). A class match
+   * whose one-word gap is a bridge verb ("does not prevent SQL injection") asserts the defect
+   * rather than denying the sink, so it does not count as a denial.
+   */
   private static boolean deniesTheSink(String asserted) {
-    return SINK_DENIED.matcher(asserted).find() || EXPLOITABILITY_DENIED.matcher(asserted).find();
+    Matcher denial = SINK_DENIED.matcher(asserted);
+    while (denial.find()) {
+      String gap = denial.group(2);
+      if (gap == null || !BRIDGE_VERB_GAP.matcher(gap).matches()) {
+        return true;
+      }
+    }
+    return EXPLOITABILITY_DENIED.matcher(asserted).find();
   }
 
   private static boolean isBlockingEligible(ReviewResponse.Finding finding) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -156,15 +156,18 @@ public class FindingVerificationService {
    * the two never read one sentence both ways. A defense noun as the verb's direct object flips the
    * sentence's meaning — "Nothing escapes validation" says every value IS validated — so the verb
    * is held to its finite and participle forms (the noun could otherwise re-match as the verb
-   * through the word gap) and the trailing lookahead rejects a defense-noun object, keeping the
-   * over-fire direction closed (#594) while "nothing escapes the value" stays an absence claim.
-   * Kept a separate pattern only because folding the pronouns into {@link #MITIGATION_ABSENT}'s
-   * negator alternation puts that pattern over the regex complexity budget.
+   * through the word gap) and the trailing lookahead rejects a defense-stemmed word within two
+   * words of the verb, so a modified or tool-named object ("nothing escapes heavy validation",
+   * "nothing escapes the sanitizer") is rejected too, keeping the over-fire direction closed (#594)
+   * while "nothing escapes the value" stays an absence claim — a defense noun further than two
+   * words out ("nothing escapes the value before validation") no longer flips the reading. Kept a
+   * separate pattern only because folding the pronouns into {@link #MITIGATION_ABSENT}'s negator
+   * alternation puts that pattern over the regex complexity budget.
    */
   private static final Pattern MITIGATION_ABSENT_SUBJECT =
       Pattern.compile(
           "\\b(nothing|nobody)\\s+(\\w+[\\s-]+){0,3}(sanitiz|escap|validat|parameteriz|encod)"
-              + "(es|ed|ing)\\b(?!\\s+(validation|sanitization|escaping|encoding|filtering)\\b)",
+              + "(es|ed|ing)\\b(?!\\s+(\\w+\\s+){0,2}(sanitiz|escap|validat|encod|filter))",
           Pattern.CASE_INSENSITIVE);
 
   /**
@@ -299,10 +302,15 @@ public class FindingVerificationService {
    * else ("If you follow the render path, React escapes the value") is swallowed with the protasis,
    * so its mitigation no longer defeats the floor — and so is a comma-spliced consequent whose
    * coordinator itself trails a comma ("this would be moot, however, React escapes it"), since a
-   * regex cannot tell that parenthetical from the one inside the protasis. Commas cannot serve both
-   * roles, and this is the safer half — the finding must ALSO name a sink and ALSO claim nothing
-   * sanitizes it before the floor can fire at all, and the floor only lifts risk, leaving
-   * confidence and every other signal where the model put them.
+   * regex cannot tell that parenthetical from the one inside the protasis. In the other direction,
+   * a coordinator word used adverbially without a following comma ("If, however unlikely, ..." or
+   * "If, but only if, ...") still ends the span early and can leave a protasis verb read as
+   * asserted: recognizing comma-delimited parentheticals in general needs pairing the delimiters,
+   * which a bounded regex cannot do, and that phrasing is rare in review findings — accepted as
+   * residual under-fire, the safe direction. Commas cannot serve both roles, and this is the safer
+   * half — the finding must ALSO name a sink and ALSO claim nothing sanitizes it before the floor
+   * can fire at all, and the floor only lifts risk, leaving confidence and every other signal where
+   * the model put them.
    *
    * <p>Plain "should" is NOT a marker. Only inverted "Should the API sanitize ..." is a hypothesis,
    * and its bare infinitive matches none of {@link #MITIGATION_ASSERTED}'s verb forms, so listing

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -135,14 +135,18 @@ public class FindingVerificationService {
           Pattern.CASE_INSENSITIVE);
 
   /**
-   * The same absence claim worded as a missing step ("no sanitization", "never escaped"), with room
-   * for a few words between the negator and the neutralizing verb. Read as a union with {@link
-   * #UNMITIGATED_ADJECTIVE}; the two are one claim split across two patterns only because one
-   * alternation of both wordings is more than the regex complexity budget allows.
+   * The same absence claim worded as a missing step ("no sanitization", "never escaped", "nothing
+   * sanitizes it"), with room for a few words between the negator and the neutralizing verb. The
+   * negators include the pronoun forms ("nothing", "nobody") so a subject-worded absence ("Nothing
+   * sanitizes the value") registers just like the step-worded one; {@link #MITIGATION_ASSERTED}
+   * excludes the same pronouns from its subject slot so the two never read one sentence both ways.
+   * Read as a union with {@link #UNMITIGATED_ADJECTIVE}; the two are one claim split across two
+   * patterns only because one alternation of both wordings is more than the regex complexity budget
+   * allows.
    */
   private static final Pattern MITIGATION_ABSENT =
       Pattern.compile(
-          "\\b(no|not|without|missing|never|lacks?|absent)\\s+(\\w+[\\s-]+){0,3}"
+          "\\b(no|not|nothing|nobody|without|missing|never|lacks?|absent)\\s+(\\w+[\\s-]+){0,3}"
               + "(sanitiz|escap|validat|parameteriz|encod)\\w*",
           Pattern.CASE_INSENSITIVE);
 
@@ -152,11 +156,14 @@ public class FindingVerificationService {
    * them out of its own negation — the sink name sits inside the denial, and a phrase like "not
    * concatenated but parameterized" matches the absence group on the very mitigation it asserts.
    * The gap is one word, so an assertion of the defect that merely contains a negation ("no
-   * protection against SQL injection") is not mistaken for a denial.
+   * protection against SQL injection") is not mistaken for a denial — and the one word it does
+   * admit must not be a bridge verb ("does not prevent SQL injection", "never blocks XSS"), which
+   * asserts the defect rather than denying the sink; the lookahead excludes
+   * prevent/stop/block/guard/protect forms while leaving "no SQL injection here" a denial.
    */
   private static final Pattern SINK_DENIED =
       Pattern.compile(
-          "\\b(no|not|never)\\s+(\\w+[\\s-]+)?"
+          "\\b(no|not|never)\\s+(?!(prevent|stop|block|guard|protect))(\\w+[\\s-]+)?"
               + "(xss|cross[- ]site scripting|sql injection|command injection|shell injection"
               + "|path traversal|directory traversal)\\b",
           Pattern.CASE_INSENSITIVE);
@@ -186,7 +193,7 @@ public class FindingVerificationService {
       Pattern.compile(
           "\\b(is|are|was|were|gets|been|already)\\s+(?!(no|not|never)\\b)(\\w+[\\s-]+){0,1}"
               + "(sanitiz|escap|validat|parameteriz|encod)(ed|es|ing)\\b"
-              + "|\\b(?!(no|not|never|nothing)\\b)\\w+\\s+"
+              + "|\\b(?!(no|not|never|nothing|nobody)\\b)\\w+\\s+"
               + "(sanitizes|escapes|validates|parameterizes|encodes)\\b",
           Pattern.CASE_INSENSITIVE);
 
@@ -205,20 +212,25 @@ public class FindingVerificationService {
    * needed for the same reason.
    *
    * <p>The clause ends at a real clause boundary — strong punctuation, or a coordinator that opens
-   * the consequent ("but", "so", "then"...) — and deliberately NOT at a comma. A protasis carries
-   * its own commas ("If the feedback API, per its own contract, always sanitizes the body on write,
-   * ..."), and stopping at the first one left the mitigation verb sitting in text read as asserted,
-   * which is the very under-firing this pattern exists to remove. The coordinator boundary is what
-   * keeps the consequent: "If it were stored as plain text this would be moot, but React escapes it
-   * at render" still asserts its mitigation, and that assertion must still defeat the floor, since
-   * over-firing the floor is the dangerous direction (#594).
+   * the consequent ("but", "so", "then"...) — and deliberately NOT at a comma. A coordinator
+   * immediately followed by a comma is a parenthetical still inside the protasis ("If, however, the
+   * API always sanitizes the body on write, ...") and does not end the span; stopping there left
+   * the mitigation verb in text read as asserted, the under-firing this pattern exists to remove. A
+   * protasis carries its own commas ("If the feedback API, per its own contract, always sanitizes
+   * the body on write, ..."), and stopping at the first one left the mitigation verb sitting in
+   * text read as asserted, which is the very under-firing this pattern exists to remove. The
+   * coordinator boundary is what keeps the consequent: "If it were stored as plain text this would
+   * be moot, but React escapes it at render" still asserts its mitigation, and that assertion must
+   * still defeat the floor, since over-firing the floor is the dangerous direction (#594).
    *
    * <p>Residual trade-off, chosen deliberately: a consequent separated by a bare comma and nothing
    * else ("If you follow the render path, React escapes the value") is swallowed with the protasis,
-   * so its mitigation no longer defeats the floor. Commas cannot serve both roles, and this is the
-   * safer half — the finding must ALSO name a sink and ALSO claim nothing sanitizes it before the
-   * floor can fire at all, and the floor only lifts risk, leaving confidence and every other signal
-   * where the model put them.
+   * so its mitigation no longer defeats the floor — and so is a comma-spliced consequent whose
+   * coordinator itself trails a comma ("this would be moot, however, React escapes it"), since a
+   * regex cannot tell that parenthetical from the one inside the protasis. Commas cannot serve both
+   * roles, and this is the safer half — the finding must ALSO name a sink and ALSO claim nothing
+   * sanitizes it before the floor can fire at all, and the floor only lifts risk, leaving
+   * confidence and every other signal where the model put them.
    *
    * <p>Plain "should" is NOT a marker. Only inverted "Should the API sanitize ..." is a hypothesis,
    * and its bare infinitive matches none of {@link #MITIGATION_ASSERTED}'s verb forms, so listing
@@ -228,7 +240,7 @@ public class FindingVerificationService {
   private static final Pattern CONDITIONAL_CLAUSE =
       Pattern.compile(
           "\\b(if|unless|whether|in case|assuming|provided that)\\b"
-              + "(?:(?!\\b(but|so|then|however|therefore|otherwise)\\b)"
+              + "(?:(?!\\b(but|so|then|however|therefore|otherwise)\\b(?!,))"
               + "[^;:.!?\\n\\r\\u2013\\u2014])*",
           Pattern.CASE_INSENSITIVE);
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -1195,7 +1195,7 @@ class FindingVerificationServiceTest {
                 "src/components/FeedbackItem.tsx",
                 37,
                 "Stored XSS: feedback body rendered via dangerouslySetInnerHTML",
-                "Nothing sanitizes or escapes the body in the provided material. If, however, the"
+                "Nothing sanitizes the body in the provided material. If, however, the"
                     + " API always sanitizes the body on write, this is moot — but nothing"
                     + " shown does.",
                 null,

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -1132,6 +1132,105 @@ class FindingVerificationServiceTest {
   }
 
   @Test
+  void floorsAFindingWhoseAbsenceClaimIsWordedAsNothingSanitizes() {
+    // #676 gap 1: MITIGATION_ABSENT's negators stopped at "no|not|never|...", so the
+    // subject-worded absence "Nothing sanitizes ..." never registered as an absence claim and the
+    // floor stayed silent on a named sink.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "medium",
+                "low",
+                "src/components/Comment.tsx",
+                14,
+                "User comment written to innerHTML",
+                "Nothing sanitizes the value before innerHTML receives it.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("high", result.findings().get(0).risk());
+    assertEquals("low", result.findings().get(0).confidence());
+  }
+
+  @Test
+  void doesNotReadDoesNotPreventSqlInjectionAsASinkDenial() {
+    // #676 gap 2: SINK_DENIED's one-word gap admitted bridge verbs, so "does not prevent SQL
+    // injection" — an assertion of the defect — read as a denial of the sink and suppressed the
+    // floor on a demonstrated string-built query.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "medium",
+                "low",
+                "src/InvoiceExporter/Data/InvoiceRepository.cs",
+                27,
+                "Unsanitized channel value concatenated into the query text",
+                "The helper does not prevent SQL injection; the value goes straight into the"
+                    + " command string.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("high", result.findings().get(0).risk());
+    assertEquals("low", result.findings().get(0).confidence());
+  }
+
+  @Test
+  void floorsAConditionalWhoseCoordinatorSitsInsideTheProtasis() {
+    // #676 gap 3: the conditional span ended at ANY coordinator, so the parenthetical "however"
+    // inside "If, however, the API always sanitizes ..." truncated the protasis and left
+    // "sanitizes" in text read as asserted, defeating the floor on a hypothesis the finding
+    // rejects in the same sentence.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "medium",
+                "medium",
+                "src/components/FeedbackItem.tsx",
+                37,
+                "Stored XSS: feedback body rendered via dangerouslySetInnerHTML",
+                "Nothing sanitizes or escapes the body in the provided material. If, however, the"
+                    + " API always sanitizes the body on write, this is moot — but nothing"
+                    + " shown does.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("high", result.findings().get(0).risk());
+    assertEquals("medium", result.findings().get(0).confidence());
+  }
+
+  @Test
+  void stillHonoursADenialWithNoWordBetweenTheNegatorAndTheSink() {
+    // The bridge-verb exclusion must not narrow the plain denial: "no XSS here" keeps
+    // suppressing the floor, since over-firing is the dangerous direction (#594).
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "low",
+                "high",
+                "src/components/Banner.tsx",
+                9,
+                "innerHTML assignment on a constant unvalidated at build time",
+                "The string is a compile-time literal, so there is no XSS here.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    assertEquals("low", result.findings().get(0).risk());
+  }
+
+  @Test
   void leavesCriticalInjectionFindingsAndUnrelatedRatingsAlone() {
     // The floor only lifts, so a critical keeps its level; and it never fires unless the finding
     // states both halves — a named sink AND the absence of any sanitization.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -1180,6 +1180,54 @@ class FindingVerificationServiceTest {
   }
 
   @Test
+  void doesNotFloorWhenTheDefenseNounIsTheObjectOfNothingEscapes() {
+    // "Nothing escapes validation" says every value IS validated — a mitigation, not an absence.
+    // The defense-noun object must not read as a pronoun-subject absence claim, and the noun must
+    // not re-match as the verb through the word gap; over-firing is the dangerous direction
+    // (#594).
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "low",
+                "high",
+                "src/components/Comment.tsx",
+                14,
+                "User comment written to innerHTML",
+                "Nothing escapes validation before the value reaches innerHTML.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    assertEquals("low", result.findings().get(0).risk());
+  }
+
+  @Test
+  void floorsWhenNothingEscapesTheValueItself() {
+    // The other reading of the same shape: "nothing escapes the value" is the absence claim, and
+    // the defense-noun rejection must not swallow it.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "medium",
+                "low",
+                "src/components/Comment.tsx",
+                14,
+                "User comment written to innerHTML",
+                "Nothing escapes the value before it reaches innerHTML.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("high", result.findings().get(0).risk());
+    assertEquals("low", result.findings().get(0).confidence());
+  }
+
+  @Test
   void doesNotReadDoesNotPreventSqlInjectionAsASinkDenial() {
     // #676 gap 2: SINK_DENIED's one-word gap admitted bridge verbs, so "does not prevent SQL
     // injection" — an assertion of the defect — read as a denial of the sink and suppressed the

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -1180,6 +1180,56 @@ class FindingVerificationServiceTest {
   }
 
   @Test
+  void doesNotFloorWhenADoSupportedMitigationFollowsThePronounAbsence() {
+    // "does escape" is emphatic but still a statement of fact, invisible to MITIGATION_ASSERTED's
+    // copula and subject-slot shapes. With the pronoun absence match dropped by NEGATING_SUBJECT,
+    // this text would otherwise floor although it says another layer neutralizes the value —
+    // the over-fire direction (#594).
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "low",
+                "high",
+                "src/components/Comment.tsx",
+                14,
+                "User comment written to innerHTML",
+                "Nothing is sanitized before innerHTML receives it, but the framework does escape"
+                    + " the value at compile time.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    assertEquals("low", result.findings().get(0).risk());
+  }
+
+  @Test
+  void doesNotReadDoesNotProhibitSqlInjectionAsASinkDenial() {
+    // "prohibit" belongs to the same warding-off family as "prevent": the negation targets the
+    // missing defense, so the sentence asserts the defect and must not defuse the floor.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "medium",
+                "low",
+                "src/InvoiceExporter/Data/InvoiceRepository.cs",
+                27,
+                "Unsanitized channel value concatenated into the query text",
+                "The helper does not prohibit SQL injection; the value goes straight into the"
+                    + " command string.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("high", result.findings().get(0).risk());
+    assertEquals("low", result.findings().get(0).confidence());
+  }
+
+  @Test
   void doesNotFloorWhenTheDefenseNounIsTheObjectOfNothingEscapes() {
     // "Nothing escapes validation" says every value IS validated — a mitigation, not an absence.
     // The defense-noun object must not read as a pronoun-subject absence claim, and the noun must
@@ -1300,6 +1350,29 @@ class FindingVerificationServiceTest {
 
     assertEquals("high", result.findings().get(0).risk());
     assertEquals("medium", result.findings().get(0).confidence());
+  }
+
+  @Test
+  void stillHonoursADenialWhoseGapWordIsNotABridgeVerb() {
+    // The bridge exclusion is verb-shaped only: an adjective or quantifier in the one-word gap
+    // ("no possible SQL injection") is still a denial and must keep suppressing the floor.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "low",
+                "high",
+                "src/InvoiceExporter/Data/InvoiceRepository.cs",
+                27,
+                "Tenant filter naming is unvalidated by convention checks",
+                "The query is built by the ORM, so there is no possible SQL injection here.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    assertEquals("low", result.findings().get(0).risk());
   }
 
   @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -1205,6 +1205,29 @@ class FindingVerificationServiceTest {
   }
 
   @Test
+  void doesNotReadDoesNotMitigateSqlInjectionAsASinkDenial() {
+    // The bridge-verb set is the defense-verb family, not just "prevent": "does not mitigate SQL
+    // injection" targets the missing defense the same way and must not read as a denial.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "medium",
+                "low",
+                "src/InvoiceExporter/Data/InvoiceRepository.cs",
+                27,
+                "Unsanitized channel value concatenated into the query text",
+                "The library does not mitigate SQL injection on this path.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("high", result.findings().get(0).risk());
+    assertEquals("low", result.findings().get(0).confidence());
+  }
+
+  @Test
   void floorsAConditionalWhoseCoordinatorSitsInsideTheProtasis() {
     // #676 gap 3: the conditional span ended at ANY coordinator, so the parenthetical "however"
     // inside "If, however, the API always sanitizes ..." truncated the protasis and left

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -1255,6 +1255,52 @@ class FindingVerificationServiceTest {
   }
 
   @Test
+  void doesNotFloorWhenTheDefenseNounObjectCarriesAModifier() {
+    // The defense-noun rejection must see through a modifier: "Nothing escapes heavy validation"
+    // still says every value IS validated.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "low",
+                "high",
+                "src/components/Comment.tsx",
+                14,
+                "User comment written to innerHTML",
+                "Nothing escapes heavy validation before the value reaches innerHTML.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    assertEquals("low", result.findings().get(0).risk());
+  }
+
+  @Test
+  void doesNotFloorWhenTheObjectNamesTheDefenseTool() {
+    // Tool-named objects belong to the same mitigated reading: "Nothing escapes the sanitizer"
+    // says the sanitizer catches everything.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "low",
+                "high",
+                "src/components/Comment.tsx",
+                14,
+                "User comment written to innerHTML",
+                "Nothing escapes the sanitizer before the value reaches innerHTML.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+    assertEquals("low", result.findings().get(0).risk());
+  }
+
+  @Test
   void floorsWhenNothingEscapesTheValueItself() {
     // The other reading of the same shape: "nothing escapes the value" is the absence claim, and
     // the defense-noun rejection must not swallow it.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -1156,6 +1156,30 @@ class FindingVerificationServiceTest {
   }
 
   @Test
+  void floorsAFindingWhoseAbsenceClaimIsWordedAsNothingIsSanitized() {
+    // The auxiliary-order twin of the pronoun-subject absence: MITIGATION_ASSERTED's first
+    // alternative starts at "is" and never sees the negating subject, so "Nothing is sanitized"
+    // read as a mitigation and defeated the very floor the pronoun negators enable.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            new ReviewResponse.Finding(
+                "medium",
+                "low",
+                "src/components/Comment.tsx",
+                14,
+                "User comment written to innerHTML",
+                "Nothing is sanitized before the value reaches innerHTML.",
+                null,
+                null));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals("high", result.findings().get(0).risk());
+    assertEquals("low", result.findings().get(0).confidence());
+  }
+
+  @Test
   void doesNotReadDoesNotPreventSqlInjectionAsASinkDenial() {
     // #676 gap 2: SINK_DENIED's one-word gap admitted bridge verbs, so "does not prevent SQL
     // injection" — an assertion of the defect — read as a denial of the sink and suppressed the


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Closes three under-fire gaps in the injection-sink floor's defeater patterns in `FindingVerificationService` — cases where the floor stayed silent on genuine unmitigated-injection-sink findings:

1. **`MITIGATION_ABSENT`** now includes the pronoun negators `nothing|nobody`, so a subject-worded absence claim ("Nothing sanitizes the value before innerHTML") registers like the step-worded one. `MITIGATION_ASSERTED`'s subject-slot lookahead gains `nobody` so the two patterns never read one sentence both ways.
2. **`SINK_DENIED`**'s one-word gap excludes bridge verbs (`prevent|stop|block|guard|protect` forms) via a negative lookahead, so "does not prevent SQL injection" — an assertion of the defect — no longer reads as a denial of the sink. "no SQL injection here" stays a denial.
3. **`CONDITIONAL_CLAUSE`**'s terminator lookahead now treats a coordinator immediately followed by a comma as a parenthetical still inside the protasis, so "If, however, the API always sanitizes …" no longer truncates the hypothetical span at "however" and leaves "sanitizes" in text read as asserted. The residual trade-off (a comma-spliced consequent whose coordinator trails a comma is swallowed with the protasis) is documented in the javadoc.

Each pattern's javadoc is updated in step. The floor still only lifts risk; confidence and other signals are untouched, and all existing defeater tests stay green.

## Related Issues

Closes #676

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

New tests pin all three shapes ("Nothing sanitizes …" floors, "does not prevent SQL injection" no longer suppresses, parenthetical-coordinator protasis floors) plus a guard that a plain "no XSS here" denial still defeats the floor. `./mvnw verify` clean locally: 3071 tests, 0 failures (Spotless, SpotBugs included).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

CHANGELOG.md gains a Fixed entry under [Unreleased].