### PR TITLE
fix(review): bound the PR description on the finding-verification call

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -690,11 +690,14 @@ public class FindingPipeline {
       BatchRun run) {
     var validated = quoteValidator.validate(batchResponse, batch.text());
     validated = frameworkFilter.filter(validated, batch.text());
+    // #736: the verification call is the one review-path call that does no budget arithmetic of
+    // its own, so the section the author alone sizes is bounded here before it is sent.
     var verified =
         findingVerificationService.verify(
             ledgerSessionId(run.session()),
             validated,
-            batchInputs.prContext(),
+            PrContextBudget.bound(
+                batchInputs.prContext(), budgetPlanner.perCallInputBudget(), tokenCounter),
             batchInputs.diff(),
             batchInputs.projectStack(),
             batchInputs.previousFindings(),
@@ -1333,11 +1336,14 @@ public class FindingPipeline {
     aiResponse = quoteValidator.validate(aiResponse, diff);
     aiResponse = frameworkFilter.filter(aiResponse, diff);
     aiResponse = deduplicator.dedupe(aiResponse);
+    // #736: the verification call is the one review-path call that does no budget arithmetic of
+    // its own, so the section the author alone sizes is bounded here before it is sent.
     aiResponse =
         findingVerificationService.verify(
             ledgerSessionId(session),
             aiResponse,
-            promptInputs.prContext(),
+            PrContextBudget.bound(
+                promptInputs.prContext(), budgetPlanner.perCallInputBudget(), tokenCounter),
             promptInputs.diff(),
             promptInputs.projectStack(),
             promptInputs.previousFindings(),

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrContextBudget.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrContextBudget.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import dev.thiagogonzaga.thrillhousebot.review.ai.TokenCounter;
+import io.quarkus.logging.Log;
+
+/**
+ * Bounds the PR title-and-description block to a share of the per-call input budget before it is
+ * sent on a call that does no other budget arithmetic — today the finding-verification call (#736).
+ *
+ * <p>The block is author-authored, untrusted, and unbounded at its source: GitHub accepts a 65,536
+ * character description, which measures 34% of the shipped 35,008-token per-call budget as ordinary
+ * prose and roughly 141% of it as dense text. The verifier call carries it on top of a diff that
+ * was already sized to fill the budget, so a long enough description pushes the request past the
+ * model's context window. That fails open — the round keeps its unverified findings and reports
+ * NONE coverage — which is exactly the problem: the author of a pull request can switch
+ * verification off for their own pull request, deterministically, by writing a large enough
+ * description.
+ *
+ * <p>This is the same treatment {@code DiffBudgetPlanner#boundPreviousFindings} gives the other
+ * untrusted, author-influenced overhead section, and it degrades the same way: a prefix survives, a
+ * disclosure the model can read replaces what was cut, and the operator gets a {@code WARN} naming
+ * the sizes. Only the mechanism differs — a description has no entry structure to condense to, so
+ * what is kept is the longest prefix that fits rather than one line per entry.
+ */
+final class PrContextBudget {
+
+  private PrContextBudget() {}
+
+  /**
+   * Share of the per-call input budget the PR context may occupy on the verifier call. A tenth of
+   * the shipped budget is ~3,500 tokens — around 14,000 characters of prose, which holds any real
+   * description with room to spare — while leaving the diff, the candidate findings and the
+   * previous findings the rest of the call. Deliberately tighter than the previous-findings share:
+   * that block is the review's own accumulated state and condensing it costs the model the prose it
+   * judges a finding resolved by, whereas the description is a fixed-purpose section whose tail is
+   * the least load-bearing text in the prompt.
+   */
+  private static final double BUDGET_SHARE = 0.10;
+
+  /**
+   * The disclosure appended after the cut. It sits outside the untrusted fence, so it reads as
+   * instruction rather than as more author-supplied data, and it forbids the one inference the cut
+   * would otherwise invite: the verifier is told the description is provided precisely so a
+   * description-versus-code candidate is checkable against it (#711), so a candidate about text
+   * that was cut has to come back unverifiable rather than refuted.
+   */
+  static final String TRUNCATION_NOTICE =
+      "(The pull request description above was truncated to fit this call's token budget; the rest"
+          + " of it is not shown. Text you cannot see here is not thereby absent from the"
+          + " description: judge a candidate that turns on what the description says only from the"
+          + " part shown, and leave it unverified rather than rejected when the part it refers to"
+          + " was cut.)";
+
+  /**
+   * The block to send, bounded to {@link #BUDGET_SHARE} of {@code perCallInputBudget} and disclosed
+   * when the bound bites. Returns the very same instance when it already fits, so the common case
+   * costs one token estimate and nothing else.
+   *
+   * <p>Budgeting being disabled needs no special case: the planner reports {@link
+   * Integer#MAX_VALUE} for it, whose tenth is a cap no description of any size can reach, so the
+   * operator's explicit no-cap choice is honored by the arithmetic itself. The cap floors at zero
+   * for the same reason — a budget too small to have a share leaves an absent or empty block
+   * untouched instead of replacing it with a notice about nothing.
+   */
+  static String bound(String prContext, int perCallInputBudget, TokenCounter tokenCounter) {
+    var cap = Math.max(0, (int) (perCallInputBudget * BUDGET_SHARE));
+    var before = tokenCounter.estimateTokens(prContext);
+    if (before <= cap) {
+      return prContext;
+    }
+    var bounded = clip(prContext, cap, tokenCounter);
+    Log.warnf(
+        "PR description context (%d tokens) exceeds its %d-token share of the per-call input"
+            + " budget; sending the first %d tokens of it with the truncation disclosed",
+        before, cap, tokenCounter.estimateTokens(bounded));
+    return bounded;
+  }
+
+  /**
+   * Cuts the block to {@code capTokens}, keeping the untrusted fence intact around what survives.
+   * The fence lines are structural rather than content: carrying them across the cut is what keeps
+   * the region from ending unterminated with the disclosure — our own instruction — swallowed
+   * inside it. The cut itself lands wherever the budget runs out, since a description has no entry
+   * or line structure the model relies on, and the disclosure says so.
+   */
+  private static String clip(String prContext, int capTokens, TokenCounter tokenCounter) {
+    var lines = prContext.split("\n", -1);
+    var fenced = lines.length > 2 && lines[0].equals(lines[lines.length - 1]);
+    var open = fenced ? lines[0] + "\n" : "";
+    var close = fenced ? "\n" + lines[0] : "";
+    var body = prContext.substring(open.length(), prContext.length() - close.length());
+    // The disclosure has to survive the cap that forced it, so its cost — and the fences' — comes
+    // off the top rather than being what gets dropped. Each part is measured as it will appear,
+    // separated by the surviving prose: measuring them joined would undercount by whatever the
+    // tokenizer merges across a seam the result does not have.
+    var reserve =
+        tokenCounter.estimateTokens(open)
+            + tokenCounter.estimateTokens(close)
+            + tokenCounter.estimateTokens("\n" + TRUNCATION_NOTICE);
+    return open
+        + longestPrefixWithin(body, capTokens - reserve, tokenCounter)
+        + close
+        + "\n"
+        + TRUNCATION_NOTICE;
+  }
+
+  /**
+   * The longest prefix of {@code text} whose estimated cost stays within {@code capTokens}, found
+   * by bisection over code points so the cut can never split a surrogate pair. Every candidate the
+   * search accepts was measured, so the result is within the cap whatever the estimator does at the
+   * boundary; a cap of zero or less yields the empty prefix.
+   */
+  private static String longestPrefixWithin(String text, int capTokens, TokenCounter tokenCounter) {
+    var low = 0;
+    var high = text.codePointCount(0, text.length());
+    while (low < high) {
+      var mid = (low + high + 1) >>> 1;
+      if (tokenCounter.estimateTokens(prefix(text, mid)) <= capTokens) {
+        low = mid;
+      } else {
+        high = mid - 1;
+      }
+    }
+    return prefix(text, low);
+  }
+
+  /** The first {@code codePoints} code points of {@code text}. */
+  private static String prefix(String text, int codePoints) {
+    return text.substring(0, text.offsetByCodePoints(0, codePoints));
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -221,6 +221,83 @@ class FindingPipelineTest {
   }
 
   @Test
+  void anAuthorSizedDescriptionIsBoundedBeforeItReachesTheVerifier() {
+    // #736: the verification call does no budget arithmetic, and the PR description reaching it is
+    // bounded nowhere — GitHub accepts 65,536 characters of it. Sent whole, on top of a diff
+    // already sized to fill the budget, it pushes the request past the model's context window; that
+    // fails open, so the author of a pull request can switch verification off for their own pull
+    // request by writing a long enough description. The block must arrive within its share of the
+    // per-call budget, with the cut disclosed to the model.
+    var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
+    var ctx = reviewContext();
+    // GitHub's maximum description length, as ordinary prose.
+    var description = "The author's stated intent for this change. ".repeat(1525);
+    assertTrue(description.length() >= 65_536, "the description is GitHub-maximum sized");
+    var prContext = PromptTemplateEscaper.fence(PromptSections.prContext("Big PR", description));
+    var template =
+        new AiReviewService.PromptInputs("d", prContext, "base", "stack", "tests", "", "");
+    // The shipped per-call budget: 48000 * 0.9 - 8192.
+    when(budgetPlanner.perCallInputBudget()).thenReturn(35_008);
+    when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("a.java", "A")), List.of(), null));
+    var summary = new ReviewResponse.Summary(1, 0, 0, 1, 0, "ok", "does things", List.of());
+    when(aiReviewService.summarize(eq(session), any()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), summary));
+
+    pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+
+    var sent = ArgumentCaptor.forClass(String.class);
+    verify(findingVerificationService, times(2))
+        .verify(anyLong(), any(), sent.capture(), any(), any(), any(), any());
+    var counter = new TokenCounter();
+    for (var block : sent.getAllValues()) {
+      assertTrue(
+          counter.estimateTokens(block) <= 3500,
+          () ->
+              "PR context reached the verifier at "
+                  + counter.estimateTokens(block)
+                  + " tokens, over its 3500-token share of the 35008-token per-call budget");
+      assertTrue(
+          block.contains("truncated to fit this call's token budget"),
+          "the cut is disclosed to the model");
+    }
+    // The untrusted fence survives the cut, with the disclosure outside it so it reads as
+    // instruction rather than as more author-supplied data.
+    var fenceLine = prContext.substring(0, prContext.indexOf('\n'));
+    var bounded = sent.getAllValues().get(0);
+    assertTrue(bounded.startsWith(fenceLine + "\n"), "the fence still opens the block");
+    assertTrue(
+        bounded.contains("\n" + fenceLine + "\n("), "the fence closes before the disclosure");
+    assertEquals(2, bounded.split(java.util.regex.Pattern.quote(fenceLine), -1).length - 1);
+  }
+
+  @Test
+  void aDescriptionInsideItsShareReachesTheVerifierByteExact() {
+    // Control for the bound above: it must bite only on the accumulation it exists to stop, so an
+    // ordinary description reaches the verifier untouched — same instance, no disclosure.
+    var session = ReviewSession.create("owner/repo", 1, "Big PR", "sha");
+    var ctx = reviewContext();
+    var prContext =
+        PromptTemplateEscaper.fence(
+            PromptSections.prContext("Big PR", "Fixes the parser. ".repeat(50)));
+    var template =
+        new AiReviewService.PromptInputs("d", prContext, "base", "stack", "tests", "", "");
+    when(budgetPlanner.perCallInputBudget()).thenReturn(35_008);
+    when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(finding("a.java", "A")), List.of(), null));
+    var summary = new ReviewResponse.Summary(1, 0, 0, 1, 0, "ok", "does things", List.of());
+    when(aiReviewService.summarize(eq(session), any()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), summary));
+
+    pipeline.run(session, template, ctx, multiBatchPlan(), new DiffLineResolver(Map.of()));
+
+    var sent = ArgumentCaptor.forClass(String.class);
+    verify(findingVerificationService, times(2))
+        .verify(anyLong(), any(), sent.capture(), any(), any(), any(), any());
+    assertEquals(List.of(prContext, prContext), sent.getAllValues());
+  }
+
+  @Test
   void multiCallDoesNotRetryABatchTruncatedAtTheModelsLengthCap() {
     // #492: a length stop is deterministic — re-sending the identical prompt against the identical
     // cap is cut at the identical point. The generic soft-fail path retries once before giving up,

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrContextBudgetTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PrContextBudgetTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.thiagogonzaga.thrillhousebot.review.ai.TokenCounter;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the PR-context bound applied on the verification call (#736). */
+class PrContextBudgetTest {
+
+  /** The shipped per-call input budget: {@code 48000 * 0.9 - 8192}. */
+  private static final int SHIPPED_BUDGET = 35_008;
+
+  private final TokenCounter counter = new TokenCounter();
+
+  /** A GitHub-maximum description, as ordinary prose. */
+  private static String maximumDescription() {
+    return "The author's stated intent for this change. ".repeat(1525);
+  }
+
+  @Test
+  void keepsTheFenceAroundWhatSurvivesAndDisclosesTheCut() {
+    var block = PromptTemplateEscaper.fence(PromptSections.prContext("T", maximumDescription()));
+
+    var bounded = PrContextBudget.bound(block, SHIPPED_BUDGET, counter);
+
+    var fenceLine = block.substring(0, block.indexOf('\n'));
+    assertTrue(counter.estimateTokens(bounded) <= SHIPPED_BUDGET / 10);
+    assertTrue(bounded.startsWith(fenceLine + "\n"));
+    assertTrue(bounded.endsWith(PrContextBudget.TRUNCATION_NOTICE));
+    assertTrue(bounded.contains("\n" + fenceLine + "\n" + PrContextBudget.TRUNCATION_NOTICE));
+    assertTrue(bounded.contains("Title: T\nDescription:\nThe author's stated intent"));
+  }
+
+  @Test
+  void boundsAnUnfencedBlockWithoutInventingAFence() {
+    var block = PromptSections.prContext("T", maximumDescription());
+
+    var bounded = PrContextBudget.bound(block, SHIPPED_BUDGET, counter);
+
+    assertFalse(bounded.contains(PromptTemplateEscaper.fencePrefix()));
+    assertTrue(bounded.startsWith("Title: T\nDescription:\n"));
+    assertTrue(bounded.endsWith("\n" + PrContextBudget.TRUNCATION_NOTICE));
+    assertTrue(counter.estimateTokens(bounded) <= SHIPPED_BUDGET / 10);
+  }
+
+  @Test
+  void boundsABlockTooShortToCarryAFence() {
+    // A two-line block has no fence to preserve — the whole of it is content, and the bound still
+    // has to hold. Driven by a budget small enough that an ordinary block overruns its share.
+    var block = "Title: T\nDescription: " + "budget ".repeat(200);
+
+    var bounded = PrContextBudget.bound(block, 1500, counter);
+
+    assertTrue(bounded.startsWith("Title: T\nDescription: budget"));
+    assertTrue(bounded.endsWith("\n" + PrContextBudget.TRUNCATION_NOTICE));
+    assertFalse(bounded.contains(PromptTemplateEscaper.fencePrefix()));
+  }
+
+  @Test
+  void leavesABlockWithinItsShareUntouched() {
+    var block = PromptTemplateEscaper.fence(PromptSections.prContext("T", "Fixes the parser."));
+
+    assertSame(block, PrContextBudget.bound(block, SHIPPED_BUDGET, counter));
+  }
+
+  @Test
+  void leavesEveryBlockUntouchedWhenBudgetingIsDisabled() {
+    // The planner reports Integer.MAX_VALUE for an explicit max-input-tokens <= 0. That is the
+    // operator asking for no cap, and this is not the place to reintroduce one.
+    var block = PromptTemplateEscaper.fence(PromptSections.prContext("T", maximumDescription()));
+
+    assertSame(block, PrContextBudget.bound(block, Integer.MAX_VALUE, counter));
+    assertSame("", PrContextBudget.bound("", Integer.MAX_VALUE, counter));
+  }
+
+  @Test
+  void cutsOnACodePointBoundary() {
+    // The cut must never split a surrogate pair: a lone half is not text the model can read, and
+    // the block is handed straight to the prompt.
+    var block = PromptSections.prContext("T", "😀".repeat(20_000));
+
+    var bounded = PrContextBudget.bound(block, SHIPPED_BUDGET, counter);
+
+    var body = bounded.substring(0, bounded.length() - PrContextBudget.TRUNCATION_NOTICE.length());
+    assertEquals(
+        body,
+        new String(
+            body.getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            java.nio.charset.StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

The finding-verification call is the one review-path call that does no budget arithmetic of its own, and the PR title-and-description block reaching it was bounded nowhere. GitHub accepts a 65,536-character description: measured with the real `TokenCounter`, that is 34% of the shipped 35,008-token per-call budget as ordinary prose and roughly 141% of it as dense text. Carried on top of a diff already sized to fill the budget, a long enough description pushes the verifier request past the model's context window. Every consequence is fail-open and disclosed — the round keeps its unverified findings and reports `(N, 0)` / NONE coverage — which is exactly the problem: the author of a pull request can switch verification off for their own pull request, deterministically, by writing a large enough description.

The fix is the size bound the section never had. `PrContextBudget.bound` gives the block a tenth of the per-call input budget and, when it overruns, keeps the longest prefix that fits:

- **Where.** At the two `FindingVerificationService.verify` call sites in `FindingPipeline`, which is where the verifier's inputs are assembled and which already owns per-call budget arithmetic for the summary call's sections (`clampOverview`, `budgetedFindingsJson`). Bounding at the seam that makes the call means no caller can reintroduce the hole, and the review call — whose overhead the planner already sizes, prContext included — is left byte-exact.
- **How much.** A tenth of the budget is ~3,500 tokens, roughly 14,000 characters of prose, which holds any real description with room to spare. Deliberately tighter than `boundPreviousFindings`' quarter share: that block is the review's own accumulated state and condensing it costs the model the prose it judges a finding resolved by, whereas the description is a fixed-purpose section whose tail is the least load-bearing text in the prompt.
- **How it degrades.** Same shape as `DiffBudgetPlanner#boundPreviousFindings`: a prefix survives, the untrusted CSPRNG fence is carried across the cut so the region can never end unterminated, a disclosure is appended *outside* the fence so it reads as instruction, and the operator gets a `WARN` naming the sizes. The mechanism differs only because a description has no entry structure to condense to — what is kept is the longest prefix that fits, bisected over code points so the cut can never split a surrogate pair.
- **What the disclosure says.** The verifier is told the description is provided precisely so a description-versus-code candidate is checkable against it (#711), so the notice forbids the one inference the cut would otherwise invite: text it cannot see is not thereby absent from the description, and a candidate that turns on the part that was cut comes back unverified rather than rejected.
- **Budgeting disabled** needs no special case: the planner reports `Integer.MAX_VALUE`, whose tenth is a cap no description of any size can reach, so the operator's explicit no-cap choice is honored by the arithmetic itself.

## Related Issues

Fixes #736

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**Red/green proof.** `FindingPipelineTest#anAuthorSizedDescriptionIsBoundedBeforeItReachesTheVerifier` drives the real pipeline with a GitHub-maximum (65,575-character) description at the shipped 35,008-token per-call budget and captures the block that reaches the verifier. Run against this branch's test with the main-code change reverted:

```
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.861 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.anAuthorSizedDescriptionIsBoundedBeforeItReachesTheVerifier -- Time elapsed: 0.304 s <<< FAILURE!
org.opentest4j.AssertionFailedError: PR context reached the verifier at 13794 tokens, over its 3500-token share of the 35008-token per-call budget ==> expected: <true> but was: <false>
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:199)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.anAuthorSizedDescriptionIsBoundedBeforeItReachesTheVerifier(FindingPipelineTest.java:254)
```

With the fix it passes: the block arrives within its 3,500-token share, the fence still opens and closes it exactly twice, and the disclosure sits outside the fence.

`FindingPipelineTest#aDescriptionInsideItsShareReachesTheVerifierByteExact` is a **control**, not proof — it passes before and after, and pins that the bound bites only on the oversized case: an ordinary description reaches the verifier as the very same instance.

`PrContextBudgetTest` covers the rest of the unit: the fenced cut, an unfenced block (no fence is invented), a block too short to carry a fence, a block within its share (same instance), budgeting disabled, and the code-point boundary of the cut.

Gates on this branch: `spotless:apply` clean, `clean compile spotbugs:check spotless:check` → **BugInstance size is 0**, `clean test` → **3384 tests, 0 failures, 0 errors**. Jacoco ∩ `git diff -U0 c4550f8...HEAD` shows zero uncovered lines and zero uncovered branches in the changed main code.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

The bound announces itself to the operator on the channel the sibling overhead bound already uses:

```
WARN  [dev.thiagogonzaga.thrillhousebot.review.PrContextBudget] PR description context (13803 tokens) exceeds its 3500-token share of the per-call input budget; sending the first 3500 tokens of it with the truncation disclosed
```

## Additional Notes

Scope note: the review call is deliberately left alone. Its overhead — prContext included — is already sized by `DiffBudgetPlanner#plan`, so an oversized description there costs diff budget and is disclosed as omitted files rather than silently dropping a guarantee. The verification call had no such accounting, which is why it is the one that changes here.
