### PR TITLE
fix(review): serial pool whose count wraps onto an added line no longer reads as concurrent dispatch

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -212,8 +212,15 @@ final class RebuttalContradiction {
    * The reviewed patch reduced to the code the revision actually runs: removed ({@code -}) lines
    * are dropped and line comments are stripped, so a dispatch construct that was deleted or only
    * mentioned in a comment cannot pose as live evidence. Added ({@code +}) and context lines are
-   * kept verbatim (including their leading marker, which {@link #clip} removes when quoting),
-   * across every file in the patch — cross-file evidence is intentional.
+   * kept across every file in the patch — cross-file evidence is intentional — with the leading
+   * {@code +} marker dropped: the marker exists for display, not for matching, and a construct
+   * whose argument wraps onto a following added line otherwise carries a {@code \n+} in the middle
+   * of its argument gap. That broke the serial-pool exclusion of {@link #CONCURRENT_DISPATCHES} —
+   * {@code newFixedThreadPool(} with the {@code 1)} on the next added line read as concurrent
+   * dispatch, because the {@code +} is neither whitespace nor a comment and hid the count from the
+   * lookahead — precisely on the code a pull request introduces (#761). Only the one marker column
+   * is dropped; the line's own text (indentation included) stays verbatim, and {@link #clip} still
+   * tolerates a marker when quoting.
    */
   private static String rightSideCode(String reviewedCode) {
     var kept = new ArrayList<String>();
@@ -221,6 +228,10 @@ final class RebuttalContradiction {
       // A unified-diff removed line (and the "---" old-file header) starts with '-'.
       if (line.startsWith("-")) {
         continue;
+      }
+      // An added line (and the "+++" new-file header) starts with '+'; drop the marker column.
+      if (line.startsWith("+")) {
+        line = line.substring(1);
       }
       kept.add(stripLineComment(line));
     }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -179,6 +179,12 @@ class RebuttalContradictionTest {
             + " downstream reconciler depends on is only worth having if exactly one thread"
             + " appends here, so please do not widen this pool without reading that thread"
             + " first */);",
+        // The count wrapped onto a following added line: its leading '+' is a diff marker, not
+        // code, and must not hide the count from the exclusion (#761).
+        "+    var pool = Executors.newFixedThreadPool(\n+        1);",
+        "+    var pool = Executors.newFixedThreadPool(\n+        1, factory);",
+        // The same wrap on context lines was already excluded and must stay so.
+        "     var pool = Executors.newFixedThreadPool(\n         1);",
       })
   void shouldNotTreatASingleThreadedFixedPoolAsConcurrentDispatch(String codeLine) {
     assertTrue(
@@ -200,6 +206,8 @@ class RebuttalContradictionTest {
         "+    var pool = Executors.newFixedThreadPool(2 /* two */);",
         "+    var pool = Executors.newFixedThreadPool(1 + 0);",
         "+    var pool = Executors.newFixedThreadPool(2 /* two\n+        threads */);",
+        // A genuinely concurrent count wrapped onto a following added line still registers.
+        "+    var pool = Executors.newFixedThreadPool(\n+        8);",
       })
   void shouldTreatAMultiThreadedFixedPoolAsConcurrentDispatch(String codeLine) {
     assertTrue(


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

## Problem

`rightSideCode` kept added lines verbatim including their leading `+` diff marker. When a `newFixedThreadPool(1)` count wrapped onto a following added line, the scan text held `newFixedThreadPool(\n+        1)` — the `+` is neither whitespace nor a block comment, so the serial-pool negative lookahead in `CONCURRENT_DISPATCHES` never saw the `1` and a serial pool registered as concurrent dispatch, overruling a correct maintainer decline.

## Fix

Strip the leading `+` marker column from added lines in `rightSideCode` before evidence matching (the issue's preferred option: markers exist for display, not matching, and this also removes the same latent exposure for every other pattern in the array). The line's own text stays verbatim, and `clip` still tolerates a marker when quoting.

## Tests

Added to `RebuttalContradictionTest`:
- wrapped-added-line `newFixedThreadPool(\n+ 1)` and `(\n+ 1, factory)` are excluded
- the same wrap on context lines stays excluded
- a wrapped `newFixedThreadPool(\n+ 8)` still registers as concurrent

All 3415 tests pass; spotless, SpotBugs green.

## Related Issues

Fixes #761

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

Local gates: `spotless:check`, `spotbugs:check`, full suite (3415 tests) pass; CI fully green including SonarCloud and codecov/patch.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

