### PR TITLE
fix(release): dispatch the docs deploy instead of relying on release: published

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,11 @@ name: Docs
 on:
   # Live site tracks GitHub Releases only — unreleased work on main /
   # release branches does not publish until a version is cut.
+  #
+  # This fires only for a release published by hand in the UI. A release created
+  # by the Release workflow uses the default GITHUB_TOKEN, and GitHub does not
+  # start workflow runs for events that token raises, so release.yml dispatches
+  # this workflow explicitly (its publish-docs job) instead of relying on it.
   release:
     types: [published]
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,40 @@ jobs:
             gh release create "${args[@]}"
           fi
 
+  # The Docs workflow's `release: published` trigger does not fire for the
+  # release created above: it is created with the default GITHUB_TOKEN, and
+  # GitHub suppresses workflow runs for events that token raises — the same
+  # guard that keeps CI from starting on the bump PR below. In the repo's whole
+  # history that trigger has never once fired, so every release through v0.6.2
+  # published its docs by hand. workflow_dispatch is exempt from the guard, so
+  # the deploy is dispatched explicitly here. The trigger stays on docs.yml for
+  # a release published by hand in the UI, which does fire it.
+  #
+  # Gated on update_latest for the same reason as the bump: the live site tracks
+  # the highest release, so a patch cut on an older line must not republish the
+  # site from its tag.
+  publish-docs:
+    needs: [verify, release, promote]
+    if: needs.promote.outputs.update_latest == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch the docs deploy against the release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.verify.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Deploying from the tag needs the github-pages environment to admit
+          # it: Settings → Environments → github-pages must carry a `v*` tag
+          # policy alongside the `main` branch rule, or the deploy job fails
+          # with "not allowed to deploy to github-pages due to environment
+          # protection rules". Failing here is deliberate — a silent miss is
+          # what let the site sit four versions behind.
+          gh workflow run docs.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG"
+          echo "Dispatched docs.yml against $TAG"
+
   bump-version:
     needs: [verify, release, promote]
     if: needs.promote.outputs.update_latest == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,22 +337,46 @@ jobs:
     if: needs.promote.outputs.update_latest == 'true'
     runs-on: ubuntu-latest
     permissions:
+      # write to dispatch the run, read to poll for it and watch it
       actions: write
     steps:
-      - name: Dispatch the docs deploy against the release tag
+      - name: Deploy the docs from the release tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.verify.outputs.tag }}
         run: |
           set -euo pipefail
-          # Deploying from the tag needs the github-pages environment to admit
-          # it: Settings → Environments → github-pages must carry a `v*` tag
-          # policy alongside the `main` branch rule, or the deploy job fails
-          # with "not allowed to deploy to github-pages due to environment
-          # protection rules". Failing here is deliberate — a silent miss is
-          # what let the site sit four versions behind.
+          # The dispatch only queues the run: `gh workflow run` exits 0 as soon
+          # as GitHub accepts it. The failure this job exists to catch happens
+          # later, inside the deploy — most likely the github-pages environment
+          # refusing the tag, which needs a `v*` policy alongside the `main`
+          # branch rule and produces "not allowed to deploy to github-pages due
+          # to environment protection rules". Waiting for the run is therefore
+          # the whole point: exiting on the dispatch would reproduce the silent
+          # miss that left the site four versions behind, just one step later.
+          before=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           gh workflow run docs.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG"
-          echo "Dispatched docs.yml against $TAG"
+
+          # The dispatch returns no run id, so resolve it by polling for a run
+          # of this workflow on this tag created at or after the dispatch. The
+          # created-after bound is what keeps an earlier manual republish of the
+          # same tag from being mistaken for this one.
+          run_id=""
+          for _ in $(seq 1 30); do
+            run_id=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow docs.yml \
+              --branch "$TAG" --event workflow_dispatch --limit 20 \
+              --json databaseId,createdAt \
+              --jq "[.[] | select(.createdAt >= \"$before\")] | sort_by(.createdAt) | last | .databaseId // empty")
+            [ -n "$run_id" ] && break
+            sleep 10
+          done
+          if [ -z "$run_id" ]; then
+            echo "::error::Dispatched docs.yml against $TAG but no run appeared within 5 minutes"
+            exit 1
+          fi
+
+          echo "Watching docs run $run_id for $TAG"
+          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status --interval 15
 
   bump-version:
     needs: [verify, release, promote]

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -50,10 +50,25 @@ file deleted since that tag, so anything outside the new archive directory and
 
 ## Publishing the docs
 
