### PR TITLE
fix(github): classify a throttle from the body, not from the line the log gets

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
@@ -17,6 +17,7 @@ package dev.thiagogonzaga.thrillhousebot.github;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
+import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
@@ -42,6 +43,25 @@ public final class GitHubApiError {
 
   /** How much of a response body is kept for the log. GitHub's error bodies are far shorter. */
   static final int MAX_BODY_CHARS = 512;
+
+  /**
+   * How much of a response body the throttle classification reads (#732, #747).
+   *
+   * <p>Sixteen times the log cap, because the two jobs the body does have nothing to do with each
+   * other. The log line is capped so one failure cannot flood a log file, and that cap is about the
+   * operator's screen; classification is a yes/no about whether a completed generation gets another
+   * attempt, and reading it off the same 512 characters made it depend on where GitHub put its
+   * message. #740 then bounded the input to redaction at {@code MAX_BODY_CHARS * 2}, which closed
+   * the one path — redaction compressing a long credential-shaped prefix away — by which deeper
+   * wording still reached the classified string at all.
+   *
+   * <p>A bound is still wanted, because the entity is read with no size limit of its own and the
+   * point of #731 was to keep the cost of explaining a failed write off the review's carrier
+   * thread. Both patterns are flat literal alternations with no backtracking, so a pass over this
+   * many characters is a linear scan measured in microseconds — the quadratic shape #731 found is
+   * in the credential redaction, which still sees only its own bound.
+   */
+  static final int MAX_CLASSIFIED_CHARS = 8 * 1024;
 
   /** Replacement for anything in a response body shaped like a credential. */
   static final String REDACTED = "***";
@@ -208,7 +228,7 @@ public final class GitHubApiError {
   private final String rateLimitRemaining;
   private final String rateLimitReset;
   private final String rateLimitResource;
-  private final String body;
+  private final Body body;
 
   private GitHubApiError(
       int status,
@@ -216,13 +236,35 @@ public final class GitHubApiError {
       String rateLimitRemaining,
       String rateLimitReset,
       String rateLimitResource,
-      String body) {
+      Body body) {
     this.status = status;
     this.retryAfter = retryAfter;
     this.rateLimitRemaining = rateLimitRemaining;
     this.rateLimitReset = rateLimitReset;
     this.rateLimitResource = rateLimitResource;
     this.body = body;
+  }
+
+  /**
+   * The two readings of one response body, kept apart because the two callers want opposite things
+   * (#732, #747).
+   *
+   * @param logged the line an operator reads: collapsed, bounded, redacted, capped at {@link
+   *     #MAX_BODY_CHARS}, and marked with an ellipsis when anything was dropped
+   * @param classified what {@link #isThrottled()} and {@link #blocksContentCreation()} match
+   *     against: the collapsed body bounded at {@link #MAX_CLASSIFIED_CHARS} and nothing else.
+   *     Reading the logged form instead made the retry decision turn on where in the body GitHub
+   *     happened to put its message — wording past the cap, or behind enough credential-shaped
+   *     material to fill the redaction bound, classified as "not a throttle" and the write was not
+   *     repeated at all. It is deliberately the <em>unredacted</em> text: masking runs before
+   *     classification would read it, and a mask that swallowed the word {@code blocked} turned a
+   *     content-creation block into a permission refusal. Nothing in here is ever logged or
+   *     returned — the two patterns answer yes or no and the string is dropped.
+   */
+  private record Body(String logged, String classified) {
+
+    /** A body that could not be read at all — no line to log, nothing to classify. */
+    private static final Body UNREADABLE = new Body("", "");
   }
 
   /** Reads the status, the throttling headers and the (redacted) body off a failed response. */
@@ -250,6 +292,11 @@ public final class GitHubApiError {
    * between "post it again in a moment" and "this will never work". 429 says so outright; a 403
    * says so only through a {@code Retry-After}, an exhausted {@code x-ratelimit-remaining}, or the
    * rate-limit wording in the body. A permission 403 carries none of the three and so fails fast.
+   *
+   * <p>The wording is looked for in {@link Body#classified}, not in the line that goes to the log:
+   * the log's cap and the redaction bound are about what an operator should be shown, and letting
+   * them decide whether a completed generation is repeated turned this into a question about where
+   * GitHub put its message (#732, #747).
    */
   public boolean isThrottled() {
     if (status == 429) {
@@ -260,7 +307,7 @@ public final class GitHubApiError {
     }
     return retryAfterSeconds().isPresent()
         || "0".equals(rateLimitRemaining)
-        || THROTTLE_WORDING.matcher(body).find();
+        || THROTTLE_WORDING.matcher(body.classified()).find();
   }
 
   /**
@@ -321,17 +368,39 @@ public final class GitHubApiError {
    * throttle still slows down.
    */
   private Duration derivedDelay(int attempt, Instant now) {
-    return parseLong(rateLimitReset)
-        .map(reset -> atLeastZero(Duration.between(now, Instant.ofEpochSecond(reset))))
+    return rateLimitResetInstant()
+        .map(reset -> atLeastZero(Duration.between(now, reset)))
         .orElseGet(() -> FALLBACK_DELAY.multipliedBy(attempt));
   }
 
   /**
+   * The instant {@code x-ratelimit-reset} names, or empty when it does not name one.
+   *
+   * <p>{@code Long.parseLong} accepts values {@link Instant#ofEpochSecond(long)} rejects: past ±31
+   * 556 889 864 403 199 seconds it throws {@link DateTimeException}, which is neither the {@link
+   * WebApplicationException} the whole write path is built around nor anything {@link
+   * GitHubWriteRetry#call} converts. It escaped that loop past every {@code catch
+   * (WebApplicationException)} between here and the caller, so {@link GitHubLostWrites} did not
+   * record the write as lost either — the write and the record of its loss went together, over a
+   * header from an intermediary. A value that cannot be an instant says nothing about when the
+   * window reopens, which is exactly what a non-numeric header already means here, so it gets the
+   * same answer: unspecified, and the linear fallback takes over.
+   */
+  private Optional<Instant> rateLimitResetInstant() {
+    try {
+      return parseLong(rateLimitReset).map(Instant::ofEpochSecond);
+    } catch (DateTimeException _) {
+      return Optional.empty();
+    }
+  }
+
+  /**
    * Whether GitHub is blocking content creation rather than throttling in some milder way — the
-   * failure whose measured width the budget is sized against (#722).
+   * failure whose measured width the budget is sized against (#722). Read off {@link
+   * Body#classified} for the reasons {@link #isThrottled()} gives.
    */
   private boolean blocksContentCreation() {
-    return CONTENT_CREATION_BLOCK.matcher(body).find();
+    return CONTENT_CREATION_BLOCK.matcher(body.classified()).find();
   }
 
   /**
@@ -344,7 +413,8 @@ public final class GitHubApiError {
     append(text, "x-ratelimit-remaining", rateLimitRemaining);
     append(text, "x-ratelimit-reset", rateLimitReset);
     append(text, "x-ratelimit-resource", rateLimitResource);
-    return text.append(" body=").append(body.isEmpty() ? "<unavailable>" : body).toString();
+    var logged = body.logged();
+    return text.append(" body=").append(logged.isEmpty() ? "<unavailable>" : logged).toString();
   }
 
   private static void append(StringBuilder text, String name, String value) {
@@ -432,12 +502,13 @@ public final class GitHubApiError {
   }
 
   /**
-   * The response body as loggable text. An inbound response is buffered first so reading it here
-   * does not consume it for the caller that later inspects the same exception; a response built
-   * in-process holds its entity as an object instead, and one that is closed or has no readable
-   * entity yields an empty body rather than breaking the failure path it exists to explain.
+   * The response body, in both of the readings {@link Body} names. An inbound response is buffered
+   * first so reading it here does not consume it for the caller that later inspects the same
+   * exception; a response built in-process holds its entity as an object instead, and one that is
+   * closed or has no readable entity yields {@link Body#UNREADABLE} rather than breaking the
+   * failure path it exists to explain.
    */
-  private static String readBody(Response response) {
+  private static Body readBody(Response response) {
     try {
       if (response.getEntity() instanceof String text) {
         return clean(text);
@@ -445,13 +516,25 @@ public final class GitHubApiError {
       response.bufferEntity();
       return clean(response.readEntity(String.class));
     } catch (RuntimeException _) {
-      return "";
+      return Body.UNREADABLE;
     }
   }
 
   /**
-   * A response body as one line of loggable text: collapsed, bounded, redacted, then capped at
-   * {@link #MAX_BODY_CHARS}.
+   * A response body read both ways: as one line of loggable text — collapsed, bounded, redacted,
+   * then capped at {@link #MAX_BODY_CHARS} — and as the wider, unredacted window the throttle
+   * classification matches against.
+   *
+   * <p>One collapse pass feeds both, and the two readings diverge after it. Everything the log line
+   * has done to it from that point on is for the log's sake: the bound is #731's cost control on a
+   * quadratic redaction, the cap is so one failure cannot flood a log file, and the mask is because
+   * a body is untrusted text on its way to an operator's screen. None of those is a statement about
+   * whether GitHub is throttling, and every one of them used to be able to decide it (#732, #747).
+   *
+   * <p>Ordering is the whole of it, so it is worth naming what each cut can still do. The
+   * classified window is cut once, from the collapsed body, so nothing between the two ever
+   * shortens it. The logged line keeps the {@code bounded → redacted → capped} order #740
+   * established, and the ellipsis still marks either cut.
    *
    * <p>The bound before the redaction is the point (#731). {@code readBody} reads the entity with
    * no size limit of its own, and redaction used to run over all of it, so the cost of explaining a
@@ -472,17 +555,19 @@ public final class GitHubApiError {
    * run that is being masked out. The ellipsis marks either cut, so a body shortened here is never
    * mistaken for a body GitHub sent whole.
    */
-  private static String clean(String raw) {
+  private static Body clean(String raw) {
     if (raw == null) {
-      return "";
+      return Body.UNREADABLE;
     }
     var collapsed = WHITESPACE.matcher(raw).replaceAll(" ").strip();
     var bounded = cutTo(collapsed, MAX_BODY_CHARS * 2);
     var redacted = redactCredentials(bounded);
     var capped = cutTo(redacted, MAX_BODY_CHARS);
-    return capped.length() < redacted.length() || bounded.length() < collapsed.length()
-        ? capped + "…"
-        : capped;
+    var logged =
+        capped.length() < redacted.length() || bounded.length() < collapsed.length()
+            ? capped + "…"
+            : capped;
+    return new Body(logged, cutTo(collapsed, MAX_CLASSIFIED_CHARS));
   }
 
   /**

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiErrorTest.java
@@ -138,6 +138,102 @@ class GitHubApiErrorTest {
     }
   }
 
+  /**
+   * #732 and #747. The body does two unrelated jobs — it is a line an operator reads, and it is the
+   * evidence on which a completed generation is either repeated or thrown away. Every narrowing the
+   * first job asks for used to narrow the second: the 512-character cap (#732), and then the
+   * 1024-character bound on the redaction input (#747), which closed the one path by which deeper
+   * wording still reached the classifier. The consequence is not a shorter wait but no retry at all
+   * — the retry returns empty on {@code !isThrottled()} and rethrows on the first attempt, which is
+   * the pre-#495 behaviour this area exists to prevent.
+   */
+  @Nested
+  class ThrottleWordingGitHubDidNotPutFirst {
+
+    private static final Instant NOW = Instant.ofEpochSecond(1_800_000_000L);
+
+    @Test
+    void isStillReadWhenItSitsPastTheLengthCapTheLogLineUses() {
+      // #732. Nothing here is credential-shaped and nothing is long enough to be bounded — the cap
+      // alone hid it. GitHub puts the message first, but a body with a long documentation_url or a
+      // set of echoed headers ahead of it does not.
+      var body =
+          "{\"documentation_url\":\""
+              + "x".repeat(600)
+              + "\",\"message\":\"You have exceeded a secondary rate limit and have been temporarily"
+              + " blocked from content creation.\"}";
+
+      var error = GitHubApiError.from(outbound(403, body));
+
+      assertTrue(error.isThrottled(), "body=" + loggedBody(outbound(403, body)));
+      assertEquals(Duration.ofSeconds(30), error.retryDelay(1, NOW));
+    }
+
+    @Test
+    void isStillReadWhenMoreCredentialShapedMaterialPrecedesItThanTheRedactionBoundHolds() {
+      // #747. v0.6.3 redacted the whole collapsed body first, so a prefix like this compressed to
+      // "***" and carried the wording forward into the classified string; bounding the redaction
+      // input at 1024 dropped it before the mask could. The audit's sweep puts the threshold
+      // between 900 characters of prefix (still classified) and 1010 (no longer).
+      var body = "Bearer " + "a".repeat(1_100) + " " + CONTENT_CREATION_BLOCK_BODY;
+
+      var error = GitHubApiError.from(outbound(403, body));
+
+      assertTrue(error.isThrottled(), "body=" + loggedBody(outbound(403, body)));
+      assertEquals(Duration.ofSeconds(30), error.retryDelay(1, NOW));
+    }
+
+    @Test
+    void isNotSomethingTheCredentialMaskCanDeleteBeforeItIsRead() {
+      // The classified window is the collapsed body, taken before redaction, so the retry decision
+      // can no longer be changed by a mask: a JWT-shaped run whose tail happens to be the word
+      // "blocked" used to swallow it and turn this block into a permission refusal.
+      var body = "{\"message\":\"prefix eyJabcdefgh.blocked from content creation\"}";
+
+      var error = GitHubApiError.from(outbound(403, body));
+
+      assertTrue(error.isThrottled(), "body=" + loggedBody(outbound(403, body)));
+      assertEquals(Duration.ofSeconds(30), error.retryDelay(1, NOW));
+    }
+
+    /** Control: the log line keeps its own cap, whatever the classifier is allowed to see. */
+    @Test
+    void doesNotWidenWhatReachesTheLog() {
+      var logged = loggedBody(outbound(403, "y".repeat(600) + " blocked from content creation"));
+
+      assertEquals(513, logged.length(), logged);
+      assertTrue(logged.endsWith("…"), logged);
+    }
+
+    /**
+     * Control, and the honest edge of the fix: the window is wide, not unbounded. The entity is
+     * read with no size limit of its own, and #731 is about not letting the configured host set the
+     * cost of explaining a failed write, so classification gets a fixed prefix — several times any
+     * body GitHub sends, and orders of magnitude past where the cap and the redaction bound used to
+     * stop it.
+     */
+    @Test
+    void isReadFromABoundedWindowRatherThanFromAnUnboundedBody() {
+      var withinTheWindow = "z".repeat(4_000) + " blocked from content creation";
+      var pastTheWindow = "z".repeat(64_000) + " blocked from content creation";
+
+      assertTrue(GitHubApiError.from(outbound(403, withinTheWindow)).isThrottled());
+      assertFalse(GitHubApiError.from(outbound(403, pastTheWindow)).isThrottled());
+    }
+
+    /** Control: a body carrying none of the wording is still a refusal, however deep it is read. */
+    @Test
+    void doesNotMakeAPermissionRefusalLookLikeAThrottle() {
+      var body =
+          "{\"documentation_url\":\""
+              + "x".repeat(4_000)
+              + "\",\"message\":\"Resource not"
+              + " accessible by integration\"}";
+
+      assertFalse(GitHubApiError.from(outbound(403, body)).isThrottled());
+    }
+  }
+
   @Nested
   class Severity {
 
@@ -194,6 +290,47 @@ class GitHubApiErrorTest {
                   "x-ratelimit-reset",
                   String.valueOf(NOW.getEpochSecond() - 90)));
       assertEquals(Duration.ZERO, error.retryDelay(1, NOW));
+    }
+
+    /**
+     * #732's second half. {@code Long.parseLong} accepts values {@code Instant.ofEpochSecond}
+     * rejects, and the {@link java.time.DateTimeException} it throws is not the {@code
+     * WebApplicationException} the write path is built around: it escaped {@code
+     * GitHubWriteRetry.call} past every catch between here and the caller, losing the write and the
+     * record of its loss together. A header that cannot name an instant says nothing about when the
+     * window reopens, which is what a non-numeric header already means here.
+     */
+    @Test
+    void aRateLimitResetTooLargeToBeAnInstantIsTreatedAsUnspecified() {
+      var error =
+          GitHubApiError.from(
+              outbound(
+                  403,
+                  SECONDARY_LIMIT_BODY,
+                  "x-ratelimit-remaining",
+                  "0",
+                  "x-ratelimit-reset",
+                  String.valueOf(Long.MAX_VALUE)));
+
+      assertTrue(error.isThrottled());
+      assertEquals(Duration.ofSeconds(5), error.retryDelay(1, NOW));
+      assertEquals(Duration.ofSeconds(10), error.retryDelay(2, NOW));
+    }
+
+    /** The same at the other end of the range: an intermediary's negative overflow. */
+    @Test
+    void aRateLimitResetTooSmallToBeAnInstantIsTreatedAsUnspecified() {
+      var error =
+          GitHubApiError.from(
+              outbound(
+                  403,
+                  SECONDARY_LIMIT_BODY,
+                  "x-ratelimit-remaining",
+                  "0",
+                  "x-ratelimit-reset",
+                  String.valueOf(Long.MIN_VALUE)));
+
+      assertEquals(Duration.ofSeconds(5), error.retryDelay(1, NOW));
     }
 
     @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubWriteRetryTest.java
@@ -313,6 +313,63 @@ class GitHubWriteRetryTest {
     assertEquals(List.of(Duration.ofSeconds(21)), slept);
   }
 
+  /**
+   * #732. Every caller of this loop — {@link GitHubLostWrites} included — catches {@code
+   * WebApplicationException}, because that is the failure a GitHub write produces. An {@code
+   * x-ratelimit-reset} outside the range of an {@code Instant} used to replace it with a {@code
+   * DateTimeException} thrown from inside the delay derivation, which no catch on the way out
+   * matched: the write was lost and the record of its loss went with it. Only an intermediary sends
+   * a header like this, and only the one header is needed.
+   */
+  @Test
+  void anOutOfRangeResetHeaderStillFailsAsTheExceptionEveryCallerCatches() {
+    var calls = new AtomicInteger();
+    var throttle =
+        throttled(
+            "x-ratelimit-remaining", "0", "x-ratelimit-reset", String.valueOf(Long.MAX_VALUE));
+
+    var thrown =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                retry.call(
+                    "a comment on o/r #7",
+                    () -> {
+                      calls.incrementAndGet();
+                      throw throttle;
+                    }));
+
+    // Unusable is unspecified: the linear fallback takes over and the budget runs its course, so
+    // the caller sees the same rejection it would have seen from any other spent throttle.
+    assertSame(throttle, thrown);
+    assertEquals(4, calls.get());
+    assertEquals(
+        List.of(Duration.ofSeconds(5), Duration.ofSeconds(10), Duration.ofSeconds(15)), slept);
+  }
+
+  /** The same header at the other end of the range, on a throttle that clears on the repeat. */
+  @Test
+  void anOutOfRangeResetHeaderOnAThrottleFallsBackToTheLinearWait() {
+    var calls = new AtomicInteger();
+
+    var result =
+        retry.call(
+            "a comment on o/r #7",
+            () -> {
+              if (calls.incrementAndGet() == 1) {
+                throw throttled(
+                    "x-ratelimit-remaining",
+                    "0",
+                    "x-ratelimit-reset",
+                    String.valueOf(Long.MIN_VALUE));
+              }
+              return "posted";
+            });
+
+    assertEquals("posted", result);
+    assertEquals(List.of(Duration.ofSeconds(5)), slept);
+  }
+
   @Test
   void everyAttemptWaitsForItsPacingSlotIncludingTheRepeats() {
     var paced = new ArrayList<Duration>();


### PR DESCRIPTION
> **Stacked on #750 (`fix/746-credential-shapes`).** Based against that branch so the diff reads clean; **re-target to `main` once #750 merges**. Only the last commit (`afb2d41`) belongs to this PR. `ci.yml` triggers on pull requests into `main`/`develop`/`release/**` only, so the full CI run happens on re-target — the gates below were run locally on this exact tree.

## What type of PR is this?

- [x] 🐛 Bug fix

## Description

One change closing two issues, because they are the same coupling seen twice.

`isThrottled()` and `blocksContentCreation()` matched against `this.body` — the string `diagnostics()` prints. So every narrowing the log line asks for narrowed the retry decision with it, and the consequence is not a shorter wait: `GitHubWriteRetry.retryDelay` returns `Optional.empty()` on `!isThrottled()`, the `WebApplicationException` is rethrown on the first attempt, and the write is **not repeated at all** — the pre-#495 behaviour this area exists to prevent. The 30-second floor #738 just widened is never consulted.

**#732** is the 512-character cap doing it: a body with a long `documentation_url` or echoed headers ahead of the message classifies as a refusal. Equally true at v0.6.3.

**#747** is the bound #740 put on the redaction *input*. v0.6.3 had exactly one path by which wording deeper than the cap still survived — redaction compressing a long credential-shaped prefix to `***` and carrying the message forward — and cutting to 1024 before redacting closed it. Threshold sweep from the audit, body = `"Bearer " + "a".repeat(n) + " " + <content-creation block>`:

| prefix | v0.6.3 | v0.6.4 |
|---|---|---|
| 900 chars | throttled, `PT30S` | throttled, `PT30S` |
| 1010 chars | throttled | **not throttled**, `PT5S` |
| 4000 chars | throttled | **not throttled**, `PT5S` |

Same remedy for both, so they land together.

**The fix.** One collapse pass now feeds two readings that are kept apart in a small `Body` record. The logged line is unchanged — same `bounded → redacted → capped` order, same ellipsis, same 512 characters. Classification reads the collapsed body bounded at 8 KB and nothing else. The bound is still wanted (the entity is read with no size limit of its own, and #731 is about not letting the configured host set the cost of explaining a failed write), but both patterns are flat literal alternations with no backtracking, so widening the window costs a linear scan; the quadratic shape #731 found is in the credential redaction, which still sees only its own 1024.

Deliberately the **unredacted** text. Masking runs before the classifier could read it, and a mask that swallowed the word `blocked` turned a content-creation block into a permission refusal — the classification tail of the JWT over-match in #746. Nothing in that window is ever logged or returned; the two patterns answer yes or no and the string is dropped.

**Also, the `Instant.ofEpochSecond` guard #732 asks for in its second half.** `Long.parseLong` accepts values `Instant.ofEpochSecond` rejects, and the resulting `DateTimeException` was thrown from inside `derivedDelay`, out through `GitHubWriteRetry.retryDelay` and `call`, past every `catch (WebApplicationException)` in the write path. `GitHubLostWrites.recording` catches that type specifically, so a write that died this way was not remembered as lost either — the write and the record of its loss went together, over one header from an intermediary. A value that cannot be an instant now means what a non-numeric header already means here: unspecified, and the linear fallback takes over.

Neither classification bug is reachable against api.github.com, whose error bodies are ~300 characters with the message first; both need a large body from the configured API host. The header case needs an intermediary sending a ~10^17 reset.

## Related Issues

Fixes #747
Fixes #732

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Eight new behavioural assertions, all red on the parent branch (`1e0d7fc`) in exactly the claimed way and green after. Verbatim, from `./mvnw -o test -Dtest=GitHubApiErrorTest,GitHubWriteRetryTest` with only the test files applied:

```
[ERROR] Failures:
[ERROR]   GitHubApiErrorTest.isStillReadWhenItSitsPastTheLengthCapTheLogLineUses body={"documentation_url":"xxxxx…xxx… ==> expected: <true> but was: <false>
[ERROR]   GitHubApiErrorTest.isStillReadWhenMoreCredentialShapedMaterialPrecedesItThanTheRedactionBoundHolds body=***… ==> expected: <true> but was: <false>
[ERROR]   GitHubApiErrorTest.isNotSomethingTheCredentialMaskCanDeleteBeforeItIsRead body={"message":"prefix *** from content creation"} ==> expected: <true> but was: <false>
[ERROR]   GitHubApiErrorTest.isReadFromABoundedWindowRatherThanFromAnUnboundedBody expected: <true> but was: <false>
[ERROR]   GitHubWriteRetryTest.anOutOfRangeResetHeaderStillFailsAsTheExceptionEveryCallerCatches:332 Unexpected exception type thrown, expected: <jakarta.ws.rs.WebApplicationException> but was: <java.time.DateTimeException>
[ERROR] Errors:
[ERROR]   GitHubApiErrorTest.aRateLimitResetTooLargeToBeAnInstantIsTreatedAsUnspecified » DateTime Instant exceeds minimum or maximum instant
[ERROR]   GitHubApiErrorTest.aRateLimitResetTooSmallToBeAnInstantIsTreatedAsUnspecified » DateTime Instant exceeds minimum or maximum instant
[ERROR]   GitHubWriteRetryTest.anOutOfRangeResetHeaderOnAThrottleFallsBackToTheLinearWait:356 » DateTime Instant exceeds minimum or maximum instant

[ERROR] Tests run: 93, Failures: 5, Errors: 3, Skipped: 0
```

The escape path in full, from the same run — this is the whole of the second finding:

```
java.time.DateTimeException: Instant exceeds minimum or maximum instant
	at java.base/java.time.Instant.ofEpochSecond(Instant.java:308)
	at …GitHubApiError.lambda$derivedDelay$0(GitHubApiError.java:325)
	at …GitHubApiError.derivedDelay(GitHubApiError.java:325)
	at …GitHubApiError.retryDelay(GitHubApiError.java:312)
	at …GitHubWriteRetry.retryDelay(GitHubWriteRetry.java:254)
	at …GitHubWriteRetry.call(GitHubWriteRetry.java:189)
```

Two of the six new `GitHubApiError` tests are labelled **controls** rather than proof, and both are green before the fix: `doesNotWidenWhatReachesTheLog` (the log line keeps its own 512-character cap and its ellipsis whatever the classifier may see) and `doesNotMakeAPermissionRefusalLookLikeAThrottle` (a 4 KB body with none of the wording is still a refusal, so the wider window did not make the classifier credulous). `isReadFromABoundedWindowRatherThanFromAnUnboundedBody` is half proof and half honest edge: wording at 4 000 characters is now read, wording at 64 000 is still not.

Gates on this tree:

- `./mvnw -B spotless:apply` → clean
- `./mvnw -B clean compile spotbugs:check spotless:check` → **BugInstance size is 0**, Error size is 0, spotless clean
- `./mvnw -B clean test` → **Tests run: 3320, Failures: 0, Errors: 0, Skipped: 0**
- jacoco ∩ `git diff -U0 fc54d93...HEAD` over changed main code → 139 changed lines, **zero uncovered lines and zero uncovered branches**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

`GitHubWriteRetry`'s main code is untouched — the guard belongs where the exception is raised, and the retry loop's contract (a `WebApplicationException` in, the same one back out) is what the new test pins from the outside.

The 8 KB window is a judgement call, not a measurement: it is sixteen times the log cap and several times any body GitHub sends, chosen so the classifier stops depending on where in a body the message sits while the pass over it stays a linear scan.
