### PR TITLE
fix(review): name the findings a round closed on the review body

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ClosedFindingNames.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ClosedFindingNames.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Names the previous findings a follow-up round closed, for every surface that reports the closure.
+ *
+ * <p>Each entry carries the {@code path:line} locator and the title — the same two identifiers an
+ * {@code @thrillhousebot resolved} directive uses to name a finding (#548), so a maintainer can
+ * read the match straight off the surface (#714). Without them a round published a bare count and
+ * nothing anywhere said <em>which</em> finding closed: the maintainer had to diff the PR's thread
+ * state across rounds to find out, and one who named several findings in a single directive could
+ * not tell which the reviewer matched and which it silently skipped — matching is by {@code
+ * path:line} plus title and the guards reject several spellings, so a skip is a real outcome.
+ *
+ * <p>Shared by the opt-in follow-up delta comment and the review body because the delta alone did
+ * not reach a default install: it is gated on {@code thrillhousebot.review.follow-up-summary
+ * .enabled}, which defaults to false, and the other naming surface — a reply on the closed
+ * finding's thread — does not exist for a finding published with no thread at all (#712). That
+ * threadless finding is exactly the one the clearing directive is the only available action for
+ * (#709), so it is where the attribution is needed most and where it was missing (#737). The review
+ * body posts on every round with something to say and is behind no flag, so the names ride it.
+ *
+ * <p>Every finding the {@code resolved} count covers is named, not only the directive-cleared ones:
+ * the list has to add up to the integer it explains, and a fix that landed is just as unnamed
+ * without it. Ids are 1-based positions in the previous round, so an id outside that list names
+ * nothing and is skipped rather than guessed at — the count stays authoritative either way.
+ */
+final class ClosedFindingNames {
+
+  private ClosedFindingNames() {}
+
+  /**
+   * How many closed findings a surface names before rolling the rest up as a count. Matches the
+   * bound {@code ReviewResult.nameList} puts on the coverage disclosure's file names, for the same
+   * reason: one comment carries all of this, and a PR can close many findings in one round.
+   */
+  private static final int NAMED_LIMIT = 10;
+
+  /**
+   * Opening words of the review-body section. Kept as a constant because {@code
+   * FollowUpAnalyzer.isSelfAuthoredStatusBody} recognizes bodies by it: this section is the bot's
+   * own prose about findings it has just closed, so a later round must never read it back as
+   * "issues flagged in the previous review" and re-open them (#455).
+   */
+  static final String REVIEW_BODY_LEAD_IN = "ThrillhouseBot closed ";
+
+  /**
+   * The review-body section naming this round's closures, or an empty string when nothing can be
+   * named. Renders the authoritative {@link ReviewResult#resolvedPreviousCount()} above the names,
+   * the same order the delta comment puts them in.
+   */
+  static String reviewBodySection(
+      ReviewResult result, List<ReviewResponse.Finding> previousFindings) {
+    var bullets = bulletList(result, previousFindings, "");
+    if (bullets.isEmpty()) {
+      return "";
+    }
+    return REVIEW_BODY_LEAD_IN
+        + result.resolvedPreviousCount()
+        + " previous finding(s) this round:\n\n"
+        + bullets;
+  }
+
+  /**
+   * The bullet list naming each finding the {@code resolved} count covers, one {@code path:line} —
+   * title line each at {@code indent}, or an empty string when none can be named.
+   */
+  static String bulletList(
+      ReviewResult result, List<ReviewResponse.Finding> previousFindings, String indent) {
+    if (previousFindings == null || previousFindings.isEmpty()) {
+      return "";
+    }
+    var named = new ArrayList<String>();
+    for (var status : result.previousStatuses()) {
+      if (!"resolved".equalsIgnoreCase(status.status())
+          || status.id() < 1
+          || status.id() > previousFindings.size()) {
+        continue;
+      }
+      named.add(describe(previousFindings.get(status.id() - 1)));
+    }
+    if (named.isEmpty()) {
+      return "";
+    }
+    var sb = new StringBuilder();
+    for (var entry : named.subList(0, Math.min(named.size(), NAMED_LIMIT))) {
+      sb.append(indent).append("- ").append(entry).append("\n");
+    }
+    if (named.size() > NAMED_LIMIT) {
+      sb.append(indent).append("- …and ").append(named.size() - NAMED_LIMIT).append(" more\n");
+    }
+    return sb.toString();
+  }
+
+  /**
+   * One closed finding as {@code `path:line` — title}. Both halves go through {@link MarkdownSafe}:
+   * they are model-authored text spliced into a list item, and a raw newline or backtick would
+   * restructure the surface. A finding with no title renders as the bare locator rather than a
+   * dangling dash — the locator alone still identifies it.
+   */
+  private static String describe(ReviewResponse.Finding finding) {
+    var locator = MarkdownSafe.inlineCode(finding.file() + ":" + finding.line());
+    var title = MarkdownSafe.inline(finding.title());
+    return title.isBlank() ? "`" + locator + "`" : "`" + locator + "` — " + title;
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -2063,7 +2063,43 @@ public class FollowUpAnalyzer {
     if (body == null || isSelfAuthoredStatusBody(body)) {
       return "";
     }
-    return body;
+    return withoutClosedFindingNames(body);
+  }
+
+  /**
+   * The body with its closed-findings section removed, wherever that section sits.
+   *
+   * <p>{@link #isSelfAuthoredStatusBody} only recognizes a body the section <em>leads</em>, which
+   * is the no-new-findings shape. A body that also carries findings opens with those instead, so it
+   * is offered to the model as prior review content — and the section rides along inside it, naming
+   * findings this round just <em>closed</em> under a prompt that asks which prior issues are still
+   * unresolved. That re-opens every one of them, which is #455's failure mode arriving one section
+   * lower than the leading-line check looks.
+   *
+   * <p>The section is the lead-in line plus the contiguous run of bullets and blanks under it. A
+   * blank line is put back when content follows, so removing it cannot join two paragraphs that
+   * were separate.
+   */
+  static String withoutClosedFindingNames(String body) {
+    var lines = body.lines().toList();
+    var out = new ArrayList<String>(lines.size());
+    var index = 0;
+    while (index < lines.size()) {
+      if (!lines.get(index).strip().startsWith(ClosedFindingNames.REVIEW_BODY_LEAD_IN)) {
+        out.add(lines.get(index));
+        index++;
+        continue;
+      }
+      index++;
+      while (index < lines.size()
+          && (lines.get(index).isBlank() || lines.get(index).strip().startsWith("- "))) {
+        index++;
+      }
+      if (!out.isEmpty() && index < lines.size()) {
+        out.add("");
+      }
+    }
+    return String.join("\n", out).strip();
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -2076,10 +2076,22 @@ public class FollowUpAnalyzer {
    * unresolved. That re-opens every one of them, which is #455's failure mode arriving one section
    * lower than the leading-line check looks.
    *
-   * <p>The section is the lead-in line plus the contiguous run of bullets and blanks under it. A
-   * blank line is put back when content follows, so removing it cannot join two paragraphs that
-   * were separate.
+   * <p>The section's own shape is consumed in order — the lead-in, the blank under it, its
+   * contiguous bullets, and the blank after them — rather than any run of blanks and bullets. The
+   * looser form ate an unrelated bullet paragraph that merely followed the section, because it
+   * crossed the separating blank and carried on through the next list. A blank line is put back
+   * when content follows, so removing the section cannot join two paragraphs that were separate.
    */
+  /** {@code index} advanced past the run of lines from it that satisfy {@code matching}. */
+  private static int skipWhile(
+      List<String> lines, int index, java.util.function.Predicate<String> matching) {
+    var at = index;
+    while (at < lines.size() && matching.test(lines.get(at))) {
+      at++;
+    }
+    return at;
+  }
+
   static String withoutClosedFindingNames(String body) {
     var lines = body.lines().toList();
     var out = new ArrayList<String>(lines.size());
@@ -2091,10 +2103,9 @@ public class FollowUpAnalyzer {
         continue;
       }
       index++;
-      while (index < lines.size()
-          && (lines.get(index).isBlank() || lines.get(index).strip().startsWith("- "))) {
-        index++;
-      }
+      index = skipWhile(lines, index, String::isBlank);
+      index = skipWhile(lines, index, line -> line.strip().startsWith("- "));
+      index = skipWhile(lines, index, String::isBlank);
       if (!out.isEmpty() && index < lines.size()) {
         out.add("");
       }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -2074,9 +2074,12 @@ public class FollowUpAnalyzer {
    * every round (#455). The bot must never treat its own output as its input.
    *
    * <p>Recognition is by the body's first non-blank line against the producers' own constants — the
-   * unresolved-previous status sentence, the clean-review message, the two CI-hold notices, and the
-   * partial-review banner — so the check cannot drift from the text it recognizes. A body a human
-   * (or an older, findings-carrying review) wrote starts with none of them and is preserved.
+   * unresolved-previous status sentence, the closed-findings section (#737), the clean-review
+   * message, the two CI-hold notices, and the partial-review banner — so the check cannot drift
+   * from the text it recognizes. The closed-findings section is the sharpest case of the rule: it
+   * names findings the round has just <em>closed</em>, so feeding it back as prior findings would
+   * re-open every one of them. A body a human (or an older, findings-carrying review) wrote starts
+   * with none of them and is preserved.
    */
   static boolean isSelfAuthoredStatusBody(String body) {
     var first = body.lines().map(String::strip).filter(line -> !line.isEmpty()).findFirst();
@@ -2085,6 +2088,7 @@ public class FollowUpAnalyzer {
     }
     var line = first.get();
     return ReviewResult.isUnresolvedPreviousMessage(line)
+        || line.startsWith(ClosedFindingNames.REVIEW_BODY_LEAD_IN)
         || line.startsWith(ReviewResult.NO_ISSUES_CI_PENDING_LEAD_IN)
         || line.startsWith(ReviewResult.NO_ISSUES_CI_UNREADABLE_LEAD_IN)
         || line.startsWith(ReviewResult.TRUNCATION_NOTICE_LEAD_IN)

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummary.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpDeltaSummary.java
@@ -16,7 +16,6 @@
 package dev.thiagogonzaga.thrillhousebot.review;
 
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,11 +38,11 @@ import java.util.Optional;
  * <p>Three counts are rendered, all sourced from the statuses the follow-up pipeline already
  * produced rather than recomputed here: findings raised this round, previous findings the round
  * closed, and previous findings still open. The closed ones are also named, one {@code path:line} —
- * title line each ({@link #resolvedNames}). A {@code justified} status (declined by a maintainer)
- * is in none of them — it is neither newly fixed nor still open — and {@code superseded} is not
- * counted either: it is an auto-close because the targeted code left the diff, not something the
- * round fixed. A superseded round also re-posts the full summary, and the caller skips this comment
- * whenever that re-post lands.
+ * title line each ({@link ClosedFindingNames}). A {@code justified} status (declined by a
+ * maintainer) is in none of them — it is neither newly fixed nor still open — and {@code
+ * superseded} is not counted either: it is an auto-close because the targeted code left the diff,
+ * not something the round fixed. A superseded round also re-posts the full summary, and the caller
+ * skips this comment whenever that re-post lands.
  *
  * <p>The counts are only as good as the previous-finding statuses handed to them: issue #455
  * records that a round returning zero findings corrupts the previous-findings context, which can
@@ -88,7 +87,7 @@ final class FollowUpDeltaSummary {
             + "- **Previous findings resolved:** "
             + resolved
             + "\n"
-            + resolvedNames(result, previousFindings)
+            + ClosedFindingNames.bulletList(result, previousFindings, "  ")
             + "- **Previous findings still open:** "
             + result.unresolvedPreviousCount()
             + "\n"
@@ -105,70 +104,5 @@ final class FollowUpDeltaSummary {
       body += "\n\n> ⚠️ " + ReviewResult.verificationBrief(result.truncation().verification());
     }
     return Optional.of(body);
-  }
-
-  /**
-   * How many closed findings the delta names before rolling the rest up as a count. Matches the
-   * bound {@code ReviewResult.nameList} puts on the coverage disclosure's file names, for the same
-   * reason: one comment carries all of this, and a PR can close many findings in one round.
-   */
-  private static final int NAMED_RESOLVED_LIMIT = 10;
-
-  /**
-   * The indented sub-list naming each finding the {@code resolved} count covers, or an empty string
-   * when none can be named. Each entry carries the {@code path:line} locator and the title — the
-   * same two identifiers an {@code @thrillhousebot resolved} directive uses to name a finding
-   * (#548), so a maintainer can read the match straight off the comment (#714).
-   *
-   * <p>Without it the round published three bare integers and no surface anywhere said
-   * <em>which</em> finding closed: the maintainer had to diff the PR's thread state across rounds
-   * to find out, and a maintainer who named several findings in one directive could not tell which
-   * the reviewer matched and which it silently skipped — matching is by {@code path:line} plus
-   * title and the guards reject several spellings, so a skip is a real outcome. That matters most
-   * for a finding published with no inline thread, where the directive is the only action that can
-   * close it at all and there is no thread state to diff either.
-   *
-   * <p>Names every finding the count counts, not only the ones a directive cleared: the list has to
-   * add up to the integer above it, and a fix that landed is just as unnamed without it. Ids are
-   * 1-based positions in the previous round, so an id outside that list names nothing and is
-   * skipped rather than guessed at — the count above stays authoritative either way.
-   */
-  private static String resolvedNames(
-      ReviewResult result, List<ReviewResponse.Finding> previousFindings) {
-    if (previousFindings == null || previousFindings.isEmpty()) {
-      return "";
-    }
-    var named = new ArrayList<String>();
-    for (var status : result.previousStatuses()) {
-      if (!"resolved".equalsIgnoreCase(status.status())
-          || status.id() < 1
-          || status.id() > previousFindings.size()) {
-        continue;
-      }
-      named.add(describe(previousFindings.get(status.id() - 1)));
-    }
-    if (named.isEmpty()) {
-      return "";
-    }
-    var sb = new StringBuilder();
-    for (var entry : named.subList(0, Math.min(named.size(), NAMED_RESOLVED_LIMIT))) {
-      sb.append("  - ").append(entry).append("\n");
-    }
-    if (named.size() > NAMED_RESOLVED_LIMIT) {
-      sb.append("  - …and ").append(named.size() - NAMED_RESOLVED_LIMIT).append(" more\n");
-    }
-    return sb.toString();
-  }
-
-  /**
-   * One closed finding as {@code `path:line` — title}. Both halves go through {@link MarkdownSafe}:
-   * they are model-authored text spliced into a list item, and a raw newline or backtick would
-   * restructure the comment. A finding with no title renders as the bare locator rather than a
-   * dangling dash — the locator alone still identifies it.
-   */
-  private static String describe(ReviewResponse.Finding finding) {
-    var locator = MarkdownSafe.inlineCode(finding.file() + ":" + finding.line());
-    var title = MarkdownSafe.inline(finding.title());
-    return title.isBlank() ? "`" + locator + "`" : "`" + locator + "` — " + title;
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestrator.java
@@ -330,7 +330,8 @@ public class ReviewOrchestrator {
               req.commitSha(),
               result,
               lineResolver,
-              summaryPosted));
+              summaryPosted,
+              previousFindings));
 
       resultSurfaced = true;
       final var doneReq = req;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -301,6 +301,8 @@ public class ReviewPublisher {
    *     ({@code publishSummary} returned {@code true}) — never assumed from {@code isFirstReview}
    *     or {@code forceSummary} alone, so a failed or skipped summary post can never suppress the
    *     review too and leave the run with no visible outcome at all.
+   * @param previousFindings the previous round's findings, in prompt-id order, so the body can name
+   *     the ones this round closed instead of leaving the closure unattributed (#737)
    */
   record PostReviewRequest(
       String auth,
@@ -310,11 +312,13 @@ public class ReviewPublisher {
       String commitSha,
       ReviewResult result,
       DiffLineResolver lineResolver,
-      boolean summaryPosted) {}
+      boolean summaryPosted,
+      List<ReviewResponse.Finding> previousFindings) {}
 
   /**
    * Back-compat convenience for tests and callers with no summary outcome to report. Defaults
-   * {@code summaryPosted} to {@code false}, so no review-suppressing skip can fire.
+   * {@code summaryPosted} to {@code false}, so no review-suppressing skip can fire, and carries no
+   * previous round, so nothing is named as closed.
    */
   void postReview(
       String auth,
@@ -325,7 +329,8 @@ public class ReviewPublisher {
       ReviewResult result,
       DiffLineResolver lineResolver) {
     postReview(
-        new PostReviewRequest(auth, owner, repo, prNumber, commitSha, result, lineResolver, false));
+        new PostReviewRequest(
+            auth, owner, repo, prNumber, commitSha, result, lineResolver, false, List.of()));
   }
 
   void postReview(PostReviewRequest post) {
@@ -339,9 +344,13 @@ public class ReviewPublisher {
     if (!result.hasIssues()) {
       // Summary-only re-run: skip restating a clean verdict when the summary re-posted; first
       // review, unresolved previous, and truncation still post.
+      // resolvedPreviousCount is part of the skip test because this body is now the surface that
+      // names what the round closed (#737): a re-posted summary states no closure at all, so
+      // skipping the review here would leave the closure unattributed on every install again.
       if (post.summaryPosted()
           && !result.isFirstReview()
           && result.unresolvedPreviousCount() == 0
+          && result.resolvedPreviousCount() == 0
           && !result.truncated()) {
         Log.infof(
             "Skipping the no-issues review for %s/%s #%d — summary-only re-run on an"
@@ -349,7 +358,15 @@ public class ReviewPublisher {
             owner, repo, prNumber);
         return;
       }
-      postNoIssuesReview(auth, owner, repo, prNumber, commitSha, result, post.summaryPosted());
+      postNoIssuesReview(
+          auth,
+          owner,
+          repo,
+          prNumber,
+          commitSha,
+          result,
+          post.summaryPosted(),
+          post.previousFindings());
       return;
     }
 
@@ -371,6 +388,7 @@ public class ReviewPublisher {
             owner, repo, prNumber);
       }
       var fallbackParts = new ArrayList<>(skippedFindingsBodyParts(inline));
+      appendClosedFindingNames(fallbackParts, result, post.previousFindings());
       fallbackParts.addAll(reopenedDeclineNotes(result));
       appendTruncationNotice(fallbackParts, result);
       createReviewWithFallback(
@@ -388,6 +406,7 @@ public class ReviewPublisher {
       bodyParts.add("ThrillhouseBot requested changes — see inline comments on the diff.");
     }
     bodyParts.addAll(skippedFindingsBodyParts(inline));
+    appendClosedFindingNames(bodyParts, result, post.previousFindings());
     bodyParts.addAll(reopenedDeclineNotes(result));
     appendTruncationNotice(bodyParts, result);
     if (!bodyParts.isEmpty()) {
@@ -411,6 +430,30 @@ public class ReviewPublisher {
   private static void appendTruncationNotice(List<String> bodyParts, ReviewResult result) {
     if (result.truncated()) {
       bodyParts.add(result.truncationNotice().strip());
+    }
+  }
+
+  /**
+   * Adds the section naming the previous findings this round closed, when there are any to name.
+   *
+   * <p>The names used to render only on the follow-up delta comment, which is opt-in and off by
+   * default, and on a reply to the closed finding's own review thread — a surface a finding
+   * published with no thread (#712) does not have, which is precisely the finding a clearing
+   * directive is the only way to close (#709). So on a default install the one case #714 called
+   * worst still closed with nothing naming what closed (#737). This body is behind no flag and
+   * already carries the round's other previous-finding disclosures — the unresolved count and the
+   * overturned-decline notes — so the names ride it too.
+   *
+   * <p>Placed below the findings sections on purpose: {@code
+   * FollowUpAnalyzer.isSelfAuthoredStatusBody} classifies a body by its first line, and this
+   * section must lead only a body that carries nothing but the bot's own status prose. It stays
+   * above the partial-coverage banner, keeping the coverage caveat outermost.
+   */
+  private static void appendClosedFindingNames(
+      List<String> bodyParts, ReviewResult result, List<ReviewResponse.Finding> previousFindings) {
+    var section = ClosedFindingNames.reviewBodySection(result, previousFindings);
+    if (!section.isEmpty()) {
+      bodyParts.add(section.strip());
     }
   }
 
@@ -511,14 +554,19 @@ public class ReviewPublisher {
       int prNumber,
       String commitSha,
       ReviewResult result,
-      boolean summaryPosted) {
+      boolean summaryPosted,
+      List<ReviewResponse.Finding> previousFindings) {
     if (result.reviewState() == ReviewState.APPROVE) {
+      // The round that closes the last open finding approves, so this is the body a cleared
+      // finding most often lands on — it has to name what it closed (#737).
+      var approveParts = new ArrayList<String>();
+      if (!result.isFirstReview()) {
+        approveParts.add(PrSummaryGenerator.ZERO_ISSUES_MESSAGE);
+      }
+      appendClosedFindingNames(approveParts, result, previousFindings);
       var req =
           new GitHubReviewClient.CreateReviewRequest(
-              commitSha,
-              result.isFirstReview() ? "" : PrSummaryGenerator.ZERO_ISSUES_MESSAGE,
-              EVENT_APPROVE,
-              List.of());
+              commitSha, String.join("\n\n", approveParts), EVENT_APPROVE, List.of());
       createReviewWithFallback(auth, owner, repo, prNumber, req);
       return;
     }
@@ -532,7 +580,7 @@ public class ReviewPublisher {
     var req =
         new GitHubReviewClient.CreateReviewRequest(
             commitSha,
-            noIssuesBody(result),
+            noIssuesBody(result, previousFindings),
             result.reviewState() == ReviewState.REQUEST_CHANGES
                 ? EVENT_REQUEST_CHANGES
                 : EVENT_COMMENT,
@@ -547,7 +595,7 @@ public class ReviewPublisher {
    * "0 … unresolved"), and truncation is disclosed here on follow-up reviews, which post no summary
    * comment to carry the first-review banner.
    */
-  private String noIssuesBody(ReviewResult result) {
+  private String noIssuesBody(ReviewResult result, List<ReviewResponse.Finding> previousFindings) {
     long unresolved = result.unresolvedPreviousCount();
     var sb = new StringBuilder();
     boolean ciHeld = false;
@@ -567,6 +615,13 @@ public class ReviewPublisher {
       sb.append(ciHeld ? "\nAdditionally, " : "")
           .append(ReviewResult.unresolvedPreviousMessage(unresolved));
       appendReopenedDeclineNotes(sb, result);
+    }
+    var closed = ClosedFindingNames.reviewBodySection(result, previousFindings);
+    if (!closed.isEmpty()) {
+      if (!sb.isEmpty()) {
+        sb.append("\n\n");
+      }
+      sb.append(closed.strip());
     }
     if (result.truncated()) {
       if (!sb.isEmpty()) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisher.java
@@ -358,15 +358,7 @@ public class ReviewPublisher {
             owner, repo, prNumber);
         return;
       }
-      postNoIssuesReview(
-          auth,
-          owner,
-          repo,
-          prNumber,
-          commitSha,
-          result,
-          post.summaryPosted(),
-          post.previousFindings());
+      postNoIssuesReview(post);
       return;
     }
 
@@ -547,15 +539,15 @@ public class ReviewPublisher {
    * a second surface with identical copy is pure noise (#334). When the summary post failed or was
    * skipped, the COMMENT review is the round's only visible signal and always posts.
    */
-  private void postNoIssuesReview(
-      String auth,
-      String owner,
-      String repo,
-      int prNumber,
-      String commitSha,
-      ReviewResult result,
-      boolean summaryPosted,
-      List<ReviewResponse.Finding> previousFindings) {
+  private void postNoIssuesReview(PostReviewRequest post) {
+    var auth = post.auth();
+    var owner = post.owner();
+    var repo = post.repo();
+    var prNumber = post.prNumber();
+    var commitSha = post.commitSha();
+    var result = post.result();
+    var summaryPosted = post.summaryPosted();
+    var previousFindings = post.previousFindings();
     if (result.reviewState() == ReviewState.APPROVE) {
       // The round that closes the last open finding approves, so this is the body a cleared
       // finding most often lands on — it has to name what it closed (#737).
@@ -616,20 +608,22 @@ public class ReviewPublisher {
           .append(ReviewResult.unresolvedPreviousMessage(unresolved));
       appendReopenedDeclineNotes(sb, result);
     }
-    var closed = ClosedFindingNames.reviewBodySection(result, previousFindings);
-    if (!closed.isEmpty()) {
-      if (!sb.isEmpty()) {
-        sb.append("\n\n");
-      }
-      sb.append(closed.strip());
-    }
-    if (result.truncated()) {
-      if (!sb.isEmpty()) {
-        sb.append("\n\n");
-      }
-      sb.append(result.truncationNotice().strip());
-    }
+    appendSection(sb, ClosedFindingNames.reviewBodySection(result, previousFindings));
+    appendSection(sb, result.truncated() ? result.truncationNotice() : "");
     return sb.toString();
+  }
+
+  /**
+   * Appends {@code section} as its own paragraph, blank-line separated from whatever precedes it.
+   */
+  private static void appendSection(StringBuilder sb, String section) {
+    if (section.isBlank()) {
+      return;
+    }
+    if (!sb.isEmpty()) {
+      sb.append("\n\n");
+    }
+    sb.append(section.strip());
   }
 
   /**

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -3556,4 +3556,29 @@ class FollowUpAnalyzerTest {
     var body = "ThrillhouseBot requested changes — see inline.\n\n- src/A.java:10 — a finding";
     assertEquals(body, FollowUpAnalyzer.withoutClosedFindingNames(body));
   }
+
+  /**
+   * The section ends at its own bullets. A list that merely follows it, past the separating blank,
+   * belongs to the review — swallowing it would drop real prior findings out of the context.
+   */
+  @Test
+  void keepsABulletParagraphThatMerelyFollowsTheClosedFindingsSection() {
+    var body =
+        """
+        ThrillhouseBot requested changes — see inline.
+
+        ThrillhouseBot closed 1 previous finding(s) this round:
+
+        - src/A.java:10 — Missing null check
+
+        - src/C.java:30 — Unbounded retry loop
+        - src/D.java:40 — Missing timeout""";
+
+    var kept = FollowUpAnalyzer.withoutClosedFindingNames(body);
+
+    assertFalse(kept.contains("Missing null check"), kept);
+    assertTrue(
+        kept.contains("Unbounded retry loop"), "a following bullet list was swallowed: " + kept);
+    assertTrue(kept.contains("Missing timeout"), kept);
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -3476,4 +3476,84 @@ class FollowUpAnalyzerTest {
         FollowUpAnalyzer.namesOnlyAmbiguousRanges("@thrillhousebot resolved `src/A.java:1-3`"),
         "an adjacent range is a continued token, which no title spelling produces");
   }
+
+  /**
+   * The section names findings this round closed. A with-findings body does not lead with it, so
+   * {@code isSelfAuthoredStatusBody} keeps the body — and the section inside it would then be
+   * offered to the model as prior issues to account for, re-opening what was just closed (#455).
+   */
+  @Test
+  void closedFindingNamesAreStrippedFromAWithFindingsBodyBeforeItBecomesPriorContext() {
+    var body =
+        """
+        ThrillhouseBot requested changes — see inline.
+
+        ThrillhouseBot closed 2 previous finding(s) this round:
+
+        - src/A.java:10 — Missing null check
+        - src/B.java:20 — Unclosed resource
+
+        > [!WARNING]
+        > Some files were not reviewed.""";
+
+    var context =
+        analyzer.buildPreviousFindingsContext(
+            List.of(
+                new GitHubReviewClient.ReviewResponse(
+                    1L,
+                    body,
+                    "CHANGES_REQUESTED",
+                    "sha",
+                    new GitHubReviewClient.ReviewResponse.User(BOT))),
+            BOT_ID);
+
+    assertFalse(
+        context.contains("Missing null check"),
+        "a finding this round closed was handed back as prior review content:\n" + context);
+    assertFalse(context.contains("ThrillhouseBot closed"), context);
+    assertTrue(
+        context.contains("requested changes"), "real review content must survive: " + context);
+    assertTrue(
+        context.contains("not reviewed"), "content after the section must survive: " + context);
+  }
+
+  /** The section is the last thing in the body, so nothing follows it to separate. */
+  @Test
+  void stripsAClosedFindingsSectionThatRunsToTheEndOfTheBody() {
+    var body =
+        """
+        ThrillhouseBot requested changes — see inline.
+
+        ThrillhouseBot closed 1 previous finding(s) this round:
+
+        - src/A.java:10 — Missing null check""";
+
+    assertEquals(
+        "ThrillhouseBot requested changes — see inline.",
+        FollowUpAnalyzer.withoutClosedFindingNames(body));
+  }
+
+  /** The section leads the body, so there is no earlier content to keep a blank line after. */
+  @Test
+  void stripsAClosedFindingsSectionThatLeadsTheBody() {
+    var body =
+        """
+        ThrillhouseBot closed 1 previous finding(s) this round:
+
+        - src/A.java:10 — Missing null check
+
+        > [!WARNING]
+        > Some files were not reviewed.""";
+
+    assertEquals(
+        "> [!WARNING]\n> Some files were not reviewed.",
+        FollowUpAnalyzer.withoutClosedFindingNames(body));
+  }
+
+  /** A control: a body carrying no such section is returned unchanged. */
+  @Test
+  void leavesABodyWithNoClosedFindingsSectionAlone() {
+    var body = "ThrillhouseBot requested changes — see inline.\n\n- src/A.java:10 — a finding";
+    assertEquals(body, FollowUpAnalyzer.withoutClosedFindingNames(body));
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewOrchestratorTest.java
@@ -572,6 +572,235 @@ class ReviewOrchestratorTest {
     }
 
     @Test
+    void closedFindingIsNamedOnTheBodyOfARoundThatAlsoPostsFindings() {
+      // #737: the surfaces #714 added — the opt-in delta comment and a reply on the closed
+      // finding's thread — leave a default install with nothing naming what a round closed, and a
+      // threadless finding (#712) has no thread to reply on at all. The review body is behind no
+      // flag, so it names the closure next to the round's other previous-finding disclosures.
+      var result =
+          new ReviewResult(
+              List.of(new Finding(RiskLevel.MEDIUM, "src/Main.java", 10, "t", "d", null, null)),
+              0,
+              0,
+              1,
+              0,
+              RiskLevel.MEDIUM,
+              ReviewState.COMMENT,
+              false,
+              "",
+              List.of(new ReviewResult.PreviousFindingStatus(1, "resolved", "cleared")),
+              List.of(),
+              0);
+
+      reviewPublisher.postReview(
+          new ReviewPublisher.PostReviewRequest(
+              "auth",
+              "owner",
+              "repo",
+              5,
+              "sha",
+              result,
+              resolverFor(fileDiffWithLine("src/Main.java", 10)),
+              false,
+              List.of(
+                  new ReviewResponse.Finding(
+                      "high", "src/Retry.java", 42, "Unbounded retry", "d", null, null))));
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      var body = captor.getValue().body();
+      assertTrue(body.contains("ThrillhouseBot closed 1 previous finding(s) this round:"), body);
+      assertTrue(body.contains("- `src/Retry.java:42` — Unbounded retry"), body);
+    }
+
+    @Test
+    void closedFindingIsNamedWhenNoFindingCouldBeAnchoredAndStaysAboveTheCoverageBanner() {
+      // The other with-findings branch: nothing landed inline, so the body already lists the
+      // findings GitHub took no thread for. The closure names ride below that list — the body's
+      // first line has to stay the findings section — and above the partial-coverage banner, which
+      // stays outermost (#737).
+      doThrow(new RuntimeException("422"))
+          .when(reviewClient)
+          .createPullRequestComment(
+              anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+      var result =
+          new ReviewResult(
+              List.of(new Finding(RiskLevel.MEDIUM, "src/Gone.java", 10, "t", "d", null, null)),
+              0,
+              0,
+              1,
+              0,
+              RiskLevel.MEDIUM,
+              ReviewState.COMMENT,
+              false,
+              "",
+              List.of(new ReviewResult.PreviousFindingStatus(1, "resolved", "cleared")),
+              List.of(),
+              7);
+
+      reviewPublisher.postReview(
+          new ReviewPublisher.PostReviewRequest(
+              "auth",
+              "owner",
+              "repo",
+              5,
+              "sha",
+              result,
+              resolverFor(),
+              false,
+              List.of(
+                  new ReviewResponse.Finding(
+                      "high", "src/Retry.java", 42, "Unbounded retry", "d", null, null))));
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      var body = captor.getValue().body();
+      assertTrue(body.contains("- `src/Retry.java:42` — Unbounded retry"), body);
+      assertTrue(
+          body.indexOf("GitHub accepted no review thread for")
+              < body.indexOf("ThrillhouseBot closed"),
+          body);
+      assertTrue(body.indexOf("ThrillhouseBot closed") < body.indexOf("partial review"), body);
+    }
+
+    @Test
+    void closedFindingIsNamedBelowTheUnresolvedSentenceOnANoNewFindingsBody() {
+      // A round can close one previous finding and leave another open. The no-new-findings body
+      // states both: the unresolved sentence first, then what actually closed, then the coverage
+      // banner (#737).
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.COMMENT,
+              false,
+              "",
+              List.of(
+                  new ReviewResult.PreviousFindingStatus(1, "resolved", "cleared"),
+                  new ReviewResult.PreviousFindingStatus(2, "unresolved", "still")),
+              List.of(),
+              7);
+
+      reviewPublisher.postReview(
+          new ReviewPublisher.PostReviewRequest(
+              "auth",
+              "owner",
+              "repo",
+              5,
+              "sha",
+              result,
+              resolverFor(),
+              false,
+              List.of(
+                  new ReviewResponse.Finding(
+                      "high", "src/Retry.java", 42, "Unbounded retry", "d", null, null),
+                  new ReviewResponse.Finding(
+                      "medium", "src/Open.java", 7, "Still open", "d", null, null))));
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      var body = captor.getValue().body();
+      assertTrue(body.contains("- `src/Retry.java:42` — Unbounded retry"), body);
+      assertFalse(body.contains("src/Open.java"), body);
+      assertTrue(body.indexOf("remain unresolved") < body.indexOf("ThrillhouseBot closed"), body);
+      assertTrue(body.indexOf("ThrillhouseBot closed") < body.indexOf("partial review"), body);
+    }
+
+    @Test
+    void closureNamesAreTheWholeBodyWhenTheRoundHasNothingElseToReport() {
+      // Nothing held the verdict back but the round still closed something: the names are all the
+      // body carries, so it opens with them (#737).
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.COMMENT,
+              false,
+              "",
+              List.of(new ReviewResult.PreviousFindingStatus(1, "resolved", "cleared")),
+              List.of(),
+              0);
+
+      reviewPublisher.postReview(
+          new ReviewPublisher.PostReviewRequest(
+              "auth",
+              "owner",
+              "repo",
+              5,
+              "sha",
+              result,
+              resolverFor(),
+              false,
+              List.of(
+                  new ReviewResponse.Finding(
+                      "high", "src/Retry.java", 42, "Unbounded retry", "d", null, null))));
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      assertTrue(
+          captor
+              .getValue()
+              .body()
+              .startsWith("ThrillhouseBot closed 1 previous finding(s) this round:"),
+          captor.getValue().body());
+    }
+
+    @Test
+    void summaryOnlyReRunStillPostsTheReviewThatNamesWhatClosed() {
+      // The clean summary-only re-run skip has to let this round through: a re-posted summary says
+      // nothing about closures, so skipping the review would put the names on no surface at all —
+      // the same default-install gap as before (#737).
+      var result =
+          new ReviewResult(
+              List.of(),
+              0,
+              0,
+              0,
+              0,
+              null,
+              ReviewState.APPROVE,
+              false,
+              "",
+              List.of(new ReviewResult.PreviousFindingStatus(1, "resolved", "cleared")),
+              List.of(),
+              0);
+
+      reviewPublisher.postReview(
+          new ReviewPublisher.PostReviewRequest(
+              "auth",
+              "owner",
+              "repo",
+              5,
+              "sha",
+              result,
+              resolverFor(),
+              true,
+              List.of(
+                  new ReviewResponse.Finding(
+                      "high", "src/Retry.java", 42, "Unbounded retry", "d", null, null))));
+
+      var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+      verify(reviewClient)
+          .createReview(eq("auth"), anyString(), eq("owner"), eq("repo"), eq(5), captor.capture());
+      var body = captor.getValue().body();
+      assertEquals("APPROVE", captor.getValue().event());
+      assertTrue(body.contains(PrSummaryGenerator.ZERO_ISSUES_MESSAGE), body);
+      assertTrue(body.contains("- `src/Retry.java:42` — Unbounded retry"), body);
+    }
+
+    @Test
     void findingsBodyOmitsNotesThatAreNotReopenedDeclines() {
       // The with-findings surface applies the same filter as the no-findings one: a plain
       // unresolved note and a resolved finding's note are both left out, so a COMMENT round whose
@@ -5549,7 +5778,7 @@ class ReviewOrchestratorTest {
 
       reviewPublisher.postReview(
           new ReviewPublisher.PostReviewRequest(
-              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true));
+              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true, List.of()));
 
       verify(reviewClient, never())
           .createReview(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
@@ -5574,7 +5803,7 @@ class ReviewOrchestratorTest {
 
       reviewPublisher.postReview(
           new ReviewPublisher.PostReviewRequest(
-              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true));
+              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true, List.of()));
 
       var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
       verify(reviewClient)
@@ -5591,7 +5820,7 @@ class ReviewOrchestratorTest {
 
       reviewPublisher.postReview(
           new ReviewPublisher.PostReviewRequest(
-              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true));
+              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true, List.of()));
 
       var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
       verify(reviewClient)
@@ -5619,7 +5848,7 @@ class ReviewOrchestratorTest {
 
       reviewPublisher.postReview(
           new ReviewPublisher.PostReviewRequest(
-              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true));
+              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true, List.of()));
 
       var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
       verify(reviewClient)
@@ -5687,7 +5916,7 @@ class ReviewOrchestratorTest {
 
       reviewPublisher.postReview(
           new ReviewPublisher.PostReviewRequest(
-              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true));
+              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true, List.of()));
 
       verify(reviewClient, never())
           .createReview(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
@@ -5712,7 +5941,7 @@ class ReviewOrchestratorTest {
 
       reviewPublisher.postReview(
           new ReviewPublisher.PostReviewRequest(
-              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true));
+              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true, List.of()));
 
       verify(reviewClient, never())
           .createReview(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
@@ -5737,7 +5966,7 @@ class ReviewOrchestratorTest {
 
       reviewPublisher.postReview(
           new ReviewPublisher.PostReviewRequest(
-              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true));
+              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true, List.of()));
 
       var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
       verify(reviewClient)
@@ -5754,7 +5983,7 @@ class ReviewOrchestratorTest {
 
       reviewPublisher.postReview(
           new ReviewPublisher.PostReviewRequest(
-              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true));
+              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true, List.of()));
 
       var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
       verify(reviewClient)
@@ -5770,7 +5999,7 @@ class ReviewOrchestratorTest {
 
       reviewPublisher.postReview(
           new ReviewPublisher.PostReviewRequest(
-              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true));
+              "auth", "owner", "repo", 5, "sha", result, resolverFor(), true, List.of()));
 
       var captor = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
       verify(reviewClient)

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisherTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewPublisherTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -35,6 +36,7 @@ import dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient;
 import dev.thiagogonzaga.thrillhousebot.github.ReviewThreadService;
 import dev.thiagogonzaga.thrillhousebot.review.ai.ReviewResponse;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -46,6 +48,10 @@ class ReviewPublisherTest {
 
   private final GitHubCommentClient commentClient = mock(GitHubCommentClient.class);
 
+  private final GitHubReviewClient reviewClient = mock(GitHubReviewClient.class);
+
+  private final ReviewThreadService reviewThreadService = mock(ReviewThreadService.class);
+
   private final ThrillhouseConfig config = mock(ThrillhouseConfig.class);
 
   private final ThrillhouseConfig.ReviewConfig reviewConfig =
@@ -56,9 +62,9 @@ class ReviewPublisherTest {
 
   private final ReviewPublisher publisher =
       new ReviewPublisher(
-          mock(GitHubReviewClient.class),
+          reviewClient,
           commentClient,
-          mock(ReviewThreadService.class),
+          reviewThreadService,
           mock(SuggestionFormatter.class),
           mock(FollowUpAnalyzer.class),
           mock(PrLabeler.class),
@@ -270,5 +276,83 @@ class ReviewPublisherTest {
         publisher.publishFollowUpDelta("auth", "o", "r", 1, RESOLVED_FOLLOW_UP, true, List.of()));
     verify(commentClient, never())
         .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+  }
+
+  /**
+   * The threadless finding of #712: raised in an earlier round, published with no inline thread of
+   * its own, and closed this round by an {@code @thrillhousebot resolved} directive.
+   */
+  private static final ReviewResponse.Finding THREADLESS_PREVIOUS =
+      new ReviewResponse.Finding(
+          "high", "src/main/java/A.java", 42, "Unbounded retry", "d", null, null);
+
+  @Test
+  void clearedThreadlessFindingIsNamedOnTheReviewBodyADefaultInstallPosts() {
+    // #737: #714 shipped two naming surfaces and a default install reaches neither for the case it
+    // called worst. The delta comment that names closures is opt-in and defaults off, and the other
+    // surface is a reply on the closed finding's thread — which a threadless finding (#712) does
+    // not have, and that is exactly the finding a clearing directive is the only way to close
+    // (#709). So the round closed it and nothing anywhere said what closed. The review body is
+    // behind no flag and posts on this round regardless, so it carries the names.
+    followUpSummaryEnabled(false);
+    var req =
+        new ReviewOrchestrator.ReviewRequest(
+            "o", "r", 1, "sha", "t", "", "base", "main", 9L, false);
+    // A thread exists on the PR, just not for this finding — so the reply surface is skipped for
+    // being unmatched, not for the PR having no inline comments at all.
+    var otherThread =
+        List.of(
+            new GitHubReviewClient.PullRequestComment(
+                5L,
+                null,
+                "src/main/java/B.java",
+                "unrelated",
+                new GitHubReviewClient.ReviewResponse.User("thrillhousebot")));
+
+    var delta =
+        publisher.publishFollowUpDelta(
+            "auth", "o", "r", 1, RESOLVED_FOLLOW_UP, false, List.of(THREADLESS_PREVIOUS));
+    publisher.resolveAddressedThreads(
+        "auth",
+        req,
+        List.of(THREADLESS_PREVIOUS),
+        otherThread,
+        RESOLVED_FOLLOW_UP.previousStatuses());
+    publisher.postReview(
+        new ReviewPublisher.PostReviewRequest(
+            "auth",
+            "o",
+            "r",
+            1,
+            "sha",
+            RESOLVED_FOLLOW_UP,
+            new DiffLineResolver(Map.of()),
+            false,
+            List.of(THREADLESS_PREVIOUS)));
+
+    // Neither of #714's surfaces reaches this maintainer: no delta comment, no thread reply.
+    assertFalse(delta);
+    verify(commentClient, never())
+        .createComment(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
+    verify(reviewClient, never())
+        .replyToReviewComment(
+            anyString(), anyString(), anyString(), anyString(), anyInt(), anyLong(), any());
+    var review = ArgumentCaptor.forClass(GitHubReviewClient.CreateReviewRequest.class);
+    verify(reviewClient)
+        .createReview(anyString(), anyString(), eq("o"), eq("r"), eq(1), review.capture());
+    var body = review.getValue().body();
+    assertTrue(body.contains("ThrillhouseBot closed 1 previous finding(s) this round:"), body);
+    assertTrue(body.contains("- `src/main/java/A.java:42` — Unbounded retry"), body);
+  }
+
+  @Test
+  void reviewBodyNamingClosuresIsNotReadBackAsAPreviousFinding() {
+    // The section names findings the round just closed, so a later round that falls back to the
+    // last bot review body for its previous-findings context must not hand them to the model as
+    // issues "flagged in the previous review" and re-open every one of them (#455).
+    var body =
+        ClosedFindingNames.reviewBodySection(RESOLVED_FOLLOW_UP, List.of(THREADLESS_PREVIOUS));
+
+    assertTrue(FollowUpAnalyzer.isSelfAuthoredStatusBody(body), body);
   }
 }


### PR DESCRIPTION
## What type of PR is this?

<!-- Check all that apply -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

## Description

#714 asked a round to name the findings it closed, and both halves shipped, but
on a default install neither reaches the maintainer:

- The names render on the follow-up delta comment, gated on
  `thrillhousebot.review.follow-up-summary.enabled` — `@WithDefault("false")`.
- The other surface is a reply on the closed finding's own review thread, which
  a finding published with no thread (#712) does not have — and that threadless
  finding is precisely the one an `@thrillhousebot resolved` directive is the
  only way to close (#709).

So clearing a threadless finding closed it and nothing anywhere said what
closed, which is the case #714 itself calls worst.

**Which direction, and the trade.** The issue offers two: render the names on a
surface that is not behind the flag, or flip the flag's default. This takes the
first.

Flipping the default would work for the counts, but it buys the naming by
turning on a whole extra PR comment on every follow-up round for every install
— a per-push comment stream is what the flag was defaulted off to avoid, and the
delta comment is deliberately skipped on any round that re-posts the summary, so
a closure landing on a superseded or `/review` round would still go unnamed. The
review body has neither problem: it is behind no flag, it posts on the round
that closes a finding, and it already carries the round's other previous-finding
disclosures — the unresolved-count sentence and the overturned-decline notes
from #720. The cost is that an install which does enable the delta sees the
names on both surfaces. That is the same trade the truncation notice already
makes here ("a duplicated notice when the summary does post is the acceptable
cost of never dropping it"), and the two surfaces never appear on the same round
by accident: each is self-contained and the delta is skipped whenever a summary
posts.

**What renders.** Below the findings sections and above the partial-coverage
banner, on every review body:

```
ThrillhouseBot closed 1 previous finding(s) this round:

- `src/main/java/A.java:42` — Unbounded retry
```

- All four body paths carry it: the approving body (the one a round that clears
  the last open finding actually posts), the no-new-findings COMMENT body, and
  both with-findings branches (inline-anchored and the un-anchored/cap-skipped
  fallback).
- Placement is load-bearing. It sits below the findings sections because
  `FollowUpAnalyzer.isSelfAuthoredStatusBody` classifies a body by its first
  line, and above the coverage banner so the coverage caveat stays outermost.
- The naming moved into `ClosedFindingNames`, shared with the delta comment, so
  both surfaces name a closure identically: the `path:line` and title the
  directive uses, bounded at ten names with the remainder rolled up, both halves
  through `MarkdownSafe`. No change to what counts as closed.
- `isSelfAuthoredStatusBody` now recognizes the section. This body is read back
  as previous-findings context when no AI response was persisted, and a section
  naming findings the round just *closed* would otherwise be handed to the model
  as issues "flagged in the previous review" and re-open every one of them —
  #455's exact failure mode.
- The summary-only re-run skip now also tests the resolved count: a re-posted
  summary states no closure, so skipping the review there would put the names on
  no surface at all again.

## Related Issues

Fixes #737

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Six new tests. The lead one drives the issue's own case end to end — a
threadless previous finding cleared this round — and asserts that neither #714
surface fires (delta off by default, no thread reply because the finding has no
thread) while the review body names it.

**Red on the unfixed behaviour.** Both runs below are with the naming removed
from the review body and the plumbing kept, so the tests compile against the
prior behaviour:

```
[ERROR] dev.thiagogonzaga.thrillhousebot.review.ReviewPublisherTest.clearedThreadlessFindingIsNamedOnTheReviewBodyADefaultInstallPosts -- Time elapsed: 0.025 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
Everything's coming up Thrillhouse! 🎉

No issues found in this PR. ==> expected: <true> but was: <false>
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:232)
	at dev.thiagogonzaga.thrillhousebot.review.ReviewPublisherTest.clearedThreadlessFindingIsNamedOnTheReviewBodyADefaultInstallPosts(ReviewPublisherTest.java:344)
```

That is the symptom exactly: the only review a default install posts for that
round is the bare celebration, with the closed finding unnamed.

The other four body paths are red the same way:

```
[ERROR] Failures:
[ERROR]   ReviewOrchestratorTest.closedFindingIsNamedBelowTheUnresolvedSentenceOnANoNewFindingsBody No new issues in this revision, but 1 previous finding(s) remain unresolved — fix them, or reply on their review thread with why they are deferred. A finding listed only under "Things to double-check" has no thread: clear it by commenting `@thrillhousebot resolved path/to/File.java:42 — <the finding's title>` on this PR.

> ⚠️ **Large PR — partial review.** 7 file(s) were omitted because the diff exceeded the size budget; the findings and verdict below cover only the reviewed portion. ==> expected: <true> but was: <false>
[ERROR]   ReviewOrchestratorTest.closedFindingIsNamedOnTheBodyOfARoundThatAlsoPostsFindings
Wanted but not invoked:
reviewClient.createReview(
    "auth",
    <any string>,
    "owner",
    "repo",
    5,
    <Capturing argument: CreateReviewRequest>
);
[ERROR]   ReviewOrchestratorTest.closedFindingIsNamedWhenNoFindingCouldBeAnchoredAndStaysAboveTheCoverageBanner ThrillhouseBot found 1 issue(s) GitHub accepted no review thread for:

- **MEDIUM:** t (`src/Gone.java:10`)
  d


> ⚠️ **Large PR — partial review.** 7 file(s) were omitted because the diff exceeded the size budget; the findings and verdict below cover only the reviewed portion. ==> expected: <true> but was: <false>
[ERROR]   ReviewOrchestratorTest.closureNamesAreTheWholeBodyWhenTheRoundHasNothingElseToReport expected: <true> but was: <false>
[ERROR]   ReviewOrchestratorTest.summaryOnlyReRunStillPostsTheReviewThatNamesWhatClosed
Wanted but not invoked:
```

`reviewBodyNamingClosuresIsNotReadBackAsAPreviousFinding` is a guard on the
#455 recognizer, not a red/green proof: it is green either way in the neutered
tree, since a section that renders nothing is trivially not read back.

Gates, `JAVA_HOME=/home/thiago/.jdks/jdk-25.0.4+7`:

- `./mvnw -B spotless:apply` — clean
- `./mvnw -B clean compile spotbugs:check spotless:check` — BUILD SUCCESS,
  `BugInstance size is 0`
- `./mvnw -B clean test` — `Tests run: 3383, Failures: 0, Errors: 0, Skipped: 0`
- jacoco ∩ `git diff -U0 c4550f8...HEAD` on changed main code — 51 trackable
  lines, 0 uncovered lines and 0 uncovered branches

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

No configuration change: `REVIEW_FOLLOW_UP_SUMMARY_ENABLED` keeps its default
and its documented meaning, and the delta comment renders exactly as before.
