### PR TITLE
fix(review): count only the verdicts the audit acted on as verification coverage

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -498,6 +499,18 @@ public class FindingVerificationService {
   private static final String VERDICTS = "verdicts";
 
   /**
+   * The decision labels the audit acts on, and so the only ones {@link #candidatesCovered} counts
+   * as a screened candidate. Read through {@link #decisionOf} by both that count and {@link
+   * #apply}'s switch, so what the review DOES with a verdict and what it CLAIMS it verified cannot
+   * drift (#710): every other label — absent, blank, or a word this service does not recognize —
+   * lands in {@code apply}'s fail-open default, where the finding posts exactly as the reviewer
+   * raised it. The strictness matches {@link #strictRisk}/{@link #strictConfidence}: an
+   * uninterpretable label from model output is treated as absent rather than guessed at.
+   */
+  private static final Set<String> ACTED_ON_DECISIONS =
+      Set.of("confirmed", "downgraded", "rejected");
+
+  /**
    * Audits the response's findings; {@code diff}, {@code projectStack} and {@code previousFindings}
    * must already be escaped for prompt templating, the same values handed to the review call.
    * Previous findings let the verifier reject re-raises of answered findings. {@code
@@ -673,17 +686,55 @@ public class FindingVerificationService {
   }
 
   /**
-   * How many distinct candidates the salvaged verdicts actually cover. Salvage is best-effort over
-   * model output, so a verdict can carry an id outside the 1-based candidate range; counting only
-   * the ids in range keeps the log honest about what stayed unverified.
+   * How many distinct candidates the verdicts actually screened — the {@code verified} half of the
+   * {@link VerificationCoverage} every lane reports, and so what the published review claims a
+   * second stage ruled on (#623). Salvage is best-effort over model output, so a verdict can carry
+   * an id outside the 1-based candidate range; counting only the ids in range keeps the log honest
+   * about what stayed unverified.
+   *
+   * <p>An id alone is not coverage. A verdict whose decision label is absent, blank or not one of
+   * {@link #ACTED_ON_DECISIONS} falls into {@link #apply}'s fail-open default, where the candidate
+   * posts exactly as the reviewer raised it — the same state a candidate with no verdict at all
+   * ends in — so counting it screened published an unverified finding inside a set the review
+   * called fully verified (#710). That is the harm #623 exists to prevent, and it is the dangerous
+   * direction: the empty-body path keeps every finding unverified and says so, while a set that
+   * mixes verified and unverified findings and reads as fully screened tells the reader nothing is
+   * outstanding. Undercounting instead only costs an over-cautious clause on a finding the audit
+   * did rule on in words this service cannot read.
+   *
+   * <p>Both cut lanes (#546/#617) measure through here, which settles the two edges a cut can land
+   * on. Nothing decidable salvaged reports {@code (N, 0)} — {@link
+   * VerificationCoverage.Outcome#NONE}, the same disclosure the empty-body path renders, because
+   * the findings are in the same state: the verifier ruled on none of them. A cut whose salvage
+   * covers every candidate reports {@code (N, N)} — genuinely {@link
+   * VerificationCoverage.Outcome#FULL}, and deliberately silent. That is not a hypothetical shape:
+   * a body cut after the verdicts array closed raises Jackson's "expected close marker for Object"
+   * against the ROOT object, and every verdict in it is complete. What the cut destroyed there is
+   * the body's tail — the closing punctuation, or elements for ids that do not exist — so every
+   * finding did receive a decision the audit applied, and disclosing a gap would tell the reader a
+   * fully screened set was not screened. The cut is logged either way, so an operator chasing the
+   * response-length cap keeps the signal the reader does not need.
    */
   private static long candidatesCovered(
       List<VerificationResponse.Verdict> salvaged, int candidates) {
     return salvaged.stream()
+        .filter(verdict -> ACTED_ON_DECISIONS.contains(decisionOf(verdict)))
         .mapToInt(VerificationResponse.Verdict::id)
         .filter(id -> id >= 1 && id <= candidates)
         .distinct()
         .count();
+  }
+
+  /**
+   * The verdict's decision, normalized the one way both {@link #apply} and {@link
+   * #candidatesCovered} read it; the empty string for a candidate with no verdict and for a verdict
+   * carrying no label. One reader so the two cannot disagree about what counts as a decision — the
+   * drift #710 was filed on.
+   */
+  private static String decisionOf(VerificationResponse.Verdict verdict) {
+    return verdict == null || verdict.verdict() == null
+        ? ""
+        : verdict.verdict().toLowerCase(Locale.ROOT);
   }
 
   /**
@@ -1105,8 +1156,7 @@ public class FindingVerificationService {
     for (var i = 0; i < response.findings().size(); i++) {
       var finding = response.findings().get(i);
       var verdict = byId.get(i + 1);
-      String decision = verdict != null && verdict.verdict() != null ? verdict.verdict() : "";
-      switch (decision.toLowerCase(Locale.ROOT)) {
+      switch (decisionOf(verdict)) {
         case "rejected" -> {
           rejected++;
           Log.infof(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -650,6 +650,132 @@ class FindingVerificationServiceTest {
   }
 
   @Test
+  void reportsPartialCoverageWhenACutSalvagesAVerdictCarryingNoDecision() {
+    // #710: the cut lands after the verdicts array closed, so Jackson fails on the ROOT object
+    // ("expected close marker for Object") and salvage recovers every element — including one the
+    // model left without a decision. That candidate posts exactly as the reviewer raised it, like
+    // one with no verdict at all, so counting its id as coverage published a set that mixes
+    // verified and unverified findings and reads as fully screened. The count follows what the
+    // audit could act on, not what carried an id.
+    ReviewResponse original =
+        response(finding("critical", "high", "Ruled on"), finding("high", "high", "Never decided"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiOk(
+                """
+            {"verdicts": [
+              {"id": 1, "verdict": "rejected", "reason": "framework idiom"},
+              {"id": 2, "reason": "still weighing this one"}]"""));
+    var reported = new ArrayList<VerificationCoverage>();
+
+    var result = service.verify(SESSION, original, "diff", "stack", "", reported::add);
+
+    // Fail-open is untouched: the undecided candidate survives at its original rating.
+    assertEquals(1, result.findings().size());
+    assertEquals("Never decided", result.findings().get(0).title());
+    assertEquals("high", result.findings().get(0).risk());
+    assertEquals(List.of(new VerificationCoverage(2, 1)), reported);
+    assertEquals(VerificationCoverage.Outcome.PARTIAL, reported.get(0).outcome());
+  }
+
+  @Test
+  void reportsPartialCoverageWhenTheLengthCapSalvagesAVerdictCarryingNoDecision() {
+    // The same drift on the reported-length-stop lane (#599), driven end to end: the truncation
+    // unwinds into the salvage, which recovers both closed elements, and only the one the audit
+    // acted on counts as coverage.
+    ReviewResponse original =
+        response(finding("critical", "high", "Ruled on"), finding("high", "high", "Never decided"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiTruncated(
+                """
+            {"verdicts": [
+              {"id": 1, "verdict": "downgraded", "risk": "low", "confidence": "low", "reason": "r"},
+              {"id": 2, "reason": "still weighing this one"}]"""));
+    var reported = new ArrayList<VerificationCoverage>();
+
+    var result = service.verify(SESSION, original, "diff", "stack", "", reported::add);
+
+    assertEquals(2, result.findings().size());
+    assertEquals("low", result.findings().get(0).risk());
+    assertEquals("high", result.findings().get(1).risk());
+    assertEquals(List.of(new VerificationCoverage(2, 1)), reported);
+    assertEquals(VerificationCoverage.Outcome.PARTIAL, reported.get(0).outcome());
+  }
+
+  @Test
+  void reportsZeroCoverageWhenACutSalvagesOnlyVerdictsCarryingNoDecision() {
+    // The zero edge of the same rule: elements came back, so the salvage is not empty and the
+    // parse failure is never rethrown — but none of them decided anything, which leaves the
+    // findings in the state the empty-body path leaves them in, and must disclose the same way.
+    ReviewResponse original =
+        response(finding("critical", "high", "Bug"), finding("low", "high", "Nit"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiOk(
+                """
+            {"verdicts": [
+              {"id": 1, "reason": "still weighing this one"},
+              {"id": 2, "verdict": "", "reason": "and this one"}]"""));
+    var reported = new ArrayList<VerificationCoverage>();
+
+    var result = service.verify(SESSION, original, "diff", "stack", "", reported::add);
+
+    assertEquals(2, result.findings().size());
+    assertEquals(List.of(new VerificationCoverage(2, 0)), reported);
+    assertEquals(VerificationCoverage.Outcome.NONE, reported.get(0).outcome());
+  }
+
+  @Test
+  void reportsFullCoverageWhenACutSalvagedEveryCandidatesVerdict() {
+    // Characterization, not red/green — the other edge #710 asks about, pinned so it cannot drift
+    // into a false alarm. A cut that lands after the verdicts array closed destroyed only the
+    // body's tail: every candidate received a decision the audit applied, so the finding set WAS
+    // fully screened and owes the reader no clause. The cut is still logged for the operator.
+    ReviewResponse original =
+        response(finding("critical", "high", "Ruled on"), finding("high", "high", "Also ruled on"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiOk(
+                """
+            {"verdicts": [
+              {"id": 1, "verdict": "rejected", "reason": "framework idiom"},
+              {"id": 2, "verdict": "confirmed", "reason": "real"}]"""));
+    var reported = new ArrayList<VerificationCoverage>();
+
+    var result = service.verify(SESSION, original, "diff", "stack", "", reported::add);
+
+    assertEquals(1, result.findings().size());
+    assertEquals(List.of(new VerificationCoverage(2, 2)), reported);
+    assertFalse(reported.get(0).disclosed());
+  }
+
+  @Test
+  void doesNotCountAVerdictWhoseDecisionTheAuditCannotRead() {
+    // Not cut at all: a complete body whose verdict carries a label this service does not act on.
+    // The finding posts exactly as raised — the fail-open default — so the review must not claim
+    // it was screened, on the same reasoning strictRisk/strictConfidence refuse to guess at a
+    // garbled rating rather than collapsing a finding on it.
+    ReviewResponse original =
+        response(finding("critical", "high", "Ruled on"), finding("high", "high", "Unreadable"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiOk(
+                """
+            {"verdicts": [
+              {"id": 1, "verdict": "rejected", "reason": "framework idiom"},
+              {"id": 2, "verdict": "needs-more-thought", "reason": "unclear"}]}"""));
+    var reported = new ArrayList<VerificationCoverage>();
+
+    var result = service.verify(SESSION, original, "diff", "stack", "", reported::add);
+
+    assertEquals(1, result.findings().size());
+    assertEquals("Unreadable", result.findings().get(0).title());
+    assertEquals(List.of(new VerificationCoverage(2, 1)), reported);
+    assertEquals(VerificationCoverage.Outcome.PARTIAL, reported.get(0).outcome());
+  }
+
+  @Test
   void reportsZeroCoverageWhenTheCutLeavesNoCompleteVerdict() {
     ReviewResponse original = response(finding("critical", "high", "Bug"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString()))


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`FindingVerificationService` reports how much of the candidate set the second-pass audit
covered, and #623 turns a non-FULL coverage into a banner, a coverage clause and a check-run
brief. The `verified` half of that record asked only whether **some** salvaged verdict carried
the candidate's id.

That is not the same question as "was this finding screened". `apply()` acts on three decisions
— `confirmed`, `downgraded`, `rejected` — and everything else (no `verdict` field, a blank one,
or a label this service does not recognize) lands in its fail-open default, where the finding
posts exactly as the reviewer raised it, indistinguishable from a candidate with no verdict at
all. The coverage count called those screened anyway, so a cut whose salvage recovered such an
element reported **FULL** coverage and every surface stayed silent about a published set that
mixed verified and unverified findings and read as fully screened.

The fix routes both `apply()`'s switch and the coverage count through one decision normalizer,
so what the review *does* with a verdict and what it *claims* it verified cannot drift.
Undercounting is the safe direction: it costs an over-cautious clause on a finding the audit
ruled on in words we cannot read, while the silence it replaces is exactly the harm #623 exists
to prevent.

**On the two cut edges the issue asks about** — both were measured against the real code, not
assumed, and are now pinned in the javadoc and in tests:

- **Zero salvaged.** Already `(N, 0)` → `NONE` on both cut lanes; unchanged. The new sibling
  case — elements salvaged but *none of them decidable* — now reports `(N, 0)` too, since the
  findings are in the state the empty-body path leaves them in.
- **All salvaged.** Stays genuinely `FULL`, deliberately. A body cut after the verdicts array
  closed raises Jackson's `Unexpected end-of-input: expected close marker for Object` against
  the **root** object, and every verdict inside it is complete and applied; what the cut
  destroyed is the body's tail. Disclosing a gap there would tell the reader a fully screened
  set was not screened. The cut is still logged for the operator either way.

Measurement note for the reported symptom: a *partial* salvage was already reported as `PARTIAL`
on both cut lanes before this change (`(3, 2)`, `(2, 1)` — pinned by existing tests and
re-confirmed by probe). The only way the cut lanes could read `FULL` was a salvage covering every
candidate — either genuinely complete verdicts (correct, and kept), or the undecidable-verdict
drift this PR closes. The log line quoted in the issue is the root-object shape: Jackson's message
is multi-line, so `salvaged N verdict(s) covering M of K candidate finding(s)` sits on a later
line of the same record, and the absence of `Finding verification: N kept, M downgraded, K
rejected` only means nothing was rejected or downgraded — `apply()` logs that line only when it
changed something.

Fail-open is untouched: coverage changes what the review says, never which findings it keeps.

## Related Issues

Closes #710

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Red/green, with the new tests run against the unfixed service first:

```
[ERROR] Tests run: 5, Failures: 4, Errors: 0, Skipped: 0
[ERROR]   FindingVerificationServiceTest.doesNotCountAVerdictWhoseDecisionTheAuditCannotRead:774
  expected: <[VerificationCoverage[candidates=2, verified=1]]> but was: <[VerificationCoverage[candidates=2, verified=2]]>
[ERROR]   FindingVerificationServiceTest.reportsPartialCoverageWhenACutSalvagesAVerdictCarryingNoDecision:677
  expected: <[VerificationCoverage[candidates=2, verified=1]]> but was: <[VerificationCoverage[candidates=2, verified=2]]>
[ERROR]   FindingVerificationServiceTest.reportsPartialCoverageWhenTheLengthCapSalvagesAVerdictCarryingNoDecision:702
  expected: <[VerificationCoverage[candidates=2, verified=1]]> but was: <[VerificationCoverage[candidates=2, verified=2]]>
[ERROR]   FindingVerificationServiceTest.reportsZeroCoverageWhenACutSalvagesOnlyVerdictsCarryingNoDecision:725
  expected: <[VerificationCoverage[candidates=2, verified=0]]> but was: <[VerificationCoverage[candidates=2, verified=2]]>
```

The fifth (`reportsFullCoverageWhenACutSalvagedEveryCandidatesVerdict`) is characterization, not
red/green: it pins the all-salvaged edge so it cannot drift into a false alarm.

Two of the new tests drive a real cut end to end rather than the record type — one through the
parse-failure lane (`STOP`, body cut after the array closed) and one through the reported
`finish_reason=length` lane, which unwinds via `AiResponseTruncatedException` into
`salvageTruncatedVerdicts`.

Downstream disclosure was verified rather than assumed: `VerdictBuilderTest`
(`partialVerificationCoverageDisclosesTheHonestXOfY`) already proves a recorded `(4, 3)` renders
`only covered 3 of the 4 finding(s)` in the summary and
`Verification covered 3 of 4 finding(s); the rest posted unverified.` in the check-run brief.

Gates, all green:

```
./mvnw -B clean compile spotbugs:check spotless:check
[INFO] --- spotbugs:4.10.3.0:check (default-cli) @ thrillhousebot ---
[INFO] BugInstance size is 0
[INFO] --- spotless:3.9.0:check (default-cli) @ thrillhousebot ---
[INFO] BUILD SUCCESS

./mvnw -B clean test
[INFO] Tests run: 3253, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

Patch coverage from `target/site/jacoco/jacoco.xml` intersected with `git diff -U0 origin/main --`:
7 instrumented changed main lines, **0 uncovered lines and 0 uncovered branches** (the
`decisionOf` ternary reports 4/4 branches, the reworked `apply()` switch 3/3).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

None.

## Additional Notes

No behaviour change to the fail-open contract, to #617's salvaging of the verdicts that closed
before a cut, or to the verdict application itself — only to what the coverage record counts as
a screened candidate.
