### PR TITLE
fix(review): give a finding a file-level thread when its line comment cannot land

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -317,20 +317,49 @@ public interface GitHubReviewClient {
    * A pull request review comment. When {@code startLine} is set, the comment spans the inclusive
    * range {@code start_line}..{@code line} so a GitHub suggestion replaces every line in it; a
    * single-line comment leaves both range fields null and they are omitted from the payload.
+   *
+   * <p>{@code subjectType} selects what the thread hangs off. It is null — and omitted — for the
+   * line-anchored comments that are the normal case, and {@value #SUBJECT_TYPE_FILE} for a thread
+   * filed on the file as a whole (#712). GitHub rejects a file-level request that also carries a
+   * position, so {@code line}, {@code side} and both range fields are nullable and left out
+   * together; the {@code NON_NULL} inclusion above is what keeps them off that payload.
    */
   @JsonInclude(JsonInclude.Include.NON_NULL)
   record CreatePullRequestCommentRequest(
       @JsonProperty("commit_id") String commitId,
       String body,
       String path,
-      int line,
+      Integer line,
       String side,
       @JsonProperty("start_line") Integer startLine,
-      @JsonProperty("start_side") String startSide) {
+      @JsonProperty("start_side") String startSide,
+      @JsonProperty("subject_type") String subjectType) {
     public CreatePullRequestCommentRequest {
       body = CommentBodyLimit.cap(body);
     }
+
+    /** The line-anchored shape, which names no subject type — GitHub defaults it to the line. */
+    public CreatePullRequestCommentRequest(
+        String commitId,
+        String body,
+        String path,
+        Integer line,
+        String side,
+        Integer startLine,
+        String startSide) {
+      this(commitId, body, path, line, side, startLine, startSide, null);
+    }
+
+    /** A thread on the file as a whole: no line, no side, no range — only the path. */
+    public static CreatePullRequestCommentRequest onFile(
+        String commitId, String body, String path) {
+      return new CreatePullRequestCommentRequest(
+          commitId, body, path, null, null, null, null, SUBJECT_TYPE_FILE);
+    }
   }
+
+  /** GitHub's {@code subject_type} for a review thread that targets a whole file. */
+  String SUBJECT_TYPE_FILE = "file";
 
   /** Reply posted into an existing review thread, keyed by the thread's root comment id in path. */
   record ReplyToReviewCommentRequest(String body) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -702,7 +702,7 @@ public class ReviewPublisher {
     var line = lineResolver.resolveRightSideLine(finding.file(), finding.line());
     if (line.isEmpty()) {
       Log.debugf(
-          "Skipping inline comment for %s:%d — line is outside PR diff",
+          "Line for %s:%d is outside the PR diff — filing the finding on the file instead",
           finding.file(), finding.line());
       return postFileLevelComment(target, finding, findingId);
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -425,11 +425,21 @@ public class ReviewPublisher {
     return parts;
   }
 
+  /**
+   * The findings that reached the review body because GitHub took no thread for them at all —
+   * neither on their line nor, since #712, on their file.
+   *
+   * <p>The wording no longer blames the diff. The old "could not be anchored to the current diff"
+   * asserted a cause the code cannot know: the same sentence covered a line genuinely outside the
+   * diff and a post GitHub simply refused, and on the round-7 corpus it was overwhelmingly the
+   * second. Two independent scorers read it as a line-attribution defect and went looking for an
+   * off-by-N that was not there, so the text now states only what happened.
+   */
   private static String unanchoredFindingsBody(List<Finding> findings) {
     var sb = new StringBuilder();
     sb.append("ThrillhouseBot found ")
         .append(findings.size())
-        .append(" issue(s) that could not be anchored to the current diff:\n\n");
+        .append(" issue(s) GitHub accepted no review thread for:\n\n");
     appendFindingList(sb, findings);
     return sb.toString();
   }
@@ -579,9 +589,14 @@ public class ReviewPublisher {
   }
 
   /**
-   * How many findings anchored as inline comments, the ones that could not be anchored, the ones
+   * How many findings opened a review thread, the ones GitHub took no thread for at all, the ones
    * skipped because {@code maxReviewComments} was reached (never tried for anchoring), and the ones
    * withheld because confidence is low (routed to the summary instead).
+   *
+   * <p>{@code posted} counts threads, not line anchors: since #712 a finding whose line-anchored
+   * comment cannot land is retried on the file, and a thread on the file is still a thread — the
+   * decline path, the status notes and the attribution all reach it. Only a finding that neither
+   * route could give a thread lands in {@code unanchored}.
    */
   record InlineCommentResult(
       int posted,
@@ -591,10 +606,11 @@ public class ReviewPublisher {
 
   /**
    * Posts each finding as its own pull request review comment on the diff. Individual comments
-   * survive 422s that would reject an entire batched review. Findings whose line falls outside the
-   * diff (or are otherwise rejected) are returned as {@code unanchored} so the caller can still
-   * report them in the review body rather than dropping them. Low-confidence medium/low findings
-   * are skipped here and surfaced in the PR summary's "Things to double-check" section instead.
+   * survive 422s that would reject an entire batched review. A finding whose line falls outside the
+   * diff, or whose line-anchored comment GitHub rejects, falls back to a thread on the file (#712);
+   * only when that fails too is it returned as {@code unanchored} so the caller can still report it
+   * in the review body rather than dropping it. Low-confidence medium/low findings are skipped here
+   * and surfaced in the PR summary's "Things to double-check" section instead.
    */
   InlineCommentResult postInlineComments(
       String auth,
@@ -632,6 +648,30 @@ public class ReviewPublisher {
   private record CommentTarget(
       String auth, String owner, String repo, int prNumber, String commitSha) {}
 
+  /**
+   * Opens one finding's review thread, preferring the diff line it cites and falling back to a
+   * thread on the file as a whole when no line-anchored comment lands (#712).
+   *
+   * <p>The fallback exists because a failure here used to end the finding's life as a review
+   * thread: it was reported in the review body as "could not be anchored to the current diff" and
+   * lost its code context, its suggestion block <em>and</em> — the expensive part — the thread
+   * every follow-up feature reaches it through. {@code FollowUpAnalyzer.recheckDeclines} is handed
+   * the inline comment list, so a finding with no thread cannot be declined at all (#709); a status
+   * note has nowhere to land; and a maintainer who clears one reads "Previous findings resolved: 1"
+   * with no way to tell which.
+   *
+   * <p>The round-7 dogfood corpus is what forced this: on twelve all-added-file pull requests, 12
+   * of 13 findings on the java PR and 11 of 13 on the node PR were published as bare bullets, and
+   * every line they cited was inside an added hunk. The line arithmetic was never wrong — {@code
+   * c/src/rollup.c:47} opened a thread in the same run in which {@code :45} was reported
+   * unanchored, and {@code src/allocator.js:12} posted forty minutes after {@code :31} and {@code
+   * :33} had been declared un-anchorable in the same file. What actually happened is that GitHub
+   * refused the POST: across the whole corpus, comment creation stopped dead for 72 seconds and
+   * again for 16, and every finding whose turn fell inside one of those windows was recorded as a
+   * line-number failure. A file-level thread is a second, independent chance at the one thing the
+   * finding cannot afford to lose, and it is also the honest answer for a line that genuinely is
+   * outside the diff.
+   */
   private boolean postFindingComment(
       CommentTarget target, Finding finding, int findingId, DiffLineResolver lineResolver) {
     var line = lineResolver.resolveRightSideLine(finding.file(), finding.line());
@@ -639,7 +679,7 @@ public class ReviewPublisher {
       Log.debugf(
           "Skipping inline comment for %s:%d — line is outside PR diff",
           finding.file(), finding.line());
-      return false;
+      return postFileLevelComment(target, finding, findingId);
     }
 
     var resolvedLine = line.getAsInt();
@@ -669,8 +709,51 @@ public class ReviewPublisher {
                 target, finding, findingId, resolvedLine, Optional.empty(), false))) {
       return true;
     }
-    Log.warnf("GitHub rejected inline comment for %s:%d", finding.file(), finding.line());
-    return false;
+    Log.warnf(
+        "GitHub rejected inline comment for %s:%d — filing it on the file instead",
+        finding.file(), finding.line());
+    return postFileLevelComment(target, finding, findingId);
+  }
+
+  /**
+   * Lead-in of a finding filed on the file rather than on its line. It names the line the finding
+   * cites so the reader can still navigate to it, and says the suggestion was dropped rather than
+   * leaving its absence to be read as "there was no fix" — GitHub can only apply a {@code
+   * suggestion} block inside a line-anchored thread, so carrying one here would render an Apply
+   * button that cannot work.
+   */
+  private static String fileLevelLeadIn(Finding finding) {
+    return "_Filed on the file: ThrillhouseBot could not open a thread on "
+        + MarkdownSafe.inlineCode(finding.file() + ":" + finding.line())
+        + ", so this finding has no line anchor and no applicable suggestion. Replies on this"
+        + " thread still count._";
+  }
+
+  /**
+   * Posts one finding as a thread on the file as a whole. Carries the same hidden finding marker as
+   * a line-anchored comment, which is what {@code FollowUpAnalyzer} binds a thread to a finding
+   * with, so the decline path, the status notes and the resolved-finding attribution all keep
+   * working on a finding that never reached its line.
+   */
+  private boolean postFileLevelComment(CommentTarget target, Finding finding, int findingId) {
+    var body =
+        fileLevelLeadIn(finding)
+            + "\n\n"
+            + suggestionFormatter.formatReviewComment(finding, false, findingId);
+    try {
+      reviewClient.createPullRequestComment(
+          target.auth(),
+          ACCEPT,
+          target.owner(),
+          target.repo(),
+          target.prNumber(),
+          GitHubReviewClient.CreatePullRequestCommentRequest.onFile(
+              target.commitSha(), body, finding.file()));
+      return true;
+    } catch (RuntimeException e) {
+      Log.debugf(e, "File-level comment rejected for %s", finding.file());
+      return false;
+    }
   }
 
   /**

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -531,9 +531,17 @@ class ReviewOrchestratorTest {
 
     @Test
     void reopenedDeclineNoteReachesTheBodyWhenNoFindingCouldBeAnchored() {
-      // Same disclosure on the other with-findings branch: nothing anchored inline, so the review
-      // body carries the un-anchored list. The decline note must ride along there too, and stay
-      // above the partial-coverage banner (#713).
+      // Same disclosure on the other with-findings branch: nothing landed inline, so the review
+      // body carries the list of findings GitHub took no thread for. The decline note must ride
+      // along there too, and stay above the partial-coverage banner (#713).
+      //
+      // Reaching that branch takes both routes failing now: a finding whose line comment is refused
+      // falls back to a file-level thread (#712), so refusing only the line-anchored post would
+      // leave the finding threaded and this body unbuilt.
+      doThrow(new RuntimeException("422"))
+          .when(reviewClient)
+          .createPullRequestComment(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), any());
       var result =
           new ReviewResult(
               List.of(new Finding(RiskLevel.MEDIUM, "src/Gone.java", 10, "t", "d", null, null)),
@@ -555,7 +563,7 @@ class ReviewOrchestratorTest {
       verify(reviewClient)
           .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
       var body = captor.getValue().body();
-      assertTrue(body.contains("could not be anchored"), body);
+      assertTrue(body.contains("GitHub accepted no review thread for"), body);
       assertTrue(body.contains(RebuttalContradiction.NOTE_LEAD_IN), body);
       assertTrue(
           body.indexOf(RebuttalContradiction.NOTE_LEAD_IN) < body.indexOf("partial review"), body);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -2431,6 +2431,13 @@ class ReviewOrchestratorTest {
         when(commentClient.createComment(
                 anyString(), anyString(), anyString(), anyString(), anyInt(), any()))
             .thenThrow(new RuntimeException("503 Service Unavailable"));
+        // The PR reports no files, so the finding has no line to anchor to and GitHub refuses the
+        // file-level fallback too (#712) — that is what leaves it for the review body, and so what
+        // makes a review the run's visible outcome at all.
+        doThrow(new RuntimeException("422"))
+            .when(reviewClient)
+            .createPullRequestComment(
+                anyString(), anyString(), anyString(), anyString(), anyInt(), any());
 
         orchestrator.review(
             new ReviewOrchestrator.ReviewRequest(
@@ -3697,21 +3704,121 @@ class ReviewOrchestratorTest {
           0);
     }
 
+    /**
+     * GitHub refusing the file-level fallback as well — the only way a finding is left with no
+     * review thread at all, and so the only way it still reaches the review body (#712).
+     */
+    private void rejectFileLevelComments() {
+      doThrow(new RuntimeException("422"))
+          .when(reviewClient)
+          .createPullRequestComment(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(req -> req.subjectType() != null));
+    }
+
+    private GitHubReviewClient.CreatePullRequestCommentRequest capturedComment() {
+      var captor =
+          ArgumentCaptor.forClass(GitHubReviewClient.CreatePullRequestCommentRequest.class);
+      verify(reviewClient)
+          .createPullRequestComment(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), captor.capture());
+      return captor.getValue();
+    }
+
+    /**
+     * #712: a line the diff does not carry costs the finding its line anchor, never its thread. The
+     * fallback is a thread on the file, which the decline path, the status notes and the
+     * resolved-finding attribution all still reach.
+     */
     @Test
-    void shouldSkipFindingsOutsideDiff() {
+    void shouldFileFindingOnTheFileWhenItsLineIsOutsideDiff() {
       var finding = new Finding(RiskLevel.MEDIUM, "missing.java", 10, "Bug", "desc", null, null);
       var result = resultWithFinding(finding, ReviewState.COMMENT);
       var resolver = new DiffLineResolver(Map.of("src/Main.java", "@@ +1,1 @@\n+line"));
+      when(suggestionFormatter.formatReviewComment(eq(finding), eq(false), anyInt()))
+          .thenReturn("body");
 
-      var posted =
-          reviewPublisher
-              .postInlineComments("Bearer tok", "owner", "repo", 7, "sha", result, resolver)
-              .posted();
+      var inline =
+          reviewPublisher.postInlineComments(
+              "Bearer tok", "owner", "repo", 7, "sha", result, resolver);
 
-      assertEquals(0, posted);
-      verify(reviewClient, never())
+      assertEquals(1, inline.posted());
+      assertTrue(inline.unanchored().isEmpty());
+      var request = capturedComment();
+      assertEquals(GitHubReviewClient.SUBJECT_TYPE_FILE, request.subjectType());
+      assertEquals("missing.java", request.path());
+      // GitHub rejects a file-level comment that also carries a position.
+      assertNull(request.line());
+      assertNull(request.side());
+      assertNull(request.startLine());
+      assertNull(request.startSide());
+      // The line the finding cites survives in the body, so the reader can still navigate to it.
+      assertTrue(request.body().contains("missing.java:10"));
+      assertTrue(request.body().endsWith("body"));
+    }
+
+    /**
+     * #712: the round-7 corpus lost 12 of 13 findings on one pull request to GitHub refusing the
+     * POST — not to a bad line number. A rejected line-anchored comment must still leave a thread.
+     */
+    @Test
+    void shouldFileFindingOnTheFileWhenGitHubRejectsTheLineAnchoredComment() {
+      var finding = new Finding(RiskLevel.HIGH, "src/Main.java", 10, "Bug", "desc", null, null);
+      var result = resultWithFinding(finding, ReviewState.REQUEST_CHANGES);
+      var resolver =
+          new DiffLineResolver(
+              Map.of("src/Main.java", fileDiffWithLine("src/Main.java", 10).patch()));
+      when(suggestionFormatter.formatReviewComment(any(), anyBoolean(), anyInt()))
+          .thenReturn("body");
+      doThrow(new RuntimeException("422"))
+          .when(reviewClient)
+          .createPullRequestComment(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(req -> req.subjectType() == null));
+
+      var inline =
+          reviewPublisher.postInlineComments(
+              "Bearer tok", "owner", "repo", 7, "sha", result, resolver);
+
+      assertEquals(1, inline.posted());
+      assertTrue(inline.unanchored().isEmpty());
+      verify(reviewClient)
+          .createPullRequestComment(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(req -> GitHubReviewClient.SUBJECT_TYPE_FILE.equals(req.subjectType())));
+    }
+
+    /** Only a finding GitHub took no thread for at all is reported in the review body. */
+    @Test
+    void shouldReportFindingWhenTheFileLevelThreadIsRejectedToo() {
+      var finding = new Finding(RiskLevel.MEDIUM, "missing.java", 10, "Bug", "desc", null, null);
+      var result = resultWithFinding(finding, ReviewState.COMMENT);
+      var resolver = new DiffLineResolver(Map.of("src/Main.java", "@@ +1,1 @@\n+line"));
+      when(suggestionFormatter.formatReviewComment(any(), anyBoolean(), anyInt()))
+          .thenReturn("body");
+      doThrow(new RuntimeException("422"))
+          .when(reviewClient)
           .createPullRequestComment(
               anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+
+      var inline =
+          reviewPublisher.postInlineComments(
+              "Bearer tok", "owner", "repo", 7, "sha", result, resolver);
+
+      assertEquals(0, inline.posted());
+      assertEquals(List.of(finding), inline.unanchored());
     }
 
     @Test
@@ -3791,7 +3898,8 @@ class ReviewOrchestratorTest {
               .posted();
 
       assertEquals(0, posted);
-      verify(reviewClient, times(2))
+      // Two line-anchored attempts (with and without the suggestion) plus the file-level fallback.
+      verify(reviewClient, times(3))
           .createPullRequestComment(
               anyString(), anyString(), anyString(), anyString(), anyInt(), any());
     }
@@ -4047,7 +4155,7 @@ class ReviewOrchestratorTest {
                   req ->
                       req.body().contains("Things to double-check")
                           && req.body().contains("Maybe nit")
-                          && !req.body().contains("could not be anchored")));
+                          && !req.body().contains("GitHub accepted no review thread")));
     }
 
     @Test
@@ -4129,11 +4237,12 @@ class ReviewOrchestratorTest {
                       req.body().contains("comment cap was reached")
                           && req.body().contains("Two")
                           && req.body().contains("desc two")
-                          && !req.body().contains("could not be anchored")));
+                          && !req.body().contains("GitHub accepted no review thread")));
     }
 
     @Test
     void shouldListFindingsWithDescriptionsInReviewBodyWhenNoneAnchorInlineOnFirstReview() {
+      rejectFileLevelComments();
       var finding =
           new Finding(RiskLevel.MEDIUM, "missing.java", 10, "Bug", "the X path NPEs", null, null);
       var result = resultWithFinding(finding, ReviewState.COMMENT); // isFirstReview = true
@@ -4165,6 +4274,7 @@ class ReviewOrchestratorTest {
 
     @Test
     void truncatedReviewDisclosesPartialReviewWhenNoFindingsAnchorInline() {
+      rejectFileLevelComments();
       var finding = new Finding(RiskLevel.MEDIUM, "missing.java", 10, "Bug", "desc", null, null);
       var result =
           new ReviewResult(
@@ -4207,6 +4317,7 @@ class ReviewOrchestratorTest {
 
     @Test
     void shouldListFindingsInReviewBodyWhenNoneAnchorInlineOnFollowUp() {
+      rejectFileLevelComments();
       var finding =
           new Finding(RiskLevel.CRITICAL, "missing.java", 10, "Auth bypass", "desc", null, null);
       var blankDescription =
@@ -4257,6 +4368,7 @@ class ReviewOrchestratorTest {
 
     @Test
     void shouldSurfaceAnUnanchoredFindingInBodyEvenWhenOthersAnchorInline() {
+      rejectFileLevelComments();
       var anchored =
           new Finding(RiskLevel.HIGH, "src/Main.java", 10, "Anchored bug", "a", null, null);
       var floating =
@@ -4294,7 +4406,12 @@ class ReviewOrchestratorTest {
 
       verify(reviewClient)
           .createPullRequestComment(
-              anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(req -> req.subjectType() == null));
       verify(reviewClient)
           .createReview(
               anyString(),
@@ -4312,6 +4429,7 @@ class ReviewOrchestratorTest {
 
     @Test
     void firstReviewStillReportsAnUnanchoredTopFindingWithItsDescriptionInTheBody() {
+      rejectFileLevelComments();
       var anchored =
           new Finding(RiskLevel.HIGH, "src/Main.java", 10, "Anchored bug", "a", null, null);
       var floating =
@@ -4363,6 +4481,7 @@ class ReviewOrchestratorTest {
 
     @Test
     void firstReviewStillListsAnUnanchoredFindingBeyondTheSummaryTopFive() {
+      rejectFileLevelComments();
       var findings = new java.util.ArrayList<Finding>();
       for (int i = 1; i <= 5; i++) {
         findings.add(new Finding(RiskLevel.HIGH, "src/Main.java", 10, "Top " + i, "d", null, null));
@@ -4489,9 +4608,16 @@ class ReviewOrchestratorTest {
               .posted();
 
       assertEquals(0, posted);
+      // Exactly one line-anchored attempt — the suggestion-less retry is what must not happen; the
+      // file-level fallback (#712) is a different request and is counted separately.
       verify(reviewClient, times(1))
           .createPullRequestComment(
-              anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(req -> req.subjectType() == null));
       verify(suggestionFormatter, never()).formatReviewComment(finding, false);
     }
 


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

A finding whose inline comment failed to post was published as a bare bullet under
"could not be anchored to the current diff" — no code context, no suggestion block and, the part
that costs the most, no review thread. Every thread-dependent feature dies with the thread:
`FollowUpAnalyzer.recheckDeclines` is handed the inline comment list, so a finding with no thread
cannot be declined at all; a status note has nowhere to land; and a maintainer who clears one reads
"Previous findings resolved: 1" with no way to tell which finding that was.

### Diagnosis

The two leads in #712 — an off-by-N in the model's line attribution, and the `position == line`
observation — are both dead ends, and the anchoring layer is not at fault.

`DiffLineResolver.resolveRightSideLine` snaps to the *nearest* right-side line of the file, so on a
file the PR adds in full — hunk header `@@ -0,0 +1,N @@`, every line addressable — it cannot return
empty for any positive line. An off-by-2 would still anchor.

The round-7 corpus confirms it per finding, not per theory:

- `c/src/rollup.c:47` opened a thread at 15:15:45 in the same review run that reported
  `c/src/rollup.c:45` un-anchorable. Same file, two lines apart, both inside `@@ -0,0 +1,64 @@`.
- `src/main/scala/rotation/RotationAuditor.scala` anchored at `:39` and `:55` while `:36` was
  reported un-anchorable, same run.
- `src/allocator.js:12` posted cleanly at 15:55, forty minutes after `:31` and `:33` in that same
  file had been declared un-anchorable.
- Every path and line named in every "unanchored" bullet is present in the PR's file list and
  inside its added hunk.

What the failures actually share is a *time window*. Ordering every review comment the bot created
across the twelve corpus PRs shows a steady ~1/second stream (the `GitHubWritePacer` envelope), then
two dead zones in which no comment creation succeeded anywhere:

| window | duration | findings lost |
|---|---|---|
| 15:14:02 → 15:15:14 | 72s | java #67 (10) and node #64 (11) — their whole remaining sets |
| 15:15:58 → 15:16:14 | 16s | scala #69 (3) and c #71 (2) |

Those windows are the entire distribution the issue reports. java and node were mid-run when the
first one opened and lost almost everything; scala and c were posting either side of the second and
lost only the findings whose turn fell inside it. The bot's own retry budget
(`GitHubWriteRetry`: 3 attempts, ≤60s of waiting) is shorter than the 72-second window, so the posts
were given up on — and `ReviewPublisher.postFindingComment` mapped that delivery failure onto
"could not be anchored to the current diff", which is a claim about line numbers the code is in no
position to make. It is also what sent two independent scorers hunting an off-by-N that was not
there.

### Fix

The anchoring itself is correct, so this implements the issue's stated fallback and makes the
reporting honest:

- **A failed line-anchored comment now falls back to a thread on the file** (`subject_type: "file"`,
  no line/side/range). It is a real review thread carrying the same hidden finding marker — which is
  what `FollowUpAnalyzer` binds a thread to a finding with — so the decline path (#709), the status
  notes and the resolved-finding attribution all keep working on a finding that never reached its
  line. It fires both when the line is genuinely outside the diff and when GitHub rejects the
  line-anchored request.
- The file-level body leads with the `path:line` the finding cites, so the reader can still navigate
  to it, and says plainly that the applicable suggestion was dropped (GitHub can only apply a
  `suggestion` block inside a line-anchored thread).
- **Only a finding GitHub took no thread for by either route** reaches the review body, and its
  heading no longer asserts a cause: "ThrillhouseBot found N issue(s) GitHub accepted no review
  thread for".

`CreatePullRequestCommentRequest` gains a nullable `subject_type` and a nullable `line`/`side`; the
existing seven-argument line-anchored shape is kept as a convenience constructor, so no other call
site changes and the line-anchored payload is byte-for-byte what it was (the record's
`@JsonInclude(NON_NULL)` keeps every null field off the wire).

## Related Issues

Closes #712

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Three new tests in `ReviewOrchestratorTest.PostInlineComments`, each run against the unfixed code
first:

- `shouldFileFindingOnTheFileWhenItsLineIsOutsideDiff` — failed `expected: <1> but was: <0>` before
  the fix; asserts `subject_type=file`, a null line/side/range, and the cited `path:line` in the
  body.
- `shouldFileFindingOnTheFileWhenGitHubRejectsTheLineAnchoredComment` — failed
  `expected: <1> but was: <0>` before the fix.
- `shouldReportFindingWhenTheFileLevelThreadIsRejectedToo` — a guard on the remaining path: with
  both routes refused the finding still reaches the review body. This one holds before and after, by
  design.

`shouldSkipFindingWhenInlineCommentRejectedTwice` failed before the fix on
`Wanted 3 times ... But was 2 times` and now pins the third (file-level) attempt. The existing tests
that assert a finding reaching the review body now make GitHub refuse the file-level fallback too,
which is the only way that outcome still occurs.

Gates, all run on this branch:

- `./mvnw -B spotless:apply` → `BUILD SUCCESS`
- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, `BUILD SUCCESS`
- `./mvnw -B clean test` → `Tests run: 3250, Failures: 0, Errors: 0, Skipped: 0`

Patch coverage: intersecting `git diff -U0 origin/main --` with `target/site/jacoco/jacoco.xml`
gives 24 executable changed lines in main sources, **0 uncovered lines and 0 uncovered branches**.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Red proof, with the fix's behavioural half reverted and only the request-record change applied:

```
[ERROR] Failures:
[ERROR]   ReviewOrchestratorTest.shouldFileFindingOnTheFileWhenGitHubRejectsTheLineAnchoredComment expected: <1> but was: <0>
[ERROR]   ReviewOrchestratorTest.shouldFileFindingOnTheFileWhenItsLineIsOutsideDiff expected: <1> but was: <0>
[ERROR]   ReviewOrchestratorTest.shouldSkipFindingWhenInlineCommentRejectedTwice
Wanted 3 times:
-> at dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.createPullRequestComment(GitHubReviewClient.java:238)
But was 2 times:
-> at dev.thiagogonzaga.thrillhousebot.review.ReviewPublisher.tryPostInlineComment(ReviewPublisher.java:693)
-> at dev.thiagogonzaga.thrillhousebot.review.ReviewPublisher.tryPostInlineComment(ReviewPublisher.java:693)

[ERROR] Tests run: 182, Failures: 3, Errors: 0, Skipped: 0
```

Green after the fix:

```
[INFO] Tests run: 3250, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## Additional Notes

This does not change the write layer. The 72-second refusal window that lost the round-7 findings
outlasts `GitHubWriteRetry`'s 60-second budget, and the fallback added here is itself a
content-creating POST, so a window that wide can still refuse both routes. What this PR removes is
the permanent consequence: a finding no longer forfeits its thread — and with it the decline path,
its status note and its attribution — because of one refused request, and the review body no longer
reports a delivery failure as a line-number failure. Whether the write budget should outlast a
window that long is a separate question about #568/#579 and is left alone here.
