### PR TITLE
fix: drop review entries whose own text concludes no defect exists (#635)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -86,6 +86,105 @@ public class FindingVerificationService {
    */
   private static final Pattern CLAUSE_BOUNDARY = Pattern.compile("(?<=[.;!?])\\s+|\\R");
 
+  /** The defect nouns a no-defect conclusion rules out; shared by the wordings below. */
+  private static final String DEFECT_NOUN = "(?:defect|finding|issue|bug|problem)";
+
+  /** The same nouns with their optional plural, where the wording ends on the noun. */
+  private static final String DEFECT_NOUNS = DEFECT_NOUN + "s?\\b";
+
+  /** The optional dismissive adjective before the noun ("no REAL issue", "no SUCH bug"). */
+  private static final String DISMISSIVE_ADJECTIVE =
+      "(?:real\\s+|actual\\s+|genuine\\s+|such\\s+)?";
+
+  /**
+   * The bare no-defect negation opening the concluding clause ("No finding here" as its own
+   * sentence, "...; no defect beyond intent"). Deliberately anchored at the clause start so a real
+   * finding that mentions "no issue" mid-argument about something else does not match (#635). One
+   * wording of the {@linkplain #NO_DEFECT_CONCLUSIONS no-defect conclusion}.
+   */
+  private static final Pattern NO_DEFECT_AT_CLAUSE_START =
+      Pattern.compile(
+          "^\\W*+no\\s+" + DISMISSIVE_ADJECTIVE + DEFECT_NOUNS, Pattern.CASE_INSENSITIVE);
+
+  /**
+   * The same negation after an existential or consequence lead-in ("there is no defect", "so no
+   * issue" mid-clause), the other anchoring that makes the bare negation a conclusion rather than a
+   * mid-argument mention.
+   */
+  private static final Pattern NO_DEFECT_AFTER_LEAD_IN =
+      Pattern.compile(
+          "\\b(?:there\\s+(?:is|was|are|were)|so|thus|hence|therefore)\\s+no\\s+"
+              + DISMISSIVE_ADJECTIVE
+              + DEFECT_NOUNS,
+          Pattern.CASE_INSENSITIVE);
+
+  /** The negation worded on the noun's state ("no defect exists", "no issue found/remains"). */
+  private static final Pattern NO_DEFECT_STATE =
+      Pattern.compile(
+          "\\bno\\s+" + DEFECT_NOUN + "s?\\s+(?:here|found|exists?|remains?)\\b",
+          Pattern.CASE_INSENSITIVE);
+
+  /** The negation on the entry's own standing ("not a defect", "not a real finding"). */
+  private static final Pattern NOT_A_DEFECT =
+      Pattern.compile(
+          "\\bnot\\s+an?\\s+" + DISMISSIVE_ADJECTIVE + DEFECT_NOUN + "\\b",
+          Pattern.CASE_INSENSITIVE);
+
+  /**
+   * The same standing negation with a negating adverb before the article ("not actually a defect",
+   * "not itself an issue"); held apart from {@link #NOT_A_DEFECT} only because one pattern carrying
+   * both slots is more than the regex complexity budget allows. The adverbs are enumerated, never a
+   * generic {@code \w+ly}: a degree adverb AFFIRMS the defect ("not merely / only / simply / purely
+   * a defect" says it IS one, and more) and "not necessarily a defect" is a hedge — none of those
+   * is a retraction, and matching them dropped real findings.
+   */
+  private static final Pattern NOT_ADVERBIALLY_A_DEFECT =
+      Pattern.compile(
+          "\\bnot\\s+(?:actually|really|truly|genuinely|itself)\\s+an?\\s+" + DEFECT_NOUN + "\\b",
+          Pattern.CASE_INSENSITIVE);
+
+  /** The negation on the code's state ("nothing defective is asserted", "nothing is wrong"). */
+  private static final Pattern NOTHING_DEFECTIVE =
+      Pattern.compile(
+          "\\bnothing\\s+(?:\\w+\\s+)?(?:defective|wrong|broken)\\b", Pattern.CASE_INSENSITIVE);
+
+  /** The negation worded as emptiness ("intentionally empty of defects", "free of issues"). */
+  private static final Pattern DEVOID_OF_DEFECTS =
+      Pattern.compile(
+          "\\b(?:free|empty|devoid)\\s+of\\s+(?:\\w+\\s+)?" + DEFECT_NOUNS,
+          Pattern.CASE_INSENSITIVE);
+
+  /**
+   * An explicit no-defect conclusion — the entry's own text ruling out the defect its title
+   * asserts. One conclusion recognized by seven wordings, held in separate patterns only because a
+   * single alternation of all of them is more than the regex complexity budget allows.
+   */
+  private static final List<Pattern> NO_DEFECT_CONCLUSIONS =
+      List.of(
+          NO_DEFECT_AT_CLAUSE_START,
+          NO_DEFECT_AFTER_LEAD_IN,
+          NO_DEFECT_STATE,
+          NOT_A_DEFECT,
+          NOT_ADVERBIALLY_A_DEFECT,
+          NOTHING_DEFECTIVE,
+          DEVOID_OF_DEFECTS);
+
+  /**
+   * What may follow the no-defect phrase for the clause to still be a whole-entry retraction:
+   * punctuation and a few closers ("here", "at all", "whatsoever"), nothing more. Any other word
+   * after the phrase means the clause goes on to say something — a scoped denial ("no defect in the
+   * fast path"), an attributed one ("...'s no defect here conclusion is wrong"), or an asserting
+   * continuation ("no defect on the happy path, but/so the error path leaks") — and a clause that
+   * says more than "nothing is wrong" must not drop the finding.
+   *
+   * <p>Possessive quantifiers throughout: the alternatives are disjoint (a non-word run can never
+   * re-parse as a closer word), so backtracking buys nothing — and a plain greedy {@code \W+}
+   * nested under {@code *} is ambiguously quantified, exponential on long non-matching tails.
+   */
+  private static final Pattern RETRACTION_TAIL =
+      Pattern.compile(
+          "(?:\\W++|(?:here|at|all|whatsoever|anymore)\\b)*+", Pattern.CASE_INSENSITIVE);
+
   /**
    * A clause that asks the reader to check something rather than hedging the defect itself. The
    * review prompt REQUIRES this clause on a finding whose sink and tainted value are both in the
@@ -591,7 +690,7 @@ public class FindingVerificationService {
       String projectStack,
       String previousFindings,
       Consumer<VerificationCoverage> coverageSink) {
-    ReviewResponse screened = demoteHedgedBlockingFindings(response);
+    ReviewResponse screened = demoteHedgedBlockingFindings(dropSelfRetractedFindings(response));
     if (!config.review().verifierEnabled() || screened.findings().isEmpty()) {
       return screened;
     }
@@ -822,6 +921,67 @@ public class FindingVerificationService {
       return;
     }
     tokenLedger.recordUsage(ledgerSessionId, usage.inputTokenCount(), usage.outputTokenCount());
+  }
+
+  /**
+   * Deterministic backstop for #635: an entry whose own description concludes that no defect exists
+   * is not a finding at all — the reviewer investigated a candidate, found it fine, and emitted the
+   * analysis anyway, with a title asserting a defect the body disclaims. Dropping it here saves the
+   * verifier the round trip of rejecting it, and keeps it out of the published review on the ~1/3
+   * of runs where verification fails open (#623).
+   *
+   * <p>Read on the description's CONCLUDING clause only — the last non-blank one — because that is
+   * where a genuine retraction lands ("...; no finding here."), while a mid-body denial about one
+   * code path followed by an asserted defect ("no issue on the happy path; the error path leaks")
+   * is a real finding that must survive. Within that clause the phrase must also be the final
+   * assertion — only a {@linkplain #RETRACTION_TAIL closing tail} may follow it — so a scoped
+   * denial ("no defect in the fast path"), an attributed one ("the previous review's no defect here
+   * conclusion is wrong"), and an asserting continuation ("no defect on the happy path, but/so the
+   * error path leaks") all keep the finding. Under-fire is the safe direction — a retraction this
+   * scan misses still reaches the verifier, which is today's behavior.
+   */
+  static ReviewResponse dropSelfRetractedFindings(ReviewResponse response) {
+    if (response.findings().isEmpty()) {
+      return response;
+    }
+    var kept = new ArrayList<ReviewResponse.Finding>(response.findings().size());
+    for (ReviewResponse.Finding finding : response.findings()) {
+      if (concludesNoDefect(finding.description())) {
+        Log.infof(
+            "Dropping finding '%s' (%s:%d): its own description concludes no defect exists",
+            LogSafe.oneLine(finding.title()), LogSafe.oneLine(finding.file()), finding.line());
+      } else {
+        kept.add(finding);
+      }
+    }
+    if (kept.size() == response.findings().size()) {
+      return response;
+    }
+    return new ReviewResponse(
+        kept, response.previousFindingsStatus(), recount(response.summary(), kept));
+  }
+
+  /** Whether the text's last non-blank clause is an unretracted no-defect conclusion. */
+  private static boolean concludesNoDefect(String description) {
+    if (description == null || description.isBlank()) {
+      return false;
+    }
+    // The text is stripped first, so split (which drops trailing empty strings) always leaves the
+    // clause holding the final non-whitespace character in the last slot.
+    String[] clauses = CLAUSE_BOUNDARY.split(description.strip());
+    String last = clauses[clauses.length - 1];
+    for (Pattern wording : NO_DEFECT_CONCLUSIONS) {
+      Matcher conclusion = wording.matcher(last);
+      // The phrase must be the clause's FINAL assertion: only a closing tail may follow it. A
+      // clause that goes on to scope the denial, attribute it, or assert something else is not a
+      // retraction of the whole entry, so it keeps the finding.
+      while (conclusion.find()) {
+        if (RETRACTION_TAIL.matcher(last).region(conclusion.end(), last.length()).matches()) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPrompts.java
@@ -396,6 +396,14 @@ public final class PrReviewPrompts {
             - If you are uncertain whether an issue is real at all, omit it rather than guess.
 
             Self-check before emitting each finding — drop the finding if any check fails:
+            - A candidate that survives your investigation as NOT a defect is discarded, never
+              emitted. "I considered this and it is fine" is reasoning, not a reportable
+              outcome: an entry whose own description concludes that no defect exists ("no
+              finding here", "no defect", "not a real issue", "the implementation is correct
+              as written") must not appear in the findings list, no matter how much analysis
+              it records. The only reportable outcome of working through a candidate is a
+              defect that survived the investigation; a title asserting a defect the body
+              then retracts is invalid.
             - suggestion_new must change behavior relative to suggestion_old. If both are
               functionally equivalent (e.g. rewriting a call into a documented shorthand or alias
               of itself), the finding is invalid.

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationServiceTest.java
@@ -177,6 +177,111 @@ class FindingVerificationServiceTest {
     assertSame(original, result);
   }
 
+  private static ReviewResponse.Finding described(String title, String description) {
+    return new ReviewResponse.Finding(
+        "medium", "medium", "src/Main.java", 10, title, description, null, null);
+  }
+
+  @Test
+  void dropsFindingWhoseOwnDescriptionConcludesNoDefectExists() {
+    // #635: the reviewer emits entries whose body investigates a candidate and concludes it is
+    // fine. The deterministic backstop drops them before the verifier spends a call on them.
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            described(
+                "dedupe key uses the raw file path without normalizing",
+                "The implementation is O(n) with a HashSet. No finding here."),
+            described(
+                "carrying() marks a notice announced even when the post failed",
+                "The code paths all match the intended tests, so there is no defect."),
+            described(
+                "BatchRun record fields shadow their former parameter names",
+                "The rename carries no semantics change; it is not a real finding."),
+            described(
+                "Producer-consumer contract preserved",
+                "Statuses scoped by previousFilesById are intentionally empty of defects."),
+            described(
+                "Rename-only change flagged in passing",
+                "The constructor keeps the same argument order, so this is not actually a bug."));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertTrue(result.findings().isEmpty());
+    assertEquals(0, result.summary().totalFindings());
+  }
+
+  @Test
+  void keepsFindingWhoseNoDefectRemarkIsNotItsConclusion() {
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    ReviewResponse original =
+        response(
+            described(
+                "Connection leak on the error path",
+                "There is no issue on the happy path; the error path leaks the connection."),
+            described(
+                "Quadratic scan added",
+                "There is no defect in the fast path, but the slow path rescans the whole list"
+                    + " per element."),
+            described("Null dereference", "request.user() is dereferenced without a guard."),
+            described("No description at all", null),
+            described("Blank description", "   "),
+            described(
+                "Quadratic slow path with a scoped final denial",
+                "The fast path is O(1); the slow path is O(n^2). There is no defect in the fast"
+                    + " path."),
+            described(
+                "Attributed denial the entry rejects",
+                "The previous review's no defect here conclusion is wrong."),
+            described(
+                "Asserting continuation with a connector",
+                "There is no defect on the happy path so the leak is on the error path."),
+            described(
+                "Degree adverb that affirms the defect",
+                "Losing the audit trail is not merely a bug."),
+            described(
+                "Hedging adverb that keeps the question open",
+                "The double release is not necessarily a defect."));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertSame(original, result);
+  }
+
+  @Test
+  void selfRetractedFindingsNeverReachTheVerifierCall() {
+    ReviewResponse original =
+        response(
+            described(
+                "Shadowed parameter names",
+                "The fields merely shadow their former parameter names; not a defect."));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertTrue(result.findings().isEmpty());
+    verifyNoInteractions(verifier);
+  }
+
+  @Test
+  void verifierScreensOnlyTheFindingsTheBackstopKept() {
+    when(verifier.verify(anyString(), anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(
+            aiOk("{\"verdicts\":[{\"id\":1,\"verdict\":\"confirmed\",\"reason\":\"real\"}]}"));
+    ReviewResponse original =
+        response(
+            described("Real bug", "The loop never terminates when the list is empty."),
+            described("Considered and fine", "After tracing the paths, no defect exists."));
+
+    var result = service.verify(SESSION, original, "diff", "stack", "");
+
+    assertEquals(1, result.findings().size());
+    assertEquals("Real bug", result.findings().get(0).title());
+    var candidates = ArgumentCaptor.forClass(String.class);
+    verify(verifier)
+        .verify(candidates.capture(), anyString(), anyString(), anyString(), anyString());
+    assertFalse(candidates.getValue().contains("Considered and fine"));
+  }
+
   @Test
   void shouldSkipVerificationWhenDisabled() {
     when(reviewConfig.verifierEnabled()).thenReturn(false);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/PrReviewPromptsContentTest.java
@@ -132,6 +132,21 @@ class PrReviewPromptsContentTest {
   }
 
   @Test
+  void generatorPromptForbidsEmittingSelfRetractedEntries() {
+    // #635: a candidate that survives investigation as NOT a defect must be discarded, not
+    // emitted as an entry whose title asserts a defect its body disclaims.
+    String sys = PrReviewPrompts.SYSTEM;
+    assertContains(
+        sys,
+        "survives your investigation as NOT a defect is discarded",
+        "the self-check must state that an investigated non-defect is dropped, never emitted");
+    assertContains(
+        sys,
+        "then retracts is invalid",
+        "the self-check must invalidate entries whose body retracts the title's claim");
+  }
+
+  @Test
   void generatorPromptKeepsTheCrossLocationConsistencyGuard() {
     String sys = PrReviewPrompts.SYSTEM;
     assertContains(


### PR DESCRIPTION
## Summary
- **Prompt fix (primary)**: adds a bullet to the review prompt's self-check list stating that a candidate which survives investigation as *not* a defect is discarded, never emitted — "I considered this and it is fine" is reasoning, not a reportable outcome, and a title asserting a defect the body retracts is invalid. This stops the tokens being spent in the first place.
- **Deterministic backstop**: `FindingVerificationService` now drops, before the verifier call, any finding whose description's concluding clause is an explicit no-defect conclusion ("No finding here", "there is no defect", "not a real finding", "intentionally empty of defects", "nothing defective", ...). This saves the verifier round trip, and keeps such entries out of the published review on the runs where verification fails open (#623). Summary counts are recomputed via the existing `recount`.
- The backstop is deliberately conservative (under-fire is the safe direction): it reads only the description's last clause, requires anchored conclusion shapes, and the no-defect phrase must be that clause's final assertion — scoped denials ("no defect in the fast path"), attributed denials, and asserting continuations all keep the finding. Anything it misses still reaches the verifier — today's behavior.

## Issue
Fixes #635

## Test plan
- [x] `FindingVerificationServiceTest`: drops all four observed retraction wordings from the issue; keeps mid-body denials, scoped/attributed denials, asserting continuations, plain assertions, null/blank descriptions; dropped entries never reach the verifier call; verifier screens only the kept candidates
- [x] `PrReviewPromptsContentTest`: asserts the new self-check bullet survives in the prompt
- [x] `./mvnw spotless:apply && ./mvnw clean compile spotbugs:check spotless:check` passes locally
- [x] `./mvnw clean test` — 3416 tests, 0 failures; changed lines fully covered per JaCoCo