### PR TITLE
fix(ai): fail fast on a provider context-length rejection instead of retrying it at full price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to ThrillhouseBot.
 
 ### Fixed
 
+- **A provider context-length rejection is no longer retried at full price** (#622): a rejection for exceeding the model's context window is deterministic, so the review call now fails fast on the first attempt instead of re-billing up to `max-ai-retries` identical requests. In a multi-call review the rejected batch's files are disclosed as not reviewed while the other batches keep their findings; a single-call review fails with a notice and check run that name the cause and the `REVIEW_MAX_INPUT_TOKENS` knob to lower, instead of generic retry advice
 - **Dashboard token test no longer assumes an en-US locale** (#661): the test now asserts the same `toLocaleString()` output the component renders, so it passes on machines with any runtime locale
 
 ## [0.6.0] — 2026-08-13

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -21,6 +21,7 @@ import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubPullRequestClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
+import dev.thiagogonzaga.thrillhousebot.review.ai.AiContextWindowExceededException;
 import dev.thiagogonzaga.thrillhousebot.review.ai.AiResponseTruncatedException;
 import dev.thiagogonzaga.thrillhousebot.review.ai.AiReviewService;
 import dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService;
@@ -590,6 +591,16 @@ public class FindingPipeline {
           // cap (#495), so the failure goes straight to the disclose step — which now salvages
           // the complete leading findings out of the buffered partial body first (#500).
           outcomesByIndex[i] = salvageTruncatedBatch(i, run, truncation.get());
+        } else if (AiContextWindowExceededException.findIn(e).isPresent()) {
+          // Deterministic like a truncation: the provider rejected the batch's request for
+          // exceeding the model's context window, and the sequential retry below would re-send
+          // the identical prompt against the identical window (#622). Straight to disclosure.
+          Log.warnf(
+              "Batch %d/%d was rejected for exceeding the model's context window; not retrying"
+                  + " (an identical request would be rejected identically) and disclosing its"
+                  + " files as not reviewed",
+              i + 1, batches.size());
+          plan.recordUncoveredFiles(filenamesOf(batches.get(i).files()));
         } else if (isSpendCeilingBlocked(e)) {
           // Deterministic like a truncation: the ledger is monotonic within a review, so a retry
           // would be refused identically. Degrade like the budgeter — disclose, with the ceiling

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -21,6 +21,7 @@ import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSession;
 import dev.thiagogonzaga.thrillhousebot.dashboard.ReviewSessionPersistence;
 import dev.thiagogonzaga.thrillhousebot.dashboard.SessionEventBroadcaster;
 import dev.thiagogonzaga.thrillhousebot.github.*;
+import dev.thiagogonzaga.thrillhousebot.review.ai.AiContextWindowExceededException;
 import dev.thiagogonzaga.thrillhousebot.review.ai.AiResponseTruncatedException;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -55,6 +56,23 @@ public class ReviewOrchestrator {
                 + " model)"
             : "")
         + ", then run /review again.";
+  }
+
+  /** FAILED check-run title when the provider rejected the request as over the window (#622). */
+  static final String CONTEXT_WINDOW_CHECK_TITLE =
+      "Review failed: the request exceeded the model's context window";
+
+  /**
+   * FAILED check-run summary for a context-window rejection: names the deterministic cause and the
+   * knob that shrinks the request, matching the PR notice, instead of the bare conclusion-only
+   * update a generic failure gets.
+   */
+  static String contextWindowCheckSummary() {
+    return "The provider rejected the review request because it exceeds the model's context"
+        + " window — the diff and its context are too large for the model. Retrying the identical"
+        + " request would be rejected identically — lower REVIEW_MAX_INPUT_TOKENS so the planned"
+        + " material fits the window (token budgeting then batches or clips the diff), then run"
+        + " /review again.";
   }
 
   private final ThrillhouseConfig config;
@@ -470,6 +488,17 @@ public class ReviewOrchestrator {
       String auth, ReviewRequest req, ReviewSession session, long checkRunId, RuntimeException e) {
     Log.errorf(e, "Review failed for %s/%s #%d", req.owner(), req.repo(), req.prNumber());
     var truncation = AiResponseTruncatedException.findIn(e);
+    var contextWindow = AiContextWindowExceededException.findIn(e);
+
+    String checkTitle = null;
+    String checkSummary = null;
+    if (truncation.isPresent()) {
+      checkTitle = TRUNCATION_CHECK_TITLE;
+      checkSummary = truncationCheckSummary(truncation.get().conciseModelImplicated());
+    } else if (contextWindow.isPresent()) {
+      checkTitle = CONTEXT_WINDOW_CHECK_TITLE;
+      checkSummary = contextWindowCheckSummary();
+    }
 
     if (checkRunId > 0) {
       try {
@@ -481,10 +510,8 @@ public class ReviewOrchestrator {
                 checkRunId,
                 CHECK_STATUS_COMPLETED,
                 CONCLUSION_FAILURE,
-                truncation.isPresent() ? TRUNCATION_CHECK_TITLE : null,
-                truncation
-                    .map(t -> truncationCheckSummary(t.conciseModelImplicated()))
-                    .orElse(null),
+                checkTitle,
+                checkSummary,
                 sessionUrl(session)));
       } catch (RuntimeException checkRunError) {
         Log.warnf(checkRunError, "Failed to mark check run %d as failed", checkRunId);
@@ -494,6 +521,8 @@ public class ReviewOrchestrator {
     if (truncation.isPresent()) {
       reviewPublisher.postTruncationFailureNotice(
           auth, req.owner(), req.repo(), req.prNumber(), truncation.get().conciseModelImplicated());
+    } else if (contextWindow.isPresent()) {
+      reviewPublisher.postContextWindowFailureNotice(auth, req.owner(), req.repo(), req.prNumber());
     } else {
       reviewPublisher.postFailureNotice(auth, req.owner(), req.repo(), req.prNumber());
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -249,6 +249,29 @@ public class ReviewPublisher {
             + conciseClause);
   }
 
+  /**
+   * The failure notice for a review request the provider rejected for exceeding the model's context
+   * window (#622). Deterministic like a truncation — the generic notice's bare {@code /review}
+   * advice would repeat a request that is rejected identically every time — so this variant names
+   * the cause and the knob that shrinks the request: {@code REVIEW_MAX_INPUT_TOKENS}, whose token
+   * budgeting batches or clips the diff to fit.
+   */
+  void postContextWindowFailureNotice(String auth, String owner, String repo, int prNumber) {
+    postFailureNoticeComment(
+        auth,
+        owner,
+        repo,
+        prNumber,
+        """
+            ⚠️ **ThrillhouseBot review could not be completed.**
+
+            The provider rejected the review request because it exceeds the model's context \
+            window — the diff and its context are too large for the model. This failure is \
+            deterministic: retrying the identical request would be rejected identically. Lower \
+            `REVIEW_MAX_INPUT_TOKENS` so the planned material fits the window (token budgeting \
+            then batches or clips the diff), then run `/review` again.""");
+  }
+
   private void postFailureNoticeComment(
       String auth, String owner, String repo, int prNumber, String body) {
     try {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiContextWindowExceededException.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiContextWindowExceededException.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Raised when the provider rejected the request outright because it exceeds the model's context
+ * window — a <em>deterministic</em> failure, not a transient one.
+ *
+ * <p>Same class of failure as {@link AiResponseTruncatedException} (#495) and the spend-ceiling
+ * refusal (#508): re-sending the identical prompt against the identical window is rejected
+ * identically, so every retry is a knowably futile billed call. Without this type the rejection is
+ * just one more {@code RuntimeException} from the provider, lands in the transient-failure retry
+ * path, and is re-billed {@code max-ai-retries} times over — on exactly the requests that are the
+ * most expensive ones a review makes, because only an oversized prompt gets here (#622).
+ *
+ * <p>Extends {@link AiReviewException} so it survives {@link
+ * AiReviewService#asAiReviewException(java.util.concurrent.ExecutionException)} with its identity
+ * intact — that unwrapper returns an {@code AiReviewException} cause as-is.
+ *
+ * <p>Detection is by provider message, because the rejection arrives as an untyped HTTP-level error
+ * whose only stable signal is its wording. The markers cover the phrasings the supported providers
+ * use for the input-side rejection; a marker miss degrades safely to today's behaviour (the failure
+ * is retried as transient), never to a lost review.
+ */
+public class AiContextWindowExceededException extends AiReviewException {
+
+  /**
+   * Provider wordings for an input-exceeds-context-window rejection, matched case-insensitively:
+   * OpenAI ({@code context_length_exceeded} / "maximum context length"), Anthropic ("prompt is too
+   * long", "input length and max_tokens exceed context limit"), and Gemini ("input token count
+   * exceeds the maximum number of tokens").
+   */
+  private static final List<String> CONTEXT_WINDOW_MARKERS =
+      List.of(
+          "context_length_exceeded",
+          "maximum context length",
+          "exceed context limit",
+          "exceeds the context limit",
+          "prompt is too long",
+          "input is too long",
+          "exceeds the maximum number of tokens");
+
+  /**
+   * Cause-chain links inspected before giving up — same bound, same rationale as {@link
+   * Throwables#findCause}: a cyclic chain must not spin the review thread.
+   */
+  private static final int MAX_CAUSE_DEPTH = 16;
+
+  public AiContextWindowExceededException(String message, Throwable cause) {
+    super(message, 1, cause);
+  }
+
+  /**
+   * The context-window rejection inside a failure's cause chain, if any — the shared walk every
+   * layer that reacts to one uses, mirroring {@link AiResponseTruncatedException#findIn}.
+   */
+  public static Optional<AiContextWindowExceededException> findIn(Throwable failure) {
+    return Throwables.findCause(failure, AiContextWindowExceededException.class);
+  }
+
+  /**
+   * Classifies a call failure as a context-window rejection: returns the typed rejection when the
+   * failure already carries one in its cause chain, wraps the failure in one when any message in
+   * the chain matches a provider marker, and returns empty otherwise — leaving the failure on the
+   * transient path it is on today.
+   */
+  public static Optional<AiContextWindowExceededException> classify(RuntimeException failure) {
+    var existing = findIn(failure);
+    if (existing.isPresent()) {
+      return existing;
+    }
+    var cause = (Throwable) failure;
+    for (var depth = 0;
+        cause != null && depth < MAX_CAUSE_DEPTH;
+        depth++, cause = cause.getCause()) {
+      var message = cause.getMessage();
+      if (message != null && matchesMarker(message)) {
+        return Optional.of(
+            new AiContextWindowExceededException(
+                "Provider rejected the request for exceeding the model's context window: "
+                    + message,
+                failure));
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static boolean matchesMarker(String message) {
+    var normalized = message.toLowerCase(Locale.ROOT);
+    return CONTEXT_WINDOW_MARKERS.stream().anyMatch(normalized::contains);
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiContextWindowExceededException.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiContextWindowExceededException.java
@@ -44,8 +44,14 @@ public class AiContextWindowExceededException extends AiReviewException {
   /**
    * Provider wordings for an input-exceeds-context-window rejection, matched case-insensitively:
    * OpenAI ({@code context_length_exceeded} / "maximum context length"), Anthropic ("prompt is too
-   * long", "input length and max_tokens exceed context limit"), and Gemini ("input token count
-   * exceeds the maximum number of tokens").
+   * long", "input length and max_tokens exceed context limit"), and Gemini ("The input token count
+   * (...) exceeds the maximum number of tokens allowed").
+   *
+   * <p>Every marker is anchored to input-side vocabulary — "context", "prompt", "input" — never to
+   * a bare token-limit phrase, so an output-side wording (e.g. a response blocked for exceeding the
+   * maximum number of tokens, which is {@link AiResponseTruncatedException}'s lane) cannot classify
+   * here and draw the input-shrinking remedy that would not fix it. Under-matching is the safe
+   * direction: a marker miss degrades to the transient-retry path, never to a lost review.
    */
   private static final List<String> CONTEXT_WINDOW_MARKERS =
       List.of(
@@ -55,7 +61,7 @@ public class AiContextWindowExceededException extends AiReviewException {
           "exceeds the context limit",
           "prompt is too long",
           "input is too long",
-          "exceeds the maximum number of tokens");
+          "input token count");
 
   /**
    * Cause-chain links inspected before giving up — same bound, same rationale as {@link

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewService.java
@@ -160,6 +160,17 @@ public class AiReviewService {
             attempt, maxAttempts, session.id);
         throw e;
       } catch (RuntimeException e) {
+        var rejection = AiContextWindowExceededException.classify(e);
+        if (rejection.isPresent()) {
+          // Deterministic like a truncation: the identical request against the identical window
+          // is rejected identically, and every attempt here is a fresh full-price call (#622).
+          Log.warnf(
+              "AI review attempt %d/%d for session %d was rejected for exceeding the model's"
+                  + " context window; not retrying (an identical request would be rejected"
+                  + " identically)",
+              attempt, maxAttempts, session.id);
+          throw rejection.get();
+        }
         lastFailure = e;
         Log.warnf(
             e, "AI review attempt %d/%d failed for session %d", attempt, maxAttempts, session.id);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -248,6 +248,37 @@ class FindingPipelineTest {
     assertTrue(captor.getValue().changedFiles().contains("a.java (not reviewed"));
   }
 
+  @Test
+  void multiCallDoesNotRetryABatchRejectedForExceedingTheContextWindow() {
+    // #622: a context-length rejection is deterministic — the sequential retry would re-send the
+    // identical prompt against the identical window. It must go straight to disclosure instead,
+    // exactly once, keeping the batches that succeeded.
+    var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
+    var ctx = reviewContext();
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(1), anyInt()))
+        .thenThrow(
+            new dev.thiagogonzaga.thrillhousebot.review.ai.AiContextWindowExceededException(
+                "Provider rejected the request for exceeding the model's context window", null));
+    when(aiReviewService.reviewBatch(eq(session), any(), eq(2), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("b.java", "B")), List.of(), null));
+    var summary = new ReviewResponse.Summary(1, 0, 0, 1, 0, "ok", "does things", List.of());
+    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
+    when(aiReviewService.summarize(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), summary));
+
+    var plan = multiBatchPlan();
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    verify(aiReviewService, times(1))
+        .reviewBatch(eq(session), any(), eq(1), anyInt()); // no second, futile call
+
+    assertEquals(1, result.findings().size());
+    assertEquals("B", result.findings().get(0).title());
+    assertEquals(List.of("a.java"), plan.runtimeUncoveredFiles());
+    assertTrue(captor.getValue().changedFiles().contains("a.java (not reviewed"));
+  }
+
   /** One complete finding element for a stubbed partial body, anchored in batch 1's file. */
   private static String bodyFinding(String title) {
     return "{\"risk\":\"medium\",\"confidence\":\"high\",\"file\":\"a.java\",\"line\":1,"

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -3003,6 +3003,78 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void aContextWindowRejectionPostsTheWindowNamingNoticeInsteadOfTheBareRetryAdvice() {
+      // #622: a context-length rejection is deterministic — advising a bare `/review` retry
+      // repeats a request that is rejected identically every time. Both surfaces must name the
+      // window and the REVIEW_MAX_INPUT_TOKENS knob instead.
+      var session = failureSession();
+
+      orchestrator.handleReviewFailure(
+          "Bearer tok",
+          reviewRequest(),
+          session,
+          99L,
+          new dev.thiagogonzaga.thrillhousebot.review.ai.AiContextWindowExceededException(
+              "Provider rejected the request for exceeding the model's context window", null));
+
+      var commentCaptor = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+      verify(commentClient)
+          .createComment(
+              eq("Bearer tok"),
+              anyString(),
+              eq("owner"),
+              eq("repo"),
+              eq(42),
+              commentCaptor.capture());
+      var body = commentCaptor.getValue().body();
+      assertTrue(body.contains("context window"), body);
+      assertTrue(body.contains("REVIEW_MAX_INPUT_TOKENS"), body);
+      assertFalse(body.contains("reply with `/review`"), body);
+
+      var checkCaptor = ArgumentCaptor.forClass(GitHubCheckRunClient.UpdateCheckRunRequest.class);
+      verify(checkRunClient)
+          .updateCheckRun(
+              eq("Bearer tok"),
+              anyString(),
+              eq("owner"),
+              eq("repo"),
+              eq(99L),
+              checkCaptor.capture());
+      var output = checkCaptor.getValue().output();
+      assertNotNull(output, "the FAILED check run must carry a context-window title/summary");
+      assertTrue(output.title().contains("context window"), output.title());
+      assertTrue(output.summary().contains("REVIEW_MAX_INPUT_TOKENS"), output.summary());
+    }
+
+    @Test
+    void aContextWindowRejectionBuriedInTheCauseChainStillGetsTheWindowNamingNotice() {
+      var session = failureSession();
+
+      orchestrator.handleReviewFailure(
+          "Bearer tok",
+          reviewRequest(),
+          session,
+          0L,
+          new IllegalStateException(
+              "wrapped",
+              new dev.thiagogonzaga.thrillhousebot.review.ai.AiContextWindowExceededException(
+                  "Provider rejected the request for exceeding the model's context window", null)));
+
+      var commentCaptor = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+      verify(commentClient)
+          .createComment(
+              eq("Bearer tok"),
+              anyString(),
+              eq("owner"),
+              eq("repo"),
+              eq(42),
+              commentCaptor.capture());
+      assertTrue(
+          commentCaptor.getValue().body().contains("REVIEW_MAX_INPUT_TOKENS"),
+          commentCaptor.getValue().body());
+    }
+
+    @Test
     void aTruncationFailurePostsTheCapNamingNoticeInsteadOfTheBareRetryAdvice() {
       // #500 scope B: a truncation is deterministic — advising a bare `/review` retry is exactly
       // the knowably-futile call #495 exists to prevent. The notice must name the cap and the

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiContextWindowExceededExceptionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiContextWindowExceededExceptionTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review.ai;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Unit tests for {@link AiContextWindowExceededException}'s classifier and cause-chain finder. */
+class AiContextWindowExceededExceptionTest {
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // OpenAI: error code and message wording.
+        "The request failed: context_length_exceeded",
+        "This model's maximum context length is 128000 tokens, however you requested 190000",
+        // Anthropic: messages API wordings.
+        "invalid_request_error: prompt is too long: 250000 tokens > 200000 maximum",
+        "input length and `max_tokens` exceed context limit: 210000 + 8192 > 200000",
+        // Gemini: input-side rejection wording.
+        "The input token count (1200000) exceeds the maximum number of tokens allowed (1048576)"
+      })
+  void classifyRecognizesTheProvidersContextWindowRejections(String providerMessage) {
+    var failure = new RuntimeException(providerMessage);
+
+    var classified = AiContextWindowExceededException.classify(failure);
+
+    assertTrue(classified.isPresent(), providerMessage);
+    assertSame(failure, classified.get().getCause());
+    assertTrue(
+        classified.get().getMessage().contains("context window"), classified.get().getMessage());
+  }
+
+  @Test
+  void classifyMatchesCaseInsensitivelyAndWalksTheCauseChain() {
+    var failure =
+        new RuntimeException(
+            "call failed", new IllegalStateException("PROMPT IS TOO LONG: 300000 tokens"));
+
+    assertTrue(AiContextWindowExceededException.classify(failure).isPresent());
+  }
+
+  @Test
+  void classifyLeavesOtherFailuresOnTheTransientPath() {
+    assertFalse(
+        AiContextWindowExceededException.classify(new RuntimeException("boom")).isPresent());
+    assertFalse(
+        AiContextWindowExceededException.classify(new RuntimeException("rate limit exceeded"))
+            .isPresent());
+    assertFalse(
+        AiContextWindowExceededException.classify(new RuntimeException((String) null)).isPresent());
+  }
+
+  @Test
+  void classifyReturnsAnAlreadyTypedRejectionWithoutRewrapping() {
+    var rejection =
+        new AiContextWindowExceededException("over the window", new RuntimeException("cause"));
+    var wrapped = new RuntimeException("wrap", rejection);
+
+    var classified = AiContextWindowExceededException.classify(wrapped);
+
+    assertTrue(classified.isPresent());
+    assertSame(rejection, classified.get());
+  }
+
+  @Test
+  void findInWalksTheCauseChainAndReturnsTheRejection() {
+    var rejection = new AiContextWindowExceededException("over the window", null);
+    var wrapped = new CompletionException(new IllegalStateException("wrap", rejection));
+
+    var found = AiContextWindowExceededException.findIn(wrapped);
+
+    assertTrue(found.isPresent());
+    assertSame(rejection, found.get());
+  }
+
+  @Test
+  void findInReturnsEmptyForAnUnrelatedFailure() {
+    assertFalse(AiContextWindowExceededException.findIn(new RuntimeException("boom")).isPresent());
+  }
+
+  @Test
+  void classifyTerminatesOnACyclicCauseChain() {
+    // Same guarantee Throwables.findCause makes: a self-caused chain must not spin the walk.
+    var cyclic = new AtomicReference<RuntimeException>();
+    var failure =
+        new RuntimeException("boom") {
+          @Override
+          public synchronized Throwable getCause() {
+            return cyclic.get();
+          }
+        };
+    cyclic.set(failure);
+
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(2),
+        () -> assertFalse(AiContextWindowExceededException.classify(failure).isPresent()));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiContextWindowExceededExceptionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiContextWindowExceededExceptionTest.java
@@ -73,6 +73,25 @@ class AiContextWindowExceededExceptionTest {
         AiContextWindowExceededException.classify(new RuntimeException((String) null)).isPresent());
   }
 
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // Output-side rejections belong to the truncation lane, not this one: classifying them
+        // here would post the input-shrinking REVIEW_MAX_INPUT_TOKENS remedy for a failure that
+        // knob cannot fix. Every marker is input-anchored so these stay unclassified.
+        "The model response was blocked: it exceeds the maximum number of tokens",
+        "The output token count exceeds the maximum number of tokens allowed (8192)",
+        "response exceeded the maximum number of tokens for this model",
+        // Generic token-limit wording with no input-side anchor stays on the transient path.
+        "too many tokens in this request, please retry later"
+      })
+  void classifyDoesNotMatchOutputSideOrGenericTokenLimitWordings(String providerMessage) {
+    assertFalse(
+        AiContextWindowExceededException.classify(new RuntimeException(providerMessage))
+            .isPresent(),
+        providerMessage);
+  }
+
   @Test
   void classifyReturnsAnAlreadyTypedRejectionWithoutRewrapping() {
     var rejection =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/AiReviewServiceTest.java
@@ -1108,6 +1108,69 @@ class AiReviewServiceTest {
   }
 
   @Test
+  void shouldNotRetryAProviderContextWindowRejection() {
+    // #622: a context-length rejection is deterministic — the identical request against the
+    // identical window is rejected identically — so exactly one full-price call must be made.
+    ReviewSession session = reviewSession();
+    when(prReviewer.reviewStream(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString()))
+        .thenReturn(
+            new ErrorTokenStream(
+                new RuntimeException(
+                    "This model's maximum context length is 128000 tokens, however you requested"
+                        + " 190000 tokens")));
+
+    var thrown =
+        assertThrows(
+            AiContextWindowExceededException.class, () -> service.review(session, PROMPT_INPUTS));
+
+    assertTrue(
+        thrown.getMessage().contains("context window"),
+        "the message must name the deterministic cause: " + thrown.getMessage());
+    verify(prReviewer, times(1))
+        .reviewStream(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString());
+  }
+
+  @Test
+  void shouldNotBroadcastRetryEventsForAContextWindowRejection() {
+    // The dashboard must not show a retry that never happens.
+    ReviewSession session = reviewSession();
+    when(prReviewer.reviewStream(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString()))
+        .thenReturn(new ErrorTokenStream(new RuntimeException("prompt is too long: 250000")));
+
+    assertThrows(
+        AiContextWindowExceededException.class, () -> service.review(session, PROMPT_INPUTS));
+
+    verify(broadcaster, never())
+        .broadcast(
+            argThat(
+                event ->
+                    SessionEventBroadcaster.SessionEvent.TYPE_RETRY.equals(event.type())
+                        || SessionEventBroadcaster.SessionEvent.TYPE_STREAM_FAILED.equals(
+                            event.type())));
+  }
+
+  @Test
   void shouldNotBroadcastRetryEventsForATruncatedResponse() {
     // The dashboard must not show a retry that never happens.
     var starts = new java.util.concurrent.atomic.AtomicInteger();


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

A provider rejection for exceeding the model's context window is deterministic — the identical request against the identical window is rejected identically — yet the AI call retry lane treated it as transient and retried it up to `max-ai-retries` times, billing every attempt in full. The requests most likely to be rejected are, by construction, the largest (and so most expensive) ones a review makes.

This PR classifies the rejection as terminal, fails fast, and surfaces it as a disclosure the maintainer can act on, following the same handling shape as the #495 truncation and the #508 spend-ceiling refusal:

- **New `AiContextWindowExceededException`** (extends `AiReviewException` so it survives the executor unwrap with its identity intact), with a message-based classifier covering the wordings OpenAI (`context_length_exceeded`, "maximum context length"), Anthropic ("prompt is too long", "exceed context limit"), and Gemini ("exceeds the maximum number of tokens") use for the input-side rejection. A marker miss degrades safely to today's retry-as-transient behaviour.
- **`AiReviewService.runWithRetries`** classifies each failure before queueing a retry: a context-window rejection is thrown immediately after the first attempt — no retries, no retry events on the dashboard.
- **Multi-call lane (`FindingPipeline`)**: a rejected batch goes straight to disclosure (its files recorded as not reviewed) instead of the sequential retry that would re-send the identical prompt; sibling batches keep their findings.
- **Single-call lane (`ReviewOrchestrator` / `ReviewPublisher`)**: the failure notice and the FAILED check run name the deterministic cause and point at `REVIEW_MAX_INPUT_TOKENS` (whose token budgeting batches or clips the diff to fit), instead of the generic "reply with `/review`" advice that would repeat a knowably futile request.

## Related Issues

Closes #622

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

`./mvnw verify` passes (Spotless, SpotBugs, unit + integration test suites). New tests cover the classifier's provider wordings, case-insensitive cause-chain walking and cyclic-chain bound; the retry lane making exactly one call and broadcasting no retry events; the multi-call batch disclosure with sibling findings kept; and the orchestrator's notice/check-run copy including the buried-in-cause-chain case. Patch coverage on changed lines verified locally against a fresh JaCoCo report from the merge-base diff.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

Changelog updated under `[Unreleased]`. Not a release blocker on its own — the bug costs money and time on requests that were already failing, rather than producing wrong output.