### PR TITLE
fix(github): keep every open delivery reachable while another is nested inside it

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWrites.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWrites.java
@@ -18,6 +18,8 @@ package dev.thiagogonzaga.thrillhousebot.github;
 import jakarta.ws.rs.WebApplicationException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -139,14 +141,25 @@ public final class GitHubLostWrites {
   private final AtomicLong ids = new AtomicLong();
 
   /**
-   * The delivery whose routes are being tried on this thread, if any. Thread confinement is what
-   * the routes already have — a finding's attempts run one after another on the thread publishing
-   * that review — so it is also the cheapest way to reach {@link #recording} from {@link
-   * #asOneDelivery} without threading a handle through the REST client interface that sits between
-   * them. Held per instance, not per class, so a test's registry cannot see {@link #SHARED}'s
-   * deliveries or vice versa.
+   * The deliveries open on this thread, innermost first. Thread confinement is what the routes
+   * already have — a finding's attempts run one after another on the thread publishing that review
+   * — so it is also the cheapest way to reach {@link #recording} from {@link #asOneDelivery}
+   * without threading a handle through the REST client interface that sits between them. Held per
+   * instance, not per class, so a test's registry cannot see {@link #SHARED}'s deliveries or vice
+   * versa.
+   *
+   * <p>A stack rather than a single slot because a group nested inside another does not end the one
+   * it is nested in (#756). The outer group's own routes go on running while the inner one is open
+   * — one of them may be what opened it — and a single slot made the outer group unreachable for
+   * exactly as long as that lasted: a route of it that <em>landed</em> settled nothing, so the
+   * group closed as never delivered and announced as lost content the pull request had received.
+   * Keeping every open group reachable is what lets {@link #deliveryFor} hand each call the group
+   * it belongs to rather than only the one that happens to be on top.
+   *
+   * <p>Absent rather than empty while nothing is open, so a thread that only ever posts ungrouped
+   * carries no deque of its own.
    */
-  private final ThreadLocal<Delivery> delivery = new ThreadLocal<>();
+  private final ThreadLocal<Deque<Delivery>> open = new ThreadLocal<>();
 
   private final Supplier<Instant> clock;
   private final int maxTargets;
@@ -211,28 +224,38 @@ public final class GitHubLostWrites {
    * finding that really is lost still announces itself — and announces itself once rather than once
    * per attempt.
    *
-   * <p>Nesting for the <em>same</em> pull request reuses the outer group rather than opening a
-   * second one, so a caller cannot lose another caller's routes by grouping its own. Nesting for a
-   * different pull request cannot reuse it: a group speaks only for the pull request it was opened
-   * on ({@link #deliveryFor}), so handing the inner routes the outer group would leave them with no
-   * accounting at all and remember each of them separately — the per-route over-count #729 removed,
-   * reintroduced for the nested caller and silently, with no log and no exception (#748). The inner
-   * group therefore takes over the thread and hands the outer one back when it closes.
+   * <p>Nesting for the <em>same</em> pull request rejoins the group already open for it rather than
+   * opening a second one, so a caller cannot lose another caller's routes by grouping its own. It
+   * rejoins that group wherever it sits on the stack, not only when it is the immediately enclosing
+   * one: an {@code A → B → A} nesting is still one delivery for {@code A}, because the group in the
+   * middle is something {@code A}'s routes ran inside rather than the end of {@code A}'s delivery
+   * (#756). Rejoining opens nothing, so the routes simply run and an exception or an error out of
+   * them leaves the group they rejoined exactly as they found it.
+   *
+   * <p>Nesting for a different pull request cannot rejoin: a group speaks only for the pull request
+   * it was opened on ({@link #deliveryFor}), so handing the inner routes the outer group would
+   * leave them with no accounting at all and remember each of them separately — the per-route
+   * over-count #729 removed, reintroduced for the nested caller and silently, with no log and no
+   * exception (#748). The inner group therefore goes on the stack above the outer one rather than
+   * in place of it, and is taken off again when it closes, on every exit path.
    */
   public <T> T asOneDelivery(Target target, Supplier<T> routes) {
-    var outer = delivery.get();
-    if (outer != null && outer.target.equals(target)) {
+    if (deliveryFor(target) != null) {
       return routes.get();
     }
+    var stack = open.get();
+    if (stack == null) {
+      stack = new ArrayDeque<>();
+      open.set(stack);
+    }
     var scope = new Delivery(target);
-    delivery.set(scope);
+    stack.push(scope);
     try {
       return routes.get();
     } finally {
-      if (outer == null) {
-        delivery.remove();
-      } else {
-        delivery.set(outer);
+      stack.pop();
+      if (stack.isEmpty()) {
+        open.remove();
       }
       if (scope.refused && !scope.landed) {
         remember(target);
@@ -241,13 +264,23 @@ public final class GitHubLostWrites {
   }
 
   /**
-   * The delivery this call is a route of, or {@code null} when it is a post of its own. A delivery
-   * for some other pull request is not this call's: the group's accounting only ever speaks for the
-   * pull request it was opened on.
+   * The delivery this call is a route of — the innermost open one whose pull request is this call's
+   * — or {@code null} when it is a post of its own. A delivery for some other pull request is not
+   * this call's: the group's accounting only ever speaks for the pull request it was opened on.
+   * Looking past such a group instead of stopping at it is what keeps an outer delivery reachable
+   * while one for another pull request is open inside it (#756).
    */
   private Delivery deliveryFor(Target target) {
-    var scope = delivery.get();
-    return scope != null && scope.target.equals(target) ? scope : null;
+    var stack = open.get();
+    if (stack == null) {
+      return null;
+    }
+    for (var scope : stack) {
+      if (scope.target.equals(target)) {
+        return scope;
+      }
+    }
+    return null;
   }
 
   /** The notice text for {@code lost} dropped posts, or empty when there is nothing pending. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWritesTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/GitHubLostWritesTest.java
@@ -533,6 +533,199 @@ class GitHubLostWritesTest {
                 + carried.get(1));
   }
 
+  /**
+   * #756. A route of the outer delivery can run while a group for another pull request is open —
+   * the inner group is nested inside the outer one, it does not end it. The route lands, so the
+   * outer delivery was delivered and must not be announced as lost.
+   */
+  @Test
+  void aRouteThatLandsInsideAGroupForAnotherPullRequestStillSettlesItsOwnDelivery() {
+    var carried = new ArrayList<String>();
+
+    lost.asOneDelivery(
+        PR,
+        () -> {
+          assertThrows(
+              WebApplicationException.class, () -> lost.recording(PR, () -> throwIt(throttled())));
+          return lost.asOneDelivery(OTHER_PR, () -> lost.recording(PR, () -> "posted"));
+        });
+    post(PR, carried, null);
+
+    assertEquals(
+        "",
+        carried.getLast(),
+        () ->
+            "a route of the outer delivery landed while a group for the other pull request was"
+                + " open, and the content it delivered was announced as lost: "
+                + carried.getLast());
+  }
+
+  /**
+   * #756, the same mechanism a level deeper. A group for this pull request nested inside a group
+   * for another one, itself nested inside a group for this pull request, is one delivery and not
+   * two: the innermost group is a route of the outermost, so its landing settles the whole thing.
+   */
+  @Test
+  void aDeliveryNestedInsideAnotherPullRequestsGroupRejoinsItsOwnDelivery() {
+    var carried = new ArrayList<String>();
+
+    lost.asOneDelivery(
+        PR,
+        () -> {
+          assertThrows(
+              WebApplicationException.class, () -> lost.recording(PR, () -> throwIt(throttled())));
+          return lost.asOneDelivery(
+              OTHER_PR, () -> lost.asOneDelivery(PR, () -> lost.recording(PR, () -> "posted")));
+        });
+    post(PR, carried, null);
+
+    assertEquals(
+        "",
+        carried.getLast(),
+        () ->
+            "one pull request's delivery was split in two by the group nested between its halves,"
+                + " so the half that landed settled nothing: "
+                + carried.getLast());
+  }
+
+  /**
+   * #756. An exception out of a group that rejoined an already-open delivery leaves that delivery
+   * open and still holding its refused route: the throw ends the routes, not the delivery they
+   * belong to, and a later route of it settles them.
+   */
+  @Test
+  void anExceptionOutOfARejoinedGroupLeavesTheDeliveryItRejoinedOpen() {
+    var carried = new ArrayList<String>();
+
+    lost.asOneDelivery(
+        PR,
+        () -> {
+          lost.asOneDelivery(
+              OTHER_PR,
+              () -> {
+                assertThrows(
+                    IllegalStateException.class,
+                    () ->
+                        lost.asOneDelivery(
+                            PR,
+                            () -> {
+                              assertThrows(
+                                  WebApplicationException.class,
+                                  () -> lost.recording(PR, () -> throwIt(throttled())));
+                              throw new IllegalStateException("the routes gave up");
+                            }));
+                return "the other pull request lost nothing";
+              });
+          return lost.recording(PR, () -> "posted");
+        });
+    post(PR, carried, null);
+
+    assertEquals(
+        "",
+        carried.getLast(),
+        () ->
+            "the throw closed a delivery of its own rather than leaving the open one alone, so a"
+                + " route held by it was remembered even though a later route landed: "
+                + carried.getLast());
+  }
+
+  /**
+   * #756, the same on the other exit path: an {@link Error} out of a group that rejoined an
+   * already-open delivery must leave that delivery exactly as it found it.
+   */
+  @Test
+  void anErrorOutOfARejoinedGroupLeavesTheDeliveryItRejoinedOpen() {
+    var carried = new ArrayList<String>();
+
+    lost.asOneDelivery(
+        PR,
+        () -> {
+          lost.asOneDelivery(
+              OTHER_PR,
+              () -> {
+                assertThrows(
+                    StackOverflowError.class,
+                    () ->
+                        lost.asOneDelivery(
+                            PR,
+                            () -> {
+                              assertThrows(
+                                  WebApplicationException.class,
+                                  () -> lost.recording(PR, () -> throwIt(throttled())));
+                              throw new StackOverflowError("simulated");
+                            }));
+                return "the other pull request lost nothing";
+              });
+          return lost.recording(PR, () -> "posted");
+        });
+    post(PR, carried, null);
+
+    assertEquals(
+        "",
+        carried.getLast(),
+        () ->
+            "the error closed a delivery of its own rather than leaving the open one alone, so a"
+                + " route held by it was remembered even though a later route landed: "
+                + carried.getLast());
+  }
+
+  /**
+   * Control (green before and after #756): a group of its own leaves nothing behind on the thread
+   * when an {@link Error} unwinds through it, so the next post on the same thread is accounted for
+   * on its own rather than swallowed by a group nobody closed.
+   */
+  @Test
+  void anErrorOutOfAGroupOfItsOwnLeavesNoDeliveryBehindOnTheThread() {
+    var carried = new ArrayList<String>();
+
+    assertThrows(
+        StackOverflowError.class,
+        () ->
+            lost.asOneDelivery(
+                PR,
+                () -> {
+                  throw new StackOverflowError("simulated");
+                }));
+    assertThrows(
+        WebApplicationException.class, () -> lost.recording(PR, () -> throwIt(throttled())));
+    post(PR, carried, null);
+
+    assertTrue(
+        carried.getLast().contains("An earlier reply"),
+        () -> "a delivery left open by the error swallowed a genuine loss: " + carried.getLast());
+  }
+
+  /**
+   * Control (green before and after #756): an exception out of a nested group for another pull
+   * request hands the outer group back, so a route of it that lands afterwards still settles it.
+   */
+  @Test
+  void anExceptionOutOfANestedGroupHandsTheOuterOneBack() {
+    var carried = new ArrayList<String>();
+
+    lost.asOneDelivery(
+        PR,
+        () -> {
+          assertThrows(
+              WebApplicationException.class, () -> lost.recording(PR, () -> throwIt(throttled())));
+          assertThrows(
+              IllegalStateException.class,
+              () ->
+                  lost.asOneDelivery(
+                      OTHER_PR,
+                      () -> {
+                        throw new IllegalStateException("the routes gave up");
+                      }));
+          return lost.recording(PR, () -> "posted");
+        });
+    post(PR, carried, null);
+
+    assertEquals(
+        "",
+        carried.getLast(),
+        () -> "the outer delivery was not handed back after the throw: " + carried.getLast());
+  }
+
   private static String throwIt(WebApplicationException failure) {
     throw failure;
   }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

`GitHubLostWrites.asOneDelivery` held the open delivery in a single-slot `ThreadLocal` and
*replaced* it for the duration of a nested group instead of stacking it. While a group for another
pull request held the thread, the outer group was not reachable at all:

- a route of the outer delivery that ran in that window called `deliveryFor(outerTarget)`, got
  `null` because the slot held the inner target, and was treated as a post of its own — so when it
  **landed** it set nothing, and the outer `Delivery.landed` stayed `false`;
- the outer group then closed with `refused && !landed` true and announced as lost a piece of
  content the pull request had actually received. That is #729's headline symptom arriving through
  the opposite door: a settled delivery whose settlement is invisible.

The same single-slot comparison split one pull request's delivery in two on an `A → B → A` nesting,
because the innermost group could only see the group directly enclosing it and so opened a second
group for `A`.

### The change

`GitHubLostWrites` now holds the deliveries open on the thread in an `ArrayDeque<Delivery>`,
innermost first, and `deliveryFor(target)` returns the **innermost entry whose target matches**
rather than the top entry when its target matches.

- Same-target nesting rejoins the group already open for that pull request wherever it sits on the
  stack. That is a strict superset of the reuse the immediately-enclosing check gave, so `A → A`
  behaves exactly as before and `A → B → A` is now one delivery for `A` rather than two.
- A group for a *different* pull request still cannot rejoin — it goes on the stack **above** the
  outer one rather than in place of it — so #748's fix is intact and the nested caller keeps its
  own accounting.
- The `finally` pops exactly one entry on every exit path, including `Exception` and `Error`, and
  drops the deque once it empties so a thread that only posts ungrouped carries none. Rejoining
  pushes nothing, so a throw out of rejoined routes leaves the delivery they rejoined as it was.

Scoped to `GitHubLostWrites`: no caller of `asOneComment` and nothing in `ReviewPublisher` changes.
The defect is latent at `73cc33d` (both `asOneComment` callers operate on the current review's pull
request), which is the posture #748 was in before #751 added a second caller.

## Related Issues

Fixes #756

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Four new behavioural tests in `GitHubLostWritesTest`, plus two controls. All four are genuinely red
on the unfixed tree at `73cc33d` and green with the fix.

### Red — verbatim, on `73cc33d` with the tests applied and the fix not

```
$ ./mvnw -B -o test -Dtest=GitHubLostWritesTest

[ERROR] Tests run: 30, Failures: 4, Errors: 0, Skipped: 0, Time elapsed: 0.328 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.github.GitHubLostWritesTest
[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubLostWritesTest.anErrorOutOfARejoinedGroupLeavesTheDeliveryItRejoinedOpen -- Time elapsed: 0.013 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 
the error closed a delivery of its own rather than leaving the open one alone, so a route held by it was remembered even though a later route landed: > [!WARNING]
> **An earlier reply on this pull request was never posted.** GitHub was rate-limiting the bot and the retries ran out, so work it had already finished was thrown away. If you were waiting on an answer, run the command again. ==> expected: <> but was: <> [!WARNING]
> **An earlier reply on this pull request was never posted.** GitHub was rate-limiting the bot and the retries ran out, so work it had already finished was thrown away. If you were waiting on an answer, run the command again.>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1222)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubLostWritesTest.anErrorOutOfARejoinedGroupLeavesTheDeliveryItRejoinedOpen(GitHubLostWritesTest.java:663)

[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubLostWritesTest.aRouteThatLandsInsideAGroupForAnotherPullRequestStillSettlesItsOwnDelivery -- Time elapsed: 0.004 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 
a route of the outer delivery landed while a group for the other pull request was open, and the content it delivered was announced as lost: > [!WARNING]
> **An earlier reply on this pull request was never posted.** GitHub was rate-limiting the bot and the retries ran out, so work it had already finished was thrown away. If you were waiting on an answer, run the command again. ==> expected: <> but was: <> [!WARNING]
> **An earlier reply on this pull request was never posted.** GitHub was rate-limiting the bot and the retries ran out, so work it had already finished was thrown away. If you were waiting on an answer, run the command again.>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1222)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubLostWritesTest.aRouteThatLandsInsideAGroupForAnotherPullRequestStillSettlesItsOwnDelivery(GitHubLostWritesTest.java:554)

[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubLostWritesTest.anExceptionOutOfARejoinedGroupLeavesTheDeliveryItRejoinedOpen -- Time elapsed: 0.004 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 
the throw closed a delivery of its own rather than leaving the open one alone, so a route held by it was remembered even though a later route landed: > [!WARNING]
> **An earlier reply on this pull request was never posted.** GitHub was rate-limiting the bot and the retries ran out, so work it had already finished was thrown away. If you were waiting on an answer, run the command again. ==> expected: <> but was: <> [!WARNING]
> **An earlier reply on this pull request was never posted.** GitHub was rate-limiting the bot and the retries ran out, so work it had already finished was thrown away. If you were waiting on an answer, run the command again.>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1222)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubLostWritesTest.anExceptionOutOfARejoinedGroupLeavesTheDeliveryItRejoinedOpen(GitHubLostWritesTest.java:623)

[ERROR] dev.thiagogonzaga.thrillhousebot.github.GitHubLostWritesTest.aDeliveryNestedInsideAnotherPullRequestsGroupRejoinsItsOwnDelivery -- Time elapsed: 0.004 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 
one pull request's delivery was split in two by the group nested between its halves, so the half that landed settled nothing: > [!WARNING]
> **An earlier reply on this pull request was never posted.** GitHub was rate-limiting the bot and the retries ran out, so work it had already finished was thrown away. If you were waiting on an answer, run the command again. ==> expected: <> but was: <> [!WARNING]
> **An earlier reply on this pull request was never posted.** GitHub was rate-limiting the bot and the retries ran out, so work it had already finished was thrown away. If you were waiting on an answer, run the command again.>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1222)
	at dev.thiagogonzaga.thrillhousebot.github.GitHubLostWritesTest.aDeliveryNestedInsideAnotherPullRequestsGroupRejoinsItsOwnDelivery(GitHubLostWritesTest.java:582)

[ERROR] Tests run: 30, Failures: 4, Errors: 0, Skipped: 0
```

Each failure is the defect exactly as described: content the pull request received announced as
lost. The four cover, in order, an `Error` out of a group that rejoins an already-open delivery, a
route landing inside a group for another pull request, an `Exception` out of a rejoining group, and
the `A → B → A` split.

### Green — with the fix

```
[INFO] Tests run: 3330, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

### Controls (green before and after — not proof of the fix)

- `anErrorOutOfAGroupOfItsOwnLeavesNoDeliveryBehindOnTheThread` — an `Error` unwinding through a
  group that opened its own entry leaves nothing on the thread, so the next post is accounted for
  on its own rather than swallowed.
- `anExceptionOutOfANestedGroupHandsTheOuterOneBack` — a throw out of a nested group for another
  pull request still hands the outer group back.

### The other direction — a genuine loss must not be forgotten

The failure mode this fix must not introduce is the opposite one: a write that really was lost
being silently dropped. The existing suite pins that and stays green —
`contentNoRouteDeliveredIsAnnouncedExactlyOnce`,
`aDeliveryThatWasRefusedRatherThanThrottledAnnouncesNothing`,
`aCallForAnotherPullRequestIsNotOneOfThisDeliverysRoutes`,
`aDeliveryNestedInsideOneForAnotherPullRequestIsGroupedOnItsOwn`,
`aNestedDeliveryIsAnnouncedOnceAndHandsTheOuterOneBack`, plus `RescuedReviewBodyLostWriteTest` and
`RescuedFindingLostWriteTest` through the real client `default` methods. Each genuine-loss path
still reports exactly once: no route delivered, the fallback itself throttled, a non-throttle
refusal, and a loss on one pull request while another pull request's delivery is open.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

Gates on `32599b3`:

```
./mvnw -B spotless:apply                                  BUILD SUCCESS
./mvnw -B clean compile spotbugs:check spotless:check     BugInstance size is 0 / BUILD SUCCESS
./mvnw -B clean test                                      Tests run: 3330, Failures: 0, Errors: 0, Skipped: 0
```

Coverage of the changed main code (jacoco ∩ `git diff -U0 73cc33d...HEAD`): **0 uncovered lines,
0 uncovered branches** across every executable changed line in `GitHubLostWrites.java` — both sides
of the empty-stack check, the pop-and-drop, the rejoin short-circuit, and the scan's
match / no-match / exhausted outcomes.

## Additional Notes

The behavioural change is confined to nesting shapes no caller reaches at `73cc33d`, so nothing
about today's posting behaviour moves. The `ThreadLocal` holds a `Deque` that is absent rather than
empty while nothing is open, so an ungrouped post still costs one `ThreadLocal.get` returning
`null`, exactly as before.
