### PR TITLE
test(review): stop RescuedFindingLostWriteTest sleeping through the content-creation floor

### DIFF
--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RescuedFindingLostWriteTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RescuedFindingLostWriteTest.java
@@ -58,10 +58,21 @@ class RescuedFindingLostWriteTest {
   private static final String FILE_LEVEL_THREAD = "the finding, filed on its file";
   private static final String REVIEW_BODY = "the review body";
 
-  /** The response measured in #722, which is what sends a route round the backoff to exhaustion. */
-  private static final String BLOCK_BODY =
-      "{\"message\":\"You have exceeded a secondary rate limit and have been temporarily blocked"
-          + " from content creation. Please retry your request again later.\"}";
+  /**
+   * A secondary rate limit, which is what sends a route round the backoff to exhaustion.
+   *
+   * <p>Not the content-creation wording measured in #722, deliberately (#749). The seam under test
+   * is the accounting, not the backoff: what these tests need from the throttle is that {@link
+   * dev.thiagogonzaga.thrillhousebot.github.GitHubApiError#isThrottled} says yes and that the route
+   * exhausts {@code GitHubWriteRetry.MAX_ATTEMPTS}, both of which a plain secondary limit does. A
+   * content-creation block additionally lifts every wait to {@code
+   * CONTENT_CREATION_BLOCK_MIN_DELAY} — 30 seconds — however the delay was derived, {@code
+   * Retry-After} included since #738. The {@code Retry-After: 0} below used to mean "no sleep" and
+   * stopped meaning it in the same release, at a cost of 461 s for this class and 94 s for a single
+   * test. Nothing here asserts on the block wording, so the cheaper body pins the same behaviour.
+   */
+  private static final String THROTTLE_BODY =
+      "{\"message\":\"You have exceeded a secondary rate limit.\"}";
 
   /**
    * The registry the client writes to is process-wide, so each test takes a pull request of its own
@@ -101,7 +112,7 @@ class RescuedFindingLostWriteTest {
   }
 
   /**
-   * The production sequence: GitHub is in a content-creation block, the line-anchored comment burns
+   * The production sequence: GitHub is refusing comment creation, the line-anchored comment burns
    * its whole retry budget, the file-level thread lands on the far side of the window, and the
    * review body goes out moments later. The finding has a working thread, so the body must not open
    * with "an earlier reply on this pull request was never posted … run the command again".
@@ -140,10 +151,10 @@ class RescuedFindingLostWriteTest {
   }
 
   /**
-   * The other direction, which the fix must not cost: when the block outlasts every route the
+   * The other direction, which the fix must not cost: when the throttle outlasts every route the
    * finding really is gone, and the maintainer does have to run the command again. Said once, for
    * one finding, rather than once per refused route — the over-count is not confined to the rescued
-   * case, and a review that lost three findings to a wide block should say three, not nine.
+   * case, and a review that lost three findings to a wide window should say three, not nine.
    */
   @Test
   void aFindingNoRouteCouldDeliverIsStillAnnouncedAsLost() {
@@ -275,10 +286,10 @@ class RescuedFindingLostWriteTest {
       return new ReviewResponse(1L, request.body(), request.event(), request.commitId(), null);
     }
 
-    /** GitHub's content-creation block, naming a deadline of "now" so the test does not sleep. */
+    /** GitHub throttling the post, naming a deadline of "now" so the test does not sleep. */
     private static WebApplicationException blocked() {
       return new WebApplicationException(
-          Response.status(403).header("Retry-After", "0").entity(BLOCK_BODY).build());
+          Response.status(403).header("Retry-After", "0").entity(THROTTLE_BODY).build());
     }
 
     @Override


### PR DESCRIPTION
## What type of PR is this?

- [x] ✅ Test

> **Stacked PR.** Based on `fix/748-review-body-delivery` (#751) so its diff stays scoped to this issue. **Re-target to `main` once #751 merges.**

## Description

`RescuedFindingLostWriteTest`'s fixture threw GitHub's content-creation block with `Retry-After: 0` and documented that as "naming a deadline of 'now' so the test does not sleep". That was true when it was written. #738 then made `CONTENT_CREATION_BLOCK_MIN_DELAY` (30 s) apply **however the delay was derived**, an explicit `Retry-After` included — and shipped in the same release. Every attempt of every exhausted route has waited the floor ever since: 3 sleeps per route, 6 exhausted routes across the class.

Neither change is wrong. The fixture simply encodes an assumption that stopped being true.

What these tests actually need from the throttle is that `GitHubApiError.isThrottled` says yes and that the route burns `GitHubWriteRetry.MAX_ATTEMPTS`. A plain secondary rate limit does both, and nothing in the class asserts on the block wording — the assertions are all about accounting. So `BLOCK_BODY` becomes `THROTTLE_BODY`, a plain secondary-limit message, with a comment on why it is deliberately not a content-creation block so the next reader does not "restore" it. All three tests and every assertion in them are unchanged.

## Related Issues

Fixes #749

Proof: audit report AUDIT7-A, finding A3.

## How Has This Been Tested?

- [x] Unit tests

This is a build-cost fix with no behavioural change, so there is no red/green proof to quote — the three tests pass before and after, on the same assertions, and that is the point. The evidence is the measured wall clock, before and after, on the same machine and JVM.

### Before (`surefire` XML, this branch's parent)

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 461.1 s -- in RescuedFindingLostWriteTest

CLASS 461.054
aFindingTheFileLevelFallbackRescuedIsNotAnnouncedAsLost   94.013
aRescuedFindingWithASuggestionIsNotAnnouncedTwiceEither  184.004
aFindingNoRouteCouldDeliverIsStillAnnouncedAsLost        182.998
```

### After

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 25.97 s -- in RescuedFindingLostWriteTest

CLASS 25.974
aFindingTheFileLevelFallbackRescuedIsNotAnnouncedAsLost    6.954
aRescuedFindingWithASuggestionIsNotAnnouncedTwiceEither    9.984
aFindingNoRouteCouldDeliverIsStillAnnouncedAsLost          9.002
```

**461.05 s → 25.97 s for the class (−435 s, 17.7x), 94.01 s → 6.95 s for the single test.** The 94 s figure was 3 x 30 s of floor plus overhead, to the second; what remains is the retry pacing the seam genuinely exercises.

A whole `clean test` on this branch drops from **12:22 to 04:40**.

### Gates

- `spotless:apply` → `clean compile spotbugs:check spotless:check`: **BugInstance size is 0**, BUILD SUCCESS
- `clean test`: **Tests run: 3308, Failures: 0, Errors: 0, Skipped: 0** — BUILD SUCCESS
- Coverage: no main code changed by this PR, so there is nothing new to cover.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
