### PR TITLE
fix(review): disclose overturned declines on every body and name the findings a round closed

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummary.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummary.java
@@ -15,6 +15,9 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -24,17 +27,19 @@ import java.util.Optional;
  * <p>Deliberately <em>not</em> a second render method on {@link PrSummaryGenerator}: that class
  * assembles the 500-line first-review summary from the model's summary object, the PR-level diff
  * stats, the walkthrough table and the optional diagram, and is gated on its own config. This
- * comment needs none of that — it is a pure function of the {@link ReviewResult} counts — so
- * folding it in would mean threading unrelated inputs through, and would put two different comment
- * shapes behind one entry point. Keeping it separate also keeps {@link
- * PrSummaryGenerator#SUMMARY_HEADING} out of the rendered body, which matters: that heading is the
- * marker {@code ReviewContextLoader.isBotSummaryComment} uses to recognize the bot's summary, and a
- * delta comment carrying it would be mistaken for one — edited in place on a superseded round, and
- * counted as an already-posted summary when deciding whether a review is the first.
+ * comment needs none of that — it is a pure function of the {@link ReviewResult} counts and the
+ * previous round's findings it names them from — so folding it in would mean threading unrelated
+ * inputs through, and would put two different comment shapes behind one entry point. Keeping it
+ * separate also keeps {@link PrSummaryGenerator#SUMMARY_HEADING} out of the rendered body, which
+ * matters: that heading is the marker {@code ReviewContextLoader.isBotSummaryComment} uses to
+ * recognize the bot's summary, and a delta comment carrying it would be mistaken for one — edited
+ * in place on a superseded round, and counted as an already-posted summary when deciding whether a
+ * review is the first.
  *
  * <p>Three counts are rendered, all sourced from the statuses the follow-up pipeline already
  * produced rather than recomputed here: findings raised this round, previous findings the round
- * closed, and previous findings still open. A {@code justified} status (declined by a maintainer)
+ * closed, and previous findings still open. The closed ones are also named, one {@code path:line} —
+ * title line each ({@link #resolvedNames}). A {@code justified} status (declined by a maintainer)
  * is in none of them — it is neither newly fixed nor still open — and {@code superseded} is not
  * counted either: it is an auto-close because the targeted code left the diff, not something the
  * round fixed. A superseded round also re-posts the full summary, and the caller skips this comment
@@ -65,7 +70,8 @@ final class FollowUpDeltaSummary {
    * re-states the same open count is exactly the per-push noise this feature must not add, and it
    * is also the shape a miscounted carry-over takes, which is better left un-amplified.
    */
-  static Optional<String> render(ReviewResult result) {
+  static Optional<String> render(
+      ReviewResult result, List<ReviewResponse.Finding> previousFindings) {
     var newFindings = result.totalFindings();
     var resolved = result.resolvedPreviousCount();
     if (newFindings == 0 && resolved == 0) {
@@ -82,6 +88,7 @@ final class FollowUpDeltaSummary {
             + "- **Previous findings resolved:** "
             + resolved
             + "\n"
+            + resolvedNames(result, previousFindings)
             + "- **Previous findings still open:** "
             + result.unresolvedPreviousCount()
             + "\n"
@@ -98,5 +105,70 @@ final class FollowUpDeltaSummary {
       body += "\n\n> ⚠️ " + ReviewResult.verificationBrief(result.truncation().verification());
     }
     return Optional.of(body);
+  }
+
+  /**
+   * How many closed findings the delta names before rolling the rest up as a count. Matches the
+   * bound {@code ReviewResult.nameList} puts on the coverage disclosure's file names, for the same
+   * reason: one comment carries all of this, and a PR can close many findings in one round.
+   */
+  private static final int NAMED_RESOLVED_LIMIT = 10;
+
+  /**
+   * The indented sub-list naming each finding the {@code resolved} count covers, or an empty string
+   * when none can be named. Each entry carries the {@code path:line} locator and the title — the
+   * same two identifiers an {@code @thrillhousebot resolved} directive uses to name a finding
+   * (#548), so a maintainer can read the match straight off the comment (#714).
+   *
+   * <p>Without it the round published three bare integers and no surface anywhere said
+   * <em>which</em> finding closed: the maintainer had to diff the PR's thread state across rounds
+   * to find out, and a maintainer who named several findings in one directive could not tell which
+   * the reviewer matched and which it silently skipped — matching is by {@code path:line} plus
+   * title and the guards reject several spellings, so a skip is a real outcome. That matters most
+   * for a finding published with no inline thread, where the directive is the only action that can
+   * close it at all and there is no thread state to diff either.
+   *
+   * <p>Names every finding the count counts, not only the ones a directive cleared: the list has to
+   * add up to the integer above it, and a fix that landed is just as unnamed without it. Ids are
+   * 1-based positions in the previous round, so an id outside that list names nothing and is
+   * skipped rather than guessed at — the count above stays authoritative either way.
+   */
+  private static String resolvedNames(
+      ReviewResult result, List<ReviewResponse.Finding> previousFindings) {
+    if (previousFindings == null || previousFindings.isEmpty()) {
+      return "";
+    }
+    var named = new ArrayList<String>();
+    for (var status : result.previousStatuses()) {
+      if (!"resolved".equalsIgnoreCase(status.status())
+          || status.id() < 1
+          || status.id() > previousFindings.size()) {
+        continue;
+      }
+      named.add(describe(previousFindings.get(status.id() - 1)));
+    }
+    if (named.isEmpty()) {
+      return "";
+    }
+    var sb = new StringBuilder();
+    for (var entry : named.subList(0, Math.min(named.size(), NAMED_RESOLVED_LIMIT))) {
+      sb.append("  - ").append(entry).append("\n");
+    }
+    if (named.size() > NAMED_RESOLVED_LIMIT) {
+      sb.append("  - …and ").append(named.size() - NAMED_RESOLVED_LIMIT).append(" more\n");
+    }
+    return sb.toString();
+  }
+
+  /**
+   * One closed finding as {@code `path:line` — title}. Both halves go through {@link MarkdownSafe}:
+   * they are model-authored text spliced into a list item, and a raw newline or backtick would
+   * restructure the comment. A finding with no title renders as the bare locator rather than a
+   * dangling dash — the locator alone still identifies it.
+   */
+  private static String describe(ReviewResponse.Finding finding) {
+    var locator = MarkdownSafe.inlineCode(finding.file() + ":" + finding.line());
+    var title = MarkdownSafe.inline(finding.title());
+    return title.isBlank() ? "`" + locator + "`" : "`" + locator + "` — " + title;
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -23,6 +23,7 @@ import dev.thiagogonzaga.thrillhousebot.dashboard.SessionEventBroadcaster;
 import dev.thiagogonzaga.thrillhousebot.github.*;
 import dev.thiagogonzaga.thrillhousebot.review.ai.AiContextWindowExceededException;
 import dev.thiagogonzaga.thrillhousebot.review.ai.AiResponseTruncatedException;
+import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
@@ -315,7 +316,7 @@ public class ReviewOrchestrator {
       boolean summaryPosted = publishSummaryBestEffort(auth, req, result);
       // Opt-in follow-up delta comment. Runs only when no summary was posted this round, and its
       // outcome is intentionally discarded — it must not feed summaryPosted below.
-      publishFollowUpDeltaBestEffort(auth, req, result, summaryPosted);
+      publishFollowUpDeltaBestEffort(auth, req, result, summaryPosted, previousFindings);
       reviewPublisher.dismissPendingBotReviews(
           auth, req.owner(), req.repo(), req.prNumber(), priorReviews);
       // summaryPosted gates the redundant-review skips: a failed summary post leaves review
@@ -486,10 +487,14 @@ public class ReviewOrchestrator {
    * stands in for the review, so it can never gate the redundant-review skips.
    */
   private void publishFollowUpDeltaBestEffort(
-      String auth, ReviewRequest req, ReviewResult result, boolean summaryPosted) {
+      String auth,
+      ReviewRequest req,
+      ReviewResult result,
+      boolean summaryPosted,
+      List<ReviewResponse.Finding> previousFindings) {
     try {
       reviewPublisher.publishFollowUpDelta(
-          auth, req.owner(), req.repo(), req.prNumber(), result, summaryPosted);
+          auth, req.owner(), req.repo(), req.prNumber(), result, summaryPosted, previousFindings);
     } catch (RuntimeException e) {
       Log.warnf(
           e,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -131,6 +131,9 @@ public class ReviewPublisher {
    *
    * @param summaryPosted whether {@link #publishSummary} created or refreshed a summary comment on
    *     this round — when it did, this comment is skipped rather than posted beside it
+   * @param previousFindings the previous round's findings, in prompt-id order, so the comment can
+   *     name the ones it closed by {@code path:line} and title instead of reporting a bare count
+   *     (#714)
    * @return {@code true} when the delta comment was created; {@code false} when the feature is off,
    *     the review is a first review, a summary was posted, or the round has no delta to report
    */
@@ -140,11 +143,12 @@ public class ReviewPublisher {
       String repo,
       int prNumber,
       ReviewResult result,
-      boolean summaryPosted) {
+      boolean summaryPosted,
+      List<ReviewResponse.Finding> previousFindings) {
     if (!config.review().followUpSummary().enabled() || result.isFirstReview() || summaryPosted) {
       return false;
     }
-    var body = FollowUpDeltaSummary.render(result);
+    var body = FollowUpDeltaSummary.render(result, previousFindings);
     if (body.isEmpty()) {
       Log.debugf(
           "No delta to report for %s/%s #%d — skipping the follow-up summary comment",
@@ -914,6 +918,10 @@ public class ReviewPublisher {
    * ReviewResult#previousStatuses}), not the raw model statuses: a decline the re-check overturned
    * is {@code unresolved} here, so its thread is correctly left open rather than resolved on a
    * status the code already rejected (F7).
+   *
+   * <p>A finding a maintainer cleared with an {@code @thrillhousebot resolved} directive also gets
+   * a reply on its thread before the thread closes (#714), so the record of the close sits at the
+   * point of the discussion rather than only in a count on a separate comment.
    */
   void resolveAddressedThreads(
       String auth,
@@ -922,13 +930,12 @@ public class ReviewPublisher {
       List<GitHubReviewClient.PullRequestComment> inlineComments,
       List<ReviewResult.PreviousFindingStatus> statuses) {
     try {
-      List<Integer> addressed =
+      List<ReviewResult.PreviousFindingStatus> addressed =
           statuses.stream()
               .filter(
                   s ->
                       "resolved".equalsIgnoreCase(s.status())
                           || "justified".equalsIgnoreCase(s.status()))
-              .map(ReviewResult.PreviousFindingStatus::id)
               .toList();
       if (addressed.isEmpty() || inlineComments.isEmpty()) {
         return;
@@ -938,13 +945,17 @@ public class ReviewPublisher {
       var threads =
           reviewThreadService.threadsByRootComment(auth, req.owner(), req.repo(), req.prNumber());
       var resolved = 0;
-      for (int findingId : addressed) {
-        var rootCommentId = rootByFinding.get(findingId);
+      for (var status : addressed) {
+        var rootCommentId = rootByFinding.get(status.id());
         ReviewThreadService.ThreadRef thread =
             rootCommentId != null ? threads.get(rootCommentId) : null;
-        if (thread != null
-            && !thread.resolved()
-            && reviewThreadService.resolve(auth, thread.id())) {
+        if (thread == null || thread.resolved()) {
+          continue;
+        }
+        if (clearedByDirective(status)) {
+          replyOnClearedThread(auth, req, rootCommentId);
+        }
+        if (reviewThreadService.resolve(auth, thread.id())) {
           resolved++;
         }
       }
@@ -955,6 +966,57 @@ public class ReviewPublisher {
       }
     } catch (RuntimeException e) {
       Log.warn("Failed to resolve addressed review threads (continuing)", e);
+    }
+  }
+
+  /**
+   * Whether this status was closed by a maintainer's clearing directive rather than by a landed fix
+   * or a model verdict. Matched on the exact note {@link FollowUpAnalyzer#conversationClearedNote}
+   * writes — that rewrite is the only producer of it — so a thread only ever gets the reply below
+   * when the directive is what closed it.
+   */
+  private boolean clearedByDirective(ReviewResult.PreviousFindingStatus status) {
+    return FollowUpAnalyzer.conversationClearedNote(botIdentity).equals(status.note());
+  }
+
+  /**
+   * The reply left on a thread the clearing directive closed. Deterministic prose, not a generated
+   * answer: it states exactly what happened, so it cannot overstate or contradict the decision the
+   * review already took. The directive is rendered inside a code span, which is precisely the form
+   * {@link FollowUpAnalyzer#isClearDirective} treats as documentation rather than a command — a bot
+   * comment that reads as a fresh directive is not something a later round should act on.
+   */
+  static String clearedThreadReply(BotIdentity botIdentity) {
+    return "✅ Closed by a maintainer's `@"
+        + botIdentity.primaryMention()
+        + " resolved` comment on the PR conversation — this finding is no longer tracked as open."
+        + " Re-open this thread if that was not intended.";
+  }
+
+  /**
+   * Posts {@link #clearedThreadReply} into the cleared finding's thread, ahead of resolving it, so
+   * the record lands inside the thread rather than after it closes. Swallows its own failures: the
+   * reply is disclosure, and losing it must not cost the thread resolution that follows.
+   */
+  private void replyOnClearedThread(
+      String auth, ReviewOrchestrator.ReviewRequest req, long rootCommentId) {
+    try {
+      reviewClient.replyToReviewComment(
+          auth,
+          ACCEPT,
+          req.owner(),
+          req.repo(),
+          req.prNumber(),
+          rootCommentId,
+          new GitHubReviewClient.ReplyToReviewCommentRequest(clearedThreadReply(botIdentity)));
+    } catch (RuntimeException e) {
+      Log.warnf(
+          e,
+          "Failed to reply on cleared thread %d for %s/%s #%d (continuing)",
+          rootCommentId,
+          req.owner(),
+          req.repo(),
+          req.prNumber());
     }
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -366,6 +366,7 @@ public class ReviewPublisher {
             owner, repo, prNumber);
       }
       var fallbackParts = new ArrayList<>(skippedFindingsBodyParts(inline));
+      fallbackParts.addAll(reopenedDeclineNotes(result));
       appendTruncationNotice(fallbackParts, result);
       createReviewWithFallback(
           auth,
@@ -382,6 +383,7 @@ public class ReviewPublisher {
       bodyParts.add("ThrillhouseBot requested changes — see inline comments on the diff.");
     }
     bodyParts.addAll(skippedFindingsBodyParts(inline));
+    bodyParts.addAll(reopenedDeclineNotes(result));
     appendTruncationNotice(bodyParts, result);
     if (!bodyParts.isEmpty()) {
       createReviewWithFallback(
@@ -561,20 +563,39 @@ public class ReviewPublisher {
   }
 
   /**
-   * Appends the explanatory note of each unresolved previous finding whose decline the re-check
-   * overturned ({@link RebuttalContradiction}) — the reply's premise, the contradicting line, and
-   * the "reply again to keep the decline" escape hatch. Without this the maintainer sees only the
-   * generic "N previous finding(s) remain unresolved" line and no reason their decline was not
-   * honored (F6). Only the reopened-decline note is surfaced; the backstop's generic carry-over
-   * note and the model's own unresolved notes stay out of the review body.
+   * The explanatory note of each unresolved previous finding whose decline the re-check overturned
+   * ({@link RebuttalContradiction}) — the reply's premise, the contradicting line, and the "reply
+   * again to keep the decline" escape hatch. Without them the maintainer sees only the generic "N
+   * previous finding(s) remain unresolved" line and no reason their decline was not honored (F6).
+   * Only the reopened-decline note is surfaced; the backstop's generic carry-over note and the
+   * model's own unresolved notes stay out of the review body.
+   *
+   * <p>Every review body must carry these, not just the no-new-findings one (#713). The note used
+   * to render from {@link #noIssuesBody} alone, so a round that happened to raise a finding took
+   * the with-findings path and dropped it silently — leaving "the model never read this as a
+   * decline" and "the model accepted the decline and the deterministic re-check overturned it"
+   * indistinguishable from outside, which is the same undisclosed-decision harm as #542/#598. Each
+   * note is self-contained (it names the claim, the contradicting line and the way to keep the
+   * decline), so it reads correctly as its own review-body section with no unresolved-count lead-in
+   * above it — that sentence opens with "No new issues in this revision", which a round posting
+   * findings must not claim.
    */
-  private static void appendReopenedDeclineNotes(StringBuilder sb, ReviewResult result) {
+  private static List<String> reopenedDeclineNotes(ReviewResult result) {
+    var notes = new ArrayList<String>();
     for (var status : result.previousStatuses()) {
       if ("unresolved".equalsIgnoreCase(status.status())
           && status.note() != null
           && status.note().startsWith(RebuttalContradiction.NOTE_LEAD_IN)) {
-        sb.append("\n\n").append(status.note().strip());
+        notes.add(status.note().strip());
       }
+    }
+    return notes;
+  }
+
+  /** {@link #reopenedDeclineNotes} appended to the no-new-findings body's unresolved line. */
+  private static void appendReopenedDeclineNotes(StringBuilder sb, ReviewResult result) {
+    for (var note : reopenedDeclineNotes(result)) {
+      sb.append("\n\n").append(note);
     }
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummaryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummaryTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -51,18 +53,27 @@ class FollowUpDeltaSummaryTest {
     return new Finding(RiskLevel.MEDIUM, file, 1, "title", "description", null, null);
   }
 
+  /** Renders with no previous round to name closed findings from — the counts-only assertions. */
+  private static Optional<String> render(ReviewResult result) {
+    return FollowUpDeltaSummary.render(result, List.of());
+  }
+
+  private static ReviewResponse.Finding previous(String file, int line, String title) {
+    return new ReviewResponse.Finding("medium", file, line, title, "description", null, null);
+  }
+
   @Test
   void noNewFindingsAndNothingResolvedRendersNothing() {
     // The anti-noise case: a follow-up pass where nothing moved. Previous findings that merely
     // stayed open are not a delta and must never produce a comment on their own.
     var result = followUp(List.of(), List.of(status(1, "unresolved"), status(2, "unresolved")), 0);
 
-    assertEquals(Optional.empty(), FollowUpDeltaSummary.render(result));
+    assertEquals(Optional.empty(), render(result));
   }
 
   @Test
   void emptyRoundWithNoPreviousStatusesRendersNothing() {
-    assertEquals(Optional.empty(), FollowUpDeltaSummary.render(followUp(List.of(), List.of(), 0)));
+    assertEquals(Optional.empty(), render(followUp(List.of(), List.of(), 0)));
   }
 
   @Test
@@ -71,7 +82,7 @@ class FollowUpDeltaSummaryTest {
     // full summary instead (and the publisher then skips this comment anyway).
     var result = followUp(List.of(), List.of(status(1, "justified"), status(2, "superseded")), 0);
 
-    assertEquals(Optional.empty(), FollowUpDeltaSummary.render(result));
+    assertEquals(Optional.empty(), render(result));
   }
 
   @Test
@@ -82,7 +93,7 @@ class FollowUpDeltaSummaryTest {
             List.of(status(1, "unresolved"), status(2, "justified")),
             0);
 
-    var body = FollowUpDeltaSummary.render(result).orElseThrow();
+    var body = render(result).orElseThrow();
 
     assertTrue(body.startsWith(FollowUpDeltaSummary.DELTA_HEADING), body);
     assertTrue(body.contains("**New findings this round:** 2"), body);
@@ -98,7 +109,7 @@ class FollowUpDeltaSummaryTest {
             List.of(status(1, "resolved"), status(2, "RESOLVED"), status(3, "unresolved")),
             0);
 
-    var body = FollowUpDeltaSummary.render(result).orElseThrow();
+    var body = render(result).orElseThrow();
 
     assertTrue(body.contains("**New findings this round:** 0"), body);
     assertTrue(body.contains("**Previous findings resolved:** 2"), body);
@@ -106,10 +117,97 @@ class FollowUpDeltaSummaryTest {
   }
 
   @Test
+  void closedFindingsAreNamedByLocatorAndTitle() {
+    // #714: three bare integers left the maintainer diffing GitHub thread state to learn which
+    // finding a clearing directive actually closed. The delta now names each one with the same
+    // `path:line` and title the directive used, and names only the ones the resolved count covers.
+    var result =
+        followUp(
+            List.of(),
+            List.of(status(1, "resolved"), status(2, "unresolved"), status(3, "RESOLVED")),
+            0);
+    var previous =
+        List.of(
+            previous("src/main/java/A.java", 10, "Guard the null token"),
+            previous("src/main/java/B.java", 20, "Still open"),
+            previous("src/main/java/C.java", 30, "Close the stream"));
+
+    var body = FollowUpDeltaSummary.render(result, previous).orElseThrow();
+
+    assertTrue(body.contains("**Previous findings resolved:** 2"), body);
+    assertTrue(body.contains("  - `src/main/java/A.java:10` — Guard the null token\n"), body);
+    assertTrue(body.contains("  - `src/main/java/C.java:30` — Close the stream\n"), body);
+    assertFalse(body.contains("src/main/java/B.java"), body);
+    // The names sit between the count they explain and the still-open line, not after it.
+    assertTrue(
+        body.indexOf("src/main/java/A.java") < body.indexOf("**Previous findings still open:** 1"),
+        body);
+  }
+
+  @Test
+  void closedFindingNamesAreBoundedAndRollTheRestUp() {
+    // A PR can close many findings in one round and this comment has a size budget, so the list is
+    // capped like the coverage disclosure's file names and the remainder becomes a count.
+    var statuses = new ArrayList<ReviewResult.PreviousFindingStatus>();
+    var previous = new ArrayList<ReviewResponse.Finding>();
+    for (int i = 1; i <= 12; i++) {
+      statuses.add(status(i, "resolved"));
+      previous.add(previous("src/F" + i + ".java", i, "Finding " + i));
+    }
+
+    var body =
+        FollowUpDeltaSummary.render(followUp(List.of(), statuses, 0), previous).orElseThrow();
+
+    assertTrue(body.contains("  - `src/F10.java:10` — Finding 10\n"), body);
+    assertFalse(body.contains("src/F11.java"), body);
+    assertTrue(body.contains("  - …and 2 more\n"), body);
+  }
+
+  @Test
+  void closedFindingWithNoTitleIsNamedByItsLocatorAlone() {
+    // A finding the model gave no title renders as the bare locator rather than a dangling dash.
+    // Both halves are model text spliced into a list item, so they route through MarkdownSafe.
+    var previous =
+        List.of(
+            previous("src/A.java", 10, null),
+            previous("src/B.java", 20, "Backticked `code` and a\nnewline"));
+
+    var body =
+        FollowUpDeltaSummary.render(
+                followUp(List.of(), List.of(status(1, "resolved"), status(2, "resolved")), 0),
+                previous)
+            .orElseThrow();
+
+    assertTrue(body.contains("  - `src/A.java:10`\n"), body);
+    assertTrue(
+        body.contains("  - `src/B.java:20` — Backticked &#96;code&#96; and a newline\n"), body);
+  }
+
+  @Test
+  void closedFindingsWithNoResolvablePreviousRoundRenderCountsOnly() {
+    // An id outside the previous round names nothing, and a round loaded without its previous
+    // findings has nothing to name from at all: the counts stay authoritative, no list renders.
+    var statuses = List.of(status(1, "resolved"), status(7, "resolved"));
+
+    var unnamed = render(followUp(List.of(), statuses, 0)).orElseThrow();
+    var absent = FollowUpDeltaSummary.render(followUp(List.of(), statuses, 0), null).orElseThrow();
+    var outOfRange =
+        FollowUpDeltaSummary.render(
+                followUp(List.of(), List.of(status(0, "resolved"), status(7, "resolved")), 0),
+                List.of(previous("src/A.java", 10, "Only finding")))
+            .orElseThrow();
+
+    assertTrue(unnamed.contains("**Previous findings resolved:** 2"), unnamed);
+    assertFalse(unnamed.contains("  - `"), unnamed);
+    assertEquals(unnamed, absent);
+    assertFalse(outOfRange.contains("  - `"), outOfRange);
+  }
+
+  @Test
   void truncatedReviewDisclosesPartialCoverage() {
     var result = followUp(List.of(finding("a.java")), List.of(), 3);
 
-    var body = FollowUpDeltaSummary.render(result).orElseThrow();
+    var body = render(result).orElseThrow();
 
     assertTrue(body.endsWith(ReviewResult.truncationDisclosure(3)), body);
     assertTrue(body.contains("Large PR — partial coverage."), body);
@@ -145,7 +243,7 @@ class FollowUpDeltaSummaryTest {
             true,
             truncation);
 
-    var body = FollowUpDeltaSummary.render(result).orElseThrow();
+    var body = render(result).orElseThrow();
 
     assertTrue(body.contains("only partially analyzed (clipped.java)"), body);
     assertTrue(body.contains("omitted entirely (omitted.java)"), body);
@@ -178,7 +276,7 @@ class FollowUpDeltaSummaryTest {
             true,
             truncation);
 
-    var body = FollowUpDeltaSummary.render(result).orElseThrow();
+    var body = render(result).orElseThrow();
 
     assertFalse(body.contains("Large PR — partial coverage"), body);
     assertFalse(body.contains("covers only part of the diff"), body);
@@ -210,7 +308,7 @@ class FollowUpDeltaSummaryTest {
             true,
             truncation);
 
-    var body = FollowUpDeltaSummary.render(result).orElseThrow();
+    var body = render(result).orElseThrow();
 
     assertFalse(body.contains("Large PR — partial coverage"), body);
     assertFalse(body.contains("covers only part of the diff"), body);
@@ -248,7 +346,7 @@ class FollowUpDeltaSummaryTest {
             true,
             truncation);
 
-    var body = FollowUpDeltaSummary.render(result).orElseThrow();
+    var body = render(result).orElseThrow();
 
     assertTrue(
         body.contains("The 2 finding(s) were not verified (no verdicts were returned)."), body);
@@ -286,7 +384,7 @@ class FollowUpDeltaSummaryTest {
             true,
             truncation);
 
-    var body = FollowUpDeltaSummary.render(result).orElseThrow();
+    var body = render(result).orElseThrow();
 
     assertTrue(body.contains("were NOT verified by the second-pass audit"), body);
     assertFalse(
@@ -295,7 +393,7 @@ class FollowUpDeltaSummaryTest {
 
   @Test
   void untruncatedReviewCarriesNoDisclosure() {
-    var body = FollowUpDeltaSummary.render(followUp(List.of(finding("a.java")), List.of(), 0));
+    var body = render(followUp(List.of(finding("a.java")), List.of(), 0));
 
     assertFalse(body.orElseThrow().contains("partial coverage"), body.orElseThrow());
   }
@@ -304,7 +402,7 @@ class FollowUpDeltaSummaryTest {
   void deltaCommentIsNeverMistakenForTheSummaryComment() {
     // The delta must not carry the summary heading: that marker decides whether a review is the
     // first one, and which comment the superseded path edits in place.
-    var body = FollowUpDeltaSummary.render(followUp(List.of(finding("a.java")), List.of(), 0));
+    var body = render(followUp(List.of(finding("a.java")), List.of(), 0));
 
     assertFalse(ReviewContextLoader.isBotSummaryComment(body.orElseThrow()), body.orElseThrow());
     assertEquals(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -5937,6 +5937,68 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void shouldReplyOnAThreadTheClearDirectiveClosedBeforeResolvingIt() {
+      // #714: a clear directive left no record anywhere near the discussion it ended — the thread
+      // simply closed. The reply states what happened at the point of the original discussion, and
+      // must land before the thread resolves so it sits inside it. Only the directive's own note
+      // earns one: a landed fix and a maintainer's decline close their threads as they always did.
+      var statuses =
+          List.of(
+              new ReviewResult.PreviousFindingStatus(
+                  1, "resolved", FollowUpAnalyzer.conversationClearedNote(BOT_ID)),
+              new ReviewResult.PreviousFindingStatus(2, "resolved", "fixed"),
+              new ReviewResult.PreviousFindingStatus(3, "justified", "intentional"));
+      when(followUpAnalyzer.matchFindingThreads(
+              ArgumentMatchers.<List<ReviewResponse.Finding>>any(), any(), any()))
+          .thenReturn(Map.of(1, 100L, 2, 200L, 3, 300L));
+      when(reviewThreadService.threadsByRootComment(AUTH, "owner", "repo", 5))
+          .thenReturn(
+              Map.of(
+                  100L, new ReviewThreadService.ThreadRef("T1", false),
+                  200L, new ReviewThreadService.ThreadRef("T2", false),
+                  300L, new ReviewThreadService.ThreadRef("T3", false)));
+      var order = inOrder(reviewClient, reviewThreadService);
+
+      reviewPublisher.resolveAddressedThreads(
+          AUTH, request(), List.of(), List.of(rootComment()), statuses);
+
+      var reply = ArgumentCaptor.forClass(GitHubReviewClient.ReplyToReviewCommentRequest.class);
+      order
+          .verify(reviewClient)
+          .replyToReviewComment(
+              eq(AUTH), anyString(), eq("owner"), eq("repo"), eq(5), eq(100L), reply.capture());
+      order.verify(reviewThreadService).resolve(AUTH, "T1");
+      assertEquals(ReviewPublisher.clearedThreadReply(BOT_ID), reply.getValue().body());
+      verify(reviewClient, times(1))
+          .replyToReviewComment(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyLong(), any());
+      verify(reviewThreadService).resolve(AUTH, "T2");
+      verify(reviewThreadService).resolve(AUTH, "T3");
+    }
+
+    @Test
+    void shouldStillResolveAClearedThreadWhenItsReplyFails() {
+      // The reply is disclosure, not the close: losing it must not cost the thread resolution.
+      var statuses =
+          List.of(
+              new ReviewResult.PreviousFindingStatus(
+                  1, "resolved", FollowUpAnalyzer.conversationClearedNote(BOT_ID)));
+      when(followUpAnalyzer.matchFindingThreads(
+              ArgumentMatchers.<List<ReviewResponse.Finding>>any(), any(), any()))
+          .thenReturn(Map.of(1, 100L));
+      when(reviewThreadService.threadsByRootComment(AUTH, "owner", "repo", 5))
+          .thenReturn(Map.of(100L, new ReviewThreadService.ThreadRef("T1", false)));
+      when(reviewClient.replyToReviewComment(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), anyLong(), any()))
+          .thenThrow(new RuntimeException("comment rejected"));
+
+      reviewPublisher.resolveAddressedThreads(
+          AUTH, request(), List.of(), List.of(rootComment()), statuses);
+
+      verify(reviewThreadService).resolve(AUTH, "T1");
+    }
+
+    @Test
     void shouldSwallowThreadResolutionFailures() {
       var statuses = List.of(new ReviewResult.PreviousFindingStatus(1, "resolved", "fixed"));
       when(followUpAnalyzer.matchFindingThreads(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -58,6 +58,15 @@ class ReviewOrchestratorTest {
   private static final String BOT_LOGIN = "thrillhousebot[bot]";
   private static final BotIdentity BOT_ID = BotIdentity.of(BOT_LOGIN);
 
+  /** A reopened decline's status note, exactly as {@link RebuttalContradiction} renders it. */
+  private static final String DECLINE_NOTE =
+      RebuttalContradiction.NOTE_LEAD_IN
+          + " the reply argues \"only ever called from the command path\", but the reviewed"
+          + " code dispatches this path concurrently — \"executor.execute(() -> execute(ctx));"
+          + "\". A single call site does not serialize work handed to an executor or a new"
+          + " thread, so the premise does not refute the finding. Reply again to keep the"
+          + " decline.";
+
   @Mock private ThrillhouseConfig config;
 
   @Mock private ThrillhouseConfig.ReviewConfig reviewConfig;
@@ -421,13 +430,7 @@ class ReviewOrchestratorTest {
       // A maintainer's decline the code contradicts is reopened as unresolved carrying the
       // contradiction note. The review body must surface that note next to the unresolved line so
       // the maintainer sees why their decline was not honored, and how to keep it (F6).
-      var note =
-          RebuttalContradiction.NOTE_LEAD_IN
-              + " the reply argues \"only ever called from the command path\", but the reviewed"
-              + " code dispatches this path concurrently — \"executor.execute(() -> execute(ctx));"
-              + "\". A single call site does not serialize work handed to an executor or a new"
-              + " thread, so the premise does not refute the finding. Reply again to keep the"
-              + " decline.";
+      var note = DECLINE_NOTE;
       var result =
           new ReviewResult(
               List.of(),
@@ -485,6 +488,112 @@ class ReviewOrchestratorTest {
       var body = captor.getValue().body();
       assertTrue(body.contains("1 previous finding(s) remain unresolved"), body);
       assertFalse(body.contains(RebuttalContradiction.NOTE_LEAD_IN), body);
+    }
+
+    @Test
+    void reopenedDeclineNoteAlsoReachesTheBodyOfARoundThatPostsFindings() {
+      // #713: the note used to render only on the no-new-findings body, so any round that also
+      // raised a finding took the with-findings path and dropped it — the maintainer was told the
+      // finding is still open and never that their stated reason had been examined and rejected.
+      // A COMMENT round whose single finding anchors inline builds an otherwise empty review body,
+      // so the note is the only thing that can put a review on the PR here.
+      var result =
+          new ReviewResult(
+              List.of(new Finding(RiskLevel.MEDIUM, "src/Main.java", 10, "t", "d", null, null)),
+              0,
+              0,
+              1,
+              0,
+              RiskLevel.MEDIUM,
+              ReviewState.COMMENT,
+              false,
+              "",
+              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", DECLINE_NOTE)),
+              List.of(),
+              0);
+
+      reviewPublisher.postReview(
+          "auth",
+          "owner",
+          "repo",
+          5,
+          "sha",
+          result,
+          resolverFor(fileDiffWithLine("src/Main.java", 10)));
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      var body = captor.getValue().body();
+      assertTrue(body.contains(RebuttalContradiction.NOTE_LEAD_IN), body);
+      assertTrue(body.contains("Reply again to keep the decline."), body);
+    }
+
+    @Test
+    void reopenedDeclineNoteReachesTheBodyWhenNoFindingCouldBeAnchored() {
+      // Same disclosure on the other with-findings branch: nothing anchored inline, so the review
+      // body carries the un-anchored list. The decline note must ride along there too, and stay
+      // above the partial-coverage banner (#713).
+      var result =
+          new ReviewResult(
+              List.of(new Finding(RiskLevel.MEDIUM, "src/Gone.java", 10, "t", "d", null, null)),
+              0,
+              0,
+              1,
+              0,
+              RiskLevel.MEDIUM,
+              ReviewState.COMMENT,
+              false,
+              "",
+              List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", DECLINE_NOTE)),
+              List.of(),
+              7);
+
+      reviewPublisher.postReview("auth", "owner", "repo", 5, "sha", result, resolverFor());
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      var body = captor.getValue().body();
+      assertTrue(body.contains("could not be anchored"), body);
+      assertTrue(body.contains(RebuttalContradiction.NOTE_LEAD_IN), body);
+      assertTrue(
+          body.indexOf(RebuttalContradiction.NOTE_LEAD_IN) < body.indexOf("partial review"), body);
+    }
+
+    @Test
+    void findingsBodyOmitsNotesThatAreNotReopenedDeclines() {
+      // The with-findings surface applies the same filter as the no-findings one: a plain
+      // unresolved note and a resolved finding's note are both left out, so a COMMENT round whose
+      // finding anchored inline still posts no review body at all (#713).
+      var result =
+          new ReviewResult(
+              List.of(new Finding(RiskLevel.MEDIUM, "src/Main.java", 10, "t", "d", null, null)),
+              0,
+              0,
+              1,
+              0,
+              RiskLevel.MEDIUM,
+              ReviewState.COMMENT,
+              false,
+              "",
+              List.of(
+                  new ReviewResult.PreviousFindingStatus(1, "unresolved", "still broken"),
+                  new ReviewResult.PreviousFindingStatus(2, "resolved", DECLINE_NOTE)),
+              List.of(),
+              0);
+
+      reviewPublisher.postReview(
+          "auth",
+          "owner",
+          "repo",
+          5,
+          "sha",
+          result,
+          resolverFor(fileDiffWithLine("src/Main.java", 10)));
+
+      verify(reviewClient, never())
+          .createReview(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
     }
 
     @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisherTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisherTest.java
@@ -33,6 +33,7 @@ import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.github.ReviewThreadService;
+import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -160,7 +161,8 @@ class ReviewPublisherTest {
   void followUpDeltaIsNotPostedWhenTheFeatureIsOff() {
     followUpSummaryEnabled(false);
 
-    assertFalse(publisher.publishFollowUpDelta("auth", "o", "r", 1, RESOLVED_FOLLOW_UP, false));
+    assertFalse(
+        publisher.publishFollowUpDelta("auth", "o", "r", 1, RESOLVED_FOLLOW_UP, false, List.of()));
     verify(commentClient, never())
         .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
   }
@@ -169,7 +171,8 @@ class ReviewPublisherTest {
   void followUpDeltaIsPostedWhenEnabledAndTheDeltaIsNonEmpty() {
     followUpSummaryEnabled(true);
 
-    assertTrue(publisher.publishFollowUpDelta("auth", "o", "r", 1, RESOLVED_FOLLOW_UP, false));
+    assertTrue(
+        publisher.publishFollowUpDelta("auth", "o", "r", 1, RESOLVED_FOLLOW_UP, false, List.of()));
 
     var body = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
     verify(commentClient)
@@ -183,6 +186,34 @@ class ReviewPublisherTest {
   }
 
   @Test
+  void postedFollowUpDeltaNamesTheFindingsItClosed() {
+    // #714: the comment used to carry the resolved count and nothing else, so a maintainer who
+    // cleared a finding by directive could only learn whether the match took by diffing the PR's
+    // thread state across rounds. The previous round reaches the publisher, so the comment can
+    // name what closed with the directive's own identifiers.
+    followUpSummaryEnabled(true);
+
+    assertTrue(
+        publisher.publishFollowUpDelta(
+            "auth",
+            "o",
+            "r",
+            1,
+            RESOLVED_FOLLOW_UP,
+            false,
+            List.of(
+                new ReviewResponse.Finding(
+                    "high", "src/main/java/A.java", 42, "Unbounded retry", "d", null, null))));
+
+    var body = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
+    verify(commentClient)
+        .createComment(anyString(), anyString(), eq("o"), eq("r"), eq(1), body.capture());
+    assertTrue(
+        body.getValue().body().contains("  - `src/main/java/A.java:42` — Unbounded retry"),
+        body.getValue().body());
+  }
+
+  @Test
   void followUpDeltaIsSkippedWhenNothingChangedThisRound() {
     // Enabled, but the round raised nothing and closed nothing — previous findings that merely
     // stayed open are not a delta, so the PR gets no comment at all.
@@ -190,7 +221,7 @@ class ReviewPublisherTest {
     var stalled =
         followUpResult(List.of(new ReviewResult.PreviousFindingStatus(1, "unresolved", "still")));
 
-    assertFalse(publisher.publishFollowUpDelta("auth", "o", "r", 1, stalled, false));
+    assertFalse(publisher.publishFollowUpDelta("auth", "o", "r", 1, stalled, false, List.of()));
     verify(commentClient, never())
         .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
   }
@@ -220,7 +251,7 @@ class ReviewPublisherTest {
             0);
 
     assertTrue(publisher.publishSummary("auth", "o", "r", 1, firstReview, false));
-    assertFalse(publisher.publishFollowUpDelta("auth", "o", "r", 1, firstReview, false));
+    assertFalse(publisher.publishFollowUpDelta("auth", "o", "r", 1, firstReview, false, List.of()));
 
     var body = ArgumentCaptor.forClass(GitHubCommentClient.CreateCommentRequest.class);
     verify(commentClient, times(1))
@@ -235,7 +266,8 @@ class ReviewPublisherTest {
     // summary comment for this round, so the delta must not land beside it.
     followUpSummaryEnabled(true);
 
-    assertFalse(publisher.publishFollowUpDelta("auth", "o", "r", 1, RESOLVED_FOLLOW_UP, true));
+    assertFalse(
+        publisher.publishFollowUpDelta("auth", "o", "r", 1, RESOLVED_FOLLOW_UP, true, List.of()));
     verify(commentClient, never())
         .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
   }


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [x] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

Two follow-up round disclosure gaps found in round-7 dogfooding, both on the
publisher surfaces, so they ship together.

**#713 — an overturned decline was explained only when the round found nothing new.**
`appendReopenedDeclineNotes` had a single call site, inside the no-new-findings
review body. Any round that also raised a finding took the with-findings path and
dropped the note, so two very different outcomes were indistinguishable from the
PR: the model never reading a reply as a decline and reporting the finding
unresolved, versus the model marking it `justified` and the deterministic re-check
overturning it on diff evidence. Both rendered as the bare "N previous finding(s)
remain unresolved" — a maintainer who wrote a considered decline saw no
acknowledgement it was read, no contradicting evidence, and no way to tell whether
to argue or to fix. Same undisclosed-decision harm as #542/#598.

The note now rides both with-findings branches (the un-anchored/cap-skipped
fallback body and the ordinary one), placed above the partial-coverage banner so
the coverage caveat stays outermost. It needs no unresolved-count lead-in: each
note is self-contained, and that sentence opens with "No new issues in this
revision", which a round posting findings must not claim. The same filter applies
on both surfaces — only a note carrying the `RebuttalContradiction` lead-in is
surfaced, never the backstop's generic carry-over note or the model's own prose.

**#714 — a cleared finding was never named.** The delta comment rendered three
bare integers, so nothing said *which* finding closed. A maintainer who cleared
one by directive saw "1" and had to diff GitHub thread state across rounds to
learn whether the match took; one who named several in a single comment could not
tell which the reviewer matched and which it silently skipped — and a skip is a
real outcome, since matching is by `path:line` plus title and the guards reject
several spellings. Worse for a finding published without an inline thread (#712),
where the directive is the only action that can close it and there is no thread
state to diff either.

Both directions from the issue are implemented:

- The delta names each closed finding under the count it explains, one
  `` `path:line` — title `` line each — the same identifiers the directive uses.
  Every finding the `resolved` count covers is named, not only directive-cleared
  ones: the list has to add up to the integer above it. Bounded at ten names with
  the remainder rolled up as a count, matching `ReviewResult.nameList`'s bound on
  the coverage disclosure's file names; both halves route through `MarkdownSafe`.
- A cleared finding's thread gets a reply before it resolves, leaving the record
  at the point of the original discussion. Deterministic prose, the directive
  rendered inside a code span (the form `FollowUpAnalyzer.isClearDirective` reads
  as documentation rather than a command), and a failed reply is swallowed so it
  can never cost the thread resolution that follows.

Out of scope, per the issue: refreshing the round-1 summary comment, whose Key
Findings block still lists a closed finding as live. That is the larger change and
may not be worth it; a delta that names what it closed removes most of the
ambiguity on its own.

## Related Issues

Closes #713
Closes #714

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Every new test was run against the unfixed code first and failed there.

**#713** — `reopenedDeclineNoteAlsoReachesTheBodyOfARoundThatPostsFindings` failed
with `Wanted but not invoked: reviewClient.createReview(...)` (the round posted its
inline comment and no review body at all), and
`reopenedDeclineNoteReachesTheBodyWhenNoFindingCouldBeAnchored` failed on a body
carrying only the un-anchored list and the partial-coverage banner. A third test
pins the negative case: a plain unresolved note and a resolved finding's note are
both left out, so that round still posts no review body.

**#714** — with the naming and the reply removed (signatures kept), the five new
tests failed on delta bodies rendering `**Previous findings resolved:** N` with no
list under it, and on `Wanted but not invoked:
reviewClient.replyToReviewComment(...)`. Restored, all pass.

Gates, in order:

```
./mvnw -B spotless:apply                                → BUILD SUCCESS
./mvnw -B clean compile spotbugs:check spotless:check   → BugInstance size is 0
                                                          Spotless: 0 needs changes
./mvnw -B clean test                                    → Tests run: 3258,
                                                          Failures: 0, Errors: 0
```

Patch coverage: `target/site/jacoco/jacoco.xml` intersected with
`git diff -U0 origin/main --` reports zero uncovered lines and zero uncovered
branches across the three changed main files.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

The delta comment gains the named sub-list under the count it explains:

```
## 🤖 ThrillhouseBot — changes since the last review

- **New findings this round:** 3
- **Previous findings resolved:** 2
  - `src/main/java/A.java:10` — Guard the null token
  - `src/main/java/C.java:30` — Close the stream
- **Previous findings still open:** 12
```

## Additional Notes

`publishFollowUpDelta` and `FollowUpDeltaSummary.render` take the previous round's
findings so the comment can name what it closed; `ReviewOrchestrator` already had
that list in hand for thread resolution and passes the same one.
