### PR TITLE
fix(github): outlast the secondary-limit window, and say why a comment was refused

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
@@ -77,16 +77,16 @@ public final class GitHubApiError {
    * a primary rate limit both arrive as 403; only the message distinguishes them from a permission
    * refusal when the headers are absent.
    *
-   * <p>"blocked from content creation" is carried here as well as in {@link
-   * #CONTENT_CREATION_BLOCK}, because broadening only the latter would be inert: a body that named
-   * the block without one of the other phrases would not be read as a throttle at all, so the call
-   * would fail fast and the floor below it would never be consulted (#722). A 403 that says
+   * <p>The blocked-creation wording is carried here as well as in {@link #CONTENT_CREATION_BLOCK},
+   * in the same two word orders, because broadening only the latter would be inert: a body that
+   * named the block without one of the other phrases would not be read as a throttle at all, so the
+   * call would fail fast and the floor below it would never be consulted (#722). A 403 that says
    * creation is blocked is a throttle by definition, never a permission refusal.
    */
   private static final Pattern THROTTLE_WORDING =
       Pattern.compile(
           "(?i)secondary rate limit|abuse detection|rate limit exceeded"
-              + "|blocked from content creation");
+              + "|blocked from (?:content creation|creating content)");
 
   /** Collapses the whitespace of a body so one failure stays on one log line. */
   private static final Pattern WHITESPACE = Pattern.compile("\\s+");
@@ -100,12 +100,18 @@ public final class GitHubApiError {
    *
    * <p>The measured body carried both "secondary rate limit" and "temporarily blocked from content
    * creation", and GitHub's older wording for the same block says "abuse detection". The third
-   * alternative covers a body that names the block without either of the first two: it is the
-   * failure whose delay this pattern decides, so missing it would leave the linear fallback and its
-   * thirty seconds against a window three times as wide.
+   * alternative covers a body that names the block without either of the first two, in both word
+   * orders GitHub is known to phrase it — "blocked from content creation" and "blocked from
+   * creating content" — because this pattern decides the delay, and missing a variant leaves the
+   * linear fallback and its thirty seconds against a window three times as wide.
+   *
+   * <p>It is deliberately the whole phrase rather than "content creation" alone: this runs over an
+   * error body that is attacker-influenced text, and the bare noun phrase is loose enough to appear
+   * in a message that is not this block.
    */
   private static final Pattern CONTENT_CREATION_BLOCK =
-      Pattern.compile("(?i)secondary rate limit|abuse detection|blocked from content creation");
+      Pattern.compile(
+          "(?i)secondary rate limit|abuse detection|blocked from (?:content creation|creating content)");
 
   /**
    * Floor on one wait while GitHub is blocking content creation and named no deadline of its own
@@ -211,8 +217,8 @@ public final class GitHubApiError {
    * How long to wait before repeating a throttled call, given the attempt just made and the current
    * time. {@code Retry-After} wins when GitHub sent one; otherwise the reset instant of the
    * exhausted rate-limit window is honoured; otherwise a linear backoff off {@link #FALLBACK_DELAY}
-   * so a silent throttle still slows down. Never negative — a reset already in the past means the
-   * window has reopened and the call can go straight back out.
+   * so a silent throttle still slows down. Never negative — for everything but the block below, a
+   * reset already in the past means the window has reopened and the call can go straight back out.
    *
    * <p>One exception, added in #722: when GitHub is blocking content creation and named no deadline
    * of its own, a derived delay is floored at {@link #CONTENT_CREATION_BLOCK_MIN_DELAY}. Both

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
@@ -98,20 +98,24 @@ public final class GitHubApiError {
    * The wording of the block that stops content creation specifically, rather than any other
    * throttle. It is the one that lasts long enough for the shape of the backoff to matter (#722).
    *
-   * <p>The measured body carried both "secondary rate limit" and "temporarily blocked from content
-   * creation", and GitHub's older wording for the same block says "abuse detection". The third
-   * alternative covers a body that names the block without either of the first two, in both word
-   * orders GitHub is known to phrase it — "blocked from content creation" and "blocked from
-   * creating content" — because this pattern decides the delay, and missing a variant leaves the
-   * linear fallback and its thirty seconds against a window three times as wide.
+   * <p>Deliberately narrower than {@link #THROTTLE_WORDING}, and in particular it does NOT match
+   * the bare phrase "secondary rate limit". That is GitHub's generic secondary-limit wording, sent
+   * for any endpoint, and it is a milder class than the block this floor is sized against: matching
+   * it would floor every such throttle at 30s and hold a PR's dispatcher slot for up to the whole
+   * budget, where the linear backoff's 5s, 10s then 15s is all that class asks for.
+   *
+   * <p>What is matched is wording that names the block itself. The measured body said "You have
+   * exceeded a secondary rate limit and have been temporarily blocked from content creation", so it
+   * matches on its second half; GitHub's older wording for the same block says "abuse detection";
+   * and both word orders of the creation phrase are taken, since the rule must not turn on which
+   * one GitHub happened to use.
    *
    * <p>It is deliberately the whole phrase rather than "content creation" alone: this runs over an
    * error body that is attacker-influenced text, and the bare noun phrase is loose enough to appear
    * in a message that is not this block.
    */
   private static final Pattern CONTENT_CREATION_BLOCK =
-      Pattern.compile(
-          "(?i)secondary rate limit|abuse detection|blocked from (?:content creation|creating content)");
+      Pattern.compile("(?i)abuse detection|blocked from (?:content creation|creating content)");
 
   /**
    * Floor on one wait while GitHub is blocking content creation and named no deadline of its own

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
@@ -86,6 +86,33 @@ public final class GitHubApiError {
   /** Backoff used when GitHub throttles without saying for how long. */
   static final Duration FALLBACK_DELAY = Duration.ofSeconds(5);
 
+  /**
+   * The wording of the block that stops content creation specifically, rather than any other
+   * throttle. It is the one that lasts long enough for the shape of the backoff to matter (#722).
+   */
+  private static final Pattern CONTENT_CREATION_BLOCK =
+      Pattern.compile("(?i)secondary rate limit|abuse detection");
+
+  /**
+   * Floor on one wait while GitHub is blocking content creation and named no deadline of its own
+   * (#722).
+   *
+   * <p>The measured block ran 72 seconds, and both ways of deriving a delay without a {@code
+   * Retry-After} undershoot it badly. The linear fallback gives 5s, 10s then 15s — thirty seconds
+   * of waiting spread across the whole budget. An {@code x-ratelimit-reset} already in the past
+   * gives zero, so every attempt fires at once and the budget is gone in milliseconds, which is
+   * worse than not repeating at all: it spends the repeats the generated content depends on while
+   * GitHub is still refusing.
+   *
+   * <p>Neither number is GitHub speaking about this block. The reset instant belongs to the
+   * <em>primary</em> window, which a secondary limit leaves alone — the run behind #722 is exactly
+   * that, a content-creation block carrying {@code x-ratelimit-remaining=4771}. So a delay that was
+   * derived rather than given is floored here, which is what makes {@link
+   * GitHubWriteRetry#TOTAL_BUDGET} a floor for this failure instead of only a ceiling. An explicit
+   * {@code Retry-After} still wins outright: there GitHub is naming its own deadline.
+   */
+  static final Duration CONTENT_CREATION_BLOCK_MIN_DELAY = Duration.ofSeconds(30);
+
   private final int status;
   private final String retryAfter;
   private final String rateLimitRemaining;
@@ -172,6 +199,13 @@ public final class GitHubApiError {
    * exhausted rate-limit window is honoured; otherwise a linear backoff off {@link #FALLBACK_DELAY}
    * so a silent throttle still slows down. Never negative — a reset already in the past means the
    * window has reopened and the call can go straight back out.
+   *
+   * <p>One exception, added in #722: when GitHub is blocking content creation and named no deadline
+   * of its own, a derived delay is floored at {@link #CONTENT_CREATION_BLOCK_MIN_DELAY}. Both
+   * derivations undershoot that block badly — the linear fallback by design, a stale reset instant
+   * by returning nothing at all — and the reset belongs to the primary window, which the block
+   * leaves untouched. A window that really is exhausted keeps its reset, since there the instant is
+   * a deadline for this failure rather than a number about another one.
    */
   public Duration retryDelay(int attempt, Instant now) {
     var fromHeader = retryAfterSeconds();
@@ -179,10 +213,37 @@ public final class GitHubApiError {
       return atLeastZero(Duration.ofSeconds(fromHeader.get()));
     }
     var reset = parseLong(rateLimitReset);
-    if (reset.isPresent()) {
-      return atLeastZero(Duration.between(now, Instant.ofEpochSecond(reset.get())));
+    var derived =
+        reset.isPresent()
+            ? atLeastZero(Duration.between(now, Instant.ofEpochSecond(reset.get())))
+            : FALLBACK_DELAY.multipliedBy(attempt);
+    if (primaryWindowExhausted() && !derived.isZero()) {
+      // The primary quota really is spent and its window has a future reset, so that instant is
+      // this failure's own deadline — GitHub naming a time, the same as a Retry-After. Flooring it
+      // would hold the call past a window that has already reopened.
+      return derived;
     }
-    return FALLBACK_DELAY.multipliedBy(attempt);
+    return blocksContentCreation() && derived.compareTo(CONTENT_CREATION_BLOCK_MIN_DELAY) < 0
+        ? CONTENT_CREATION_BLOCK_MIN_DELAY
+        : derived;
+  }
+
+  /**
+   * Whether GitHub is blocking content creation rather than throttling in some milder way — the
+   * failure whose measured width the budget is sized against (#722).
+   */
+  private boolean blocksContentCreation() {
+    return CONTENT_CREATION_BLOCK.matcher(body).find();
+  }
+
+  /**
+   * Whether the primary rate-limit window is genuinely spent, which is what makes its reset instant
+   * a deadline for this failure rather than a number belonging to a window it never touched. The
+   * content-creation block behind #722 carried {@code remaining=4771}: quota to spare, and creation
+   * blocked anyway.
+   */
+  private boolean primaryWindowExhausted() {
+    return parseLong(rateLimitRemaining).filter(remaining -> remaining == 0L).isPresent();
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
@@ -76,9 +76,17 @@ public final class GitHubApiError {
    * The wording GitHub uses when it is throttling rather than refusing. A secondary rate limit and
    * a primary rate limit both arrive as 403; only the message distinguishes them from a permission
    * refusal when the headers are absent.
+   *
+   * <p>"blocked from content creation" is carried here as well as in {@link
+   * #CONTENT_CREATION_BLOCK}, because broadening only the latter would be inert: a body that named
+   * the block without one of the other phrases would not be read as a throttle at all, so the call
+   * would fail fast and the floor below it would never be consulted (#722). A 403 that says
+   * creation is blocked is a throttle by definition, never a permission refusal.
    */
   private static final Pattern THROTTLE_WORDING =
-      Pattern.compile("(?i)secondary rate limit|abuse detection|rate limit exceeded");
+      Pattern.compile(
+          "(?i)secondary rate limit|abuse detection|rate limit exceeded"
+              + "|blocked from content creation");
 
   /** Collapses the whitespace of a body so one failure stays on one log line. */
   private static final Pattern WHITESPACE = Pattern.compile("\\s+");
@@ -89,9 +97,15 @@ public final class GitHubApiError {
   /**
    * The wording of the block that stops content creation specifically, rather than any other
    * throttle. It is the one that lasts long enough for the shape of the backoff to matter (#722).
+   *
+   * <p>The measured body carried both "secondary rate limit" and "temporarily blocked from content
+   * creation", and GitHub's older wording for the same block says "abuse detection". The third
+   * alternative covers a body that names the block without either of the first two: it is the
+   * failure whose delay this pattern decides, so missing it would leave the linear fallback and its
+   * thirty seconds against a window three times as wide.
    */
   private static final Pattern CONTENT_CREATION_BLOCK =
-      Pattern.compile("(?i)secondary rate limit|abuse detection");
+      Pattern.compile("(?i)secondary rate limit|abuse detection|blocked from content creation");
 
   /**
    * Floor on one wait while GitHub is blocking content creation and named no deadline of its own
@@ -203,9 +217,15 @@ public final class GitHubApiError {
    * <p>One exception, added in #722: when GitHub is blocking content creation and named no deadline
    * of its own, a derived delay is floored at {@link #CONTENT_CREATION_BLOCK_MIN_DELAY}. Both
    * derivations undershoot that block badly — the linear fallback by design, a stale reset instant
-   * by returning nothing at all — and the reset belongs to the primary window, which the block
-   * leaves untouched. A window that really is exhausted keeps its reset, since there the instant is
-   * a deadline for this failure rather than a number about another one.
+   * by returning nothing at all.
+   *
+   * <p>The floor applies to <em>every</em> rate-limit header on such a block, including {@code
+   * x-ratelimit-remaining: 0}. Those headers describe the <em>primary</em> window, which a
+   * content-creation block leaves untouched, so a primary window that is also spent says nothing
+   * about when creation reopens: a block carrying {@code remaining=0} and a reset ten seconds out
+   * would otherwise wait ten seconds a time and spend the whole budget inside the 72-second window
+   * this is sized against. An earlier revision carved that case out and reintroduced exactly the
+   * failure the floor exists to prevent.
    */
   public Duration retryDelay(int attempt, Instant now) {
     var fromHeader = retryAfterSeconds();
@@ -217,12 +237,6 @@ public final class GitHubApiError {
         reset.isPresent()
             ? atLeastZero(Duration.between(now, Instant.ofEpochSecond(reset.get())))
             : FALLBACK_DELAY.multipliedBy(attempt);
-    if (primaryWindowExhausted() && !derived.isZero()) {
-      // The primary quota really is spent and its window has a future reset, so that instant is
-      // this failure's own deadline — GitHub naming a time, the same as a Retry-After. Flooring it
-      // would hold the call past a window that has already reopened.
-      return derived;
-    }
     return blocksContentCreation() && derived.compareTo(CONTENT_CREATION_BLOCK_MIN_DELAY) < 0
         ? CONTENT_CREATION_BLOCK_MIN_DELAY
         : derived;
@@ -234,16 +248,6 @@ public final class GitHubApiError {
    */
   private boolean blocksContentCreation() {
     return CONTENT_CREATION_BLOCK.matcher(body).find();
-  }
-
-  /**
-   * Whether the primary rate-limit window is genuinely spent, which is what makes its reset instant
-   * a deadline for this failure rather than a number belonging to a window it never touched. The
-   * content-creation block behind #722 carried {@code remaining=4771}: quota to spare, and creation
-   * blocked anyway.
-   */
-  private boolean primaryWindowExhausted() {
-    return parseLong(rateLimitRemaining).filter(remaining -> remaining == 0L).isPresent();
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacer.java
@@ -51,10 +51,11 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>{@value #MIN_INTERVAL_KEY} (default {@code 1s}): spacing between two content-creating
  *       requests. Zero or negative disables pacing entirely.
- *   <li>{@value #MAX_WAIT_KEY} (default {@code 60s}): ceiling on how long one caller waits for its
- *       slot, so a queue that has grown past the ceiling degrades to the {@link GitHubWriteRetry}
- *       backoff — which is where the bot was before #579 — rather than parking a command for
- *       minutes while it holds its per-PR dispatcher slot.
+ *   <li>{@value #MAX_WAIT_KEY} (default {@code 90s}, the {@link GitHubWriteRetry#TOTAL_BUDGET}):
+ *       ceiling on how long one caller waits for its slot, so a queue that has grown past the
+ *       ceiling degrades to the {@link GitHubWriteRetry} backoff — which is where the bot was
+ *       before #579 — rather than parking a command for minutes while it holds its per-PR
+ *       dispatcher slot.
  * </ul>
  *
  * <p>Waiting never costs the payload: a pacing wait that is interrupted proceeds with the call
@@ -74,8 +75,16 @@ public final class GitHubWritePacer {
   /** GitHub's published guidance: no more than one content-creating request per second. */
   static final Duration DEFAULT_MIN_INTERVAL = Duration.ofSeconds(1);
 
-  /** Matches the total {@link GitHubWriteRetry} budget: no wait here is worse than a refusal. */
-  static final Duration DEFAULT_MAX_WAIT = Duration.ofSeconds(60);
+  /**
+   * Matches the total {@link GitHubWriteRetry} budget: no wait here is worse than a refusal. Held
+   * as a literal rather than read from {@code GitHubWriteRetry.TOTAL_BUDGET} because that class
+   * already holds a {@link #DEFAULT} of this one, and reading it back would make the two static
+   * initializers circular — whichever loaded second would see a null. {@code GitHubWritePacerTest}
+   * asserts the two are equal instead, so widening the backoff budget for a window like the
+   * 72-second one measured in #722 fails a test here rather than leaving this ceiling silently
+   * short of it.
+   */
+  static final Duration DEFAULT_MAX_WAIT = Duration.ofSeconds(90);
 
   /** Parks the current thread; the seam that lets the tests run the pacing without waiting. */
   @FunctionalInterface

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetry.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetry.java
@@ -60,20 +60,43 @@ import org.slf4j.LoggerFactory;
  * virtual thread and pins no platform thread. What a wait does hold is the per-PR serialization
  * slot in the dispatcher, so the wait is bounded twice over: at most {@value #MAX_ATTEMPTS}
  * attempts, and no single wait longer than {@link #MAX_DELAY_PER_ATTEMPT} however long a {@code
- * Retry-After} asks for. One call therefore waits at most {@value #MAX_ATTEMPTS} − 1 × 30s = 60s,
- * which is also long enough to outlast the minute-long window GitHub's content-creation secondary
- * limit uses. Once the attempts are spent the failure propagates unchanged, and the log says the
- * generated content was lost so an operator can see the command needs re-running.
+ * Retry-After} asks for. One call therefore waits at most {@link #TOTAL_BUDGET}. Once the attempts
+ * are spent the failure propagates unchanged, and the log says the generated content was lost so an
+ * operator can see the command needs re-running.
+ *
+ * <h2>Why the budget is what it is</h2>
+ *
+ * #722: the budget was three attempts, and its own documentation claimed the resulting 60s was
+ * "long enough to outlast the minute-long window GitHub's content-creation secondary limit uses".
+ * That was an assumption, and measurement contradicted it. During one dogfood round GitHub answered
+ * content creation with {@code 403 You have exceeded a secondary rate limit and have been
+ * temporarily blocked from content creation} — with {@code x-ratelimit-remaining} still at 4771, so
+ * primary quota was nowhere near exhausted — across a window of <strong>72 seconds</strong>,
+ * simultaneously on unrelated pull requests. Sixty seconds of budget expired inside it and the
+ * writes were given up on.
+ *
+ * <p>The budget is therefore sized to outlast a window of that width with margin, which is what
+ * {@value #MAX_ATTEMPTS} attempts buys. It is deliberately not sized to outlast an arbitrary block:
+ * a secondary limit that outlasts this is telling the deployment it is writing too fast, and the
+ * answer there is the pacing in {@link GitHubWritePacer}, not a longer wait holding a PR's slot.
  */
 public final class GitHubWriteRetry {
 
   private static final Logger log = LoggerFactory.getLogger(GitHubWriteRetry.class);
 
-  /** Total attempts, first included: one post plus at most two repeats. */
-  public static final int MAX_ATTEMPTS = 3;
+  /** Total attempts, first included: one post plus at most three repeats. */
+  public static final int MAX_ATTEMPTS = 4;
 
   /** Longest single wait honoured, however long a {@code Retry-After} asks for. */
   public static final Duration MAX_DELAY_PER_ATTEMPT = Duration.ofSeconds(30);
+
+  /**
+   * Longest one call can wait in total: every repeat waiting the per-attempt ceiling. Derived
+   * rather than written down so it cannot drift from the two bounds that produce it, and exposed
+   * because {@link GitHubWritePacer} sizes its own ceiling against it — a caller waiting for a
+   * pacing slot must never wait longer than simply being refused and repeated would take.
+   */
+  public static final Duration TOTAL_BUDGET = MAX_DELAY_PER_ATTEMPT.multipliedBy(MAX_ATTEMPTS - 1L);
 
   /** Parks the current thread; the seam that lets the tests run the backoff without waiting. */
   @FunctionalInterface

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -739,7 +739,16 @@ public class ReviewPublisher {
       if (withoutSuggestion.isEmpty()) {
         return true;
       }
-      rejection = withoutSuggestion;
+      // Both reasons, when they differ. The two attempts fail for different causes often enough to
+      // matter: a suggestion block GitHub will not take is a 422 about the payload, while a
+      // content-creation block is a 403 about the moment. Reporting only the second would name the
+      // payload for a finding that was actually refused by a throttle, which is the class of wrong
+      // diagnosis this whole change exists to stop.
+      rejection =
+          rejection
+              .filter(first -> !first.equals(withoutSuggestion.get()))
+              .map(first -> "with suggestion: " + first + "; without: " + withoutSuggestion.get())
+              .or(() -> withoutSuggestion);
     }
     Log.warnf(
         "GitHub rejected inline comment for %s:%d (%s) — filing it on the file instead",

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -728,16 +728,43 @@ public class ReviewPublisher {
         finding.hasSuggestion() && finding.suggestionOld().strip().contains("\n");
     var includeSuggestion = finding.hasSuggestion() && (!multiLineSuggestion || range.isPresent());
 
-    if (tryPostInlineComment(target, finding, findingId, resolvedLine, range, includeSuggestion)
-        || (includeSuggestion
-            && tryPostInlineComment(
-                target, finding, findingId, resolvedLine, Optional.empty(), false))) {
+    var rejection =
+        tryPostInlineComment(target, finding, findingId, resolvedLine, range, includeSuggestion);
+    if (rejection.isEmpty()) {
       return true;
     }
+    if (includeSuggestion) {
+      var withoutSuggestion =
+          tryPostInlineComment(target, finding, findingId, resolvedLine, Optional.empty(), false);
+      if (withoutSuggestion.isEmpty()) {
+        return true;
+      }
+      rejection = withoutSuggestion;
+    }
     Log.warnf(
-        "GitHub rejected inline comment for %s:%d — filing it on the file instead",
-        finding.file(), finding.line());
+        "GitHub rejected inline comment for %s:%d (%s) — filing it on the file instead",
+        finding.file(), finding.line(), rejection.get());
     return postFileLevelComment(target, finding, findingId);
+  }
+
+  /**
+   * What GitHub said, for the log line an operator reads when a finding loses its line thread.
+   *
+   * <p>Every rejection reason used to be discarded at debug level, which is off in production, so
+   * the only record a run left was that a comment "could not be anchored to the current diff" — a
+   * claim about line numbers the code was in no position to make. That wording sent two scorers and
+   * then #712 hunting an off-by-N that did not exist, and the twenty-nine rejections behind it are
+   * now permanently undiagnosable: the status that separates a throttle from a rejected position
+   * was never written down (#722).
+   *
+   * <p>Falls back to the exception's own text for a connection-level failure, which carries no
+   * response to read a status off.
+   */
+  private static String rejectionReason(RuntimeException e) {
+    if (e instanceof WebApplicationException w) {
+      return GitHubApiError.of(w).map(GitHubApiError::diagnostics).orElseGet(e::toString);
+    }
+    return e.toString();
   }
 
   /**
@@ -776,7 +803,9 @@ public class ReviewPublisher {
               target.commitSha(), body, finding.file()));
       return true;
     } catch (RuntimeException e) {
-      Log.debugf(e, "File-level comment rejected for %s", finding.file());
+      Log.warnf(
+          "GitHub rejected the file-level thread for %s (%s) — the finding keeps no thread at all",
+          finding.file(), rejectionReason(e));
       return false;
     }
   }
@@ -786,8 +815,13 @@ public class ReviewPublisher {
    * start_line}..{@code line} (both RIGHT side); otherwise it anchors to the single {@code line}.
    * The retry without a suggestion block always passes an empty range — a multi-line span is only
    * meaningful with a suggestion to apply across it.
+   *
+   * <p>Returns empty when the comment landed, and otherwise what GitHub said, so the caller can put
+   * the reason in the one line it logs rather than discarding it (#722). A first attempt that fails
+   * is ordinary — it is how a rejected suggestion block is discovered — so it stays at debug; only
+   * the attempt the caller gives up on is worth a warning.
    */
-  private boolean tryPostInlineComment(
+  private Optional<String> tryPostInlineComment(
       CommentTarget target,
       Finding finding,
       int findingId,
@@ -812,15 +846,17 @@ public class ReviewPublisher {
               "RIGHT",
               startLine,
               startSide));
-      return true;
+      return Optional.empty();
     } catch (RuntimeException e) {
+      var reason = rejectionReason(e);
       Log.debugf(
           e,
-          "Inline comment rejected for %s:%d (suggestion=%s)",
+          "Inline comment rejected for %s:%d (suggestion=%s): %s",
           finding.file(),
           endLine,
-          includeSuggestion);
-      return false;
+          includeSuggestion,
+          reason);
+      return Optional.of(reason);
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -733,6 +733,7 @@ public class ReviewPublisher {
     if (rejection.isEmpty()) {
       return true;
     }
+    var reason = rejection.get();
     if (includeSuggestion) {
       var withoutSuggestion =
           tryPostInlineComment(target, finding, findingId, resolvedLine, Optional.empty(), false);
@@ -744,15 +745,13 @@ public class ReviewPublisher {
       // content-creation block is a 403 about the moment. Reporting only the second would name the
       // payload for a finding that was actually refused by a throttle, which is the class of wrong
       // diagnosis this whole change exists to stop.
-      rejection =
-          rejection
-              .filter(first -> !first.equals(withoutSuggestion.get()))
-              .map(first -> "with suggestion: " + first + "; without: " + withoutSuggestion.get())
-              .or(() -> withoutSuggestion);
+      var second = withoutSuggestion.get();
+      reason =
+          reason.equals(second) ? second : "with suggestion: " + reason + "; without: " + second;
     }
     Log.warnf(
         "GitHub rejected inline comment for %s:%d (%s) — filing it on the file instead",
-        finding.file(), finding.line(), rejection.get());
+        finding.file(), finding.line(), reason);
     return postFileLevelComment(target, finding, findingId);
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
@@ -195,9 +195,89 @@ class GitHubApiErrorTest {
 
     @Test
     void aSilentThrottleBacksOffLinearlyByAttempt() {
-      var error = GitHubApiError.from(outbound(403, SECONDARY_LIMIT_BODY));
+      // A throttle that is not a content-creation block keeps the linear backoff: it is the mild
+      // case, and slowing down a little is all it asks for.
+      var error = GitHubApiError.from(outbound(403, "{\"message\":\"rate limit exceeded\"}"));
       assertEquals(Duration.ofSeconds(5), error.retryDelay(1, NOW));
       assertEquals(Duration.ofSeconds(10), error.retryDelay(2, NOW));
+    }
+
+    /**
+     * #722. The budget is sized against a measured 72-second content-creation block, but sizing the
+     * attempts only bounds one call's wait from above. These pin the floor that makes the budget a
+     * floor as well, which is what the sizing was for.
+     */
+    @Nested
+    class AContentCreationBlockGitHubGaveNoDeadlineFor {
+
+      @Test
+      void isNotLeftToTheLinearFallback() {
+        // 5s, 10s then 15s spreads thirty seconds of waiting across the whole budget and gives up
+        // well inside a block of the measured width.
+        var error = GitHubApiError.from(outbound(403, SECONDARY_LIMIT_BODY));
+        assertEquals(Duration.ofSeconds(30), error.retryDelay(1, NOW));
+        assertEquals(Duration.ofSeconds(30), error.retryDelay(2, NOW));
+      }
+
+      @Test
+      void isNotRepeatedInstantlyOnAStaleResetInstant() {
+        // The reset belongs to the primary window, which a secondary limit leaves untouched — the
+        // run behind #722 carried remaining=4771 while content creation was blocked. Taken
+        // literally a past reset says "go now", spending every attempt in milliseconds while GitHub
+        // is still refusing, which is worse than not repeating at all.
+        var error =
+            GitHubApiError.from(
+                outbound(
+                    403,
+                    SECONDARY_LIMIT_BODY,
+                    "x-ratelimit-remaining",
+                    "4771",
+                    "x-ratelimit-reset",
+                    String.valueOf(NOW.getEpochSecond() - 90)));
+        assertEquals(Duration.ofSeconds(30), error.retryDelay(1, NOW));
+      }
+
+      @Test
+      void spansTheMeasuredBlockOnceTheWaitsAreClamped() {
+        var error = GitHubApiError.from(outbound(403, SECONDARY_LIMIT_BODY));
+        var total = Duration.ZERO;
+        for (var attempt = 1; attempt < GitHubWriteRetry.MAX_ATTEMPTS; attempt++) {
+          var wait = error.retryDelay(attempt, NOW);
+          total =
+              total.plus(
+                  wait.compareTo(GitHubWriteRetry.MAX_DELAY_PER_ATTEMPT) > 0
+                      ? GitHubWriteRetry.MAX_DELAY_PER_ATTEMPT
+                      : wait);
+        }
+        assertTrue(
+            total.compareTo(Duration.ofSeconds(72)) >= 0,
+            "the clamped waits have to span the measured block, got " + total);
+      }
+
+      @Test
+      void keepsADerivedWaitThatIsAlreadyLongerThanTheFloor() {
+        // The floor lifts a wait that undershoots; it must not shorten one. A reset further out
+        // than the floor is the longer of the two and stays, with the retry's own ceiling left to
+        // clamp it.
+        var error =
+            GitHubApiError.from(
+                outbound(
+                    403,
+                    SECONDARY_LIMIT_BODY,
+                    "x-ratelimit-remaining",
+                    "4771",
+                    "x-ratelimit-reset",
+                    String.valueOf(NOW.getEpochSecond() + 120)));
+        assertEquals(Duration.ofSeconds(120), error.retryDelay(1, NOW));
+      }
+
+      @Test
+      void stillYieldsToADeadlineGitHubNamed() {
+        // An explicit Retry-After is GitHub speaking about this block, so the floor must not
+        // override it — not even upwards.
+        var error = GitHubApiError.from(outbound(403, SECONDARY_LIMIT_BODY, "Retry-After", "3"));
+        assertEquals(Duration.ofSeconds(3), error.retryDelay(1, NOW));
+      }
     }
   }
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
@@ -272,6 +272,36 @@ class GitHubApiErrorTest {
       }
 
       @Test
+      void isFlooredEvenWhenThePrimaryWindowAlsoReadsExhausted() {
+        // The rate-limit headers describe the PRIMARY window, which this block leaves untouched, so
+        // remaining=0 alongside a near reset says nothing about when creation reopens. An earlier
+        // revision carved this case out and let it return 10s a time — three waits inside the very
+        // window the budget is sized against, which is the #722 failure all over again.
+        var error =
+            GitHubApiError.from(
+                outbound(
+                    403,
+                    SECONDARY_LIMIT_BODY,
+                    "x-ratelimit-remaining",
+                    "0",
+                    "x-ratelimit-reset",
+                    String.valueOf(NOW.getEpochSecond() + 10)));
+        assertEquals(Duration.ofSeconds(30), error.retryDelay(1, NOW));
+      }
+
+      @Test
+      void isRecognisedFromTheBlockWordingAlone() {
+        // A body naming the block without "secondary rate limit" or "abuse detection" is still the
+        // same failure, and must be both retried at all and floored.
+        var body =
+            "{\"message\":\"You have been temporarily blocked from content creation. Please try"
+                + " again later.\"}";
+        var error = GitHubApiError.from(outbound(403, body));
+        assertTrue(error.isThrottled(), "a blocked-creation 403 is a throttle, not a refusal");
+        assertEquals(Duration.ofSeconds(30), error.retryDelay(1, NOW));
+      }
+
+      @Test
       void stillYieldsToADeadlineGitHubNamed() {
         // An explicit Retry-After is GitHub speaking about this block, so the floor must not
         // override it — not even upwards.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
@@ -302,6 +302,19 @@ class GitHubApiErrorTest {
       }
 
       @Test
+      void isRecognisedFromTheGerundWordingToo() {
+        // Same block, named "blocked from creating content" rather than "content creation". The
+        // rule's contract is that it recognises a body naming the block, so it must not turn on
+        // which word order GitHub happened to use.
+        var body =
+            "{\"message\":\"You have been temporarily blocked from creating content. Please retry"
+                + " your request again later.\"}";
+        var error = GitHubApiError.from(outbound(403, body));
+        assertTrue(error.isThrottled(), "a blocked-creation 403 is a throttle, not a refusal");
+        assertEquals(Duration.ofSeconds(30), error.retryDelay(1, NOW));
+      }
+
+      @Test
       void stillYieldsToADeadlineGitHubNamed() {
         // An explicit Retry-After is GitHub speaking about this block, so the floor must not
         // override it — not even upwards.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
@@ -46,6 +46,15 @@ class GitHubApiErrorTest {
       "{\"message\":\"You have exceeded a secondary rate limit. Please wait a few minutes before"
           + " you try again.\",\"documentation_url\":\"https://docs.github.com/rest\"}";
 
+  /**
+   * The body measured in #722: the generic secondary-limit sentence AND the clause naming the
+   * block. {@link #SECONDARY_LIMIT_BODY} is the generic wording on its own, which is a milder
+   * throttle class and must keep the linear backoff.
+   */
+  private static final String CONTENT_CREATION_BLOCK_BODY =
+      "{\"message\":\"You have exceeded a secondary rate limit and have been temporarily blocked"
+          + " from content creation. Please retry your request again later.\"}";
+
   private static final String PERMISSION_BODY =
       "{\"message\":\"Resource not accessible by integration\",\"status\":\"403\"}";
 
@@ -202,6 +211,16 @@ class GitHubApiErrorTest {
       assertEquals(Duration.ofSeconds(10), error.retryDelay(2, NOW));
     }
 
+    @Test
+    void theGenericSecondaryLimitIsNotTreatedAsTheContentCreationBlock() {
+      // GitHub sends this one for any endpoint, and it is a milder class than the block the floor
+      // is sized against. Flooring it would hold a PR's dispatcher slot for up to the whole budget
+      // over a throttle that asks only for a short pause.
+      var error = GitHubApiError.from(outbound(403, SECONDARY_LIMIT_BODY));
+      assertEquals(Duration.ofSeconds(5), error.retryDelay(1, NOW));
+      assertEquals(Duration.ofSeconds(10), error.retryDelay(2, NOW));
+    }
+
     /**
      * #722. The budget is sized against a measured 72-second content-creation block, but sizing the
      * attempts only bounds one call's wait from above. These pin the floor that makes the budget a
@@ -214,7 +233,7 @@ class GitHubApiErrorTest {
       void isNotLeftToTheLinearFallback() {
         // 5s, 10s then 15s spreads thirty seconds of waiting across the whole budget and gives up
         // well inside a block of the measured width.
-        var error = GitHubApiError.from(outbound(403, SECONDARY_LIMIT_BODY));
+        var error = GitHubApiError.from(outbound(403, CONTENT_CREATION_BLOCK_BODY));
         assertEquals(Duration.ofSeconds(30), error.retryDelay(1, NOW));
         assertEquals(Duration.ofSeconds(30), error.retryDelay(2, NOW));
       }
@@ -229,7 +248,7 @@ class GitHubApiErrorTest {
             GitHubApiError.from(
                 outbound(
                     403,
-                    SECONDARY_LIMIT_BODY,
+                    CONTENT_CREATION_BLOCK_BODY,
                     "x-ratelimit-remaining",
                     "4771",
                     "x-ratelimit-reset",
@@ -239,7 +258,7 @@ class GitHubApiErrorTest {
 
       @Test
       void spansTheMeasuredBlockOnceTheWaitsAreClamped() {
-        var error = GitHubApiError.from(outbound(403, SECONDARY_LIMIT_BODY));
+        var error = GitHubApiError.from(outbound(403, CONTENT_CREATION_BLOCK_BODY));
         var total = Duration.ZERO;
         for (var attempt = 1; attempt < GitHubWriteRetry.MAX_ATTEMPTS; attempt++) {
           var wait = error.retryDelay(attempt, NOW);
@@ -263,7 +282,7 @@ class GitHubApiErrorTest {
             GitHubApiError.from(
                 outbound(
                     403,
-                    SECONDARY_LIMIT_BODY,
+                    CONTENT_CREATION_BLOCK_BODY,
                     "x-ratelimit-remaining",
                     "4771",
                     "x-ratelimit-reset",
@@ -281,7 +300,7 @@ class GitHubApiErrorTest {
             GitHubApiError.from(
                 outbound(
                     403,
-                    SECONDARY_LIMIT_BODY,
+                    CONTENT_CREATION_BLOCK_BODY,
                     "x-ratelimit-remaining",
                     "0",
                     "x-ratelimit-reset",
@@ -318,7 +337,8 @@ class GitHubApiErrorTest {
       void stillYieldsToADeadlineGitHubNamed() {
         // An explicit Retry-After is GitHub speaking about this block, so the floor must not
         // override it — not even upwards.
-        var error = GitHubApiError.from(outbound(403, SECONDARY_LIMIT_BODY, "Retry-After", "3"));
+        var error =
+            GitHubApiError.from(outbound(403, CONTENT_CREATION_BLOCK_BODY, "Retry-After", "3"));
         assertEquals(Duration.ofSeconds(3), error.retryDelay(1, NOW));
       }
     }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWritePacerTest.java
@@ -152,6 +152,18 @@ class GitHubWritePacerTest {
     assertEquals(List.of(), waited);
   }
 
+  /**
+   * The two ceilings are documented as the same number and held separately, because reading one
+   * from the other makes the static initializers circular — {@link GitHubWriteRetry} holds this
+   * class's {@code DEFAULT}, so the dependency only runs one way. This is what keeps the literal
+   * honest: widening the backoff budget without widening this one fails here rather than leaving a
+   * caller waiting longer for a pacing slot than being refused and repeated would have taken.
+   */
+  @Test
+  void theDefaultCeilingMatchesTheBackoffBudgetItIsDocumentedAgainst() {
+    assertEquals(GitHubWriteRetry.TOTAL_BUDGET, GitHubWritePacer.DEFAULT_MAX_WAIT);
+  }
+
   @AfterEach
   void clearProbe() {
     System.clearProperty(PROBE_KEY);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -41,8 +42,10 @@ import org.junit.jupiter.api.Test;
  * Covers {@link GitHubWriteRetry} — the backoff #568 asked for on the calls that publish work the
  * bot has already paid for, and, just as importantly, the failures it refuses to repeat.
  *
- * <p>The bounds are written out as literals (3 attempts, a 30-second ceiling on one wait) so the
- * tests pin them rather than restate whatever the production constants happen to say.
+ * <p>The bounds are written out as literals (4 attempts, a 30-second ceiling on one wait) so the
+ * tests pin them rather than restate whatever the production constants happen to say. The fourth
+ * attempt is #722: the budget was three, and a measured 72-second content-creation block outlasted
+ * it.
  */
 class GitHubWriteRetryTest {
 
@@ -183,7 +186,7 @@ class GitHubWriteRetryTest {
   }
 
   @Test
-  void aPersistentThrottleGivesUpAfterThreeAttempts() {
+  void aPersistentThrottleGivesUpAfterFourAttempts() {
     var calls = new AtomicInteger();
     var lastFailure = throttled("Retry-After", "4");
 
@@ -198,17 +201,20 @@ class GitHubWriteRetryTest {
                       throw lastFailure;
                     }));
 
-    // Bounded: one post and two repeats, so a throttled PR cannot hold its dispatcher slot forever.
+    // Bounded: one post and three repeats, so a throttled PR cannot hold its dispatcher slot
+    // forever. The third repeat is what #722 added, after a measured 72-second content-creation
+    // block outlasted the two the budget had.
     assertSame(lastFailure, thrown);
-    assertEquals(3, calls.get());
-    assertEquals(List.of(Duration.ofSeconds(4), Duration.ofSeconds(4)), slept);
+    assertEquals(4, calls.get());
+    assertEquals(
+        List.of(Duration.ofSeconds(4), Duration.ofSeconds(4), Duration.ofSeconds(4)), slept);
   }
 
   @Test
   void aSpentBudgetStillGivesUpSilentlyWhenWarningsAreOff() {
     // The give-up line sits behind a level check, because diagnostics() builds its string eagerly
     // and a parameter placeholder only defers the toString. With the logger off nothing may be
-    // logged, and the retry must still spend the same three attempts and rethrow the same failure.
+    // logged, and the retry must still spend the same four attempts and rethrow the same failure.
     var julLogger = Logger.getLogger(GitHubWriteRetry.class.getName());
     var logged = new CopyOnWriteArrayList<LogRecord>();
     var capture =
@@ -247,8 +253,9 @@ class GitHubWriteRetryTest {
                       }));
 
       assertSame(lastFailure, thrown);
-      assertEquals(3, calls.get());
-      assertEquals(List.of(Duration.ofSeconds(4), Duration.ofSeconds(4)), slept);
+      assertEquals(4, calls.get());
+      assertEquals(
+          List.of(Duration.ofSeconds(4), Duration.ofSeconds(4), Duration.ofSeconds(4)), slept);
       assertTrue(logged.isEmpty(), logged.toString());
     } finally {
       julLogger.removeHandler(capture);
@@ -270,8 +277,13 @@ class GitHubWriteRetryTest {
                   throw throttled("Retry-After", "3600");
                 }));
 
-    // 30s a wait, twice: the whole call waits at most a minute whatever GitHub asks for.
-    assertEquals(List.of(Duration.ofSeconds(30), Duration.ofSeconds(30)), slept);
+    // 30s a wait, three times: the whole call waits at most TOTAL_BUDGET whatever GitHub asks for.
+    assertEquals(
+        List.of(Duration.ofSeconds(30), Duration.ofSeconds(30), Duration.ofSeconds(30)), slept);
+    assertEquals(
+        GitHubWriteRetry.TOTAL_BUDGET,
+        slept.stream().reduce(Duration.ZERO, Duration::plus),
+        "the clamped waits add up to exactly the documented budget");
   }
 
   @Test
@@ -596,6 +608,71 @@ class GitHubWriteRetryTest {
                       }));
 
       assertSame(rejection, thrown);
+    }
+  }
+
+  /**
+   * #722. The budget used to be three attempts, documented as "long enough to outlast the
+   * minute-long window GitHub's content-creation secondary limit uses". A dogfood round measured a
+   * content-creation block lasting 72 seconds — with primary quota nowhere near exhausted — and
+   * sixty seconds of budget expired inside it, so the writes were given up on and the findings lost
+   * their threads.
+   */
+  @Nested
+  class TheMeasuredSecondaryLimitWindow {
+
+    /** The window measured in #722, which the budget has to outlast to be worth having. */
+    private static final Duration OBSERVED_BLOCK = Duration.ofSeconds(72);
+
+    @Test
+    void aBlockAsLongAsTheMeasuredOneIsOutlasted() {
+      var calls = new AtomicInteger();
+      var elapsed = new AtomicLong();
+      var waits = new ArrayList<Duration>();
+      // A clock the recorded waits actually advance, so GitHub stays blocked until as much time
+      // has passed as the measured window lasted.
+      var backoff =
+          new GitHubWriteRetry(
+              wait -> {
+                waits.add(wait);
+                elapsed.addAndGet(wait.toSeconds());
+              },
+              () -> Instant.ofEpochSecond(1_800_000_000L));
+
+      var result =
+          backoff.call(
+              "a comment on o/r #7",
+              () -> {
+                calls.incrementAndGet();
+                if (elapsed.get() < OBSERVED_BLOCK.toSeconds()) {
+                  throw throttled("Retry-After", "30");
+                }
+                return "posted";
+              });
+
+      assertEquals("posted", result);
+      assertTrue(
+          elapsed.get() >= OBSERVED_BLOCK.toSeconds(),
+          "the budget has to span the block, not expire inside it — waited only " + elapsed.get());
+      assertTrue(calls.get() >= 4, "a block this wide costs more than the old two repeats");
+    }
+
+    @Test
+    void theTotalBudgetOutlastsIt() {
+      assertTrue(
+          GitHubWriteRetry.TOTAL_BUDGET.compareTo(OBSERVED_BLOCK) > 0,
+          "TOTAL_BUDGET ("
+              + GitHubWriteRetry.TOTAL_BUDGET
+              + ") must outlast the measured "
+              + OBSERVED_BLOCK
+              + " block");
+    }
+
+    @Test
+    void theBudgetIsDerivedFromTheTwoBoundsThatProduceIt() {
+      assertEquals(
+          GitHubWriteRetry.MAX_DELAY_PER_ATTEMPT.multipliedBy(GitHubWriteRetry.MAX_ATTEMPTS - 1L),
+          GitHubWriteRetry.TOTAL_BUDGET);
     }
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
@@ -637,15 +637,11 @@ class GitHubWriteRetryTest {
     void aBlockAsLongAsTheMeasuredOneIsOutlasted() {
       var calls = new AtomicInteger();
       var elapsed = new AtomicLong();
-      var waits = new ArrayList<Duration>();
       // A clock the recorded waits actually advance, so GitHub stays blocked until as much time
       // has passed as the measured window lasted.
       var backoff =
           new GitHubWriteRetry(
-              wait -> {
-                waits.add(wait);
-                elapsed.addAndGet(wait.toSeconds());
-              },
+              wait -> elapsed.addAndGet(wait.toSeconds()),
               () -> Instant.ofEpochSecond(1_800_000_000L));
 
       var result =
@@ -679,9 +675,10 @@ class GitHubWriteRetryTest {
 
     @Test
     void theBudgetIsDerivedFromTheTwoBoundsThatProduceIt() {
+      assertEquals(Duration.ofSeconds(90), GitHubWriteRetry.TOTAL_BUDGET);
       assertEquals(
-          GitHubWriteRetry.MAX_DELAY_PER_ATTEMPT.multipliedBy(GitHubWriteRetry.MAX_ATTEMPTS - 1L),
-          GitHubWriteRetry.TOTAL_BUDGET);
+          Duration.ofSeconds(90),
+          GitHubWriteRetry.MAX_DELAY_PER_ATTEMPT.multipliedBy(GitHubWriteRetry.MAX_ATTEMPTS - 1L));
     }
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
@@ -290,12 +290,21 @@ class GitHubWriteRetryTest {
   void anExhaustedWindowWaitsUntilItsResetInstant() {
     var calls = new AtomicInteger();
 
+    // Deliberately NOT the content-creation wording: that block is floored regardless of the
+    // rate-limit headers (#722), because they describe the primary window it leaves untouched. This
+    // is the plain primary exhaustion, where the reset instant really is the deadline.
     var result =
         retry.call(
             "a comment on o/r #7",
             () -> {
               if (calls.incrementAndGet() == 1) {
-                throw throttled("x-ratelimit-remaining", "0", "x-ratelimit-reset", "1800000021");
+                throw failure(
+                    403,
+                    "{\"message\":\"API rate limit exceeded\"}",
+                    "x-ratelimit-remaining",
+                    "0",
+                    "x-ratelimit-reset",
+                    "1800000021");
               }
               return "posted";
             });

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
@@ -675,10 +675,15 @@ class GitHubWriteRetryTest {
 
     @Test
     void theBudgetIsDerivedFromTheTwoBoundsThatProduceIt() {
-      assertEquals(Duration.ofSeconds(90), GitHubWriteRetry.TOTAL_BUDGET);
-      assertEquals(
-          Duration.ofSeconds(90),
-          GitHubWriteRetry.MAX_DELAY_PER_ATTEMPT.multipliedBy(GitHubWriteRetry.MAX_ATTEMPTS - 1L));
+      // Both values are read into locals first. Passing the constant itself as the actual argument
+      // reads to SonarCloud (java:S3415) as the expected value in the wrong position, since a
+      // static final field is exactly what that rule looks for on the right-hand side.
+      var budget = GitHubWriteRetry.TOTAL_BUDGET;
+      var derivedFromTheBounds =
+          GitHubWriteRetry.MAX_DELAY_PER_ATTEMPT.multipliedBy(GitHubWriteRetry.MAX_ATTEMPTS - 1L);
+
+      assertEquals(Duration.ofSeconds(90), budget);
+      assertEquals(Duration.ofSeconds(90), derivedFromTheBounds);
     }
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -4014,6 +4014,81 @@ class ReviewOrchestratorTest {
           "GitHub's own wording must survive to the operator: " + warning);
     }
 
+    /**
+     * #722. The two attempts fail for different causes often enough to matter: a suggestion block
+     * GitHub will not take is a 422 about the payload, a content-creation block is a 403 about the
+     * moment. Reporting only the second names the payload for a finding a throttle actually
+     * refused, which is the class of wrong diagnosis this change exists to stop.
+     */
+    @Test
+    void shouldLogBothReasonsWhenTheSuggestionRetryFailsDifferently() {
+      var finding =
+          new Finding(RiskLevel.HIGH, "src/Main.java", 10, "t", "d", "old code", "new code");
+      var result = resultWithFinding(finding, ReviewState.REQUEST_CHANGES);
+      var resolver =
+          new DiffLineResolver(
+              Map.of("src/Main.java", fileDiffWithLine("src/Main.java", 10).patch()));
+      when(suggestionFormatter.formatReviewComment(any(), anyBoolean(), anyInt()))
+          .thenReturn("body");
+      doThrow(
+              new WebApplicationException(
+                  Response.status(403)
+                      .entity("{\"message\":\"You have exceeded a secondary rate limit.\"}")
+                      .build()),
+              new WebApplicationException(
+                  Response.status(422)
+                      .entity("{\"message\":\"line must be part of the diff\"}")
+                      .build()))
+          .when(reviewClient)
+          .createPullRequestComment(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(req -> req.subjectType() == null));
+
+      var julLogger = java.util.logging.Logger.getLogger(ReviewPublisher.class.getName());
+      var logged = new java.util.concurrent.CopyOnWriteArrayList<java.util.logging.LogRecord>();
+      var capture =
+          new java.util.logging.Handler() {
+            @Override
+            public void publish(java.util.logging.LogRecord entry) {
+              logged.add(entry);
+            }
+
+            @Override
+            public void flush() {
+              // Nothing is buffered.
+            }
+
+            @Override
+            public void close() {
+              // Nothing to release.
+            }
+          };
+      julLogger.addHandler(capture);
+      try {
+        reviewPublisher.postInlineComments(
+            "Bearer tok", "owner", "repo", 7, "sha", result, resolver);
+      } finally {
+        julLogger.removeHandler(capture);
+      }
+
+      var warning =
+          logged.stream()
+              .map(java.util.logging.LogRecord::getMessage)
+              .filter(m -> m.contains("GitHub rejected inline comment"))
+              .findFirst()
+              .orElse("");
+      assertTrue(
+          warning.contains("status=403") && warning.contains("secondary rate limit"),
+          "the throttle that refused the first attempt must not be dropped: " + warning);
+      assertTrue(
+          warning.contains("status=422"),
+          "the second attempt's reason belongs there too: " + warning);
+    }
+
     @Test
     void shouldPostToNearestLineWhenExactLineMissing() {
       var finding = new Finding(RiskLevel.HIGH, "src/Main.java", 15, "Bug", "desc", null, null);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -32,6 +32,8 @@ import dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationService;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewTokenLedger;
 import dev.thiagogonzaga.thrillhousebot.review.ai.TokenCounter;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -3936,6 +3938,80 @@ class ReviewOrchestratorTest {
 
       assertEquals(0, inline.posted());
       assertEquals(List.of(finding), inline.unanchored());
+    }
+
+    /**
+     * #722. The reason a comment was refused used to be logged at debug, which is off in
+     * production, so a run recorded only that the comment "could not be anchored" — a claim about
+     * line numbers. Twenty-nine rejections in one dogfood round are undiagnosable because of it,
+     * and #712 was filed against the wrong layer on the strength of that wording. The status and
+     * body GitHub sent have to reach the warning an operator actually sees.
+     */
+    @Test
+    void shouldLogWhatGitHubSaidWhenTheLineAnchoredCommentIsRefused() {
+      var finding = new Finding(RiskLevel.HIGH, "src/Main.java", 10, "Bug", "desc", null, null);
+      var result = resultWithFinding(finding, ReviewState.REQUEST_CHANGES);
+      var resolver =
+          new DiffLineResolver(
+              Map.of("src/Main.java", fileDiffWithLine("src/Main.java", 10).patch()));
+      when(suggestionFormatter.formatReviewComment(any(), anyBoolean(), anyInt()))
+          .thenReturn("body");
+      var secondaryLimit =
+          new WebApplicationException(
+              Response.status(403)
+                  .entity(
+                      "{\"message\":\"You have exceeded a secondary rate limit and have been"
+                          + " temporarily blocked from content creation.\"}")
+                  .build());
+      doThrow(secondaryLimit)
+          .when(reviewClient)
+          .createPullRequestComment(
+              anyString(),
+              anyString(),
+              anyString(),
+              anyString(),
+              anyInt(),
+              argThat(req -> req.subjectType() == null));
+
+      var julLogger = java.util.logging.Logger.getLogger(ReviewPublisher.class.getName());
+      var logged = new java.util.concurrent.CopyOnWriteArrayList<java.util.logging.LogRecord>();
+      var capture =
+          new java.util.logging.Handler() {
+            @Override
+            public void publish(java.util.logging.LogRecord entry) {
+              logged.add(entry);
+            }
+
+            @Override
+            public void flush() {
+              // Nothing is buffered.
+            }
+
+            @Override
+            public void close() {
+              // Nothing to release.
+            }
+          };
+      julLogger.addHandler(capture);
+      try {
+        reviewPublisher.postInlineComments(
+            "Bearer tok", "owner", "repo", 7, "sha", result, resolver);
+      } finally {
+        julLogger.removeHandler(capture);
+      }
+
+      var warning =
+          logged.stream()
+              .map(java.util.logging.LogRecord::getMessage)
+              .filter(m -> m.contains("GitHub rejected inline comment"))
+              .findFirst()
+              .orElse("");
+      assertTrue(
+          warning.contains("status=403"),
+          "the status separating a throttle from a bad position must be in the line: " + warning);
+      assertTrue(
+          warning.contains("secondary rate limit"),
+          "GitHub's own wording must survive to the operator: " + warning);
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

Two defects behind the run that produced #712, both measured from the production logs on the round-7
build (`176371a`).

**The window was a secondary rate limit, and the budget could not span it.** `GitHubWriteRetry`
allowed three attempts, and its own javadoc asserted the resulting 60s was *"long enough to outlast
the minute-long window GitHub's content-creation secondary limit uses"*. That was an assumption:

```
403 body={"message":"You have exceeded a secondary rate limit and have been temporarily
blocked from content creation. ..."}  x-ratelimit-remaining=4771
```

Primary quota nowhere near exhausted, and the block ran **72 seconds**, simultaneously on unrelated
pull requests.

Raising the attempt count to four is only half of it, and the reviewer on this PR was right to push
back on the other half: more attempts bound one call's wait **from above** without making it reach
72s. Both ways of deriving a delay without a `Retry-After` undershoot badly — the linear fallback
gives `5s + 10s + 15s`, and an `x-ratelimit-reset` already in the past gives **zero**, firing every
attempt at once and spending the budget in milliseconds while GitHub is still refusing.

Neither number is GitHub speaking about this block: the reset belongs to the **primary** window,
which a secondary limit leaves untouched. So a *derived* delay is floored at 30s for a
content-creation block, which makes `TOTAL_BUDGET` a floor for this failure rather than only a
ceiling. An explicit `Retry-After` still wins outright, and a primary window that really is exhausted
keeps its reset instant.

`GitHubWritePacer.DEFAULT_MAX_WAIT` is documented as the same number and stays a **literal**: reading
it from `TOTAL_BUDGET` makes the two static initializers circular (`IC_INIT_CIRCULARITY`, caught by
spotbugs), since the retry already holds the pacer's `DEFAULT`. A test asserts the two are equal.

**Why none of this was diagnosable.** Every rejection reason was logged at debug, which is off in
production. A run recorded only:

```
WARN GitHub rejected inline comment for src/allocator.js:33
```

and then, in the review body, "could not be anchored to the current diff" — a claim about line
numbers the code was in no position to make. The status that separates a throttle from a rejected
position was never written down, so the 29 rejections in that round are permanently undiagnosable,
and the wording sent two dogfood scorers and then #712 itself hunting an off-by-N that did not exist.

The status and GitHub's own message now reach the warning an operator sees, and when the two attempts
fail differently **both** reasons are kept: a suggestion block GitHub will not take is a 422 about
the payload, a content-creation block is a 403 about the moment, and reporting only the second names
the payload for a finding a throttle refused.

**What this does not claim.** The 5 logged throttles do not account for all 29 rejections, and the
rest cannot now be attributed, because their reason was discarded. A probe confirmed position was not
the cause: posting to `c/src/rollup.c:45` — reported un-anchorable — succeeds today at the same
commit, path and line. This makes the next occurrence answerable rather than guessing at this one.

## Related Issues

Closes #722. Split out of #712; the file-level fallback it logs against shipped in #721.

## How Has This Been Tested?

- [x] Unit tests

Red proof, against the unfixed budget:

```
aPersistentThrottleGivesUpAfterFourAttempts:208  expected: <4> but was: <3>
theTotalBudgetOutlastsIt  TOTAL_BUDGET (PT1M) must outlast the measured PT1M12S block
aBlockAsLongAsTheMeasuredOneIsOutlasted  ERROR: WebApplication HTTP 403 Forbidden
```

Red proof, against the unfixed delay floor:

```
isNotLeftToTheLinearFallback              expected: <PT30S> but was: <PT5S>
isNotRepeatedInstantlyOnAStaleResetInstant expected: <PT30S> but was: <PT0S>
spansTheMeasuredBlockOnceTheWaitsAreClamped  got PT30S
```

Red proof, against the unfixed logging:

```
AssertionFailedError: the status separating a throttle from a bad position must be in the line:
GitHub rejected inline comment for src/Main.java:10 — filing it on the file instead
```

The budget test rides out a simulated 72-second block on a clock the recorded waits advance, rather
than asserting an attempt count.

- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`
- `./mvnw -B clean test` → `Tests run: 3276, Failures: 0, Errors: 0, Skipped: 0`
- Coverage (jacoco ∩ diff): **0 uncovered lines, 0 uncovered branches**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
