### PR TITLE
refactor(github): carry the bearer shape's case-insensitivity as a compile flag

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubApiError.java
@@ -93,15 +93,17 @@ public final class GitHubApiError {
       Pattern.compile("(?i)(gh[pousr]_\\w{4,})|(github_pat_\\w{4,})");
 
   /**
-   * The bearer and JWT shapes — the value half of {@link #CREDENTIAL_SHAPED_PREFIX}'s union, tried
-   * second on a position tie exactly as the one-alternation form tried its alternatives in order.
+   * The bearer shape, and with {@link #JWT_SHAPED_VALUE} below it the value half of {@link
+   * #CREDENTIAL_SHAPED_PREFIX}'s union — tried after the prefixes on a position tie, exactly as the
+   * one-alternation form tried its alternatives in order. The reasoning behind both values lives
+   * here, since neither shape's choices make sense without the other's.
    *
-   * <p>Everything after the first dot is optional in both length and count, so a token the bound
-   * below cut anywhere past that dot is masked whole — including a cut landing in the first few
-   * payload characters, which a {@code {8,}} on each segment would have let through. Requiring all
-   * three segments made redaction depend on where the cut happened to land: a token whose second
-   * dot fell past the bound went through unmasked, and its header and the payload characters that
-   * fit reached the log.
+   * <p>In the JWT shape, everything after the first dot is optional in both length and count, so a
+   * token the bound below cut anywhere past that dot is masked whole — including a cut landing in
+   * the first few payload characters, which a {@code {8,}} on each segment would have let through.
+   * Requiring all three segments made redaction depend on where the cut happened to land: a token
+   * whose second dot fell past the bound went through unmasked, and its header and the payload
+   * characters that fit reached the log.
    *
    * <p>The first dot stays mandatory, so the one shape still not masked is a cut before it: the
    * {@code eyJ} header prefix alone, which carries the algorithm and type claims and no secret.
@@ -112,13 +114,15 @@ public final class GitHubApiError {
    * whole alternation and the header was unanchored: any {@code eyj} in any case, anywhere inside a
    * longer run, followed by a dot at any distance. {@code eyjafjallajokull.internal.example.com}
    * came out as {@code ***.com} and a base64 blob with a filename after it came out as {@code ***}.
-   * So the case-insensitivity is scoped here, to the bearer shape. {@link #JWT_SHAPED_VALUE} is
-   * case-sensitive instead, because its {@code eyJ} is not a spelling but arithmetic: base64url of
-   * a header opening {@code &#123;"} gives {@code ey} plus a third character fixed by the first
-   * key's leading byte, which is {@code J} for every key beginning with a letter. RFC 7515 requires
-   * {@code alg}, so a real header encodes to {@code eyJ}; a nonstandard first key that is a digit
-   * or empty encodes to {@code eyI} and is deliberately not matched, since widening the anchor
-   * would mask ordinary prose beginning {@code ey} for a shape no issuer emits.
+   * So the case-insensitivity is confined to this pattern, as a compile flag rather than an inline
+   * group — {@link Pattern#CASE_INSENSITIVE} alone is ASCII-only, which is what the shape wants.
+   * {@link #JWT_SHAPED_VALUE} is case-sensitive instead, because its {@code eyJ} is not a spelling
+   * but arithmetic: base64url of a header opening {@code &#123;"} gives {@code ey} plus a third
+   * character fixed by the first key's leading byte, which is {@code J} for every key beginning
+   * with a letter. RFC 7515 requires {@code alg}, so a real header encodes to {@code eyJ}; a
+   * nonstandard first key that is a digit or empty encodes to {@code eyI} and is deliberately not
+   * matched, since widening the anchor would mask ordinary prose beginning {@code ey} for a shape
+   * no issuer emits.
    *
    * <p>The value takes the same four-character floor as {@link #CREDENTIAL_SHAPED_PREFIX}, for the
    * same reason: the {@code Bearer } that precedes it is the discriminator, and ten characters only
@@ -131,7 +135,7 @@ public final class GitHubApiError {
    * leftmost-match design above exists to swallow.
    */
   private static final Pattern BEARER_SHAPED_VALUE =
-      Pattern.compile("(?i:bearer\\s+[\\w.~+/=-]{4,})");
+      Pattern.compile("bearer\\s+[\\w.~+/=-]{4,}", Pattern.CASE_INSENSITIVE);
 
   /**
    * The JWT shape, kept apart from {@link #BEARER_SHAPED_VALUE} rather than alternated with it: one


### PR DESCRIPTION
## What type of PR is this?

- [x] ♻️ Refactor

## Description

#750 split `CREDENTIAL_SHAPED_VALUE` into `BEARER_SHAPED_VALUE` and `JWT_SHAPED_VALUE` to get the combined pattern's complexity back under budget. That split left one loose end, which the analysis on that PR flagged and which merged with it:

```
java:S6395 | MAJOR | GitHubApiError.java:134 | Unwrap this unnecessarily grouped subpattern.
```

The rule is right. `(?i:bearer\s+[\w.~+/=-]{4,})` existed to scope case-insensitivity to the *bearer alternative* of a two-alternative pattern — that scoping was #746's fix, and it is why `eyjafjallajokull.internal.example.com` stopped coming out as `***.com`. Once the alternation was gone there was nothing left to scope the flag away from, so the group wraps the entire pattern and does nothing.

The flag moves to the compile call:

```java
Pattern.compile("bearer\\s+[\\w.~+/=-]{4,}", Pattern.CASE_INSENSITIVE)
```

**Behaviour is identical, and the identity matters.** `Pattern.CASE_INSENSITIVE` without `UNICODE_CASE` matches ASCII case only — exactly what `(?i:...)` did. That is the correct scope here: the shape is matching the literal HTTP `Bearer` auth-scheme token, not prose, so Unicode case folding would only widen what a log line masks. The javadoc now records it, so the ASCII scope reads as the decision it is rather than as something to "fix" by adding `UNICODE_CASE`.

`JWT_SHAPED_VALUE` stays case-sensitive, unchanged.

## Related Issues

Follow-up to #750; no separate issue filed, since the finding arrived through the analysis on that PR and is a two-line correction to it.

## How Has This Been Tested?

- [x] Unit tests

No new test, and deliberately so: this is a refactor with no behavioural delta, so there is no red state to demonstrate. A test written for it would pass before the change as well, which proves nothing.

The existing coverage is what pins the equivalence, and two tests in `GitHubApiErrorTest` bear directly on it:

- `masksABearerHeaderWhateverCaseItArrivedIn` — the case-insensitivity survives the move off the inline group
- `doesNotMaskOrdinaryTextThatMerelyBeginsLikeAJwtHeaderInSomeOtherCase` — the JWT shape stays case-*sensitive*, i.e. the flag did not leak across the split

Both are **controls**: green before and after.

### Gates

- `./mvnw -B spotless:apply` → clean
- `./mvnw -B clean compile spotbugs:check spotless:check` → **BugInstance size is 0**, BUILD SUCCESS
- `./mvnw -B clean test` → **Tests run: 3324, Failures: 0, Errors: 0, Skipped: 0**
- jacoco ∩ `git diff -U0 HEAD` on changed main code → one executable line changed (the `Pattern.compile` call), **zero uncovered lines, zero uncovered branches**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The rest of the diff is javadoc. The block above `BEARER_SHAPED_VALUE` still opened by calling itself "the bearer and JWT shapes", which was accurate while it documented one field and stopped being so when the split made two. It now says which shape each paragraph is about and why the two are documented together.
