### PR TITLE
fix(review): collapse duplicate verdict ids the same way in both readers

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -728,6 +729,9 @@ public class FindingVerificationService {
    * an id outside the 1-based candidate range; counting only the ids in range keeps the log honest
    * about what stayed unverified.
    *
+   * <p>Duplicate ids are collapsed through {@link #byCandidateId} before any label is read, so the
+   * verdict counted for an id is exactly the one {@link #apply} acted on (#735).
+   *
    * <p>An id alone is not coverage. A verdict whose decision label is absent, blank or not one of
    * {@link #ACTED_ON_DECISIONS} falls into {@link #apply}'s fail-open default, where the candidate
    * posts exactly as the reviewer raised it — the same state a candidate with no verdict at all
@@ -753,12 +757,38 @@ public class FindingVerificationService {
    */
   private static long candidatesCovered(
       List<VerificationResponse.Verdict> salvaged, int candidates) {
-    return salvaged.stream()
-        .filter(verdict -> ACTED_ON_DECISIONS.contains(decisionOf(verdict)))
-        .mapToInt(VerificationResponse.Verdict::id)
-        .filter(id -> id >= 1 && id <= candidates)
-        .distinct()
+    return byCandidateId(salvaged).entrySet().stream()
+        .filter(entry -> entry.getKey() >= 1 && entry.getKey() <= candidates)
+        .filter(entry -> ACTED_ON_DECISIONS.contains(decisionOf(entry.getValue())))
         .count();
+  }
+
+  /**
+   * The one verdict per candidate id, first element wins — the single collapse both {@link #apply}
+   * and {@link #candidatesCovered} resolve duplicates through, so neither can read a verdict the
+   * other ignored (#735).
+   *
+   * <p>Sharing {@link #decisionOf} was only half of what #710 needs. The two readers also have to
+   * agree on <em>which</em> verdict an id's decision is read from, and they did not: {@code apply}
+   * collapsed duplicates first and read the label from the survivor, while the count filtered by
+   * label first and de-duplicated the ids that were left. An id carrying an undecidable element
+   * followed by a decidable one therefore landed in {@code apply}'s fail-open default — the finding
+   * posts exactly as the reviewer raised it — while the count called that candidate screened, which
+   * is the published-set-reads-as-fully-screened harm #623 exists to prevent, reached by a narrower
+   * route. The drift is one-directional (the reverse order already agreed), so it only ever
+   * over-counted, i.e. exclusively toward the dangerous side.
+   *
+   * <p>Duplicates are model output, not a hypothetical: the collapse predates this fix, first-wins
+   * is the behaviour the audit already applies, and the count now inherits it rather than inventing
+   * a second resolution.
+   */
+  private static Map<Integer, VerificationResponse.Verdict> byCandidateId(
+      List<VerificationResponse.Verdict> verdicts) {
+    var byId = new HashMap<Integer, VerificationResponse.Verdict>();
+    for (VerificationResponse.Verdict verdict : verdicts) {
+      byId.putIfAbsent(verdict.id(), verdict);
+    }
+    return byId;
   }
 
   /**
@@ -766,11 +796,16 @@ public class FindingVerificationService {
    * #candidatesCovered} read it; the empty string for a candidate with no verdict and for a verdict
    * carrying no label. One reader so the two cannot disagree about what counts as a decision — the
    * drift #710 was filed on.
+   *
+   * <p>Stripped, so the strictness genuinely matches {@link #strictRisk}/{@link #strictConfidence}
+   * as documented: {@code "rejected "} was unreadable as a decision while {@code "high "} was a
+   * readable rating, an asymmetry nothing intended (#735). Both readers take the same value, so
+   * this never drove a drift — it only cost an over-cautious keep and an under-count.
    */
   private static String decisionOf(VerificationResponse.Verdict verdict) {
     return verdict == null || verdict.verdict() == null
         ? ""
-        : verdict.verdict().toLowerCase(Locale.ROOT);
+        : verdict.verdict().strip().toLowerCase(Locale.ROOT);
   }
 
   /**
@@ -1181,11 +1216,7 @@ public class FindingVerificationService {
   }
 
   ReviewResponse apply(ReviewResponse response, VerificationResponse verification) {
-    var byId = new HashMap<Integer, VerificationResponse.Verdict>();
-    for (VerificationResponse.Verdict verdict : verification.verdicts()) {
-      byId.putIfAbsent(verdict.id(), verdict);
-    }
-
+    var byId = byCandidateId(verification.verdicts());
     var kept = new ArrayList<ReviewResponse.Finding>();
     var rejected = 0;
     var downgraded = 0;

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -777,6 +777,84 @@ class FindingVerificationServiceTest {
   }
 
   @Test
+  void doesNotCountADuplicateIdWhoseFirstVerdictTheAuditCannotRead() {
+    // #735: a complete, well-formed body carrying two verdicts for the same id, the first of them
+    // undecidable. apply() collapses duplicates first-wins and lands in its fail-open default, so
+    // the finding posts exactly as the reviewer raised it; the count has to read that same first
+    // verdict rather than the decidable duplicate behind it, or the published set claims a second
+    // stage ruled on a finding it never ruled on — #710's harm on an uncut body.
+    ReviewResponse original =
+        response(finding("critical", "high", "Undecided"), finding("high", "high", "Ruled on"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiOk(
+                """
+            {"verdicts": [
+              {"id": 1, "reason": "still weighing this one"},
+              {"id": 1, "verdict": "rejected", "reason": "framework idiom"},
+              {"id": 2, "verdict": "confirmed", "reason": "real"}]}"""));
+    var reported = new ArrayList<VerificationCoverage>();
+
+    var result = service.verify(SESSION, original, "diff", "stack", "", reported::add);
+
+    assertEquals(2, result.findings().size());
+    assertEquals("Undecided", result.findings().get(0).title());
+    assertEquals(List.of(new VerificationCoverage(2, 1)), reported);
+    assertEquals(VerificationCoverage.Outcome.PARTIAL, reported.get(0).outcome());
+    assertTrue(reported.get(0).disclosed());
+  }
+
+  @Test
+  void countsADuplicateIdWhoseFirstVerdictTheAuditActedOn() {
+    // The control for the case above: the same duplicate in the other order. apply() rejects on the
+    // first element, so the count must include the id — the two readers agreed here already, and
+    // collapsing the duplicate in the count must not turn that agreement into an under-count.
+    ReviewResponse original =
+        response(finding("critical", "high", "Ruled on"), finding("high", "high", "Also"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiOk(
+                """
+            {"verdicts": [
+              {"id": 1, "verdict": "rejected", "reason": "framework idiom"},
+              {"id": 1, "reason": "still weighing this one"},
+              {"id": 2, "verdict": "confirmed", "reason": "real"}]}"""));
+    var reported = new ArrayList<VerificationCoverage>();
+
+    var result = service.verify(SESSION, original, "diff", "stack", "", reported::add);
+
+    assertEquals(1, result.findings().size());
+    assertEquals("Also", result.findings().get(0).title());
+    assertEquals(List.of(new VerificationCoverage(2, 2)), reported);
+    assertFalse(reported.get(0).disclosed());
+  }
+
+  @Test
+  void readsADecisionLabelPaddedWithWhitespace() {
+    // #735: decisionOf did not strip while strictRisk/strictConfidence do, so "rejected " was
+    // unreadable as a decision even though "high " is a readable rating — an asymmetry against a
+    // javadoc claiming the strictness matches. Both readers take the same value, so the finding is
+    // acted on and counted together.
+    ReviewResponse original =
+        response(finding("critical", "high", "Padded"), finding("high", "high", "Kept"));
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiOk(
+                """
+            {"verdicts": [
+              {"id": 1, "verdict": "rejected\\n", "reason": "framework idiom"},
+              {"id": 2, "verdict": " CONFIRMED ", "reason": "real"}]}"""));
+    var reported = new ArrayList<VerificationCoverage>();
+
+    var result = service.verify(SESSION, original, "diff", "stack", "", reported::add);
+
+    assertEquals(1, result.findings().size());
+    assertEquals("Kept", result.findings().get(0).title());
+    assertEquals(List.of(new VerificationCoverage(2, 2)), reported);
+    assertFalse(reported.get(0).disclosed());
+  }
+
+  @Test
   void reportsZeroCoverageWhenTheCutLeavesNoCompleteVerdict() {
     ReviewResponse original = response(finding("critical", "high", "Bug"));
     when(verifier.verify(anyString(), anyString(), anyString(), anyString(), anyString()))


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

#719 routed `apply()` and the coverage count through one decision normalizer so that "what the review *does* with a verdict and what it *claims* it verified cannot drift". The normalizer was shared; the **duplicate-id resolution was not**.

- `apply()` collapsed duplicates *first* — `putIfAbsent`, so the first element for an id wins — and read the label off the survivor.
- `candidatesCovered` filtered by label *first* and de-duplicated the surviving ids afterwards.

For an id carrying an undecidable element followed by a decidable one the two therefore read **different verdicts for the same id**. `apply()` lands in its fail-open default and the finding posts exactly as the reviewer raised it; the count calls that candidate screened. With every other candidate decided that is `VerificationCoverage(N, N)` → `FULL` → `disclosed() == false`: no banner, no coverage clause, no check-run brief. And because nothing was rejected or downgraded on that path, `apply()` short-circuits before the `N kept, M downgraded, K rejected` line, so the operator log says nothing either. A published set containing a finding the audit never ruled on, reported as fully screened — the harm #623 exists to prevent and #710 was filed on, reached by a narrower route and on a **complete, well-formed body**, not only a cut one.

Two properties worth stating:

- **The drift is one-directional.** The reverse ordering (decidable element first) already agreed with `apply()`. So this only ever *over*-counted — exclusively toward the dangerous side.
- **Duplicates are not a hypothetical input shape.** The `putIfAbsent` collapse predates this fix precisely because the model emits them; the whole salvage/fail-open stack exists because this body is unreliable model output.

Both readers now resolve duplicates through **one collapse** (`byCandidateId`), so the verdict the count reads for an id is exactly the one the audit acted on. Nothing else about the count changes: the id-range filter and `ACTED_ON_DECISIONS` are untouched, and the fail-open contract is untouched — coverage changes what the review says, never which findings it keeps.

Also in this PR: **`decisionOf` now strips.** Its siblings `strictRisk`/`strictConfidence` both do `value.strip().toLowerCase(...)`, and the javadoc on `ACTED_ON_DECISIONS` claims the strictness matches them — it was stricter, so `"rejected "` was unreadable as a decision while `"high "` was a readable rating. Both readers take that same value, so this never drove a drift; it cost an over-cautious keep plus an under-count. The asymmetry was unintended, so it is closed here.

## Related Issues

Fixes #735

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Three tests added to `FindingVerificationServiceTest`:

- `doesNotCountADuplicateIdWhoseFirstVerdictTheAuditCannotRead` — the defect itself: a complete, parseable body with two verdicts for id 1, the first undecidable. Asserts the finding is kept **and** the coverage is `(2, 1)` / `PARTIAL` / disclosed.
- `readsADecisionLabelPaddedWithWhitespace` — `"rejected\n"` is acted on and `" CONFIRMED "` is counted.
- `countsADuplicateIdWhoseFirstVerdictTheAuditActedOn` — the **control**, the same duplicate in the other order. It passes both before and after the change (that is its point: the collapse must not turn the pre-existing agreement into an under-count), so it is not offered as red/green proof.

### Red/green proof

The two behavioural tests run against the unfixed `FindingVerificationService`, verbatim:

```
[ERROR] Tests run: 3, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 3.107 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.doesNotCountADuplicateIdWhoseFirstVerdictTheAuditCannotRead -- Time elapsed: 2.984 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <[VerificationCoverage[candidates=2, verified=1]]> but was: <[VerificationCoverage[candidates=2, verified=2]]>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1199)
	at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.doesNotCountADuplicateIdWhoseFirstVerdictTheAuditCannotRead(FindingVerificationServiceTest.java:802)

[ERROR] dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.readsADecisionLabelPaddedWithWhitespace -- Time elapsed: 0.012 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <1> but was: <2>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:569)
	at dev.thiagogonzaga.thrillhousebot.review.ai.FindingVerificationServiceTest.readsADecisionLabelPaddedWithWhitespace(FindingVerificationServiceTest.java:851)
```

The first failure is the drift exactly as claimed: the coverage counted 2 of 2 while `apply()` had ruled on 1. The second is the unstripped label: the padded `rejected` was not acted on, so both findings survived. With the fix, `FindingVerificationServiceTest` runs 109 tests, 0 failures.

### Gates

| Gate | Result |
|---|---|
| `spotless:apply` → `clean compile spotbugs:check spotless:check` | BUILD SUCCESS, **BugInstance size is 0** |
| `clean test` | **Tests run: 3285, Failures: 0, Errors: 0, Skipped: 0** |
| jacoco ∩ `git diff -U0 aa3c556...HEAD` (main) | every changed executable line `mi=0`, `mb=0` — **zero uncovered lines, zero uncovered branches** |

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

No configuration change, no behaviour change to which findings are published — only to what the review claims it screened, and in the safe direction: a candidate the audit could not rule on now reads as unverified instead of silently counting as screened. `VerificationCoverage`'s compact constructor already clamped the over-count to `candidates`, so no invalid record was ever produced; what the over-count did was turn PARTIAL into FULL, or shrink a real gap.

The suggested patch on the issue rebuilt a second collapse inside `candidatesCovered`, including a null-element guard. Verified against the real code and adjusted: the collapse is factored into one private helper both readers call, rather than duplicated, and the null guard is deliberately omitted — `VerificationResponse`'s compact constructor and `TruncatedResponseSalvager.salvageArray` both go through `List.copyOf`, which rejects null elements outright, so a null verdict cannot reach either reader and a guard would be dead, untestable code.
