### PR TITLE
fix(review): converge on an anchor the maintainer has already litigated

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -450,6 +450,15 @@ public class FindingPipeline {
     refined =
         followUpAnalyzer.dropRepliedDuplicates(
             refined, ctx.priorAiResponseJsons(), ctx.inlineComments(), botIdentity);
+    // #726: a novel lower-confidence hypothesis on an anchor the maintainer has already
+    // dispositioned twice is a re-roll of the dice, not a finding to disposition again.
+    refined =
+        FollowUpAnalyzer.withoutPreviouslyLitigated(
+            refined,
+            ctx.priorAiResponses(),
+            ctx.inlineComments(),
+            ctx.conversationComments(),
+            botIdentity);
     refined = populateMissingAnchors(refined, lineResolver);
 
     if (tokenLedger.ceilingReached(ledgerSessionId(session))) {
@@ -1351,6 +1360,15 @@ public class FindingPipeline {
     aiResponse =
         followUpAnalyzer.dropRepliedDuplicates(
             aiResponse, ctx.priorAiResponseJsons(), ctx.inlineComments(), botIdentity);
+    // #726: a novel lower-confidence hypothesis on an anchor the maintainer has already
+    // dispositioned twice is a re-roll of the dice, not a finding to disposition again.
+    aiResponse =
+        FollowUpAnalyzer.withoutPreviouslyLitigated(
+            aiResponse,
+            ctx.priorAiResponses(),
+            ctx.inlineComments(),
+            ctx.conversationComments(),
+            botIdentity);
     aiResponse = populateMissingAnchors(aiResponse, lineResolver);
     persistAiResponse(session, aiResponse);
     return aiResponse;

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -739,7 +739,8 @@ public class FollowUpAnalyzer {
       return response;
     }
     var dispositioned =
-        dispositionedFindings(priorRounds, inlineComments, conversationComments, botIdentity);
+        distinct(
+            dispositionedFindings(priorRounds, inlineComments, conversationComments, botIdentity));
     if (dispositioned.isEmpty()) {
       return response;
     }
@@ -797,15 +798,34 @@ public class FollowUpAnalyzer {
    * rounds carried it, so it is counted once.
    */
   private static int litigating(
-      ReviewResponse.Finding finding, List<ReviewResponse.Finding> dispositioned) {
-    var counted = new ArrayList<ReviewResponse.Finding>();
-    for (var prior : dispositioned) {
-      if (sameAnchor(finding, prior)
-          && counted.stream().noneMatch(seen -> isSameFinding(prior, seen))) {
-        counted.add(prior);
+      ReviewResponse.Finding finding, List<ReviewResponse.Finding> distinctDispositioned) {
+    var count = 0;
+    for (var prior : distinctDispositioned) {
+      if (sameAnchor(finding, prior)) {
+        count++;
       }
     }
-    return counted.size();
+    return count;
+  }
+
+  /**
+   * {@code dispositioned} with findings that are the same defect collapsed to one, so a defect the
+   * maintainer dispositioned once and the model then re-raised across rounds counts once toward the
+   * limit rather than once per round.
+   *
+   * <p>Collapsed here, once per call, rather than inside {@link #litigating}: that runs per finding
+   * in the response, and folding the same list again for each of them repeated the whole comparison
+   * for no new answer. {@link #isSameFinding} already requires the same file and a line within
+   * tolerance, so collapsing across the list and collapsing within one anchor give the same groups.
+   */
+  private static List<ReviewResponse.Finding> distinct(List<ReviewResponse.Finding> dispositioned) {
+    var distinct = new ArrayList<ReviewResponse.Finding>(dispositioned.size());
+    for (var prior : dispositioned) {
+      if (distinct.stream().noneMatch(seen -> isSameFinding(prior, seen))) {
+        distinct.add(prior);
+      }
+    }
+    return distinct;
   }
 
   /** Whether two findings sit at the same location, within the drift a revision may introduce. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -682,6 +682,138 @@ public class FollowUpAnalyzer {
     return null;
   }
 
+  /**
+   * How many distinct findings on one anchor a maintainer must have dispositioned before a further
+   * lower-confidence finding on that same anchor stops being raised (#726).
+   *
+   * <p>Two, not one: the first decline settles one hypothesis, and a second look at the same lines
+   * is ordinary review. It is the third and later ones that stop being review and start being a
+   * fresh roll of the dice — the observed run was five rounds over essentially unchanged code, each
+   * minting a brand-new lower-confidence item on the same ~30 lines, each contradicting the last,
+   * and each costing the maintainer a manual disposition.
+   */
+  static final int LITIGATED_ANCHOR_LIMIT = 2;
+
+  /**
+   * Deterministic convergence for an anchor the maintainer has already litigated: withholds a new
+   * <em>lower-confidence</em> finding whose location has already carried {@link
+   * #LITIGATED_ANCHOR_LIMIT} distinct maintainer-dispositioned findings on this pull request
+   * (#726).
+   *
+   * <p>{@link #dropRepliedDuplicates} already stops a prior finding from being re-raised, but it
+   * matches on the defect: a new title with a new premise on the same lines is not the same
+   * finding, so it passes. That is exactly what re-review of an unchanged diff produces — each
+   * round invents a novel speculative hypothesis against the same lines, previous-findings tracking
+   * never converges because nothing is repeated, and the maintainer disposes of a new item every
+   * round. This pass matches on the <em>anchor</em> instead, which is the thing the rounds actually
+   * have in common.
+   *
+   * <p>Three properties keep it from suppressing real review:
+   *
+   * <ul>
+   *   <li>only findings that never post inline are eligible — {@link Finding#postsInline} routes
+   *       low-confidence findings below high risk to the summary's "Things to double-check", and
+   *       that is the whole reported class. A high-confidence finding, and any critical/high-risk
+   *       one, is untouched however often its anchor has been argued over;
+   *   <li>the count is of <em>distinct</em> dispositioned findings ({@link #isSameFinding}), so one
+   *       finding carried across rounds cannot reach the limit on its own;
+   *   <li>a disposition means a maintainer acted — a reply on the finding's thread, or an {@code
+   *       @thrillhousebot resolved} comment naming it on the PR conversation, which is the only
+   *       hatch a threadless finding has (#548). The bot's own rounds never raise the count.
+   * </ul>
+   *
+   * <p>The trade it accepts: if the code under a twice-litigated anchor genuinely changes, a new
+   * lower-confidence observation there is withheld too. That is the cheap direction — the same
+   * defect surfacing at high confidence or at critical/high risk is exempt, and the withheld class
+   * is by construction the one the review already declines to put on the diff.
+   *
+   * @param priorRounds every completed prior round's parsed response, newest first
+   */
+  public static ReviewResponse withoutPreviouslyLitigated(
+      ReviewResponse response,
+      List<ReviewResponse> priorRounds,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      List<GitHubCommentClient.IssueComment> conversationComments,
+      BotIdentity botIdentity) {
+    if (response.findings().isEmpty() || priorRounds.isEmpty()) {
+      return response;
+    }
+    var dispositioned =
+        dispositionedFindings(priorRounds, inlineComments, conversationComments, botIdentity);
+    if (dispositioned.isEmpty()) {
+      return response;
+    }
+    var kept = new ArrayList<ReviewResponse.Finding>();
+    var withheld = false;
+    for (ReviewResponse.Finding finding : response.findings()) {
+      var litigated =
+          Finding.fromAiResponse(finding).postsInline() ? 0 : litigating(finding, dispositioned);
+      if (litigated < LITIGATED_ANCHOR_LIMIT) {
+        kept.add(finding);
+        continue;
+      }
+      withheld = true;
+      Log.infof(
+          "Withholding lower-confidence finding '%s' (%s:%d) — %d finding(s) on that anchor were"
+              + " already dispositioned by a maintainer on this pull request",
+          LogSafe.oneLine(finding.title()),
+          LogSafe.oneLine(finding.file()),
+          finding.line(),
+          litigated);
+    }
+    if (!withheld) {
+      return response;
+    }
+    return new ReviewResponse(
+        kept,
+        response.previousFindingsStatus(),
+        FindingVerificationService.recount(response.summary(), kept));
+  }
+
+  /**
+   * Every prior finding a maintainer answered on its thread or cleared from the PR conversation.
+   * Rounds carry no nulls ({@code ReviewContext} copies its list), so none is filtered here.
+   */
+  private static List<ReviewResponse.Finding> dispositionedFindings(
+      List<ReviewResponse> priorRounds,
+      List<GitHubReviewClient.PullRequestComment> inlineComments,
+      List<GitHubCommentClient.IssueComment> conversationComments,
+      BotIdentity botIdentity) {
+    var dispositioned = new ArrayList<ReviewResponse.Finding>();
+    for (var round : priorRounds) {
+      for (var prior : round.findings()) {
+        if (answeredRootComment(prior, inlineComments, botIdentity) != null
+            || clearedInConversation(prior, conversationComments, botIdentity)) {
+          dispositioned.add(prior);
+        }
+      }
+    }
+    return dispositioned;
+  }
+
+  /**
+   * How many <em>distinct</em> dispositioned findings share {@code finding}'s anchor. A prior the
+   * count already covers by {@link #isSameFinding} is the same defect argued once, however many
+   * rounds carried it, so it is counted once.
+   */
+  private static int litigating(
+      ReviewResponse.Finding finding, List<ReviewResponse.Finding> dispositioned) {
+    var counted = new ArrayList<ReviewResponse.Finding>();
+    for (var prior : dispositioned) {
+      if (sameAnchor(finding, prior)
+          && counted.stream().noneMatch(seen -> isSameFinding(prior, seen))) {
+        counted.add(prior);
+      }
+    }
+    return counted.size();
+  }
+
+  /** Whether two findings sit at the same location, within the drift a revision may introduce. */
+  private static boolean sameAnchor(ReviewResponse.Finding finding, ReviewResponse.Finding prior) {
+    return FilePaths.same(finding.file(), prior.file())
+        && Math.abs(finding.line() - prior.line()) <= DUPLICATE_LINE_TOLERANCE;
+  }
+
   private static boolean isSameFinding(
       ReviewResponse.Finding finding, ReviewResponse.Finding prior) {
     if (finding.file() == null || !FilePaths.same(finding.file(), prior.file())) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -297,6 +297,132 @@ class FindingPipelineTest {
     assertEquals(List.of(prContext, prContext), sent.getAllValues());
   }
 
+  /** A finding the review routes to "Things to double-check": low confidence, risk below high. */
+  private static ReviewResponse.Finding doubleCheckFinding(String file, int line, String title) {
+    return new ReviewResponse.Finding("medium", "low", file, line, title, title, null, null);
+  }
+
+  /** A prior round that raised exactly {@code finding}. */
+  private static ReviewResponse round(ReviewResponse.Finding finding) {
+    return new ReviewResponse(List.of(finding), List.of(), null);
+  }
+
+  /** A write-capable maintainer's "@thrillhousebot resolved" comment on the PR conversation. */
+  private static dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient.IssueComment
+      maintainerClears(long id, String locator, String title) {
+    return new dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient.IssueComment(
+        id,
+        "@thrillhousebot resolved `" + locator + "` — " + title,
+        new dev.thiagogonzaga.thrillhousebot.github.GitHubReviewClient.ReviewResponse.User(
+            "maintainer"),
+        "MEMBER");
+  }
+
+  /** Review context carrying prior rounds and the PR conversation that dispositioned them. */
+  private static ReviewContextLoader.ReviewContext litigatedContext(
+      List<ReviewResponse> priorRounds,
+      List<dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient.IssueComment>
+          conversationComments) {
+    return new ReviewContextLoader.ReviewContext(
+        List.of(),
+        "raw legacy diff",
+        "",
+        0,
+        List.of(),
+        List.of(),
+        priorRounds,
+        false,
+        true,
+        null,
+        List.of(),
+        "",
+        new InstructionsResolver.ResolvedInstructions("", ""),
+        PathScopedInstructions.NONE,
+        List.of(),
+        "",
+        "",
+        "",
+        "",
+        List.of(new FileDiff("a.java", "modified", 3, 0, 3, "")),
+        () -> new DiffLineResolver(Map.of()),
+        null,
+        conversationComments);
+  }
+
+  @Test
+  void aThirdSpeculativeItemOnATwiceDispositionedAnchorIsWithheld() {
+    // #726: re-reviews of an unchanged diff mint a brand-new lower-confidence "Things to
+    // double-check" item on the same lines every round — novel by title and anchor each time, so
+    // previous-findings tracking never converges — and the maintainer disposes of a fresh one per
+    // round. Two dispositioned findings on the anchor is the evidence that the anchor has been
+    // litigated; the third speculative item must not become another open finding.
+    var session = persistedSession();
+    var firstRound = doubleCheckFinding("src/A.java", 10, "Wording rules match only the noun");
+    var secondRound = doubleCheckFinding("src/A.java", 11, "The pattern over-matches instead");
+    var ctx =
+        litigatedContext(
+            List.of(round(secondRound), round(firstRound)),
+            List.of(
+                maintainerClears(901L, "src/A.java:10", firstRound.title()),
+                maintainerClears(902L, "src/A.java:11", secondRound.title())));
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    var plan = singleBatchPlan(batch("a.java"), List.of());
+    when(aiReviewService.review(eq(session), any()))
+        .thenReturn(
+            new ReviewResponse(
+                List.of(
+                    doubleCheckFinding("src/A.java", 12, "Reworded message drops the 30s floor"),
+                    finding("src/B.java", "Unrelated defect elsewhere")),
+                List.of(),
+                new ReviewResponse.Summary(2, 0, 0, 2, 0, "ok", "does things", List.of())));
+
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+    assertEquals(
+        List.of("Unrelated defect elsewhere"),
+        result.findings().stream().map(ReviewResponse.Finding::title).toList(),
+        "a third lower-confidence item on the twice-dispositioned anchor must not be raised");
+  }
+
+  @Test
+  void aHighConfidenceFindingOnATwiceDispositionedAnchorStillPosts() {
+    // Control for the convergence rule: it passes before and after, and pins the boundary the rule
+    // must never cross. Only the class the review already keeps off the diff is eligible — a
+    // finding that posts inline is untouched however often its anchor has been argued over.
+    var session = persistedSession();
+    var firstRound = doubleCheckFinding("src/A.java", 10, "Wording rules match only the noun");
+    var secondRound = doubleCheckFinding("src/A.java", 11, "The pattern over-matches instead");
+    var ctx =
+        litigatedContext(
+            List.of(round(secondRound), round(firstRound)),
+            List.of(
+                maintainerClears(901L, "src/A.java:10", firstRound.title()),
+                maintainerClears(902L, "src/A.java:11", secondRound.title())));
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    var plan = singleBatchPlan(batch("a.java"), List.of());
+    var confident =
+        new ReviewResponse.Finding(
+            "high",
+            "high",
+            "src/A.java",
+            12,
+            "Reworded message drops the 30s floor",
+            "d",
+            null,
+            null);
+    when(aiReviewService.review(eq(session), any()))
+        .thenReturn(
+            new ReviewResponse(
+                List.of(confident),
+                List.of(),
+                new ReviewResponse.Summary(1, 1, 0, 0, 0, "ok", "does things", List.of())));
+
+    var result = pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    assertEquals(
+        List.of("Reworded message drops the 30s floor"),
+        result.findings().stream().map(ReviewResponse.Finding::title).toList());
+  }
+
   @Test
   void multiCallDoesNotRetryABatchTruncatedAtTheModelsLengthCap() {
     // #492: a length stop is deterministic — re-sending the identical prompt against the identical

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzerTest.java
@@ -3476,4 +3476,184 @@ class FollowUpAnalyzerTest {
         FollowUpAnalyzer.namesOnlyAmbiguousRanges("@thrillhousebot resolved `src/A.java:1-3`"),
         "an adjacent range is a continued token, which no title spelling produces");
   }
+
+  // ---------------------------------------------------------------------------------------------
+  // #726 — an anchor the maintainer has already litigated twice stops attracting fresh speculative
+  // items. Only the class that never posts inline is eligible, and only distinct dispositioned
+  // findings count.
+  // ---------------------------------------------------------------------------------------------
+
+  /** A finding routed to "Things to double-check": low confidence, risk below high. */
+  private static ReviewResponse.Finding speculative(String file, int line, String title) {
+    return new ReviewResponse.Finding("medium", "low", file, line, title, title, null, null);
+  }
+
+  private static ReviewResponse roundOf(ReviewResponse.Finding... findings) {
+    return new ReviewResponse(List.of(findings), List.of(), null);
+  }
+
+  private static GitHubCommentClient.IssueComment clears(ReviewResponse.Finding finding, long id) {
+    return new GitHubCommentClient.IssueComment(
+        id,
+        "@thrillhousebot resolved `"
+            + finding.file()
+            + ":"
+            + finding.line()
+            + "` — "
+            + finding.title(),
+        new GitHubReviewClient.ReviewResponse.User("maintainer"),
+        "MEMBER");
+  }
+
+  private static final ReviewResponse.Finding LITIGATED_ONE =
+      speculative("src/A.java", 10, "Wording rules match only the exact noun phrase");
+
+  private static final ReviewResponse.Finding LITIGATED_TWO =
+      speculative("src/A.java", 11, "The block pattern over-matches the generic wording");
+
+  /** The two prior rounds, newest first, whose findings the maintainer cleared. */
+  private static List<ReviewResponse> twiceLitigatedRounds() {
+    return List.of(roundOf(LITIGATED_TWO), roundOf(LITIGATED_ONE));
+  }
+
+  private static List<GitHubCommentClient.IssueComment> bothCleared() {
+    return List.of(clears(LITIGATED_ONE, 901L), clears(LITIGATED_TWO, 902L));
+  }
+
+  private static ReviewResponse withCurrent(ReviewResponse.Finding... findings) {
+    return new ReviewResponse(
+        List.of(findings),
+        List.of(new ReviewResponse.PreviousFindingStatus(1, "unresolved", "still there")),
+        new ReviewResponse.Summary(findings.length, 0, 0, findings.length, 0, "a", "p", List.of()));
+  }
+
+  private static List<String> titlesOf(ReviewResponse response) {
+    return response.findings().stream().map(ReviewResponse.Finding::title).toList();
+  }
+
+  @Test
+  void withholdsAThirdSpeculativeItemOnATwiceClearedAnchor() {
+    var current =
+        withCurrent(
+            speculative("src/A.java", 12, "A reworded block message drops the 30s floor"),
+            speculative("src/Other.java", 4, "Unrelated, on an anchor nobody litigated"));
+
+    var pruned =
+        FollowUpAnalyzer.withoutPreviouslyLitigated(
+            current, twiceLitigatedRounds(), List.of(), bothCleared(), BOT_ID);
+
+    assertEquals(List.of("Unrelated, on an anchor nobody litigated"), titlesOf(pruned));
+    assertEquals(
+        current.previousFindingsStatus(),
+        pruned.previousFindingsStatus(),
+        "previous-findings accounting is untouched");
+    assertEquals(1, pruned.summary().totalFindings(), "the summary counts are recounted");
+  }
+
+  @Test
+  void countsAMaintainerReplyOnTheFindingsThreadAsADisposition() {
+    // The other half of a disposition: a finding that did post inline was answered on its thread.
+    var replies =
+        List.of(
+            comment(100L, null, "src/A.java", "**MEDIUM — " + LITIGATED_ONE.title() + "**", BOT),
+            comment(101L, 100L, "src/A.java", "Deliberate — see the issue history", "maintainer"),
+            comment(200L, null, "src/A.java", "**MEDIUM — " + LITIGATED_TWO.title() + "**", BOT),
+            comment(201L, 200L, "src/A.java", "Also deliberate", "maintainer"));
+
+    var pruned =
+        FollowUpAnalyzer.withoutPreviouslyLitigated(
+            withCurrent(speculative("src/A.java", 12, "A third hypothesis on the same lines")),
+            twiceLitigatedRounds(),
+            replies,
+            List.of(),
+            BOT_ID);
+
+    assertEquals(List.of(), titlesOf(pruned));
+  }
+
+  @Test
+  void keepsAFindingThatPostsInlineHoweverOftenTheAnchorWasLitigated() {
+    var confident =
+        new ReviewResponse.Finding(
+            "high", "high", "src/A.java", 12, "The floor is dropped outright", "d", null, null);
+
+    var pruned =
+        FollowUpAnalyzer.withoutPreviouslyLitigated(
+            withCurrent(confident), twiceLitigatedRounds(), List.of(), bothCleared(), BOT_ID);
+
+    assertEquals(List.of("The floor is dropped outright"), titlesOf(pruned));
+  }
+
+  @Test
+  void keepsASecondSpeculativeItemAfterOnlyOneDisposition() {
+    // One decline settles one hypothesis; a second look at the same lines is ordinary review.
+    var pruned =
+        FollowUpAnalyzer.withoutPreviouslyLitigated(
+            withCurrent(speculative("src/A.java", 12, "A second hypothesis on the same lines")),
+            twiceLitigatedRounds(),
+            List.of(),
+            List.of(clears(LITIGATED_ONE, 901L)),
+            BOT_ID);
+
+    assertEquals(List.of("A second hypothesis on the same lines"), titlesOf(pruned));
+  }
+
+  @Test
+  void countsOneDefectArguedTwiceAsOneLitigation() {
+    // The same finding carried across rounds and cleared in each is one argument, not two.
+    var repeated = speculative("src/A.java", 10, LITIGATED_ONE.title());
+
+    var pruned =
+        FollowUpAnalyzer.withoutPreviouslyLitigated(
+            withCurrent(speculative("src/A.java", 12, "A second hypothesis on the same lines")),
+            List.of(roundOf(repeated), roundOf(LITIGATED_ONE)),
+            List.of(),
+            List.of(clears(LITIGATED_ONE, 901L), clears(repeated, 902L)),
+            BOT_ID);
+
+    assertEquals(List.of("A second hypothesis on the same lines"), titlesOf(pruned));
+  }
+
+  @Test
+  void leavesOtherAnchorsAlone() {
+    var pruned =
+        FollowUpAnalyzer.withoutPreviouslyLitigated(
+            withCurrent(
+                speculative("src/B.java", 12, "Same lines, another file"),
+                speculative("src/A.java", 40, "Same file, far from the litigated lines")),
+            twiceLitigatedRounds(),
+            List.of(),
+            bothCleared(),
+            BOT_ID);
+
+    assertEquals(
+        List.of("Same lines, another file", "Same file, far from the litigated lines"),
+        titlesOf(pruned));
+  }
+
+  @Test
+  void keepsEverythingWhenNoPriorFindingWasDispositioned() {
+    var untouched = withCurrent(speculative("src/A.java", 12, "A third hypothesis"));
+
+    assertSame(
+        untouched,
+        FollowUpAnalyzer.withoutPreviouslyLitigated(
+            untouched, twiceLitigatedRounds(), List.of(), List.of(), BOT_ID),
+        "no maintainer acted, so nothing has been litigated");
+  }
+
+  @Test
+  void keepsEverythingWithNothingToCompareAgainst() {
+    var empty = new ReviewResponse(List.of(), List.of(), null);
+    assertSame(
+        empty,
+        FollowUpAnalyzer.withoutPreviouslyLitigated(
+            empty, twiceLitigatedRounds(), List.of(), bothCleared(), BOT_ID));
+
+    var firstRound = withCurrent(speculative("src/A.java", 12, "A first hypothesis"));
+    assertSame(
+        firstRound,
+        FollowUpAnalyzer.withoutPreviouslyLitigated(
+            firstRound, List.of(), List.of(), bothCleared(), BOT_ID));
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactor
- [ ] 🚀 Performance
- [ ] ✅ Test
- [ ] 🔒 Security
- [ ] 📦 Dependency update
- [ ] 🏗️ CI/CD

> **Stacked on #766** (`fix/736-bound-pr-context`). Review the top commit; the base retargets to `main` when the parent merges.

## Description

Five consecutive rounds over essentially unchanged code each produced a brand-new lower-confidence "Things to double-check" item against the same ~30 lines, and the rounds contradicted each other — round 2 argued the opposite of round 1, round 5's premise was refuted by the same PR's other half. Because every item was novel by title and premise, previous-findings tracking had nothing to converge on: each `/review` was a fresh roll of speculative hypotheticals against the same lines, and the maintainer had to disposition a new one every round.

`FollowUpAnalyzer#dropRepliedDuplicates` already stops a prior finding from being *re-raised*, but it matches on the **defect** (title similarity or content overlap), and a new title with a new premise on the same lines is not the same defect, so it passes straight through. The new pass matches on the **anchor** instead — the one thing the rounds actually have in common.

**The rule.** Once `LITIGATED_ANCHOR_LIMIT` (2) *distinct* findings on one `path:line` have been dispositioned by a maintainer on this pull request, a further finding on that anchor is withheld, with an `INFO` naming the finding, the anchor and the count.

**Which of the issue's three directions, and why.** The third — a deterministic per-anchor cap. The first (feed the declines and their justifications back as prompt context with an instruction to engage them) is more of what already exists and did not converge: the block already carries the prior findings, their threads and an "answered in earlier rounds — do NOT raise these again" instruction, and the model still minted a variant every round; adding prose asks the same model to be persuaded by the same evidence, and it costs shared overhead on every batch call. The second (down-rank) does not help either, because the class in question is *already* down-ranked — these items are exactly the ones confidence-routing keeps off the diff, and they still hold approval and still need a manual disposition, which is the reported cost. Only a deterministic rule converges, and the anchor is the deterministic thing.

**Why it cannot suppress real review**, by construction:

- **Only findings that never post inline are eligible.** `Finding#postsInline` routes low-confidence findings below high risk to the summary, and that is the whole reported class. A high-confidence finding, and any critical/high-risk finding, is untouched however often its anchor has been argued over — the constraint the issue sets.
- **Distinct findings only.** One defect carried across rounds and cleared in each is one argument, not two (`isSameFinding` clusters them), so the limit cannot be reached by repetition of a single item.
- **A disposition means a maintainer acted** — a reply on the finding's own thread, or an `@thrillhousebot resolved` comment naming it on the PR conversation, which is the only hatch a threadless finding has (#548). The bot's own rounds never raise the count.
- **The limit is two**, so the first decline settles one hypothesis and a second look at the same lines is still ordinary review. It is the third and later ones that stop being review.

**The trade it accepts:** if the code under a twice-litigated anchor genuinely changes, a new lower-confidence observation there is withheld too. That is the cheap direction — the same defect surfacing at high confidence or at critical/high risk is exempt, and the withheld class is by construction the one the review already declines to put on the diff. Withholding is disclosed to the operator in the log, the way the sibling `dropRepliedDuplicates` drop is; no new review surface is introduced, since giving the noise a section would be the opposite of converging.

Applied at both `FindingVerificationService`-adjacent seams in `FindingPipeline`, immediately after `dropRepliedDuplicates`, so the two passes read as the pair they are.

## Related Issues

Fixes #726

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**Red/green proof.** `FindingPipelineTest#aThirdSpeculativeItemOnATwiceDispositionedAnchorIsWithheld` runs the real pipeline over a context with two prior rounds whose findings the maintainer cleared with `@thrillhousebot resolved`, and a current round raising a third, novel, lower-confidence item on the same lines plus an unrelated finding elsewhere. Run against this branch's test with the main-code change reverted:

```
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.260 s <<< FAILURE! -- in dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest
[ERROR] dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.aThirdSpeculativeItemOnATwiceDispositionedAnchorIsWithheld -- Time elapsed: 1.186 s <<< FAILURE!
org.opentest4j.AssertionFailedError: a third lower-confidence item on the twice-dispositioned anchor must not be raised ==> expected: <[Unrelated defect elsewhere]> but was: <[Reworded message drops the 30s floor, Unrelated defect elsewhere]>
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1210)
	at dev.thiagogonzaga.thrillhousebot.review.FindingPipelineTest.aThirdSpeculativeItemOnATwiceDispositionedAnchorIsWithheld(FindingPipelineTest.java:380)
```

With the fix it passes, and the unrelated finding is kept.

`FindingPipelineTest#aHighConfidenceFindingOnATwiceDispositionedAnchorStillPosts` is a **control**, not proof — it passes before and after, and pins the boundary the rule must never cross.

`FollowUpAnalyzerTest` adds eight focused cases on the new pass: the conversation-clear signal, the thread-reply signal, an inline-posting finding on the same anchor, one disposition only, one defect argued twice counting once, other files and distant lines, no disposition at all, and the empty inputs. The previous-findings accounting and the recounted summary are asserted alongside.

Gates on this branch: `spotless:apply` clean, `clean compile spotbugs:check spotless:check` → **BugInstance size is 0**, `clean test` → **3394 tests, 0 failures, 0 errors**. Jacoco ∩ `git diff -U0 c4550f8...HEAD` shows zero uncovered lines and zero uncovered branches in the changed main code (checked against the parent commit and against `c4550f8`).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

```
INFO  [dev.thiagogonzaga.thrillhousebot.review.FollowUpAnalyzer] Withholding lower-confidence finding 'A reworded block message drops the 30s floor' (src/A.java:12) — 2 finding(s) on that anchor were already dispositioned by a maintainer on this pull request
```

## Additional Notes

This is distinct from #512 (phantom unresolved): those are stale carryovers, these are new inventions per round. The pass touches neither previous-findings statuses nor the verdict — it only decides whether this round raises the item.
