### PR TITLE
fix(github): mask a credential the bound cut, and stop masking ordinary text

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
@@ -17,6 +17,7 @@ package dev.thiagogonzaga.thrillhousebot.github;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
+import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
@@ -42,6 +43,25 @@ public final class GitHubApiError {
 
   /** How much of a response body is kept for the log. GitHub's error bodies are far shorter. */
   static final int MAX_BODY_CHARS = 512;
+
+  /**
+   * How much of a response body the throttle classification reads (#732, #747).
+   *
+   * <p>Sixteen times the log cap, because the two jobs the body does have nothing to do with each
+   * other. The log line is capped so one failure cannot flood a log file, and that cap is about the
+   * operator's screen; classification is a yes/no about whether a completed generation gets another
+   * attempt, and reading it off the same 512 characters made it depend on where GitHub put its
+   * message. #740 then bounded the input to redaction at {@code MAX_BODY_CHARS * 2}, which closed
+   * the one path — redaction compressing a long credential-shaped prefix away — by which deeper
+   * wording still reached the classified string at all.
+   *
+   * <p>A bound is still wanted, because the entity is read with no size limit of its own and the
+   * point of #731 was to keep the cost of explaining a failed write off the review's carrier
+   * thread. Both patterns are flat literal alternations with no backtracking, so a pass over this
+   * many characters is a linear scan measured in microseconds — the quadratic shape #731 found is
+   * in the credential redaction, which still sees only its own bound.
+   */
+  static final int MAX_CLASSIFIED_CHARS = 8 * 1024;
 
   /** Replacement for anything in a response body shaped like a credential. */
   static final String REDACTED = "***";
@@ -208,7 +228,7 @@ public final class GitHubApiError {
   private final String rateLimitRemaining;
   private final String rateLimitReset;
   private final String rateLimitResource;
-  private final String body;
+  private final Body body;
 
   private GitHubApiError(
       int status,
@@ -216,13 +236,35 @@ public final class GitHubApiError {
       String rateLimitRemaining,
       String rateLimitReset,
       String rateLimitResource,
-      String body) {
+      Body body) {
     this.status = status;
     this.retryAfter = retryAfter;
     this.rateLimitRemaining = rateLimitRemaining;
     this.rateLimitReset = rateLimitReset;
     this.rateLimitResource = rateLimitResource;
     this.body = body;
+  }
+
+  /**
+   * The two readings of one response body, kept apart because the two callers want opposite things
+   * (#732, #747).
+   *
+   * @param logged the line an operator reads: collapsed, bounded, redacted, capped at {@link
+   *     #MAX_BODY_CHARS}, and marked with an ellipsis when anything was dropped
+   * @param classified what {@link #isThrottled()} and {@link #blocksContentCreation()} match
+   *     against: the collapsed body bounded at {@link #MAX_CLASSIFIED_CHARS} and nothing else.
+   *     Reading the logged form instead made the retry decision turn on where in the body GitHub
+   *     happened to put its message — wording past the cap, or behind enough credential-shaped
+   *     material to fill the redaction bound, classified as "not a throttle" and the write was not
+   *     repeated at all. It is deliberately the <em>unredacted</em> text: masking runs before
+   *     classification would read it, and a mask that swallowed the word {@code blocked} turned a
+   *     content-creation block into a permission refusal. Nothing in here is ever logged or
+   *     returned — the two patterns answer yes or no and the string is dropped.
+   */
+  private record Body(String logged, String classified) {
+
+    /** A body that could not be read at all — no line to log, nothing to classify. */
+    private static final Body UNREADABLE = new Body("", "");
   }
 
   /** Reads the status, the throttling headers and the (redacted) body off a failed response. */
@@ -250,6 +292,11 @@ public final class GitHubApiError {
    * between "post it again in a moment" and "this will never work". 429 says so outright; a 403
    * says so only through a {@code Retry-After}, an exhausted {@code x-ratelimit-remaining}, or the
    * rate-limit wording in the body. A permission 403 carries none of the three and so fails fast.
+   *
+   * <p>The wording is looked for in {@link Body#classified}, not in the line that goes to the log:
+   * the log's cap and the redaction bound are about what an operator should be shown, and letting
+   * them decide whether a completed generation is repeated turned this into a question about where
+   * GitHub put its message (#732, #747).
    */
   public boolean isThrottled() {
     if (status == 429) {
@@ -260,7 +307,7 @@ public final class GitHubApiError {
     }
     return retryAfterSeconds().isPresent()
         || "0".equals(rateLimitRemaining)
-        || THROTTLE_WORDING.matcher(body).find();
+        || THROTTLE_WORDING.matcher(body.classified()).find();
   }
 
   /**
@@ -321,17 +368,39 @@ public final class GitHubApiError {
    * throttle still slows down.
    */
   private Duration derivedDelay(int attempt, Instant now) {
-    return parseLong(rateLimitReset)
-        .map(reset -> atLeastZero(Duration.between(now, Instant.ofEpochSecond(reset))))
+    return rateLimitResetInstant()
+        .map(reset -> atLeastZero(Duration.between(now, reset)))
         .orElseGet(() -> FALLBACK_DELAY.multipliedBy(attempt));
   }
 
   /**
+   * The instant {@code x-ratelimit-reset} names, or empty when it does not name one.
+   *
+   * <p>{@code Long.parseLong} accepts values {@link Instant#ofEpochSecond(long)} rejects: past ±31
+   * 556 889 864 403 199 seconds it throws {@link DateTimeException}, which is neither the {@link
+   * WebApplicationException} the whole write path is built around nor anything {@link
+   * GitHubWriteRetry#call} converts. It escaped that loop past every {@code catch
+   * (WebApplicationException)} between here and the caller, so {@link GitHubLostWrites} did not
+   * record the write as lost either — the write and the record of its loss went together, over a
+   * header from an intermediary. A value that cannot be an instant says nothing about when the
+   * window reopens, which is exactly what a non-numeric header already means here, so it gets the
+   * same answer: unspecified, and the linear fallback takes over.
+   */
+  private Optional<Instant> rateLimitResetInstant() {
+    try {
+      return parseLong(rateLimitReset).map(Instant::ofEpochSecond);
+    } catch (DateTimeException _) {
+      return Optional.empty();
+    }
+  }
+
+  /**
    * Whether GitHub is blocking content creation rather than throttling in some milder way — the
-   * failure whose measured width the budget is sized against (#722).
+   * failure whose measured width the budget is sized against (#722). Read off {@link
+   * Body#classified} for the reasons {@link #isThrottled()} gives.
    */
   private boolean blocksContentCreation() {
-    return CONTENT_CREATION_BLOCK.matcher(body).find();
+    return CONTENT_CREATION_BLOCK.matcher(body.classified()).find();
   }
 
   /**
@@ -344,7 +413,8 @@ public final class GitHubApiError {
     append(text, "x-ratelimit-remaining", rateLimitRemaining);
     append(text, "x-ratelimit-reset", rateLimitReset);
     append(text, "x-ratelimit-resource", rateLimitResource);
-    return text.append(" body=").append(body.isEmpty() ? "<unavailable>" : body).toString();
+    var logged = body.logged();
+    return text.append(" body=").append(logged.isEmpty() ? "<unavailable>" : logged).toString();
   }
 
   private static void append(StringBuilder text, String name, String value) {
@@ -432,12 +502,13 @@ public final class GitHubApiError {
   }
 
   /**
-   * The response body as loggable text. An inbound response is buffered first so reading it here
-   * does not consume it for the caller that later inspects the same exception; a response built
-   * in-process holds its entity as an object instead, and one that is closed or has no readable
-   * entity yields an empty body rather than breaking the failure path it exists to explain.
+   * The response body, in both of the readings {@link Body} names. An inbound response is buffered
+   * first so reading it here does not consume it for the caller that later inspects the same
+   * exception; a response built in-process holds its entity as an object instead, and one that is
+   * closed or has no readable entity yields {@link Body#UNREADABLE} rather than breaking the
+   * failure path it exists to explain.
    */
-  private static String readBody(Response response) {
+  private static Body readBody(Response response) {
     try {
       if (response.getEntity() instanceof String text) {
         return clean(text);
@@ -445,13 +516,25 @@ public final class GitHubApiError {
       response.bufferEntity();
       return clean(response.readEntity(String.class));
     } catch (RuntimeException _) {
-      return "";
+      return Body.UNREADABLE;
     }
   }
 
   /**
-   * A response body as one line of loggable text: collapsed, bounded, redacted, then capped at
-   * {@link #MAX_BODY_CHARS}.
+   * A response body read both ways: as one line of loggable text — collapsed, bounded, redacted,
+   * then capped at {@link #MAX_BODY_CHARS} — and as the wider, unredacted window the throttle
+   * classification matches against.
+   *
+   * <p>One collapse pass feeds both, and the two readings diverge after it. Everything the log line
+   * has done to it from that point on is for the log's sake: the bound is #731's cost control on a
+   * quadratic redaction, the cap is so one failure cannot flood a log file, and the mask is because
+   * a body is untrusted text on its way to an operator's screen. None of those is a statement about
+   * whether GitHub is throttling, and every one of them used to be able to decide it (#732, #747).
+   *
+   * <p>Ordering is the whole of it, so it is worth naming what each cut can still do. The
+   * classified window is cut once, from the collapsed body, so nothing between the two ever
+   * shortens it. The logged line keeps the {@code bounded → redacted → capped} order #740
+   * established, and the ellipsis still marks either cut.
    *
    * <p>The bound before the redaction is the point (#731). {@code readBody} reads the entity with
    * no size limit of its own, and redaction used to run over all of it, so the cost of explaining a
@@ -472,17 +555,19 @@ public final class GitHubApiError {
    * run that is being masked out. The ellipsis marks either cut, so a body shortened here is never
    * mistaken for a body GitHub sent whole.
    */
-  private static String clean(String raw) {
+  private static Body clean(String raw) {
     if (raw == null) {
-      return "";
+      return Body.UNREADABLE;
     }
     var collapsed = WHITESPACE.matcher(raw).replaceAll(" ").strip();
     var bounded = cutTo(collapsed, MAX_BODY_CHARS * 2);
     var redacted = redactCredentials(bounded);
     var capped = cutTo(redacted, MAX_BODY_CHARS);
-    return capped.length() < redacted.length() || bounded.length() < collapsed.length()
-        ? capped + "…"
-        : capped;
+    var logged =
+        capped.length() < redacted.length() || bounded.length() < collapsed.length()
+            ? capped + "…"
+            : capped;
+    return new Body(logged, cutTo(collapsed, MAX_CLASSIFIED_CHARS));
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
@@ -60,9 +60,16 @@ public final class GitHubApiError {
    * the token pass does. So {@link #redactCredentials} still scans once, taking the leftmost match
    * across both patterns — split in two, prefixes here and value shapes there, only because one
    * alternation of all four shapes is more than the regex complexity budget allows.
+   *
+   * <p>Four value characters, not ten (#746). The sigil is the whole discriminator here — {@code
+   * ghp_} and {@code github_pat_} do not occur in prose, so the length floor was buying nothing the
+   * sigil did not already buy, while costing the one thing that matters: a token the bound before
+   * redaction severs below the floor stops matching and reaches the log with its first nine
+   * characters intact. This is the same reasoning #740 applied to the JWT alternative below and did
+   * not carry across to the shapes that still needed it.
    */
   private static final Pattern CREDENTIAL_SHAPED_PREFIX =
-      Pattern.compile("(?i)(gh[pousr]_\\w{10,})|(github_pat_\\w{10,})");
+      Pattern.compile("(?i)(gh[pousr]_\\w{4,})|(github_pat_\\w{4,})");
 
   /**
    * The bearer and JWT shapes — the value half of {@link #CREDENTIAL_SHAPED_PREFIX}'s union, tried
@@ -79,9 +86,23 @@ public final class GitHubApiError {
    * {@code eyJ} header prefix alone, which carries the algorithm and type claims and no secret.
    * Matching a dotless run instead would mask every long unbroken run of word characters and blank
    * the very body this line exists to explain.
+   *
+   * <p>Which is what the widened tail did anyway until #746, because the {@code (?i)} covered the
+   * whole alternation and the header was unanchored: any {@code eyj} in any case, anywhere inside a
+   * longer run, followed by a dot at any distance. {@code eyjafjallajokull.internal.example.com}
+   * came out as {@code ***.com} and a base64 blob with a filename after it came out as {@code ***}.
+   * So the case-insensitivity is scoped to the bearer half — a JWT header is base64url of {@code
+   * &#123;"}, which is always literally {@code eyJ} — and {@code (?<![\w-])} pins the header to the
+   * start of a token, leaving the cut-token property #740 added intact: a cut anywhere past the
+   * first dot still masks the whole run.
+   *
+   * <p>The bearer value takes the same four-character floor as {@link #CREDENTIAL_SHAPED_PREFIX},
+   * for the same reason: {@code Bearer } is the discriminator, and ten characters only meant the
+   * bound could sever a header value into something that no longer looked like one.
    */
   private static final Pattern CREDENTIAL_SHAPED_VALUE =
-      Pattern.compile("(?i)(bearer\\s+[\\w.~+/=-]{10,})" + "|(eyJ[\\w-]{8,}(?:\\.[\\w-]*){1,2})");
+      Pattern.compile(
+          "(?i:bearer\\s+[\\w.~+/=-]{4,})" + "|((?<![\\w-])eyJ[\\w-]{8,}(?:\\.[\\w-]*){1,2})");
 
   /**
    * The wording GitHub uses when it is throttling rather than refusing. A secondary rate limit and
@@ -113,6 +134,16 @@ public final class GitHubApiError {
    *
    * <p>{@code \p{IsCc}} is the Unicode general category rather than POSIX {@code \p{Cntrl}}, so it
    * reaches the C1 controls (U+0080–U+009F, NEL among them) as well as C0 and DEL.
+   *
+   * <p>{@code \p{IsCf}} is here for the same harm rather than for line integrity: bidi overrides
+   * and isolates (RLO, LRM, LRI) reorder what an operator reads, and the invisible joiners and
+   * spaces (ZWJ, ZWNJ, ZWSP, the BOM, the soft hyphen) let two different bodies render identically
+   * — both forge a record's meaning as surely as a forged boundary forges its extent. The accepted
+   * cost is that an echoed user string loses its grapheme clusters: an emoji ZWJ sequence or an
+   * Indic conjunct is split apart. A {@code body=} field is a diagnostic identity rather than a
+   * rendering surface, and which characters arrived is the question it exists to answer. Replacing
+   * with a space rather than deleting is part of the same bargain — deletion would let {@code
+   * admin<ZWSP>istrator} close up into a different real word, a space cannot.
    */
   private static final Pattern WHITESPACE =
       Pattern.compile("[\\s\\p{IsCc}\\p{IsCf}\\u2028\\u2029]+");

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.core.Response;
 import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -71,15 +72,15 @@ public final class GitHubApiError {
    * an error body, but a body is untrusted text on its way to a log file, so a token-shaped run of
    * characters is masked rather than trusted to be harmless.
    *
-   * <p>Deliberately ONE alternation, read as a union across this pattern and {@link
-   * #CREDENTIAL_SHAPED_VALUE}, rather than one masking pass per shape: the shapes overlap, and a
-   * single pass masks each overlap as the leftmost match, whereas masking in passes decides the
-   * overlap by pass order and leaves material the one-pass form masks. Whichever order is chosen,
-   * {@code "…ghp_<7 chars>Bearer <20 chars>"} keeps its token prefix unmasked if the bearer pass
-   * runs first, and {@code "Bearer ghp_<10 chars>.<tail>"} keeps the tail of the bearer value if
-   * the token pass does. So {@link #redactCredentials} still scans once, taking the leftmost match
-   * across both patterns — split in two, prefixes here and value shapes there, only because one
-   * alternation of all four shapes is more than the regex complexity budget allows.
+   * <p>Deliberately read as a union across this pattern, {@link #BEARER_SHAPED_VALUE} and {@link
+   * #JWT_SHAPED_VALUE}, rather than one masking pass per shape: the shapes overlap, and a single
+   * pass masks each overlap as the leftmost match, whereas masking in passes decides the overlap by
+   * pass order and leaves material the one-pass form masks. Whichever order is chosen, {@code
+   * "…ghp_<7 chars>Bearer <20 chars>"} keeps its token prefix unmasked if the bearer pass runs
+   * first, and {@code "Bearer ghp_<10 chars>.<tail>"} keeps the tail of the bearer value if the
+   * token pass does. So {@link #redactCredentials} still scans once, taking the leftmost match
+   * across every pattern — split apart, prefixes here and the value shapes beside it, only because
+   * one alternation of all four shapes is more than the regex complexity budget allows.
    *
    * <p>Four value characters, not ten (#746). The sigil is the whole discriminator here — {@code
    * ghp_} and {@code github_pat_} do not occur in prose, so the length floor was buying nothing the
@@ -111,18 +112,35 @@ public final class GitHubApiError {
    * whole alternation and the header was unanchored: any {@code eyj} in any case, anywhere inside a
    * longer run, followed by a dot at any distance. {@code eyjafjallajokull.internal.example.com}
    * came out as {@code ***.com} and a base64 blob with a filename after it came out as {@code ***}.
-   * So the case-insensitivity is scoped to the bearer half — a JWT header is base64url of {@code
-   * &#123;"}, which is always literally {@code eyJ} — and {@code (?<![\w-])} pins the header to the
-   * start of a token, leaving the cut-token property #740 added intact: a cut anywhere past the
-   * first dot still masks the whole run.
+   * So the case-insensitivity is scoped here, to the bearer shape. {@link #JWT_SHAPED_VALUE} is
+   * case-sensitive instead, because its {@code eyJ} is not a spelling but arithmetic: base64url of
+   * a header opening {@code &#123;"} gives {@code ey} plus a third character fixed by the first
+   * key's leading byte, which is {@code J} for every key beginning with a letter. RFC 7515 requires
+   * {@code alg}, so a real header encodes to {@code eyJ}; a nonstandard first key that is a digit
+   * or empty encodes to {@code eyI} and is deliberately not matched, since widening the anchor
+   * would mask ordinary prose beginning {@code ey} for a shape no issuer emits.
    *
-   * <p>The bearer value takes the same four-character floor as {@link #CREDENTIAL_SHAPED_PREFIX},
-   * for the same reason: {@code Bearer } is the discriminator, and ten characters only meant the
-   * bound could sever a header value into something that no longer looked like one.
+   * <p>The value takes the same four-character floor as {@link #CREDENTIAL_SHAPED_PREFIX}, for the
+   * same reason: the {@code Bearer } that precedes it is the discriminator, and ten characters only
+   * meant the bound could sever a header value into something that no longer looked like one.
+   *
+   * <p>The word {@code bearer} is consumed with the value rather than left in the line, which does
+   * mask the noun in prose such as {@code missing bearer token}. Masking only the value was tried
+   * and is worse: the match then starts after {@code bearer }, so on {@code Bearer ghp_….tail} the
+   * token shape wins the tie at that position and the tail escapes — the overlap that the one-pass,
+   * leftmost-match design above exists to swallow.
    */
-  private static final Pattern CREDENTIAL_SHAPED_VALUE =
-      Pattern.compile(
-          "(?i:bearer\\s+[\\w.~+/=-]{4,})" + "|((?<![\\w-])eyJ[\\w-]{8,}(?:\\.[\\w-]*){1,2})");
+  private static final Pattern BEARER_SHAPED_VALUE =
+      Pattern.compile("(?i:bearer\\s+[\\w.~+/=-]{4,})");
+
+  /**
+   * The JWT shape, kept apart from {@link #BEARER_SHAPED_VALUE} rather than alternated with it: one
+   * pattern carrying both ran past the regex-complexity budget, and {@link #redactCredentials}
+   * already scans any number of shapes in one pass, taking the leftmost match and preferring the
+   * earlier shape on a tie — the order these are declared in.
+   */
+  private static final Pattern JWT_SHAPED_VALUE =
+      Pattern.compile("(?<![\\w-])eyJ[\\w-]{8,}(?:\\.[\\w-]*){1,2}");
 
   /**
    * The wording GitHub uses when it is throttling rather than refusing. A secondary rate limit and
@@ -452,9 +470,12 @@ public final class GitHubApiError {
    */
   private static String redactCredentials(String text) {
     Matcher[] shapes = {
-      CREDENTIAL_SHAPED_PREFIX.matcher(text), CREDENTIAL_SHAPED_VALUE.matcher(text)
+      CREDENTIAL_SHAPED_PREFIX.matcher(text),
+      BEARER_SHAPED_VALUE.matcher(text),
+      JWT_SHAPED_VALUE.matcher(text)
     };
-    var starts = new int[] {-1, -1};
+    var starts = new int[shapes.length];
+    Arrays.fill(starts, -1);
     var ends = new int[shapes.length];
     var out = new StringBuilder(text.length());
     var from = 0;
@@ -539,14 +560,14 @@ public final class GitHubApiError {
    * <p>The bound before the redaction is the point (#731). {@code readBody} reads the entity with
    * no size limit of its own, and redaction used to run over all of it, so the cost of explaining a
    * failed write was set by whatever the configured API host chose to send. {@link
-   * #CREDENTIAL_SHAPED_VALUE}'s JWT alternative is quadratic on a body of repeated {@code eyJ} —
-   * {@code [\w-]} excludes {@code .}, so each greedy run consumes to end-of-input, fails to find
-   * its separator and backtracks a character at a time, from one in every three positions.
-   * Measured: 20 000 chars cost 331 ms, 40 000 cost 1 213 ms, 80 000 cost 4 843 ms, 160 000 cost 19
-   * 404 ms, and a 1.2 MB body cost about eighteen minutes of CPU — spent on the review's own
-   * carrier thread, inside the failure path that exists to explain a failed write, before the retry
-   * decision it feeds is even reached. GitHub's real error bodies are ~300 characters; a GHES or
-   * reverse-proxy error page, a misconfigured base URL or a compromised endpoint is not.
+   * #JWT_SHAPED_VALUE} is quadratic on a body of repeated {@code eyJ} — {@code [\w-]} excludes
+   * {@code .}, so each greedy run consumes to end-of-input, fails to find its separator and
+   * backtracks a character at a time, from one in every three positions. Measured: 20 000 chars
+   * cost 331 ms, 40 000 cost 1 213 ms, 80 000 cost 4 843 ms, 160 000 cost 19 404 ms, and a 1.2 MB
+   * body cost about eighteen minutes of CPU — spent on the review's own carrier thread, inside the
+   * failure path that exists to explain a failed write, before the retry decision it feeds is even
+   * reached. GitHub's real error bodies are ~300 characters; a GHES or reverse-proxy error page, a
+   * misconfigured base URL or a compromised endpoint is not.
    *
    * <p>The collapse above is one linear pass over the whole body; cutting first bounds the
    * redaction pass at a constant. The cut is twice {@link #MAX_BODY_CHARS} so that redaction, which

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
@@ -623,6 +623,88 @@ class GitHubApiErrorTest {
 
       assertEquals("***…", body);
     }
+
+    /**
+     * #746. The bound before redaction is the only cut that can sever a token — the cap runs after
+     * the mask — and a shape with a ten-character floor stops matching once it has been severed
+     * below it. A run of credential-shaped material ahead of the token compresses to {@code ***},
+     * so what the bound left of the secret survives the cap and reaches the warn line whole.
+     */
+    @Nested
+    class ACredentialTheBoundCutJustShortOfItsLengthFloor {
+
+      /** Enough credential-shaped material to redact to {@code ***} and clear the cap for us. */
+      private static final String COMPRESSIBLE = "Bearer " + "a".repeat(900);
+
+      /** A body whose {@code sigil} lands so that the 1024-char bound leaves nine value chars. */
+      private static String cutAfterNineCharactersOf(String sigil, String value) {
+        var padding = 1_024 - sigil.length() - 9 - COMPRESSIBLE.length();
+        return COMPRESSIBLE + ",".repeat(padding) + sigil + value;
+      }
+
+      @Test
+      void isStillMaskedForATokenPrefix() {
+        var logged =
+            loggedBody(outbound(403, cutAfterNineCharactersOf("ghp_", "A1b2C3d4E5f6G7h8I9j0K1")));
+
+        assertFalse(logged.contains("ghp_A1b2C3d4E"), logged);
+      }
+
+      @Test
+      void isStillMaskedForAFineGrainedPersonalAccessToken() {
+        var logged =
+            loggedBody(
+                outbound(403, cutAfterNineCharactersOf("github_pat_", "A1b2C3d4E5f6G7h8I9j0K1")));
+
+        assertFalse(logged.contains("github_pat_A1b2C3d4E"), logged);
+      }
+
+      @Test
+      void isStillMaskedForABearerValue() {
+        var logged =
+            loggedBody(outbound(403, cutAfterNineCharactersOf("Bearer ", "S3cr3tV4lu3W1thM0re")));
+
+        assertFalse(logged.contains("Bearer S3cr3tV4l"), logged);
+      }
+    }
+
+    /**
+     * #746. The JWT header is base64url of {@code &#123;"} and is therefore always literally {@code
+     * eyJ}. Reading it case-insensitively made an Icelandic volcano a credential and blanked the
+     * hostname the operator needed — the exact outcome the shape's own javadoc says it was narrowed
+     * to avoid.
+     */
+    @Test
+    void doesNotMaskOrdinaryTextThatMerelyBeginsLikeAJwtHeaderInSomeOtherCase() {
+      var body = "{\"message\":\"cannot resolve host eyjafjallajokull.internal.example.com\"}";
+
+      assertEquals(body, loggedBody(outbound(502, body)));
+    }
+
+    /**
+     * #746. Nor is the header a credential when it turns up in the middle of a longer run: an
+     * unanchored {@code eyJ} let one request id blank four hundred characters of the body around
+     * it. A JWT starts at a token boundary, so the shape is pinned to one.
+     */
+    @Test
+    void doesNotMaskAJwtHeaderFoundInsideALongerRunOfWordCharacters() {
+      var body = "{\"message\":\"request id 7f3aeyJQm9keVRleHRIZXJl.log not found\"}";
+
+      assertEquals(body, loggedBody(outbound(404, body)));
+    }
+
+    /**
+     * Control, not proof — green before the fix as well. It pins the half of the {@code (?i)} that
+     * has to survive being scoped to one alternative: GitHub sends {@code Bearer}, but the header
+     * name is case-insensitive by RFC 7235 and an echoed one may arrive in any case.
+     */
+    @Test
+    void masksABearerHeaderWhateverCaseItArrivedIn() {
+      assertEquals(
+          "*** and more", loggedBody(outbound(401, "BEARER abcdefghij0123456789 and more")));
+      assertEquals(
+          "*** and more", loggedBody(outbound(401, "bearer abcdefghij0123456789 and more")));
+    }
   }
 
   @Nested

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
@@ -138,6 +138,102 @@ class GitHubApiErrorTest {
     }
   }
 
+  /**
+   * #732 and #747. The body does two unrelated jobs — it is a line an operator reads, and it is the
+   * evidence on which a completed generation is either repeated or thrown away. Every narrowing the
+   * first job asks for used to narrow the second: the 512-character cap (#732), and then the
+   * 1024-character bound on the redaction input (#747), which closed the one path by which deeper
+   * wording still reached the classifier. The consequence is not a shorter wait but no retry at all
+   * — the retry returns empty on {@code !isThrottled()} and rethrows on the first attempt, which is
+   * the pre-#495 behaviour this area exists to prevent.
+   */
+  @Nested
+  class ThrottleWordingGitHubDidNotPutFirst {
+
+    private static final Instant NOW = Instant.ofEpochSecond(1_800_000_000L);
+
+    @Test
+    void isStillReadWhenItSitsPastTheLengthCapTheLogLineUses() {
+      // #732. Nothing here is credential-shaped and nothing is long enough to be bounded — the cap
+      // alone hid it. GitHub puts the message first, but a body with a long documentation_url or a
+      // set of echoed headers ahead of it does not.
+      var body =
+          "{\"documentation_url\":\""
+              + "x".repeat(600)
+              + "\",\"message\":\"You have exceeded a secondary rate limit and have been temporarily"
+              + " blocked from content creation.\"}";
+
+      var error = GitHubApiError.from(outbound(403, body));
+
+      assertTrue(error.isThrottled(), "body=" + loggedBody(outbound(403, body)));
+      assertEquals(Duration.ofSeconds(30), error.retryDelay(1, NOW));
+    }
+
+    @Test
+    void isStillReadWhenMoreCredentialShapedMaterialPrecedesItThanTheRedactionBoundHolds() {
+      // #747. v0.6.3 redacted the whole collapsed body first, so a prefix like this compressed to
+      // "***" and carried the wording forward into the classified string; bounding the redaction
+      // input at 1024 dropped it before the mask could. The audit's sweep puts the threshold
+      // between 900 characters of prefix (still classified) and 1010 (no longer).
+      var body = "Bearer " + "a".repeat(1_100) + " " + CONTENT_CREATION_BLOCK_BODY;
+
+      var error = GitHubApiError.from(outbound(403, body));
+
+      assertTrue(error.isThrottled(), "body=" + loggedBody(outbound(403, body)));
+      assertEquals(Duration.ofSeconds(30), error.retryDelay(1, NOW));
+    }
+
+    @Test
+    void isNotSomethingTheCredentialMaskCanDeleteBeforeItIsRead() {
+      // The classified window is the collapsed body, taken before redaction, so the retry decision
+      // can no longer be changed by a mask: a JWT-shaped run whose tail happens to be the word
+      // "blocked" used to swallow it and turn this block into a permission refusal.
+      var body = "{\"message\":\"prefix eyJabcdefgh.blocked from content creation\"}";
+
+      var error = GitHubApiError.from(outbound(403, body));
+
+      assertTrue(error.isThrottled(), "body=" + loggedBody(outbound(403, body)));
+      assertEquals(Duration.ofSeconds(30), error.retryDelay(1, NOW));
+    }
+
+    /** Control: the log line keeps its own cap, whatever the classifier is allowed to see. */
+    @Test
+    void doesNotWidenWhatReachesTheLog() {
+      var logged = loggedBody(outbound(403, "y".repeat(600) + " blocked from content creation"));
+
+      assertEquals(513, logged.length(), logged);
+      assertTrue(logged.endsWith("…"), logged);
+    }
+
+    /**
+     * Control, and the honest edge of the fix: the window is wide, not unbounded. The entity is
+     * read with no size limit of its own, and #731 is about not letting the configured host set the
+     * cost of explaining a failed write, so classification gets a fixed prefix — several times any
+     * body GitHub sends, and orders of magnitude past where the cap and the redaction bound used to
+     * stop it.
+     */
+    @Test
+    void isReadFromABoundedWindowRatherThanFromAnUnboundedBody() {
+      var withinTheWindow = "z".repeat(4_000) + " blocked from content creation";
+      var pastTheWindow = "z".repeat(64_000) + " blocked from content creation";
+
+      assertTrue(GitHubApiError.from(outbound(403, withinTheWindow)).isThrottled());
+      assertFalse(GitHubApiError.from(outbound(403, pastTheWindow)).isThrottled());
+    }
+
+    /** Control: a body carrying none of the wording is still a refusal, however deep it is read. */
+    @Test
+    void doesNotMakeAPermissionRefusalLookLikeAThrottle() {
+      var body =
+          "{\"documentation_url\":\""
+              + "x".repeat(4_000)
+              + "\",\"message\":\"Resource not"
+              + " accessible by integration\"}";
+
+      assertFalse(GitHubApiError.from(outbound(403, body)).isThrottled());
+    }
+  }
+
   @Nested
   class Severity {
 
@@ -194,6 +290,47 @@ class GitHubApiErrorTest {
                   "x-ratelimit-reset",
                   String.valueOf(NOW.getEpochSecond() - 90)));
       assertEquals(Duration.ZERO, error.retryDelay(1, NOW));
+    }
+
+    /**
+     * #732's second half. {@code Long.parseLong} accepts values {@code Instant.ofEpochSecond}
+     * rejects, and the {@link java.time.DateTimeException} it throws is not the {@code
+     * WebApplicationException} the write path is built around: it escaped {@code
+     * GitHubWriteRetry.call} past every catch between here and the caller, losing the write and the
+     * record of its loss together. A header that cannot name an instant says nothing about when the
+     * window reopens, which is what a non-numeric header already means here.
+     */
+    @Test
+    void aRateLimitResetTooLargeToBeAnInstantIsTreatedAsUnspecified() {
+      var error =
+          GitHubApiError.from(
+              outbound(
+                  403,
+                  SECONDARY_LIMIT_BODY,
+                  "x-ratelimit-remaining",
+                  "0",
+                  "x-ratelimit-reset",
+                  String.valueOf(Long.MAX_VALUE)));
+
+      assertTrue(error.isThrottled());
+      assertEquals(Duration.ofSeconds(5), error.retryDelay(1, NOW));
+      assertEquals(Duration.ofSeconds(10), error.retryDelay(2, NOW));
+    }
+
+    /** The same at the other end of the range: an intermediary's negative overflow. */
+    @Test
+    void aRateLimitResetTooSmallToBeAnInstantIsTreatedAsUnspecified() {
+      var error =
+          GitHubApiError.from(
+              outbound(
+                  403,
+                  SECONDARY_LIMIT_BODY,
+                  "x-ratelimit-remaining",
+                  "0",
+                  "x-ratelimit-reset",
+                  String.valueOf(Long.MIN_VALUE)));
+
+      assertEquals(Duration.ofSeconds(5), error.retryDelay(1, NOW));
     }
 
     @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
@@ -313,6 +313,63 @@ class GitHubWriteRetryTest {
     assertEquals(List.of(Duration.ofSeconds(21)), slept);
   }
 
+  /**
+   * #732. Every caller of this loop — {@link GitHubLostWrites} included — catches {@code
+   * WebApplicationException}, because that is the failure a GitHub write produces. An {@code
+   * x-ratelimit-reset} outside the range of an {@code Instant} used to replace it with a {@code
+   * DateTimeException} thrown from inside the delay derivation, which no catch on the way out
+   * matched: the write was lost and the record of its loss went with it. Only an intermediary sends
+   * a header like this, and only the one header is needed.
+   */
+  @Test
+  void anOutOfRangeResetHeaderStillFailsAsTheExceptionEveryCallerCatches() {
+    var calls = new AtomicInteger();
+    var throttle =
+        throttled(
+            "x-ratelimit-remaining", "0", "x-ratelimit-reset", String.valueOf(Long.MAX_VALUE));
+
+    var thrown =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                retry.call(
+                    "a comment on o/r #7",
+                    () -> {
+                      calls.incrementAndGet();
+                      throw throttle;
+                    }));
+
+    // Unusable is unspecified: the linear fallback takes over and the budget runs its course, so
+    // the caller sees the same rejection it would have seen from any other spent throttle.
+    assertSame(throttle, thrown);
+    assertEquals(4, calls.get());
+    assertEquals(
+        List.of(Duration.ofSeconds(5), Duration.ofSeconds(10), Duration.ofSeconds(15)), slept);
+  }
+
+  /** The same header at the other end of the range, on a throttle that clears on the repeat. */
+  @Test
+  void anOutOfRangeResetHeaderOnAThrottleFallsBackToTheLinearWait() {
+    var calls = new AtomicInteger();
+
+    var result =
+        retry.call(
+            "a comment on o/r #7",
+            () -> {
+              if (calls.incrementAndGet() == 1) {
+                throw throttled(
+                    "x-ratelimit-remaining",
+                    "0",
+                    "x-ratelimit-reset",
+                    String.valueOf(Long.MIN_VALUE));
+              }
+              return "posted";
+            });
+
+    assertEquals("posted", result);
+    assertEquals(List.of(Duration.ofSeconds(5)), slept);
+  }
+
   @Test
   void everyAttemptWaitsForItsPacingSlotIncludingTheRepeats() {
     var paced = new ArrayList<Duration>();


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔒 Security

## Description

Two halves of one oversight in `GitHubApiError`'s credential shapes, both introduced by #740.

**1. The bound strands a token prefix unmasked (security, bounded at ≤9 characters).**
`clean()` cuts the collapsed body to 1024 characters *before* `redactCredentials`. The JWT alternative was widened in #740 precisely so a token the cut severs is still masked — but `gh[pousr]_\w{10,}`, `github_pat_\w{10,}` and `bearer\s+[\w.~+/=-]{10,}` kept their ten-character floors. A token straddling index 1024 with six to nine value characters on the visible side falls below every one of those quantifiers, stops matching, and reaches the warn line. v0.6.3 redacted the whole collapsed body and capped afterwards, so the same input was masked whole.

The three floors drop to `{4,}`. The sigil is the discriminator — `ghp_`, `github_pat_` and `Bearer ` do not occur in prose — so the length was buying nothing the sigil did not already buy, while costing the one case the pre-cut can produce. The cap site cuts *after* redaction and can never strand, so this is the only site that could.

**2. The widened JWT shape masks ordinary text.**
`eyJ[\w-]{8,}(?:\.[\w-]*){1,2}` compiled under a pattern-wide `(?i)` with an unanchored header, so it matched `eyj` in any case, anywhere inside a longer run, followed by a dot at any distance. Measured on the shipped code:

| input | v0.6.4 |
|---|---|
| `cannot resolve host eyjafjallajokull.internal.example.com` | `cannot resolve host ***.com` |
| `request id 7f3aeyJQm9keVRleHRIZXJl.log not found` | `request id 7f3a*** not found` |

That is the exact outcome the shape's own javadoc says it was narrowed to avoid, and it is not fail-safe for either job the line has — explaining a failure to an operator, and feeding the retry decision, which reads the redacted body.

A JWT header is base64url of `{"` and is therefore always literally `eyJ`, so `(?i)` is scoped to the bearer alternative alone and a negative lookbehind on `[\w-]` pins the header to a token boundary. The cut-token property #740 added is untouched: a cut anywhere past the first dot still masks the whole run, which `masksAJwtTheBoundCutWithinTheFirstPayloadCharacters` and `masksAJwtTheBoundCutMidPayload` still pin.

**Doc.** `\p{IsCf}` is in the shipped collapse class but was missing from the javadoc paragraph that exists to explain that class. It is the half with the widest blast radius (bidi overrides, ZWJ/ZWNJ/ZWSP, the BOM, the soft hyphen), so it now carries its own defence, including the accepted cost — an echoed user string loses its grapheme clusters — and why the replacement is a space rather than a deletion.

Not reachable against api.github.com, which does not echo credentials and whose error bodies are ~300 characters. Both halves need the same non-GitHub host the #740 severity note already describes: a GHES or reverse-proxy error page, a misconfigured base URL, a compromised endpoint.

## Related Issues

Fixes #746

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Five new behavioural tests, all red on `fc54d93` in exactly the claimed way and green after. Verbatim, from `./mvnw -o test -Dtest=GitHubApiErrorTest` with only the test file applied:

```
[ERROR] GitHubApiErrorTest.isStillMaskedForATokenPrefix ***,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,ghp_A1b2C3d4E… ==> expected: <false> but was: <true>
[ERROR] GitHubApiErrorTest.isStillMaskedForAFineGrainedPersonalAccessToken ***,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,github_pat_A1b2C3d4E… ==> expected: <false> but was: <true>
[ERROR] GitHubApiErrorTest.isStillMaskedForABearerValue ***,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,Bearer S3cr3tV4l… ==> expected: <false> but was: <true>
[ERROR] GitHubApiErrorTest.doesNotMaskOrdinaryTextThatMerelyBeginsLikeAJwtHeaderInSomeOtherCase expected: <{"message":"cannot resolve host eyjafjallajokull.internal.example.com"}> but was: <{"message":"cannot resolve host ***.com"}>
[ERROR] GitHubApiErrorTest.doesNotMaskAJwtHeaderFoundInsideALongerRunOfWordCharacters expected: <{"message":"request id 7f3aeyJQm9keVRleHRIZXJl.log not found"}> but was: <{"message":"request id 7f3a*** not found"}>

[ERROR] Tests run: 55, Failures: 5, Errors: 0, Skipped: 0
```

`masksABearerHeaderWhateverCaseItArrivedIn` is a **control**, not proof — it is green before the fix as well. It pins the half of the `(?i)` that has to survive being scoped to one alternative, so a later tightening cannot quietly drop bearer's case-insensitivity.

Gates on this tree:

- `./mvnw -B spotless:apply` → clean
- `./mvnw -B clean compile spotbugs:check spotless:check` → **BugInstance size is 0**, Error size is 0, spotless clean
- `./mvnw -B clean test` → **Tests run: 3310, Failures: 0, Errors: 0, Skipped: 0**
- jacoco ∩ `git diff -U0 fc54d93...HEAD` over changed main code → 33 changed lines, **zero uncovered lines and zero uncovered branches**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

Scoped to the two credential patterns and the collapse javadoc. The ordering in `clean()` is unchanged — the bound before redaction is #731's fix and stays — so the 200 KB timing test (`doesNotScanAWholeOversizedBodyLookingForCredentials`) and the oversized-body ellipsis test stay green; anchoring the header in fact removes the last backtracking path on an `eyJ`-dense run.

The other consequence named in the audit — redaction eating the wording `isThrottled()` reads — is not addressed here. It is fixed by classifying ahead of redaction, which is #747/#732's change, stacked on this branch.