-`.github/workflows/docs.yml` deploys the live site on `release: published` only,
-so the site tracks releases rather than `main`. That trigger runs **against the
-tag ref**, which makes the deploy depend on one repo setting: the `github-pages`
-environment must allow the tag to deploy.
+`.github/workflows/docs.yml` deploys the live site from a release tag, so the
+site tracks releases rather than `main`. Two things have to hold for that to
+happen on its own, and through v0.6.2 neither did.
+
+**The deploy is dispatched, not triggered.** `docs.yml` declares
+`release: published`, but that event never fires for our releases: the `release`
+job creates them with the default `GITHUB_TOKEN`, and GitHub does not start
+workflow runs for events that token raises — the same recursion guard that keeps
+CI from starting on the bump PR. In the repo's whole history the trigger has
+never once fired, and every release through v0.6.2 published its docs by hand.
+The `publish-docs` job in `release.yml` now dispatches `docs.yml` against the
+tag after the release is created, gated on the release being the highest one so
+a patch on an older line cannot republish the site from its tag.
+`workflow_dispatch` is exempt from the recursion guard. The declared trigger is
+kept because a release published by hand in the UI does fire it.
+
+**The tag must be allowed to deploy.** The build runs **against the tag ref**,
+so the deploy depends on one repo setting: the `github-pages` environment must
+admit the tag.
 
 Current policies, under **Settings → Environments → github-pages → Deployment
 branches and tags**:
@@ -68,14 +83,20 @@ Without the tag rule the deploy fails at the very last step with:
 > Tag "vX.Y.Z" is not allowed to deploy to github-pages due to environment
 > protection rules.
 
-That is what happened to every release through 0.6.1, and the workaround —
+That is what happened to every release through v0.6.1, and the workaround —
 dispatching the workflow from `main` — publishes `main`'s docs instead of the
-release's, which is exactly what the release-only trigger exists to prevent. If
-a deploy fails this way, fix the policy and re-run the workflow against the tag
-rather than dispatching from `main`. Inspect the policies with:
+release's, which is exactly what tracking releases exists to prevent. If a deploy
+fails this way, fix the policy and re-run against the tag rather than dispatching
+from `main`. Inspect the policies with:
 
 ```bash
 gh api repos/<owner>/<repo>/environments/github-pages/deployment-branch-policies
+```
+
+To republish an already-released version by hand, for a docs hotfix on its tag:
+
+```bash
+gh workflow run docs.yml --ref vX.Y.Z
 ```
 
 ## Automated version bump

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -66,6 +66,14 @@ a patch on an older line cannot republish the site from its tag.
 `workflow_dispatch` is exempt from the recursion guard. The declared trigger is
 kept because a release published by hand in the UI does fire it.
 
+The job then **waits for the run it dispatched** and fails with it. `gh workflow
+run` returns as soon as GitHub accepts the dispatch, so a job that stopped there
+would go green while the deploy failed underneath it — the same silent miss one
+step later. The run carries no id back, so the job polls for a `docs.yml` run on
+the tag created at or after the dispatch, which is also what stops an earlier
+manual republish of the same tag from being mistaken for it. A release whose
+docs fail to publish now fails visibly in the release pipeline.
+
 **The tag must be allowed to deploy.** The build runs **against the tag ref**,
 so the deploy depends on one repo setting: the `github-pages` environment must
 admit the tag.


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🏗️ CI/CD
- [x] 📝 Documentation

## Description

The docs site has never deployed itself, including for v0.6.2 just now.

`docs.yml` declares `release: published`, but the `release` job creates the release with the default
`GITHUB_TOKEN`, and GitHub does not start workflow runs for events that token raises — the same
recursion guard already documented for the bump PR. The trigger has fired **zero times** in the
repo's history:

```
docs.yml runs by event: pull_request 96, workflow_dispatch 4, release 0
```

Every release through v0.6.2 published its docs by hand.

**On the `v*` tag policy from #715.** That was a real and separate bug — the build runs against the
tag ref, so the deploy would have been refused by the `github-pages` environment even if the event
had fired. But it was not why nothing ran, and my note in that PR saying the next release would
deploy itself was wrong. What it did fix is the manual path: dispatching against a tag works now for
the first time, which is how v0.6.2's docs went live.

**The fix.** A `publish-docs` job in `release.yml` dispatches `docs.yml` against the release tag once
the release exists. `workflow_dispatch` is exempt from the recursion guard. Three details:

- **Gated on `update_latest`**, like `bump-version`. The live site tracks the highest release, so a
  patch cut on an older line must not republish the site from its tag.
- **Fails loudly** rather than warning. A silent miss is what left the site four versions behind.
- **Runs after `release`**, so the docs never go live for a version whose release did not complete.

The declared `release: published` trigger stays on `docs.yml`, because a release published by hand in
the UI does fire it. Its comment now says so instead of implying it is the live path.

`docs/RELEASING.md` described only the tag policy and claimed the next release would deploy itself.
It now separates the two conditions, records that the trigger does not fire on its own, and gives the
command to republish a tag after a docs hotfix.

## Related Issues

Follows #715, which added the `github-pages` tag policy and the docs-freeze procedure.

## How Has This Been Tested?

- [x] Manual testing

- `actionlint .github/workflows/release.yml .github/workflows/docs.yml` → clean
- `npm run build` in `website/` → all internal links valid
- The dispatch path itself was exercised by hand against `v0.6.2`
  (`gh workflow run docs.yml --ref v0.6.2`): build and deploy both succeeded, and the live site now
  serves v0.6.2 with v0.6.0 and v0.6.1 in the picker
- End to end, the `publish-docs` job can only be proven by the next release

No production code changes.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
