### PR TITLE
fix(review): stop counting dispatch text inside a string literal as live concurrency evidence

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -239,9 +239,16 @@ final class RebuttalContradiction {
   }
 
   /**
-   * Drops a trailing {@code //} line comment, leaving any code before it intact. A {@code ://}
-   * sequence (a URL scheme) is not treated as a comment start, and neither is a {@code //} that
-   * sits inside a string literal.
+   * Drops a trailing {@code //} line comment, leaving any code before it intact, and blanks the
+   * contents of every closed string literal to spaces (keeping the delimiters, so offsets are
+   * unchanged). A {@code ://} sequence (a URL scheme) is not treated as a comment start, and
+   * neither is a {@code //} that sits inside a string literal.
+   *
+   * <p>The blanking is the over-fire mirror of the carve-out below: keeping the whole line when the
+   * only {@code //} is quoted also kept the literal's contents as scan text, so dispatch text
+   * quoted in a string — {@code "hand work to .submit( here"} — reached {@link
+   * #CONCURRENT_DISPATCHES} and overruled a decline over code that dispatches nothing. Quoted prose
+   * is never live code, so it is erased rather than matched.
    *
    * <p>The string-literal carve-out matters because cutting at the wrong {@code //} silently throws
    * away the rest of the line — including any dispatch construct on it. A line such as {@code
@@ -278,39 +285,40 @@ final class RebuttalContradiction {
    * any dispatch after it — the same false negative the carve-out above exists to close, one legal
    * interior quote away from the shapes that are covered. Closing it needs delimiter-aware openers
    * rather than a toggle; tracked in #651.
+   *
+   * <p>Two limits of the blanking are accepted for the same reason — each needs knowledge a
+   * line-scoped toggle cannot have, and both are the tokenizer #651 asks for. A literal spanning
+   * lines (a Go raw string, a Java text block) is not blanked: its opener has no closer on the
+   * line, so it is rescanned as ordinary text, and the content lines carry no delimiter at all —
+   * dispatch text quoted there still over-fires. Carrying quote state across lines is not the fix,
+   * because the scan text is a whole multi-file patch rejoined: one stray delimiter would blank
+   * unrelated files' code and silently drop real dispatches — trading a narrow over-fire for a
+   * broad false negative. And a backtick literal is always blanked whole, including a JavaScript
+   * template literal's {@code ${...}} interpolation, which is live code: a dispatch that appears
+   * only inside an interpolation is missed (under-fire, the decline stands). Telling a JS template
+   * apart from a Go raw string quoting literal {@code ${...}} text needs a language hint; erasing
+   * is the conservative side, since over-fire argues with a maintainer who is right.
    */
   private static String stripLineComment(String line) {
-    var at = commentStart(line);
-    return at < 0 ? line : line.substring(0, at);
-  }
-
-  /**
-   * Index where a real {@code //} comment opens on {@code line}, or {@code -1} when none does.
-   * Literals are stepped over whole, so a {@code //} they hold is not a comment start.
-   */
-  private static int commentStart(String line) {
+    var out = new StringBuilder(line.length());
     var i = 0;
     while (i < line.length()) {
       var c = line.charAt(i);
       if (c == '"' || c == '\'' || c == '`') {
-        var close = endOfLiteral(line, i);
-        if (close < 0) {
-          // Never closed, so the opener was not one — rescan it as ordinary text.
-          i++;
-        } else {
-          i = close + 1;
-        }
+        i = appendBlankedLiteral(line, i, out);
       } else if (isDoubleSlash(line, i)) {
         if (i > 0 && line.charAt(i - 1) == ':') {
+          out.append("//");
           i += 2;
         } else {
-          return i;
+          return out.toString();
         }
       } else {
+        out.append(c);
         i++;
       }
     }
-    return -1;
+    return out.toString();
   }
 
   /**
@@ -332,6 +340,70 @@ final class RebuttalContradiction {
       }
     }
     return -1;
+  }
+
+  /**
+   * Handles the quote opener at {@code open}: appends its rendering to {@code out} and returns the
+   * index the scan resumes at. A closed literal is stepped over whole — and blanked. Its delimiters
+   * stay (space for space, so every offset after it is unchanged and lineAround still quotes the
+   * real line shape), but its contents are prose, not code the revision runs: a log message, an
+   * error string or a fixture that mentions ".submit(" must not read as live dispatch and overrule
+   * a decline that was right. An opener that never closes — or a lone apostrophe (a Rust lifetime)
+   * paired with a later char literal's opener, whose "span" is really live code — was not one; it
+   * is appended verbatim and rescanned as ordinary text.
+   */
+  private static int appendBlankedLiteral(String line, int open, StringBuilder out) {
+    var quote = line.charAt(open);
+    var close = endOfLiteral(line, open);
+    out.append(quote);
+    if (close < 0 || isMisreadApostrophePair(line, quote, open, close)) {
+      return open + 1;
+    }
+    out.append(" ".repeat(close - open - 1));
+    out.append(line.charAt(close));
+    return close + 1;
+  }
+
+  /**
+   * Whether a {@code '}-quoted span is really two unrelated apostrophes with live code between
+   * them, rather than a literal. A lone apostrophe in non-string context — a Rust lifetime ({@code
+   * &'a ctx}, {@code foo::<'a>}) — followed later on the line by a real char literal ({@code '\n'})
+   * or another lifetime pairs with that later apostrophe, and blanking the span would erase any
+   * dispatch between them: a false negative the pre-blanking scanner did not have. Three tells mark
+   * a span as misread, each shaped so genuine quoted prose (which may hold {@code .submit(} text —
+   * the very thing the blanking exists to erase) keeps blanking: the opener sits directly after
+   * {@code &} or {@code <}, which is Rust lifetime syntax and never a string opener; the span holds
+   * a {@code ;}, which is statement shape, not prose; or the pairing closer itself opens a
+   * char-literal-shaped span, meaning the "closer" was really the next literal's opener. The
+   * residual miss — quoted prose that defeats every tell and also names a dispatch construct — is
+   * far narrower than erasing arbitrary real code. Double-quote and backtick openers have no
+   * lifetime-style bare use, so the guard applies to {@code '} alone.
+   */
+  private static boolean isMisreadApostrophePair(String line, char quote, int open, int close) {
+    if (quote != '\'') {
+      return false;
+    }
+    // Lifetime position: an apostrophe directly after & or < ( &'a ctx, foo::<'a> ) is Rust
+    // syntax, never a string opener, whatever its span holds.
+    if (open > 0 && (line.charAt(open - 1) == '&' || line.charAt(open - 1) == '<')) {
+      return true;
+    }
+    // Statement separator: a ; inside the span is code shape, not quoted prose.
+    if (line.substring(open + 1, close).indexOf(';') >= 0) {
+      return true;
+    }
+    // The pairing closer itself opens a char-literal-shaped span — '\n', ',', or a longer escape
+    // like a Rust unicode char (backslash-u{1F600}): the "closer" was really the next literal's
+    // opener, and everything between the two apostrophes is live code. Char-shaped means at most
+    // two characters — one character or a simple escape — or an escape sequence: backslash-led
+    // and short enough for the longest real spelling, Rust's backslash-u{10FFFF} at 9 characters.
+    // Ten leaves a margin without reading a backslash-led prose span as a char.
+    var closerAsOpener = endOfLiteral(line, close);
+    if (closerAsOpener < 0) {
+      return false;
+    }
+    var charSpan = line.substring(close + 1, closerAsOpener);
+    return charSpan.length() <= 2 || (charSpan.length() <= 10 && charSpan.charAt(0) == '\\');
   }
 
   /** Whether a doubled slash sits at {@code at}. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -243,6 +243,78 @@ class RebuttalContradictionTest {
   }
 
   /**
+   * Dispatch text quoted inside a string literal is prose, not live code. Matching it overruled a
+   * maintainer whose "it runs serially" decline was correct — the over-fire direction, which is the
+   * more expensive one because it argues with a maintainer who is right.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // A log or documentation string naming the construct.
+        "+    var m = \"hand work to .submit( here\";",
+        "+    log.info(\"call executor.execute( to enqueue\");",
+        // A single-quoted and a backtick (Go raw) literal.
+        "+    msg := 'use pool.submit( for async work'",
+        "+    doc := `each event calls handler.execute(ctx)`",
+        // Every other construct the matcher knows, quoted rather than run.
+        "+    var s = \"Executors.newCachedThreadPool() would be wrong here\";",
+        "+    var s = \"Executors.newFixedThreadPool(8) was removed\";",
+        "+    var s = \"CompletableFuture.runAsync is not used\";",
+        "+    var s = \"do not add new Thread( calls\";",
+        "+    var s = \"items.parallelStream() is banned in this module\";",
+        // An escaped quote does not close the literal early and expose the dispatch text.
+        "+    var s = \"a\\\".submit(\";",
+        // Two single-quoted strings on one line: the first's closer sits more than a char
+        // literal's width from the next opener, so both stay literals and both are blanked.
+        "+    var s = 'quote .submit( here' + 'more prose text here'",
+        // The same shape with the openers far enough apart that even an escape-length span
+        // cannot be mistaken for a char literal.
+        "+    var s = 'quote .submit( here' and afterwards 'more prose text here'",
+      })
+  void shouldNotTreatDispatchTextInsideAStringLiteralAsEvidence(String codeLine) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine + "\n").isEmpty(),
+        "the dispatch text sits inside a string literal, so it is not live code: " + codeLine);
+  }
+
+  /** The other direction: a real dispatch next to an unrelated literal still registers. */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "+    log.info(\"enqueue\"); executor.submit(() -> run(ctx));",
+        "+    executor.submit(() -> run(ctx)); log.info(\"enqueued one task\");",
+        // The literal itself quotes dispatch text, and the real dispatch follows it.
+        "+    log.info(\"about to .submit( work\"); executor.submit(() -> run(ctx));",
+        // An unclosed opener is ordinary text, so the dispatch after it stays visible.
+        "+    let f = &'a ctx; executor.submit(() -> run(ctx));",
+        // A lifetime's apostrophe pairing with a later char literal's opener must not blank the
+        // live code between them: the ; inside the would-be span marks it as code, not a literal.
+        "+    let f = &'a ctx; executor.submit(() -> run(ctx)); let nl = '\\n';",
+        "+    let f = &'a ctx; executor.submit(() -> run(ctx)); let sep = ',';",
+        // A turbofish lifetime pairing with a later char literal: no ; sits inside the misread
+        // span, so the lifetime position (after <) and the char-literal-shaped closer are the
+        // tells that keep the dispatch between the apostrophes live.
+        "+    foo::<'a>(executor.submit(|| ()), '\\n');",
+        // Two lifetimes with the dispatch between them and no char literal at all.
+        "+    fn go<'a>(e: &'a Exec) { e.submit(run); }",
+        // A span holding a ; is code shape even with the apostrophe in column zero, where there
+        // is no prefix character to consult.
+        "+'a; b' executor.submit(() -> run(ctx))",
+        // A stray apostrophe in an identifier pairing with a char literal's opener: neither a
+        // lifetime prefix nor a ; exists, so the char-literal-shaped closer is the tell.
+        "+    log(don't panic, executor.submit(() -> run(ctx)), '\\n')",
+        // A trait-bound lifetime (not after & or <) pairing with a long char-literal escape: the
+        // escape-shaped closer is the tell that keeps the dispatch live.
+        "+    fn f<T: 'a>(e: &mut Exec) { e.submit(run) } let c = '\\u{1F600}';",
+        "+    fn f<T: 'a>(e: &mut Exec) { e.submit(run) } let c = '\\u0041';",
+      })
+  void shouldKeepRealDispatchNextToAStringLiteral(String codeLine) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine + "\n").isPresent(),
+        "the dispatch sits outside the literal, so it is live code: " + codeLine);
+  }
+
+  /**
    * The mirror of the case above: a real trailing comment must stay stripped. Honouring a backslash
    * escape inside a Go raw string — where a backslash is literal — stepped over the closing
    * backtick, left the quote state open, and let the comment's own text pose as live code.


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

## Problem

`RebuttalContradiction.stripLineComment` became quote-aware in #647 so a `//` inside a string literal no longer truncates the line. That fixed a false negative but opened the over-fire direction: the literal's contents were still handed to `CONCURRENT_DISPATCHES`, so a log message, error string, or fixture that merely mentions `.submit(` or `.execute(` counted as proof of live concurrent dispatch and overruled a maintainer whose "it runs serially" decline was correct.

## Fix

The same quote-aware scan now blanks the contents of every closed string literal to spaces, keeping the delimiters so every offset (and `lineAround` quoting) is unchanged. Quoted prose is erased before `CONCURRENT_DISPATCHES` ever sees it; unclosed openers, escaped quotes, `://` URLs, and trailing-comment stripping behave exactly as before.

## Tests

- New `shouldNotTreatDispatchTextInsideAStringLiteralAsEvidence`: dispatch text quoted in double-, single-, and backtick literals (one case per construct the matcher knows, plus an escaped-quote case) registers no evidence.
- New `shouldKeepRealDispatchNextToAStringLiteral`: real dispatch on the same line as an unrelated literal — including one that itself quotes dispatch text — still registers.
- #647's quoted-`//` fixtures stay green; full suite: 3425 tests, 0 failures.

## Related Issues

Fixes #762

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

Local gates: `spotless:check`, `spotbugs:check`, full suite (3425 tests) pass; CI fully green including SonarCloud and codecov/patch.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

