### PR TITLE
fix(review): keep a description gap whose every matching finding was demoted

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGenerator.java
@@ -103,6 +103,12 @@ public class PrSummaryGenerator {
    * finding that states the same thing. The claim still reaches the reader at its most specific
    * surface, so it is not repeated here — but the check plainly ran, and saying so is what keeps a
    * collapsed section from reading exactly like a skipped one (#637).
+   *
+   * <p>"Reported as a finding below" is load-bearing, and the deduplicator holds it up: it
+   * collapses a gap only onto a finding that posts inline, so a gap whose every match was demoted
+   * into the collapsed double-check block survives as a bullet and this body is never reached for
+   * it (#718). Reaching it means at least one gap collapsed onto a finding published as a finding
+   * proper.
    */
   static final String GAPS_ALL_REPORTED_AS_FINDINGS =
       "Every mismatch found between the description and the change is reported as a finding below,"
@@ -458,10 +464,10 @@ public class PrSummaryGenerator {
    * meaning no summary came back at all, which the summary-degradation banners already disclose.
    *
    * <p>The states are: gaps survived, so they are listed; the model reported gaps but every one of
-   * them restated a finding and #588 collapsed them all away, which used to delete the whole
-   * section along with them (the sharpest measured case — the review found the contradicted bug and
-   * still said nothing about the description); and the model reported none, which is now stated
-   * rather than implied by an absent heading.
+   * them restated an inline finding and #588 collapsed them all away, which used to delete the
+   * whole section along with them (the sharpest measured case — the review found the contradicted
+   * bug and still said nothing about the description); and the model reported none, which is now
+   * stated rather than implied by an absent heading.
    *
    * <p>A PR with an empty body reaches the last state too, since the model reports no gaps for a
    * description it never received and the renderer cannot tell the two apart from the response

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicator.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
  * <p>Precedence is inline finding &gt; description-gap bullet &gt; walkthrough row, so:
  *
  * <ul>
- *   <li>a description gap that restates a finding (or an earlier gap) is dropped;
+ *   <li>a description gap that restates a finding published inline (or an earlier gap) is dropped;
  *   <li>a walkthrough row keeps its <em>first</em> clause always — a row summarising a file that
  *       also carries an inline finding is normal and useful — and drops only the clauses appended
  *       after it that restate an already-published claim.
@@ -189,12 +189,23 @@ final class SummarySurfaceDeduplicator {
   /**
    * Collapses {@code descriptionGaps} and {@code fileSummaries} against the findings already
    * published as their own items, and against each other in precedence order.
+   *
+   * <p>Only findings that {@linkplain Finding#postsInline post inline} outrank a gap bullet. A
+   * finding the verifier demoted is published as a hedged bullet inside the collapsed "Things to
+   * double-check" block and opens no review thread, so it is a <em>weaker</em> surface than the gap
+   * — hedged, folded away by default, never on the diff — and collapsing onto it leaves the ⚠️
+   * heading asserting a mismatch that nothing below states outright (#718). The gap was stated
+   * without hedging, so when every finding it matches was demoted it stays a bullet and reaches the
+   * reader that way. Demoted findings still outrank a walkthrough clause, which carries neither the
+   * claim's own wording nor the {@code path:line} the double-check bullet prints, so they keep
+   * trimming those.
    */
   static Surfaces collapse(
       List<String> descriptionGaps, Map<String, String> fileSummaries, List<Finding> findings) {
     var claims = new ArrayList<Claim>(2 * findings.size() + descriptionGaps.size());
+    var demoted = new ArrayList<Claim>(2 * findings.size());
     for (Finding finding : findings) {
-      claims.addAll(claimsOf(finding));
+      (finding.postsInline() ? claims : demoted).addAll(claimsOf(finding));
     }
     var keptGaps = new ArrayList<String>(descriptionGaps.size());
     for (String gap : descriptionGaps) {
@@ -204,6 +215,7 @@ final class SummarySurfaceDeduplicator {
         claims.add(candidate);
       }
     }
+    claims.addAll(demoted);
     var trimmed = HashMap.<String, String>newHashMap(fileSummaries.size());
     for (var entry : fileSummaries.entrySet()) {
       trimmed.put(entry.getKey(), trimRestatedClauses(entry.getValue(), claims));

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrSummaryGeneratorTest.java
@@ -1560,6 +1560,60 @@ class PrSummaryGeneratorTest {
   }
 
   @Test
+  void descriptionGapsSectionListsTheGapWhenEveryFindingItRestatesWasDemoted() {
+    // #717: the model reported one description gap, #588 collapsed it onto the one finding that
+    // states the same claim, and the verifier then demoted that finding into the collapsed
+    // double-check block. The ⚠️ heading was left promising a mismatch "reported as a finding
+    // below" while the only thing below was a hedged maybe behind a toggle (#718).
+    var gap =
+        "The PR description says the docs deploy now fails loudly instead of a silent miss, but"
+            + " the publish-docs job exits 0 as soon as `gh workflow run` accepts the dispatch, so"
+            + " a deploy-stage failure in the dispatched docs.yml run leaves release.yml green"
+            + " with no signal.";
+    var findings =
+        List.of(
+            new Finding(
+                RiskLevel.MEDIUM,
+                Confidence.LOW,
+                ".github/workflows/release.yml",
+                88,
+                "publish-docs exits 0 once the dispatch is accepted, so a failure in the dispatched"
+                    + " docs.yml run leaves release.yml green",
+                "desc",
+                null,
+                null));
+    var aiSummary =
+        new ReviewResponse.Summary(
+            1, 0, 0, 1, 0, "ok", null, List.of(gap), List.of(), List.of(), null);
+    var result =
+        new ReviewResult(
+            findings,
+            0,
+            0,
+            1,
+            0,
+            RiskLevel.MEDIUM,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            0);
+
+    var summary = generator.generate(1, 10, 0, List.of(), aiSummary, result);
+
+    assertTrue(summary.contains("### ⚠️ Description vs. Implementation"), summary);
+    // The unhedged statement of the mismatch reaches the reader instead of being deleted in
+    // favour of the hedged double-check bullet, which is the weaker surface of the two.
+    assertTrue(summary.contains(gap), summary);
+    assertFalse(
+        summary.contains(
+            "Every mismatch found between the description and the change is reported as a finding"
+                + " below, so it is not repeated here."),
+        summary);
+  }
+
+  @Test
   void descriptionGapsSectionStatesTheCheckFoundNothingWhenTheModelReportedNoGap() {
     var aiSummary =
         new ReviewResponse.Summary(0, 0, 0, 0, 0, "ok", "Adds a cache wrapper.", List.of());

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicatorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/SummarySurfaceDeduplicatorTest.java
@@ -36,6 +36,73 @@ class SummarySurfaceDeduplicatorTest {
     return new Finding(RiskLevel.HIGH, "src/A.java", 1, title, "desc", null, null);
   }
 
+  /** A medium-risk, low-confidence finding: routed out of the inline threads by the verifier. */
+  private static Finding demoted(String title) {
+    return new Finding(
+        RiskLevel.MEDIUM, Confidence.LOW, "src/A.java", 1, title, "desc", null, null);
+  }
+
+  private static final String DISPATCH_GAP =
+      "The PR description says the docs deploy now fails loudly instead of a silent miss, but the"
+          + " publish-docs job exits 0 as soon as `gh workflow run` accepts the dispatch, so a"
+          + " deploy-stage failure in the dispatched docs.yml run leaves release.yml green with no"
+          + " signal.";
+
+  private static final String DISPATCH_TITLE =
+      "publish-docs exits 0 once the dispatch is accepted, so a failure in the dispatched docs.yml"
+          + " run leaves release.yml green";
+
+  @Test
+  void keepsAGapWhoseEveryMatchingFindingWasDemotedOutOfTheInlineSurface() {
+    // The verifier demoted the one finding the gap restates, so it is published only as a hedged
+    // bullet inside the collapsed double-check block. Collapsing onto that leaves the ⚠️ section
+    // asserting a mismatch that nothing below states outright (#718).
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            List.of(DISPATCH_GAP), Map.of(), List.of(demoted(DISPATCH_TITLE)));
+
+    assertEquals(List.of(DISPATCH_GAP), surfaces.descriptionGaps());
+  }
+
+  @Test
+  void collapsesThatSameGapOntoTheFindingWhenItPostsInline() {
+    // Control for the test above: the pair matches, so demotion is the only thing that changed.
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            List.of(DISPATCH_GAP), Map.of(), List.of(finding(DISPATCH_TITLE)));
+
+    assertEquals(List.of(), surfaces.descriptionGaps());
+  }
+
+  @Test
+  void collapsesAGapThatAlsoRestatesAnInlineFindingAlongsideTheDemotedOne() {
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            List.of(DISPATCH_GAP),
+            Map.of(),
+            List.of(demoted(DISPATCH_TITLE), finding(DISPATCH_TITLE)));
+
+    assertEquals(List.of(), surfaces.descriptionGaps());
+  }
+
+  @Test
+  void aDemotedFindingStillTrimsAWalkthroughClauseThatRestatesIt() {
+    // A demoted finding outranks a walkthrough clause even though it no longer outranks a gap: the
+    // double-check bullet prints the claim's own wording and its path:line, the clause does not.
+    var surfaces =
+        SummarySurfaceDeduplicator.collapse(
+            List.of(),
+            Map.of(
+                "src/A.java",
+                "Added HTTP client for worker registry; returns only the first page of workers"
+                    + " (pagination not walked); also adds a retry budget"),
+            List.of(demoted("Worker registry pagination not followed; only first page returned")));
+
+    assertEquals(
+        "Added HTTP client for worker registry; also adds a retry budget",
+        surfaces.fileSummaries().get("src/A.java"));
+  }
+
   @ParameterizedTest(name = "{0}")
   @MethodSource("gapsNoFindingRestates")
   void keepsAGapNoFindingRestates(String label, String gap, String findingTitle) {


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

A description gap collapsed onto a finding that the verifier then demoted left the ⚠️ "Description
vs. Implementation" section asserting a mismatch that nothing below it stated. The section said
every mismatch "is reported as a finding below", while the only thing below was a hedged
`_(low confidence — verify before acting)_` bullet folded inside the collapsed "Things to
double-check" block, on no review thread. The model's own unhedged statement of the mismatch had
been deleted in its favour.

The collapse itself was right — one gap, one finding, the same claim — and nothing here weakens it.
`restates` is untouched: the word-set overlap, the phrase arm, the polarity gate and the stemmer all
behave exactly as before, and every existing collapse still happens.

What changes is which findings a gap may be collapsed *onto*. `SummarySurfaceDeduplicator.collapse`
now weighs a gap only against findings that pass `Finding.postsInline()`. Verification runs before
the summary is rendered, so the final confidence is already available at the point of the decision;
it simply was not consulted. A demoted finding is not the *more specific* surface the precedence
rule assumes — it is a weaker one: hedged, collapsed by default, never posted on the diff. When
every finding a gap matches was demoted, the gap stays a bullet and reaches the reader the way the
model stated it.

Demoted findings still outrank a walkthrough clause and keep trimming those: the double-check bullet
prints the claim's own wording and its `path:line`, which an appended walkthrough clause does not.
Only the gap-versus-finding precedence moved.

This also restores the premise the section's wording rests on. "Reported as a finding below" is now
load-bearing rather than aspirational: a gap can only be collapsed onto a finding published as a
finding proper, so the state where the ⚠️ heading and that sentence both survive with nothing posted
inline is no longer reachable.

The cheaper alternative — keep collapsing and reword the section to say the mismatch is among the
lower-confidence items — was rejected: it leaves the mismatch hedged, which is the part that is
wrong.

## Related Issues

Fixes #718

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Four tests added. Two are red on the unfixed tree in exactly the claimed way; two are controls that
pin down what did *not* change.

`SummarySurfaceDeduplicatorTest.keepsAGapWhoseEveryMatchingFindingWasDemotedOutOfTheInlineSurface`
and `PrSummaryGeneratorTest.descriptionGapsSectionListsTheGapWhenEveryFindingItRestatesWasDemoted`
replay #717: the reported gap about the docs dispatch, and the one MEDIUM/LOW finding stating the
same claim. Verbatim output with only the test changes applied and `src/main` at `c4550f8`:

```
[ERROR] Tests run: 25, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.040 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.SummarySurfaceDeduplicatorTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.SummarySurfaceDeduplicatorTest.keepsAGapWhoseEveryMatchingFindingWasDemotedOutOfTheInlineSurface -- Time elapsed: 0.001 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <[The PR description says the docs deploy now fails loudly instead of a silent miss, but the publish-docs job exits 0 as soon as `gh workflow run` accepts the dispatch, so a deploy-stage failure in the dispatched docs.yml run leaves release.yml green with no signal.]> but was: <[]>
	at dev.thiagogonzaga.thrillhousebot.review.SummarySurfaceDeduplicatorTest.keepsAGapWhoseEveryMatchingFindingWasDemotedOutOfTheInlineSurface(SummarySurfaceDeduplicatorTest.java:64)

[ERROR] Tests run: 67, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.860 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.PrSummaryGeneratorTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.PrSummaryGeneratorTest.descriptionGapsSectionListsTheGapWhenEveryFindingItRestatesWasDemoted -- Time elapsed: 0.003 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
## 🤖 ThrillhouseBot PR Summary
 ==> expected: <true> but was: <false>
	at dev.thiagogonzaga.thrillhousebot.review.PrSummaryGeneratorTest.descriptionGapsSectionListsTheGapWhenEveryFindingItRestatesWasDemoted(PrSummaryGeneratorTest.java:1608)

[ERROR] Tests run: 92, Failures: 2, Errors: 0, Skipped: 0
[INFO] BUILD FAILURE
```

The summary the second failure dumps is the render from the issue, reproduced line for line:

```
### ⚠️ Description vs. Implementation
Every mismatch found between the description and the change is reported as a finding below, so it is not repeated here.

### Changes Overview
```

Both pass with the fix applied.

The two controls are green on both sides of the fix and are labelled as such, not offered as proof:
`collapsesThatSameGapOntoTheFindingWhenItPostsInline` shows the gap and finding genuinely match, so
demotion is the only variable between it and the red test, and
`aDemotedFindingStillTrimsAWalkthroughClauseThatRestatesIt` pins the walkthrough precedence that
deliberately did not move. `collapsesAGapThatAlsoRestatesAnInlineFindingAlongsideTheDemotedOne`
covers the mixed list.

Gates, `JAVA_HOME=jdk-25.0.4+7`:

- `./mvnw -B spotless:apply` — no reformatting needed
- `./mvnw -B clean compile spotbugs:check spotless:check` — `BugInstance size is 0`, BUILD SUCCESS
- `./mvnw -B clean test` — `Tests run: 3381, Failures: 0, Errors: 0, Skipped: 0`, BUILD SUCCESS
- jacoco over `git diff -U0 c4550f8...HEAD`: all three executable changed lines covered, `mi=0` and `mb=0` on each (the ternary in `collapse` reports `cb=2`, both arms taken); the rest of the diff is javadoc

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

`restates`, `contradicts`, `overlaps`, `sharesPhrase`, `claim` and `stem` are byte-for-byte
unchanged. The only behavioural edit is the partition of the finding claims in `collapse`, which
narrows what a gap may be deleted for and never widens it, so no gap that survived before can be
dropped now.
