### PR TITLE
fix(webhook): build command mention triggers from the configured bot logins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to ThrillhouseBot.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mention-form commands follow the configured bot login** (#698): `TriggerDetector` builds the `@<bot> <command>` trigger patterns from `BotIdentity.mentionNames()` instead of a hardcoded slug, so `@my-review-bot review` works on a custom-login install; the mention's `@` must open the comment or follow a non-word character, so an email local part never triggers a command. Slash forms and default-config behavior are unchanged
+
 ## [0.6.1] — 2026-08-13
 
 Fixes for defects found after 0.6.0 shipped, most of them during the audit of

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetector.java
@@ -28,14 +28,6 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class TriggerDetector {
 
-  /**
-   * Command word → its matching patterns, in detection precedence order. A comment carrying more
-   * than one command resolves to the first entry that matches, so {@code review} stays first to
-   * preserve the original trigger behavior. Each command accepts both the {@code /word} slash form
-   * and the {@code @Thrillhousebot word} mention form.
-   */
-  private static final Map<CommentCommand, List<Pattern>> COMMAND_PATTERNS = buildPatterns();
-
   private static final Pattern FENCED_CODE = Pattern.compile("(?s)```.*?```|~~~.*?~~~");
   private static final Pattern BLOCKQUOTE_LINE = Pattern.compile("(?m)^[ \\t]*>.*$");
   private static final Pattern INLINE_CODE = Pattern.compile("`[^`\\n]*`");
@@ -54,6 +46,17 @@ public class TriggerDetector {
    */
   private final Pattern mentionPattern;
 
+  /**
+   * Command word → its matching patterns, in detection precedence order. A comment carrying more
+   * than one command resolves to the first entry that matches, so {@code review} stays first to
+   * preserve the original trigger behavior. Each command accepts both the {@code /word} slash form
+   * and the {@code @<bot> word} mention form, where the mention alternative is built from {@link
+   * BotIdentity#mentionNames()} — not a hardcoded slug — so mention-form commands work on
+   * custom-login installs exactly like the conversational-mention gate (#679, #698). Compiled once
+   * per identity, not per comment.
+   */
+  private final Map<CommentCommand, List<Pattern>> commandPatterns;
+
   @Inject
   public TriggerDetector(ThrillhouseConfig config) {
     this(config.github().botLogins());
@@ -71,30 +74,38 @@ public class TriggerDetector {
     this.mentionPattern =
         Pattern.compile(
             ".*(?:^|[^\\w@])@(?:" + mentions + ")\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    this.commandPatterns = buildPatterns(mentions);
   }
 
-  private static Map<CommentCommand, List<Pattern>> buildPatterns() {
+  private static Map<CommentCommand, List<Pattern>> buildPatterns(String mentionAlternation) {
     var patterns = new LinkedHashMap<CommentCommand, List<Pattern>>();
-    patterns.put(CommentCommand.REVIEW, patternsFor("review"));
-    patterns.put(CommentCommand.HELP, patternsFor("help"));
-    patterns.put(CommentCommand.SUMMARY, patternsFor("summary"));
-    patterns.put(CommentCommand.DESCRIBE, patternsFor("describe"));
-    patterns.put(CommentCommand.CHANGELOG, patternsFor("changelog"));
-    patterns.put(CommentCommand.ADD_DOCS, patternsFor("add-docs"));
-    patterns.put(CommentCommand.IMPROVE, patternsFor("improve"));
-    patterns.put(CommentCommand.GENERATE_TESTS, patternsFor("generate-tests"));
-    patterns.put(CommentCommand.RESOLVE, patternsFor("resolve"));
-    patterns.put(CommentCommand.PAUSE, patternsFor("pause"));
-    patterns.put(CommentCommand.RESUME, patternsFor("resume"));
+    patterns.put(CommentCommand.REVIEW, patternsFor("review", mentionAlternation));
+    patterns.put(CommentCommand.HELP, patternsFor("help", mentionAlternation));
+    patterns.put(CommentCommand.SUMMARY, patternsFor("summary", mentionAlternation));
+    patterns.put(CommentCommand.DESCRIBE, patternsFor("describe", mentionAlternation));
+    patterns.put(CommentCommand.CHANGELOG, patternsFor("changelog", mentionAlternation));
+    patterns.put(CommentCommand.ADD_DOCS, patternsFor("add-docs", mentionAlternation));
+    patterns.put(CommentCommand.IMPROVE, patternsFor("improve", mentionAlternation));
+    patterns.put(CommentCommand.GENERATE_TESTS, patternsFor("generate-tests", mentionAlternation));
+    patterns.put(CommentCommand.RESOLVE, patternsFor("resolve", mentionAlternation));
+    patterns.put(CommentCommand.PAUSE, patternsFor("pause", mentionAlternation));
+    patterns.put(CommentCommand.RESUME, patternsFor("resume", mentionAlternation));
     return patterns;
   }
 
-  private static List<Pattern> patternsFor(String word) {
+  /**
+   * Patterns for one command word: the {@code /word} slash form (unchanged) and the {@code @<bot>
+   * word} mention form. The mention alternative anchors the {@code @} at the start of the comment
+   * or after a non-word, non-{@code @} character, the way a GitHub mention is written — an email
+   * address's local part ("foo@thrillhousebot.example") never triggers a command (#698).
+   */
+  private static List<Pattern> patternsFor(String word, String mentionAlternation) {
     return List.of(
         Pattern.compile(
             ".*(?:^|\\s)/" + word + "(?:\\s|$).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL),
         Pattern.compile(
-            ".*@thrillhousebot\\s+" + word + "\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+            ".*(?:^|[^\\w@])@(?:" + mentionAlternation + ")\\s+" + word + "\\b.*",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
   }
 
   /**
@@ -118,7 +129,7 @@ public class TriggerDetector {
       return CommentCommand.NONE;
     }
     var body = stripQuotedContext(commentBody);
-    for (var entry : COMMAND_PATTERNS.entrySet()) {
+    for (var entry : commandPatterns.entrySet()) {
       if (entry.getValue().stream().anyMatch(p -> p.matcher(body).matches())) {
         return entry.getKey();
       }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/webhook/TriggerDetectorTest.java
@@ -143,6 +143,46 @@ class TriggerDetectorTest {
     assertTrue(detector.containsBotMention("(@thrillhousebot wdyt?)"));
   }
 
+  /**
+   * The mention-form commands must follow the configured bot login just like the conversational
+   * gate — a hardcoded slug leaves {@code @my-review-bot review} dead on a custom-login install
+   * while the slash forms still work (#698).
+   */
+  @Test
+  void shouldDetectMentionFormCommandForTheConfiguredBotLogin() {
+    var custom = new TriggerDetector(List.of("my-review-bot[bot]"));
+
+    assertTrue(custom.isReviewTrigger("@my-review-bot review"));
+    assertEquals(CommentCommand.REVIEW, custom.detectCommand("please @My-Review-Bot review this"));
+    assertEquals(CommentCommand.DESCRIBE, custom.detectCommand("@my-review-bot describe"));
+    assertEquals(
+        CommentCommand.NONE,
+        custom.detectCommand("@thrillhousebot review"),
+        "the default slug is not this install's bot");
+    assertEquals(
+        CommentCommand.REVIEW,
+        custom.detectCommand("/review"),
+        "slash forms are login-independent");
+  }
+
+  /** Default-config behavior is unchanged, including the shipped alternate slug. */
+  @Test
+  void shouldStillDetectMentionFormCommandUnderTheDefaultIdentity() {
+    assertTrue(detector.isReviewTrigger("@thrillhousebot review"));
+    assertTrue(detector.isReviewTrigger("@Thrillhousebot review please"));
+    assertEquals(CommentCommand.REVIEW, detector.detectCommand("@thrillhouse-bot review"));
+    assertEquals(CommentCommand.IMPROVE, detector.detectCommand("hey @thrillhousebot improve"));
+  }
+
+  /** An email address's local part is not a mention, so it never triggers a command (#698). */
+  @Test
+  void shouldNotDetectMentionFormCommandInsideAnEmailAddress() {
+    assertEquals(CommentCommand.NONE, detector.detectCommand("foo@thrillhousebot review"));
+    var custom = new TriggerDetector(List.of("my-review-bot[bot]"));
+    assertEquals(CommentCommand.NONE, custom.detectCommand("mail foo@my-review-bot review"));
+    assertEquals(CommentCommand.REVIEW, custom.detectCommand("(@my-review-bot review)"));
+  }
+
   @Test
   void shouldNotDetectMentionWithoutBot() {
     assertFalse(detector.containsBotMention("looks good"));


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

`TriggerDetector.patternsFor` still built the command mention pattern from a hardcoded `@thrillhousebot` slug, so mention-form commands (`@my-review-bot review`, `describe`, `improve`, …) were dead on an install whose GitHub App runs under a different login, while the slash forms (`/review`) still worked.

The command patterns are now built from `BotIdentity.mentionNames()` exactly like the conversational-mention gate from #679:

- each mention name is `Pattern.quote`d — a login is data, never regex
- the `(?:^|[^\w@])@` anchor requires the `@` to open the comment or follow a non-word, non-`@` character, so an email address's local part (`foo@thrillhousebot review`) never triggers a command
- case-insensitive, compiled once per identity (the pattern map moved from a static field to a per-instance field), not per comment

Slash forms are untouched, `stripQuotedContext` still runs before matching, and default-config behavior is unchanged (`@thrillhousebot review` and the shipped alternate slug `@thrillhouse-bot` still work).

## Related Issues

Closes #698

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

New tests in `TriggerDetectorTest`: a custom login (`my-review-bot[bot]`) triggers mention-form `review`/`describe` and rejects the default slug; default identity still detects both shipped slugs; email local parts (`foo@thrillhousebot review`) do not trigger; slash forms remain login-independent. `./mvnw verify` clean locally.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

CHANGELOG `[Unreleased]` Fixed entry added. Follow-up to #679 (PR #692).
