### PR TITLE
fix(github): stop announcing a finding the file-level fallback rescued as lost

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWrites.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWrites.java
@@ -52,6 +52,17 @@ import org.slf4j.LoggerFactory;
  * <p>The wording deliberately does not name the command. This layer sees a comment on a pull
  * request, not the {@code /describe} or {@code /improve} that produced it, and an honest "if you
  * were waiting on an answer, re-run it" is more useful than a guess.
+ *
+ * <h2>What counts as one loss</h2>
+ *
+ * A loss is a piece of content the pull request never received, not an HTTP call GitHub refused.
+ * The two stopped being the same thing in #721, which gave a finding a second and third route to
+ * the pull request: a refused line-anchored comment is now followed by a thread on the file, and
+ * the finding is only lost when every route fails. Counting refusals would tell the maintainer
+ * their content was thrown away while it sits on the PR above the notice — and count it twice over
+ * when the finding carries a suggestion, because that route is tried with and without it (#729).
+ * {@link #asOneDelivery} is how a caller says "these calls are one piece of content": inside it
+ * nothing is remembered until every route has had its turn, and then only if none of them landed.
  */
 public final class GitHubLostWrites {
 
@@ -105,12 +116,38 @@ public final class GitHubLostWrites {
    */
   private static final Loss NOTHING = new Loss(0, 0, 0, Instant.EPOCH);
 
+  /**
+   * One piece of content and the alternative routes being tried for it, while they are being tried.
+   * {@code refused} is set by a throttled route, {@code landed} by a route that got through; a
+   * delivery that ends refused and not landed is the one loss the whole group is worth.
+   */
+  private static final class Delivery {
+    private final Target target;
+    private boolean landed;
+    private boolean refused;
+
+    private Delivery(Target target) {
+      this.target = target;
+    }
+  }
+
   /** The process-wide registry: a loss recorded on one code path is announced by any other. */
   static final GitHubLostWrites SHARED =
       new GitHubLostWrites(Instant::now, DEFAULT_MAX_TARGETS, DEFAULT_TTL);
 
   private final Map<Target, Loss> pending = new ConcurrentHashMap<>();
   private final AtomicLong ids = new AtomicLong();
+
+  /**
+   * The delivery whose routes are being tried on this thread, if any. Thread confinement is what
+   * the routes already have — a finding's attempts run one after another on the thread publishing
+   * that review — so it is also the cheapest way to reach {@link #recording} from {@link
+   * #asOneDelivery} without threading a handle through the REST client interface that sits between
+   * them. Held per instance, not per class, so a test's registry cannot see {@link #SHARED}'s
+   * deliveries or vice versa.
+   */
+  private final ThreadLocal<Delivery> delivery = new ThreadLocal<>();
+
   private final Supplier<Instant> clock;
   private final int maxTargets;
   private final Duration ttl;
@@ -140,16 +177,67 @@ public final class GitHubLostWrites {
    * but can still leave one behind when GitHub throttles it away.
    */
   public <T> T recording(Target target, Supplier<T> send) {
+    var scope = deliveryFor(target);
     try {
-      return send.get();
+      var result = send.get();
+      if (scope != null) {
+        scope.landed = true;
+      }
+      return result;
     } catch (WebApplicationException e) {
       // Only a throttle: a permission refusal or a 422 is a defect to fix, not a post to re-run,
       // and announcing it on the PR would be noise on every single comment.
       if (GitHubApiError.of(e).filter(GitHubApiError::isThrottled).isPresent()) {
-        remember(target);
+        if (scope == null) {
+          remember(target);
+        } else {
+          // Held, not remembered: a later route may still deliver this content (#729).
+          scope.refused = true;
+        }
       }
       throw e;
     }
+  }
+
+  /**
+   * Runs several content-creating calls that are alternative routes to the pull request for one
+   * piece of content — a finding's line-anchored comment, the same comment without its suggestion
+   * block, and the thread on the file (#721) — so the pull request hears about at most one loss,
+   * and only when no route delivered it.
+   *
+   * <p>Routes that fail for anything but a throttle are as invisible here as they are to {@link
+   * #recording}: a 422 about the payload is a defect to fix rather than a post worth re-running. A
+   * group in which some route was throttled and none landed is remembered exactly once, so a
+   * finding that really is lost still announces itself — and announces itself once rather than once
+   * per attempt.
+   *
+   * <p>Nesting reuses the outer group rather than opening a second one, so a caller cannot lose
+   * another caller's routes by grouping its own.
+   */
+  public <T> T asOneDelivery(Target target, Supplier<T> routes) {
+    if (delivery.get() != null) {
+      return routes.get();
+    }
+    var scope = new Delivery(target);
+    delivery.set(scope);
+    try {
+      return routes.get();
+    } finally {
+      delivery.remove();
+      if (scope.refused && !scope.landed) {
+        remember(target);
+      }
+    }
+  }
+
+  /**
+   * The delivery this call is a route of, or {@code null} when it is a post of its own. A delivery
+   * for some other pull request is not this call's: the group's accounting only ever speaks for the
+   * pull request it was opened on.
+   */
+  private Delivery deliveryFor(Target target) {
+    var scope = delivery.get();
+    return scope != null && scope.target.equals(target) ? scope : null;
   }
 
   /** The notice text for {@code lost} dropped posts, or empty when there is nothing pending. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubReviewClient.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
@@ -227,6 +228,10 @@ public interface GitHubReviewClient {
    * inline comment is anchored to a diff line, so it is a poor place to announce an unrelated
    * dropped post and does not carry a notice — but losing one is still a loss the pull request
    * should hear about, so it leaves a notice for the next comment to carry (#578).
+   *
+   * <p>A caller with more than one route to the same piece of content wraps them in {@link
+   * #asOneComment}, which is what keeps a comment a later route delivered from being announced as
+   * lost (#729).
    */
   default PullRequestCommentResponse createPullRequestComment(
       String auth,
@@ -244,6 +249,25 @@ public interface GitHubReviewClient {
                 credential ->
                     createPullRequestCommentOnce(
                         credential, accept, owner, repo, pullNumber, request)));
+  }
+
+  /**
+   * Runs {@code routes} — several {@link #createPullRequestComment} calls that are alternative ways
+   * of getting the <em>same</em> content onto the pull request — as one delivery, so a throttle
+   * that costs one route its turn is only announced to the pull request if no route delivered the
+   * content at all (#729).
+   *
+   * <p>Without this the accounting counts refused HTTP calls rather than lost content: #721's
+   * file-level fallback lands the finding and the review body published moments later still leads
+   * with "an earlier reply on this pull request was never posted … run the command again", twice
+   * over for a finding whose suggestion block earned the line-anchored route a second attempt.
+   *
+   * <p>Lives here rather than at the call site because the notice registry is this package's, and
+   * the call it groups is {@link #createPullRequestComment} on this interface.
+   */
+  static <T> T asOneComment(String owner, String repo, int pullNumber, Supplier<T> routes) {
+    return GitHubLostWrites.SHARED.asOneDelivery(
+        new GitHubLostWrites.Target(owner, repo, pullNumber), routes);
   }
 
   /** One HTTP attempt at a thread reply. Callers want {@link #replyToReviewComment} instead. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -696,8 +696,24 @@ public class ReviewPublisher {
    * line-number failure. A file-level thread is a second, independent chance at the one thing the
    * finding cannot afford to lose, and it is also the honest answer for a line that genuinely is
    * outside the diff.
+   *
+   * <p>All of a finding's routes are one delivery ({@link GitHubReviewClient#asOneComment}). The
+   * dropped-post notice counts content the pull request never received, and a finding rescued here
+   * was received — announcing it as lost told the maintainer to re-run a command whose output was
+   * sitting on the pull request already, and said it twice when a suggestion block earned the
+   * line-anchored route a second attempt (#729).
    */
   private boolean postFindingComment(
+      CommentTarget target, Finding finding, int findingId, DiffLineResolver lineResolver) {
+    return GitHubReviewClient.asOneComment(
+        target.owner(),
+        target.repo(),
+        target.prNumber(),
+        () -> postFindingCommentRoutes(target, finding, findingId, lineResolver));
+  }
+
+  /** The routes themselves, in preference order. See {@link #postFindingComment}. */
+  private boolean postFindingCommentRoutes(
       CommentTarget target, Finding finding, int findingId, DiffLineResolver lineResolver) {
     var line = lineResolver.resolveRightSideLine(finding.file(), finding.line());
     if (line.isEmpty()) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWritesTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWritesTest.java
@@ -16,6 +16,7 @@
 package dev.thiagogonzaga.thrillhousebot.github;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -341,6 +342,121 @@ class GitHubLostWritesTest {
   @Test
   void aTargetNamesThePullRequestItLostThePostOn() {
     assertEquals("owner/repo #7", PR.toString());
+  }
+
+  /**
+   * #729. Two routes to the same finding: GitHub throttles the line-anchored comment away and the
+   * file-level thread lands. The content is on the pull request, so there is nothing to announce
+   * and nothing to re-run.
+   */
+  @Test
+  void contentARouteDeliveredIsNotAnnouncedAsLost() {
+    var carried = new ArrayList<String>();
+
+    lost.asOneDelivery(
+        PR,
+        () -> {
+          assertThrows(
+              WebApplicationException.class, () -> lost.recording(PR, () -> throwIt(throttled())));
+          return lost.recording(PR, () -> "posted");
+        });
+    post(PR, carried, null);
+
+    assertEquals(
+        "",
+        carried.getLast(),
+        () ->
+            "the finding was delivered by its second route, but the next comment still told the"
+                + " maintainer to run the command again: \""
+                + carried.getLast()
+                + "\"");
+  }
+
+  /**
+   * #729's other half: three refused routes are one lost finding, not three — and were counted as
+   * two even when the finding was rescued, because a suggestion block earns the line-anchored route
+   * a second attempt.
+   */
+  @Test
+  void contentNoRouteDeliveredIsAnnouncedExactlyOnce() {
+    var carried = new ArrayList<String>();
+
+    lost.asOneDelivery(
+        PR,
+        () -> {
+          for (var route = 0; route < 3; route++) {
+            assertThrows(
+                WebApplicationException.class,
+                () -> lost.recording(PR, () -> throwIt(throttled())));
+          }
+          return "no route landed";
+        });
+    post(PR, carried, null);
+
+    assertTrue(carried.getLast().contains("An earlier reply"), carried.getLast());
+    assertFalse(
+        carried.getLast().contains("earlier replies"),
+        () -> "one lost finding was counted once per refused route: " + carried.getLast());
+  }
+
+  /** A delivery no throttle touched is not a loss, however its routes failed. */
+  @Test
+  void aDeliveryThatWasRefusedRatherThanThrottledAnnouncesNothing() {
+    var carried = new ArrayList<String>();
+
+    lost.asOneDelivery(
+        PR,
+        () -> {
+          assertThrows(
+              WebApplicationException.class, () -> lost.recording(PR, () -> throwIt(refusal())));
+          return "no route landed";
+        });
+    post(PR, carried, null);
+
+    assertEquals("", carried.getLast());
+  }
+
+  /**
+   * The group speaks for the pull request it was opened on and no other: a post that lands on a
+   * different pull request cannot rescue this one's finding, and one thrown away there is still
+   * that pull request's own loss.
+   */
+  @Test
+  void aCallForAnotherPullRequestIsNotOneOfThisDeliverysRoutes() {
+    var carried = new ArrayList<String>();
+
+    lost.asOneDelivery(
+        PR,
+        () -> {
+          assertThrows(
+              WebApplicationException.class, () -> lost.recording(PR, () -> throwIt(throttled())));
+          assertThrows(
+              WebApplicationException.class,
+              () -> lost.recording(OTHER_PR, () -> throwIt(throttled())));
+          return lost.recording(OTHER_PR, () -> "posted on the other pull request");
+        });
+    post(PR, carried, null);
+    post(OTHER_PR, carried, null);
+
+    assertTrue(carried.get(0).contains("An earlier reply"), carried.get(0));
+    assertTrue(carried.get(1).contains("An earlier reply"), carried.get(1));
+  }
+
+  /** A group inside a group is the same delivery, so the outer one's routes are not lost. */
+  @Test
+  void aDeliveryNestedInsideAnotherIsOneDelivery() {
+    var carried = new ArrayList<String>();
+
+    lost.asOneDelivery(
+        PR,
+        () -> {
+          assertThrows(
+              WebApplicationException.class, () -> lost.recording(PR, () -> throwIt(throttled())));
+          return lost.asOneDelivery(PR, () -> lost.recording(PR, () -> "posted"));
+        });
+    post(PR, carried, null);
+
+    assertEquals("", carried.getLast(), carried.getLast());
   }
 
   private static String throwIt(WebApplicationException failure) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RescuedFindingLostWriteTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RescuedFindingLostWriteTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.thiagogonzaga.thrillhousebot.config.BotIdentity;
+import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
+import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
+import dev.thiagogonzaga.thrillhousebot.github.ReviewThreadService;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * #729 — what the pull request is told about a finding that #721's file-level fallback rescued.
+ *
+ * <p>This drives {@link GitHubReviewClient}'s own {@code default} methods, so the {@code recording}
+ * and {@code carrying} calls that do the dropped-post accounting really run. That is the whole
+ * point: {@code ReviewOrchestratorTest} declares the client a Mockito {@code @Mock}, which stubs
+ * those {@code default} methods away, so no publisher test had ever executed the accounting and a
+ * regression visible on every throttled review was invisible to the suite. Only the client is real
+ * here — the other collaborators stay mocks, because the seam under test is the client's.
+ *
+ * <p>Both directions are pinned: a finding a later route delivered must leave no notice behind, and
+ * a finding no route could deliver must still leave one.
+ */
+class RescuedFindingLostWriteTest {
+
+  private static final String FILE_LEVEL_THREAD = "the finding, filed on its file";
+  private static final String REVIEW_BODY = "the review body";
+
+  /** The response measured in #722, which is what sends a route round the backoff to exhaustion. */
+  private static final String BLOCK_BODY =
+      "{\"message\":\"You have exceeded a secondary rate limit and have been temporarily blocked"
+          + " from content creation. Please retry your request again later.\"}";
+
+  /**
+   * The registry the client writes to is process-wide, so each test takes a pull request of its own
+   * rather than reading another's bookkeeping.
+   */
+  private static final AtomicInteger PR_NUMBERS = new AtomicInteger(700);
+
+  private int prNumber;
+  private FakeReviewClient reviewClient;
+  private ReviewPublisher publisher;
+
+  @BeforeEach
+  void setUp() {
+    prNumber = PR_NUMBERS.incrementAndGet();
+    reviewClient = new FakeReviewClient();
+    var suggestionFormatter = mock(SuggestionFormatter.class);
+    // Distinguishable bodies: the line-anchored comment is tried with the suggestion block and
+    // again without it, and telling those two routes apart is what pins the double count.
+    when(suggestionFormatter.formatReviewComment(any(), eq(true), anyInt()))
+        .thenReturn("the finding, with its suggestion");
+    when(suggestionFormatter.formatReviewComment(any(), eq(false), anyInt()))
+        .thenReturn("the finding");
+    var config = mock(ThrillhouseConfig.class);
+    var reviewConfig = mock(ThrillhouseConfig.ReviewConfig.class);
+    when(config.review()).thenReturn(reviewConfig);
+    when(reviewConfig.maxReviewComments()).thenReturn(10);
+    publisher =
+        new ReviewPublisher(
+            reviewClient,
+            mock(GitHubCommentClient.class),
+            mock(ReviewThreadService.class),
+            suggestionFormatter,
+            mock(FollowUpAnalyzer.class),
+            mock(PrLabeler.class),
+            config,
+            BotIdentity.of("thrillhousebot[bot]"));
+  }
+
+  /**
+   * The production sequence: GitHub is in a content-creation block, the line-anchored comment burns
+   * its whole retry budget, the file-level thread lands on the far side of the window, and the
+   * review body goes out moments later. The finding has a working thread, so the body must not open
+   * with "an earlier reply on this pull request was never posted … run the command again".
+   */
+  @Test
+  void aFindingTheFileLevelFallbackRescuedIsNotAnnouncedAsLost() {
+    reviewClient.blockLineAnchoredComments();
+
+    var inline = postFinding(findingWithoutSuggestion());
+
+    assertEquals(1, inline.posted(), "the fallback was supposed to land the finding");
+    assertEquals(List.of(FILE_LEVEL_THREAD), reviewClient.landed);
+    assertNoNotice(postReviewBody());
+  }
+
+  /**
+   * The same for a finding carrying a suggestion block. The line-anchored route is tried twice —
+   * with the suggestion and without — and each attempt was its own piece of accounting, so one
+   * rescued finding was charged two losses and the body read "2 earlier replies … were never
+   * posted".
+   */
+  @Test
+  void aRescuedFindingWithASuggestionIsNotAnnouncedTwiceEither() {
+    reviewClient.blockLineAnchoredComments();
+
+    var inline = postFinding(findingWithSuggestion());
+
+    assertEquals(1, inline.posted());
+    assertEquals(
+        2,
+        reviewClient.lineAnchoredRoutes().size(),
+        () ->
+            "the suggestion block is what earns the line-anchored comment a second route: "
+                + reviewClient.lineAnchoredRoutes());
+    assertNoNotice(postReviewBody());
+  }
+
+  /**
+   * The other direction, which the fix must not cost: when the block outlasts every route the
+   * finding really is gone, and the maintainer does have to run the command again. Said once, for
+   * one finding, rather than once per refused route — the over-count is not confined to the rescued
+   * case, and a review that lost three findings to a wide block should say three, not nine.
+   */
+  @Test
+  void aFindingNoRouteCouldDeliverIsStillAnnouncedAsLost() {
+    reviewClient.blockEveryComment();
+
+    var finding = findingWithoutSuggestion();
+    var inline = postFinding(finding);
+
+    assertEquals(0, inline.posted());
+    assertEquals(List.of(finding), inline.unanchored());
+    var body = postReviewBody();
+    assertTrue(
+        body.startsWith("> [!WARNING]"),
+        () -> "a genuinely lost finding said nothing on the pull request: " + body);
+    assertTrue(body.contains("An earlier reply on this pull request was never posted."), body);
+    assertFalse(
+        body.contains("earlier replies"),
+        () -> "one lost finding was counted once per refused route: " + body);
+    assertTrue(body.endsWith("\n\n" + REVIEW_BODY), body);
+  }
+
+  // -------------------------------------------------------------------------------- the fixture
+
+  private static Finding findingWithoutSuggestion() {
+    return new Finding(RiskLevel.HIGH, "src/Main.java", 10, "Bug", "desc", null, null);
+  }
+
+  private static Finding findingWithSuggestion() {
+    return new Finding(RiskLevel.HIGH, "src/Main.java", 10, "Bug", "desc", "old", "new");
+  }
+
+  private ReviewPublisher.InlineCommentResult postFinding(Finding finding) {
+    var result =
+        new ReviewResult(
+            List.of(finding),
+            0,
+            1,
+            0,
+            0,
+            RiskLevel.HIGH,
+            ReviewState.REQUEST_CHANGES,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
+    var resolver = new DiffLineResolver(Map.of("src/Main.java", "@@ -10,1 +10,1 @@\n-old\n+new"));
+    return publisher.postInlineComments(
+        "Bearer tok", "owner", "repo", prNumber, "sha", result, resolver);
+  }
+
+  /** Publishes the review body — the next content on the PR, and the surface a notice rides on. */
+  private String postReviewBody() {
+    publisher.createReviewWithFallback(
+        "Bearer tok",
+        "owner",
+        "repo",
+        prNumber,
+        new GitHubReviewClient.CreateReviewRequest("sha", REVIEW_BODY, "COMMENT", List.of()));
+    return reviewClient.reviewBodies.getLast();
+  }
+
+  private static void assertNoNotice(String body) {
+    assertEquals(
+        REVIEW_BODY,
+        body,
+        () ->
+            "the finding was delivered by its file-level thread, but the review body posted"
+                + " moments later still told the maintainer it had been thrown away: "
+                + body);
+  }
+
+  /**
+   * A {@link GitHubReviewClient} that is real everywhere the accounting lives: only the {@code
+   * *Once} HTTP attempts are stubbed, so {@code createPullRequestComment}, {@code createReview} and
+   * the retry and backoff between them all execute exactly as they do in production.
+   */
+  private static final class FakeReviewClient implements GitHubReviewClient {
+
+    private final List<String> landed = new ArrayList<>();
+    private final List<String> reviewBodies = new ArrayList<>();
+    private final Set<String> lineAnchoredBodies = new LinkedHashSet<>();
+    private boolean blockLineAnchored;
+    private boolean blockFileLevel;
+
+    private void blockLineAnchoredComments() {
+      blockLineAnchored = true;
+    }
+
+    private void blockEveryComment() {
+      blockLineAnchored = true;
+      blockFileLevel = true;
+    }
+
+    /** The distinct line-anchored routes tried, rather than the HTTP attempts each one spent. */
+    private Set<String> lineAnchoredRoutes() {
+      return lineAnchoredBodies;
+    }
+
+    @Override
+    public PullRequestCommentResponse createPullRequestCommentOnce(
+        String auth,
+        String accept,
+        String owner,
+        String repo,
+        int pullNumber,
+        CreatePullRequestCommentRequest request) {
+      var fileLevel = SUBJECT_TYPE_FILE.equals(request.subjectType());
+      if (!fileLevel) {
+        lineAnchoredBodies.add(request.body());
+      }
+      if (fileLevel ? blockFileLevel : blockLineAnchored) {
+        throw blocked();
+      }
+      var body = fileLevel ? FILE_LEVEL_THREAD : request.body();
+      landed.add(body);
+      return new PullRequestCommentResponse(1L, body, request.path(), request.line());
+    }
+
+    @Override
+    public ReviewResponse createReviewOnce(
+        String auth,
+        String accept,
+        String owner,
+        String repo,
+        int pullNumber,
+        CreateReviewRequest request) {
+      reviewBodies.add(request.body());
+      return new ReviewResponse(1L, request.body(), request.event(), request.commitId(), null);
+    }
+
+    /** GitHub's content-creation block, naming a deadline of "now" so the test does not sleep. */
+    private static WebApplicationException blocked() {
+      return new WebApplicationException(
+          Response.status(403).header("Retry-After", "0").entity(BLOCK_BODY).build());
+    }
+
+    @Override
+    public List<ReviewResponse> listReviewsPageOnce(
+        String auth,
+        String accept,
+        String owner,
+        String repo,
+        int pullNumber,
+        int perPage,
+        int page) {
+      return List.of();
+    }
+
+    @Override
+    public List<PullRequestComment> listPullRequestCommentsPageOnce(
+        String auth,
+        String accept,
+        String owner,
+        String repo,
+        int pullNumber,
+        int perPage,
+        int page) {
+      return List.of();
+    }
+
+    @Override
+    public PullRequestComment getPullRequestCommentOnce(
+        String auth, String accept, String owner, String repo, long commentId) {
+      throw new UnsupportedOperationException("not part of this seam");
+    }
+
+    @Override
+    public PullRequestCommentResponse replyToReviewCommentOnce(
+        String auth,
+        String accept,
+        String owner,
+        String repo,
+        int pullNumber,
+        long commentId,
+        ReplyToReviewCommentRequest request) {
+      throw new UnsupportedOperationException("not part of this seam");
+    }
+
+    @Override
+    public void deletePendingReview(
+        String auth, String accept, String owner, String repo, int pullNumber, long reviewId) {
+      throw new UnsupportedOperationException("not part of this seam");
+    }
+  }
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [x] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

A finding that #721's file-level fallback rescued still told the pull request it had been thrown
away.

`GitHubReviewClient.createPullRequestComment` wraps every attempt in `GitHubLostWrites.recording`,
which remembers a loss when a throttle exhausts the write budget. Before #721 that was honest — the
finding really was gone. #721 changed the outcome without changing the accounting: the line-anchored
comment is refused, `ReviewPublisher` falls back to a thread on the file, the thread lands, the
finding is counted as posted, and nothing retracts the remembered loss. The very next content the
review publishes is the review body, which goes out through `GitHubLostWrites.carrying` and leads
with

> **An earlier reply on this pull request was never posted.** … If you were waiting on an answer,
> run the command again.

while the finding sits on the PR directly above it, and re-running the command duplicates the
review. It was also double-counted: each of the two line-anchored routes (with the suggestion block,
and without) is its own `recording` call, so one rescued finding rendered "**2 earlier replies…**".

### The fix

The accounting counted refused HTTP calls. It has to count content the pull request never received,
because since #721 a finding is one piece of content with up to three routes to the PR.

`GitHubLostWrites.asOneDelivery(target, routes)` groups those routes. Inside it a throttled route is
held rather than remembered; a route that lands marks the delivery delivered; and only a delivery
that ends refused and undelivered is remembered — once, however many routes were refused.
`GitHubReviewClient.asOneComment` exposes it next to the `createPullRequestComment` it groups (the
registry is that package's), and `ReviewPublisher.postFindingComment` wraps one finding's routes in
it.

Three consequences, all intended:

- A rescued finding produces no notice at all.
- A rescued finding with a suggestion block produces no notice either — the second line-anchored
  route is the same delivery, not a second loss.
- A finding **no** route could deliver still produces its notice, and now says "an earlier reply"
  for the one finding it lost rather than one count per refused route.

Nothing else changes. A route refused for anything but a throttle stays as invisible as it was (a
422 about the payload is a defect to fix, not a post to re-run), and a call outside a delivery — a
thread reply, a review body — records exactly as before.

The delivery is thread-confined, which is the confinement the routes already have: one finding's
attempts run one after another on the thread publishing that review. That avoids threading a handle
through the REST client interface that sits between `asOneDelivery` and `recording`, and it keeps
deliveries for different pull requests, and different registries, from seeing each other. A group
nested inside another reuses the outer one, and a call for a different pull request made inside a
delivery is accounted to that pull request rather than to the group.

## Related Issues

Fixes #729

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

`RescuedFindingLostWriteTest` is the proof, and it deliberately does **not** mock
`GitHubReviewClient`. `ReviewOrchestratorTest` declares that client a Mockito `@Mock`, which stubs
the `default` methods away, so the `recording`/`carrying` accounting had never executed in any
publisher test — which is exactly why a suite of 3290 green tests could not see this. The new test
stubs only the six `*Once` HTTP attempts and lets the real `createPullRequestComment`,
`createReview`, retry, backoff and pacer run, driving `ReviewPublisher.postInlineComments` and then
`createReviewWithFallback` against GitHub's measured content-creation-block response.

### Red — the three tests against unfixed code (`aa3c556`), verbatim

```
Tests run: 3, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 28.17 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.RescuedFindingLostWriteTest
dev.thiagogonzaga.thrillhousebot.review.RescuedFindingLostWriteTest.aFindingTheFileLevelFallbackRescuedIsNotAnnouncedAsLost -- Time elapsed: 9.158 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
the finding was delivered by its file-level thread, but the review body posted moments later still told the maintainer it had been thrown away: > [!WARNING]
> **An earlier reply on this pull request was never posted.** GitHub was rate-limiting the bot and the retries ran out, so work it had already finished was thrown away. If you were waiting on an answer, run the command again.

the review body ==> expected: <the review body> but was: <> [!WARNING]
> **An earlier reply on this pull request was never posted.** GitHub was rate-limiting the bot and the retries ran out, so work it had already finished was thrown away. If you were waiting on an answer, run the command again.

the review body>

dev.thiagogonzaga.thrillhousebot.review.RescuedFindingLostWriteTest.aRescuedFindingWithASuggestionIsNotAnnouncedTwiceEither -- Time elapsed: 9.926 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
the finding was delivered by its file-level thread, but the review body posted moments later still told the maintainer it had been thrown away: > [!WARNING]
> **2 earlier replies on this pull request were never posted.** GitHub was rate-limiting the bot and the retries ran out, so work it had already finished was thrown away. If you were waiting on an answer, run the command again.

the review body ==> expected: <the review body> but was: <> [!WARNING]
> **2 earlier replies on this pull request were never posted.** GitHub was rate-limiting the bot and the retries ran out, so work it had already finished was thrown away. If you were waiting on an answer, run the command again.

the review body>

dev.thiagogonzaga.thrillhousebot.review.RescuedFindingLostWriteTest.aFindingNoRouteCouldDeliverIsStillAnnouncedAsLost -- Time elapsed: 9.001 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
> [!WARNING]
> **2 earlier replies on this pull request were never posted.** GitHub was rate-limiting the bot and the retries ran out, so work it had already finished was thrown away. If you were waiting on an answer, run the command again.

the review body>
 ==> expected: <true> but was: <false>
```

The first two are the audit's `P5` and `P5b` reproduced through the production call path rather than
against the registry directly. The third fails because the notice reads "2 earlier replies" for the
one finding it lost — the over-count is not confined to the rescued case — and it is the test that
stops this change from buying a quiet PR by making a real loss silent.

### Green

All three pass with the fix. `GitHubLostWritesTest` adds five tests pinning the grouping directly: a
rescued delivery, a delivery no route landed, a delivery no throttle touched, a call for another
pull request made inside one, and a nested group.

### Gates

- `./mvnw -B spotless:apply` → `BUILD SUCCESS`
- `./mvnw -B clean compile spotbugs:check spotless:check` → `BugInstance size is 0`, `Error size is
  0`, `BUILD SUCCESS`
- `./mvnw -B clean test` → `Tests run: 3290, Failures: 0, Errors: 0, Skipped: 0`, `BUILD SUCCESS`
- jacoco ∩ `git diff -U0 aa3c556...HEAD`: 28 executable changed lines and 14 branches in the
  changed main code, zero missed on both

## Additional Notes

`RescuedFindingLostWriteTest` takes about 25 seconds, and that is `GitHubWritePacer`, not the
assertions: driving the real write path means honouring GitHub's one-content-creating-request-per-
second envelope, and proving a route is refused to exhaustion costs the full four attempts. The
shapes were chosen for the fewest attempts that still make each claim, and the pacer is left alone
on purpose — `GitHubWritePacingTest` asserts against that same shared envelope, so turning it off
for the test JVM would trade this proof for that one.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
