### PR TITLE
fix(deps): bump the Quarkus platform to 3.38.2 for the Netty CORS advisory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.38.1</quarkus.platform.version>
+        <quarkus.platform.version>3.38.2</quarkus.platform.version>
         <quarkus-langchain4j.version>1.12.2</quarkus-langchain4j.version>
         <opentelemetry.version>1.62.0</opentelemetry.version>
         <opentelemetry.alpha.version>1.62.0-alpha</opentelemetry.alpha.version>


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔒 Security
- [x] ⬆️ Dependency

## Description

OpenSSF Scorecard's Vulnerabilities check reports the project at **9** with one open advisory:

**GHSA-8c42-7qj2-3j46** / CVE-2026-59903 — *Netty Vulnerable to Cache Poisoning and Information Disclosure via CORS Vary Header Overwrite* (CVSS 3.1 `AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N`, High).

`netty-codec-http`'s CORS handler **overwrites** the `Vary` header instead of appending to it. A shared cache in front of the service then keys a response without the origin that produced it, and can serve one origin's response to another.

Affected ranges, from OSV:

| line | introduced | fixed |
|---|---|---|
| 4.1.x | 0 | **4.1.137.Final** |
| 4.2.x | 4.2.0.Final | 4.2.17.Final |

The resolved tree carries `io.netty:netty-codec-http:4.1.136.Final` — one patch below the fix — because `quarkus-bom` 3.38.1 manages that version.

## The fix

`quarkus.platform.version` 3.38.1 → **3.38.2**, which already manages `netty-codec-http:4.1.137.Final`.

Taken in preference to a `netty-bom` override in `dependencyManagement`: an override closes the advisory just as well but leaves a pin that has to be noticed and removed once the platform catches up, and it pins one library family out of step with the platform that resolves the rest. A patch-level platform bump has neither cost.

Verified against Maven's own resolution rather than by reading the BOM:

```
before:  io.netty:netty-codec-http:jar:4.1.136.Final:compile
after:   io.netty:netty-codec-http:jar:4.1.137.Final:compile
```

Every `io.netty` artifact in the tree moves to `4.1.137.Final` together — which is what importing the netty BOM would have been for. (`netty-tcnative-classes` is at `2.0.81.Final`; it versions independently and is not in scope of this advisory.)

## Related Issues

Closes the Scorecard Vulnerabilities finding. No issue was filed — the advisory surfaced through the Scorecard report.

## How Has This Been Tested?

- [x] Unit tests

A platform bump is not a metadata change, so the whole suite ran rather than the scan alone.

- `./mvnw -B spotless:apply` → clean
- `./mvnw -B clean compile spotbugs:check spotless:check` → **BugInstance size is 0**, BUILD SUCCESS
- `./mvnw -B clean test` → **Tests run: 3389, Failures: 0, Errors: 0, Skipped: 0**
- `./mvnw -B dependency:tree` → no `io.netty` artifact below `4.1.137.Final`

No new test: there is no behavioural delta to prove. The advisory is closed by the resolved version, and the dependency tree above is the evidence; a test asserting a dependency version would pin the symptom rather than the property.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

3.38.1 → 3.38.2 is a patch release of the platform, so no extension API moved. This does **not** affect #707, whose OpenTelemetry 1.65.0 bump is blocked by a binary incompatibility with the OTel extension rather than by the platform's patch level.
