### PR TITLE
fix: disclose patchless files under their own reason, not the review budget (#628)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/AbstractPrSuggestionGenerator.java
@@ -256,22 +256,26 @@ public abstract class AbstractPrSuggestionGenerator {
 
   /**
    * The partial-coverage disclosure for a run, sourced from the token-budget plan: files that did
-   * not fit any batch and files clipped to fit one. Both are named, so a large PR says which parts
-   * of the change set the command did not cover rather than only how many — and coverage is now
-   * bounded by {@code max-ai-calls}, never by the diff render's line cap.
+   * not fit any batch, files clipped to fit one, and files GitHub returned no patch text for
+   * (#628). All are named, so a large PR says which parts of the change set the command did not
+   * cover rather than only how many — and coverage is now bounded by {@code max-ai-calls}, never by
+   * the diff render's line cap.
    */
   protected static String disclosure(DiffBudgetPlanner.BudgetPlan plan) {
     if (!plan.truncated()) {
       return "";
     }
     return ReviewResult.truncationDisclosure(
-        plan.omittedFiles().size() + plan.clippedFiles().size(),
+        plan.omittedFiles().size() + plan.clippedFiles().size() + plan.patchlessFiles().size(),
         new ReviewResult.TruncationDetail(
             plan.omittedFiles(),
             plan.clippedFiles(),
+            plan.patchlessFiles(),
             List.of(),
             List.of(),
-            SummaryDegradation.NONE));
+            List.of(),
+            SummaryDegradation.NONE,
+            VerificationCoverage.EMPTY));
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlanner.java
@@ -108,11 +108,18 @@ public class DiffBudgetPlanner {
    * but every batch that succeeded keeps its findings. Written only through {@link
    * #recordUncoveredFiles(List)}; its accessor returns a defensive copy so the mutable backing
    * never escapes. The {@code effective*} accessors fold it into the planned omissions.
+   *
+   * <p>{@code patchlessFiles} names the reviewable files GitHub reported with real changes but no
+   * patch text (binary, or a text diff too large to display). They hold APPROVE and are disclosed
+   * exactly like budget omissions, but they were never candidates for a batch — there was nothing
+   * to read — so they are carried as their own class (#628): disclosing them as "exceeded the
+   * review budget" would send the operator at a knob that cannot help.
    */
   public record BudgetPlan(
       List<DiffBatch> batches,
       List<String> omittedFiles,
       List<String> clippedFiles,
+      List<String> patchlessFiles,
       boolean budgeted,
       List<String> runtimeUncoveredFiles,
       List<String> spendCeilingSkippedFiles,
@@ -123,6 +130,7 @@ public class DiffBudgetPlanner {
       batches = List.copyOf(batches);
       omittedFiles = List.copyOf(omittedFiles);
       clippedFiles = List.copyOf(clippedFiles);
+      patchlessFiles = patchlessFiles == null ? List.of() : List.copyOf(patchlessFiles);
       // Kept mutable on purpose (not List.copyOf): the review pass records runtime batch failures
       // onto this shared instance after the plan is built.
       runtimeUncoveredFiles =
@@ -140,6 +148,34 @@ public class DiffBudgetPlanner {
           verificationCoverageRef == null
               ? new java.util.concurrent.atomic.AtomicReference<>(VerificationCoverage.EMPTY)
               : verificationCoverageRef;
+    }
+
+    /**
+     * Convenience constructor for plans built before the patchless-files class existed (and tests):
+     * no patchless file was seen, so no such disclosure is rendered. The planner passes the real
+     * list through the canonical constructor.
+     */
+    public BudgetPlan(
+        List<DiffBatch> batches,
+        List<String> omittedFiles,
+        List<String> clippedFiles,
+        boolean budgeted,
+        List<String> runtimeUncoveredFiles,
+        List<String> spendCeilingSkippedFiles,
+        List<String> responseCutFiles,
+        java.util.concurrent.atomic.AtomicReference<SummaryDegradation> summaryDegradationRef,
+        java.util.concurrent.atomic.AtomicReference<VerificationCoverage> verificationCoverageRef) {
+      this(
+          batches,
+          omittedFiles,
+          clippedFiles,
+          List.of(),
+          budgeted,
+          runtimeUncoveredFiles,
+          spendCeilingSkippedFiles,
+          responseCutFiles,
+          summaryDegradationRef,
+          verificationCoverageRef);
     }
 
     /**
@@ -298,10 +334,12 @@ public class DiffBudgetPlanner {
     }
 
     public boolean truncated() {
-      // Clipped unseen hunks, files a failed batch never covered, and files whose response was
-      // cut mid-body all withhold coverage like omitted files — each holds APPROVE.
+      // Clipped unseen hunks, files a failed batch never covered, files whose response was cut
+      // mid-body, and files GitHub gave no patch for all withhold coverage like omitted files —
+      // each holds APPROVE.
       return !omittedFiles.isEmpty()
           || !clippedFiles.isEmpty()
+          || !patchlessFiles.isEmpty()
           || !runtimeUncoveredFiles.isEmpty()
           || !responseCutFiles.isEmpty();
     }
@@ -666,7 +704,8 @@ public class DiffBudgetPlanner {
    * Rendered sections plus the files no clipping could fit (omitted by name, never packed) and the
    * files that were clipped to fit (covered, but only partially analyzed).
    */
-  private record Rendered(List<Sized> sized, List<String> unclippable, List<String> clipped) {}
+  private record Rendered(
+      List<Sized> sized, List<String> unclippable, List<String> clipped, List<String> patchless) {}
 
   private Rendered renderAndSize(
       List<GitHubPullRequestClient.FileDiff> reviewable, int diffBudgetTokens) {
@@ -684,7 +723,8 @@ public class DiffBudgetPlanner {
                 Comparator.nullsLast(Comparator.naturalOrder())));
 
     var reviewableNames = ReviewDiffFormatter.namesOf(reviewable);
-    var rendered = new Rendered(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+    var rendered =
+        new Rendered(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
     for (var file : ordered) {
       var section = formatter.formatFileSection(file, reviewableNames);
       if (diffBudgetTokens <= 0) {
@@ -713,8 +753,9 @@ public class DiffBudgetPlanner {
       // display, while still reporting real additions/deletions. Its rendered section is a bare
       // header with no ```diff``` body — there is nothing for the model to read — so packing it
       // would count the file as fully reviewed and let an unbacked "resolved" claim through.
-      // Omit it by name like an unclippable file: never packed, holds APPROVE, disclosed.
-      recordName(rendered.unclippable(), file.filename());
+      // Never packed, holds APPROVE, disclosed — but as its own class, not as a budget omission:
+      // the file did not exceed anything, GitHub simply returned no content (#628).
+      recordName(rendered.patchless(), file.filename());
       return;
     }
     var tokens = tokenCounter.estimateTokens(section);
@@ -801,7 +842,8 @@ public class DiffBudgetPlanner {
     // exactly one class or the disclosure would list it twice and the verdict double-count it.
     var omittedSet = new HashSet<>(omitted);
     var clipped = rendered.clipped().stream().filter(n -> !omittedSet.contains(n)).toList();
-    return new BudgetPlan(batches, omitted, clipped, true, null, null, null, null, null);
+    return new BudgetPlan(
+        batches, omitted, clipped, rendered.patchless(), true, null, null, null, null, null);
   }
 
   /** Index of the first open bin with room for {@code tokens}, or -1 if none. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -253,7 +253,9 @@ public class FindingPipeline {
     if (plan.multiCall()) {
       return runMultiCall(session, promptInputs, ctx, plan, lineResolver);
     }
-    if (plan.budgeted() && plan.batches().isEmpty() && !plan.omittedFiles().isEmpty()) {
+    if (plan.budgeted()
+        && plan.batches().isEmpty()
+        && (!plan.omittedFiles().isEmpty() || !plan.patchlessFiles().isEmpty())) {
       return summarizeWithoutReview(session, promptInputs, ctx, plan);
     }
     var singleInputs = promptInputs;
@@ -785,8 +787,9 @@ public class FindingPipeline {
       ReviewContextLoader.ReviewContext ctx,
       DiffBudgetPlanner.BudgetPlan plan) {
     Log.warnf(
-        "No reviewable file fits the per-call token budget (%d omitted); skipping the review call",
-        plan.omittedFiles().size());
+        "No reviewable file could be sent (%d over the per-call token budget, %d with no patch"
+            + " text); skipping the review call",
+        plan.omittedFiles().size(), plan.patchlessFiles().size());
     var summaryInputs =
         new AiReviewService.SummaryInputs(
             promptInputs.prContext(),
@@ -1076,6 +1079,11 @@ public class FindingPipeline {
     for (var name : plan.omittedFiles()) {
       rows.add(name + " (exceeded the review call budget)");
     }
+    // Patchless files are withheld for a fourth reason (#628): GitHub returned no patch text for
+    // them, so there was never any content to send — not a budget problem.
+    for (var name : plan.patchlessFiles()) {
+      rows.add(name + " (no diff content from GitHub — binary, or too large to display)");
+    }
     if (rows.isEmpty()) {
       return "";
     }
@@ -1183,6 +1191,7 @@ public class FindingPipeline {
     header.append(changeScopeSummary(ctx));
     var sb = new StringBuilder();
     var omitted = Set.copyOf(plan.omittedFiles());
+    var patchless = Set.copyOf(plan.patchlessFiles());
     var uncovered = Set.copyOf(plan.runtimeUncoveredFiles());
     // effectiveClippedFiles drops any clipped file a failed batch left wholly uncovered, so it is
     // disclosed once, as uncovered, not also marked "partially analyzed".
@@ -1193,6 +1202,7 @@ public class FindingPipeline {
     var responseCut = Set.copyOf(plan.responseCutFiles());
     for (var file : ctx.reviewableFiles()) {
       if (ReviewDiffFormatter.namesContain(omitted, file.filename())
+          || ReviewDiffFormatter.namesContain(patchless, file.filename())
           || ReviewDiffFormatter.namesContain(uncovered, file.filename())) {
         continue;
       }
@@ -1208,6 +1218,12 @@ public class FindingPipeline {
     }
     for (var name : plan.omittedFiles()) {
       sb.append(name).append(" (omitted — exceeded the review call budget; not analyzed)\n");
+    }
+    for (var name : plan.patchlessFiles()) {
+      sb.append(name)
+          .append(
+              " (not analyzed — GitHub provided no diff content: binary, or too large to"
+                  + " display)\n");
     }
     // A file skipped at the spend ceiling is recorded as runtime-uncovered too (it holds approval
     // like any uncovered file), but its cause is a deliberate stop, not a call that failed. The

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipeline.java
@@ -73,6 +73,13 @@ public class FindingPipeline {
   /** Withheld paths named in the review call's notice before the rest is rolled up by count. */
   private static final int MAX_WITHHELD_PATHS = 20;
 
+  /**
+   * Per-file summary-overview note for a file GitHub returned no patch text for (#628): the honest
+   * reason, so the summary model never blames the review budget for it.
+   */
+  private static final String PATCHLESS_OVERVIEW_NOTE =
+      " (not analyzed — GitHub provided no diff content: binary, or too large to display)\n";
+
   private record BatchOutcome(
       int index,
       List<ReviewResponse.Finding> findings,
@@ -1220,10 +1227,7 @@ public class FindingPipeline {
       sb.append(name).append(" (omitted — exceeded the review call budget; not analyzed)\n");
     }
     for (var name : plan.patchlessFiles()) {
-      sb.append(name)
-          .append(
-              " (not analyzed — GitHub provided no diff content: binary, or too large to"
-                  + " display)\n");
+      sb.append(name).append(PATCHLESS_OVERVIEW_NOTE);
     }
     // A file skipped at the spend ceiling is recorded as runtime-uncovered too (it holds approval
     // like any uncovered file), but its cause is a deliberate stop, not a call that failed. The

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResult.java
@@ -166,7 +166,10 @@ public record ReviewResult(
   /**
    * Which files the review left uncovered, by name and by reason: {@code omittedFileNames} were
    * never sent because the diff exceeded the token budget, {@code clippedFileNames} were
-   * hunk-clipped and only partially analyzed, {@code spendCeilingSkippedFileNames} had their review
+   * hunk-clipped and only partially analyzed, {@code patchlessFileNames} had no patch text to
+   * review at all — GitHub reports real additions/deletions but returns no content for binary files
+   * and for text diffs too large to display, so no budget could have covered them and the rendered
+   * copy must not blame the budget (#628) — {@code spendCeilingSkippedFileNames} had their review
    * call skipped because the review's token spend ceiling ({@code REVIEW_MAX_TOKENS_PER_REVIEW})
    * was reached — a different reason with a different fix, so the rendered copy names it separately
    * — and {@code responseCutFileNames} were only partially reviewed because the model's response
@@ -191,6 +194,7 @@ public record ReviewResult(
   public record TruncationDetail(
       List<String> omittedFileNames,
       List<String> clippedFileNames,
+      List<String> patchlessFileNames,
       List<String> spendCeilingSkippedFileNames,
       List<String> responseCutFileNames,
       List<String> callFailedFileNames,
@@ -203,8 +207,33 @@ public record ReviewResult(
             List.of(),
             List.of(),
             List.of(),
+            List.of(),
             SummaryDegradation.NONE,
             VerificationCoverage.EMPTY);
+
+    /**
+     * Convenience constructor for details built before the patchless class existed (and tests): no
+     * patchless file was seen, so no such clause is rendered. The production path ({@code
+     * VerdictBuilder}) passes the real list through the canonical constructor.
+     */
+    public TruncationDetail(
+        List<String> omittedFileNames,
+        List<String> clippedFileNames,
+        List<String> spendCeilingSkippedFileNames,
+        List<String> responseCutFileNames,
+        List<String> callFailedFileNames,
+        SummaryDegradation summaryDegradation,
+        VerificationCoverage verification) {
+      this(
+          omittedFileNames,
+          clippedFileNames,
+          List.of(),
+          spendCeilingSkippedFileNames,
+          responseCutFileNames,
+          callFailedFileNames,
+          summaryDegradation,
+          verification);
+    }
 
     /**
      * Convenience constructor for details built before the verification-coverage class existed (and
@@ -251,6 +280,7 @@ public record ReviewResult(
     public TruncationDetail {
       omittedFileNames = omittedFileNames == null ? List.of() : List.copyOf(omittedFileNames);
       clippedFileNames = clippedFileNames == null ? List.of() : List.copyOf(clippedFileNames);
+      patchlessFileNames = patchlessFileNames == null ? List.of() : List.copyOf(patchlessFileNames);
       spendCeilingSkippedFileNames =
           spendCeilingSkippedFileNames == null
               ? List.of()
@@ -271,8 +301,8 @@ public record ReviewResult(
     }
 
     /**
-     * Whether any per-file coverage gap exists — a name in any of the five file classes. False for
-     * a detail whose only content is a summary degradation: the findings then cover the whole diff,
+     * Whether any per-file coverage gap exists — a name in any of the six file classes. False for a
+     * detail whose only content is a summary degradation: the findings then cover the whole diff,
      * so surfaces whose framing is per-file partial coverage (the on-demand disclosure, the delta
      * comment) treat such a detail as empty (#516) while the summary-aware surfaces (banner,
      * coverage clause, check-run brief) still disclose the degradation.
@@ -280,6 +310,7 @@ public record ReviewResult(
     public boolean hasFileGaps() {
       return !omittedFileNames.isEmpty()
           || !clippedFileNames.isEmpty()
+          || !patchlessFileNames.isEmpty()
           || !spendCeilingSkippedFileNames.isEmpty()
           || !responseCutFileNames.isEmpty()
           || !callFailedFileNames.isEmpty();
@@ -570,6 +601,16 @@ public record ReviewResult(
     if (!parts.isEmpty()) {
       clauses.add(String.join(" and ", parts) + " because the diff exceeded the review budget");
     }
+    // Patchless files carry their own reason (#628): GitHub returned no patch text for them —
+    // binary content, or a text diff too large to display — so there was never anything to
+    // review, and the budget wording would point the operator at a knob that changes nothing.
+    if (!detail.patchlessFileNames().isEmpty()) {
+      clauses.add(
+          String.format(
+              "%d file(s) could not be reviewed because GitHub provided no diff content for them"
+                  + " — binary files, or text diffs too large to display (%s)",
+              detail.patchlessFileNames().size(), nameList(detail.patchlessFileNames())));
+    }
     if (!detail.spendCeilingSkippedFileNames().isEmpty()) {
       clauses.add(
           String.format(
@@ -709,6 +750,12 @@ public record ReviewResult(
     if (!truncation.clippedFileNames().isEmpty()) {
       parts.add(
           String.format("%d file(s) partially analyzed", truncation.clippedFileNames().size()));
+    }
+    if (!truncation.patchlessFileNames().isEmpty()) {
+      parts.add(
+          String.format(
+              "%d file(s) without diff content from GitHub",
+              truncation.patchlessFileNames().size()));
     }
     if (!truncation.spendCeilingSkippedFileNames().isEmpty()) {
       parts.add(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilder.java
@@ -141,6 +141,9 @@ public class VerdictBuilder {
                 withoutNames(
                     withoutNames(plan.effectiveOmittedFiles(), ceilingSkipped), callFailed),
                 clipped,
+                // Patchless files are their own class (#628): they hold approval like an omission,
+                // but the disclosure must say GitHub returned no content, not blame the budget.
+                plan.patchlessFiles(),
                 ceilingSkipped,
                 responseCut,
                 callFailed,
@@ -156,7 +159,10 @@ public class VerdictBuilder {
                 verificationCoverage);
     var omitted =
         plan.budgeted()
-            ? plan.effectiveOmittedFiles().size() + clipped.size() + responseCut.size()
+            ? plan.effectiveOmittedFiles().size()
+                + clipped.size()
+                + responseCut.size()
+                + plan.patchlessFiles().size()
             : ctx.omittedFiles();
     // GitHub PR-level totals when available; ignore-glob drops can undercount diff-derived stats.
     // Pure renames are excluded from reviewableFiles for AI budget (#386) but still belong in the
@@ -169,6 +175,7 @@ public class VerdictBuilder {
     // skips (the detail keeps them separate only so the disclosure names the ceiling) — while
     // clipped and response-cut files keep theirs: those were partially reviewed.
     var omittedNames = new HashSet<>(truncation.omittedFileNames());
+    omittedNames.addAll(truncation.patchlessFileNames());
     omittedNames.addAll(truncation.spendCeilingSkippedFileNames());
     omittedNames.addAll(truncation.callFailedFileNames());
     var changedFiles =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/DiffBudgetPlannerTest.java
@@ -252,6 +252,16 @@ class DiffBudgetPlannerTest {
   }
 
   @Test
+  void aPlanBuiltWithANullPatchlessListExposesAnEmptyOne() {
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(), List.of(), List.of(), null, true, null, null, null, null, null);
+
+    assertEquals(List.of(), plan.patchlessFiles());
+    assertFalse(plan.truncated());
+  }
+
+  @Test
   void aPatchlessChangedFileIsOmittedByNameNotSilentlyReviewed() {
     // GitHub returns patch == null for binary files and for text diffs too large to display, while
     // still reporting real additions/deletions. Such a file survives isPureRename (non-zero change
@@ -260,7 +270,10 @@ class DiffBudgetPlannerTest {
     var patchless = new FileDiff("src/Huge.java", "modified", 4000, 10, 4010, null);
     var plan = planner.plan(List.of(patchless), 100_000, 3);
 
-    assertEquals(List.of("src/Huge.java"), plan.omittedFiles());
+    assertEquals(List.of("src/Huge.java"), plan.patchlessFiles());
+    assertTrue(
+        plan.omittedFiles().isEmpty(),
+        "a patch-less file is not a budget omission — nothing exceeded the budget (#628)");
     assertTrue(
         plan.truncated(), "an omitted patch-less file makes the review partial (holds APPROVE)");
     assertTrue(
@@ -275,7 +288,8 @@ class DiffBudgetPlannerTest {
     var real = file("src/App.java", 5, patch(5));
     var plan = planner.plan(List.of(blank, real), 100_000, 3);
 
-    assertEquals(List.of("src/Blob.bin"), plan.omittedFiles());
+    assertEquals(List.of("src/Blob.bin"), plan.patchlessFiles());
+    assertTrue(plan.omittedFiles().isEmpty());
     assertEquals(List.of("src/App.java"), coveredFilenames(plan));
     assertTrue(plan.truncated());
   }
@@ -290,6 +304,8 @@ class DiffBudgetPlannerTest {
 
     assertTrue(
         plan.omittedFiles().isEmpty(), "a zero-change patch-less file is not a coverage gap");
+    assertTrue(
+        plan.patchlessFiles().isEmpty(), "a zero-change patch-less file is not a coverage gap");
     assertFalse(plan.truncated(), "a pure rename must not hold APPROVE");
   }
 
@@ -864,7 +880,8 @@ class DiffBudgetPlannerTest {
 
     var plan = planner.plan(files, 10000, 3);
 
-    assertEquals(List.of("(unnamed file)"), plan.omittedFiles());
+    assertEquals(List.of("(unnamed file)"), plan.patchlessFiles());
+    assertTrue(plan.omittedFiles().isEmpty(), plan.omittedFiles().toString());
     assertTrue(plan.clippedFiles().isEmpty(), plan.clippedFiles().toString());
     assertTrue(plan.truncated(), "an unreviewed file must keep withholding approval");
   }
@@ -881,7 +898,8 @@ class DiffBudgetPlannerTest {
     var plan = planner.plan(files, 10_000, 3);
 
     assertEquals(List.of("src/App.java"), coveredFilenames(plan));
-    assertEquals(List.of("(unnamed file)"), plan.omittedFiles(), "the patchless file has no diff");
+    assertEquals(
+        List.of("(unnamed file)"), plan.patchlessFiles(), "the patchless file has no diff");
   }
 
   @Test
@@ -933,7 +951,7 @@ class DiffBudgetPlannerTest {
 
     assertEquals(List.of("src/App.java"), coveredFilenames(plan), "the named file is reviewed");
     assertEquals(
-        List.of("(unnamed file)"), plan.omittedFiles(), "the nameless gap is still counted");
+        List.of("(unnamed file)"), plan.patchlessFiles(), "the nameless gap is still counted");
     assertTrue(plan.truncated(), "an unreviewed file must keep withholding approval");
     assertFalse(
         planner

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/FindingPipelineTest.java
@@ -1114,6 +1114,101 @@ class FindingPipelineTest {
     assertTrue(diff.contains("- vendor/bundle.js (exceeded the review call budget)"), diff);
   }
 
+  /** #628: a patchless file is named as content GitHub withheld, never as a budget overflow. */
+  @Test
+  void withheldNoticeNamesPatchlessFilesWithoutBlamingTheBudget() {
+    var session = ReviewSession.create("owner/repo", 1, "Add an icon", "sha");
+    var app = new FileDiff("src/App.java", "modified", 3, 0, 3, "@@ -1 +1 @@\n+x\n");
+    var ctx = reviewContext(List.of(app), List.of(app), null);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(batch("src/App.java")),
+            List.of(),
+            List.of(),
+            List.of("assets/logo.png"),
+            true,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    var diff = captureBudgetedReviewDiff(session, ctx, plan);
+
+    assertTrue(
+        diff.contains(
+            "- assets/logo.png (no diff content from GitHub — binary, or too large to display)"),
+        diff);
+    assertFalse(diff.contains("exceeded the review call budget"), diff);
+  }
+
+  /** #628: the summary overview gives a patchless file its honest reason and drops its row. */
+  @Test
+  void summaryOverviewNamesPatchlessFilesWithoutBlamingTheBudget() {
+    var session = ReviewSession.create("owner/repo", 1, "Add an icon", "sha");
+    var app = new FileDiff("src/App.java", "modified", 3, 0, 3, "@@ -1 +1 @@\n+x\n");
+    var logo = new FileDiff("assets/logo.png", "added", 9, 0, 9, null);
+    var ctx = reviewContext(List.of(app, logo), List.of(app, logo), null);
+    var template = new AiReviewService.PromptInputs("d", "ctx", "base", "stack", "tests", "", "");
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(batch("src/App.java"), batch("src/App.java")),
+            List.of(),
+            List.of(),
+            List.of("assets/logo.png"),
+            true,
+            null,
+            null,
+            null,
+            null,
+            null);
+    when(aiReviewService.reviewBatch(eq(session), any(), anyInt(), anyInt()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+    var captor = ArgumentCaptor.forClass(AiReviewService.SummaryInputs.class);
+    when(aiReviewService.summarize(eq(session), captor.capture()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    pipeline.run(session, template, ctx, plan, new DiffLineResolver(Map.of()));
+
+    var overview = captor.getValue().changedFiles();
+    assertTrue(
+        overview.contains(
+            "assets/logo.png (not analyzed — GitHub provided no diff content: binary, or too"
+                + " large to display)"),
+        overview);
+    assertFalse(overview.contains("assets/logo.png (added"), overview);
+    assertFalse(overview.contains("exceeded the review call budget"), overview);
+  }
+
+  /** #628: a plan whose only gap is patchless still skips the review call, like all-omitted. */
+  @Test
+  void aPatchlessOnlyPlanSkipsTheReviewCallAndKeepsTheSummary() {
+    var session = persistedSession();
+    var template =
+        new AiReviewService.PromptInputs("raw legacy diff", "ctx", "base", "s", "t", "", "");
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of("assets/logo.png"),
+            true,
+            null,
+            null,
+            null,
+            null,
+            null);
+    when(aiReviewService.summarize(eq(session), any()))
+        .thenReturn(new ReviewResponse(List.of(), List.of(), null));
+
+    var result =
+        pipeline.run(session, template, reviewContext(), plan, new DiffLineResolver(Map.of()));
+
+    verify(aiReviewService, never()).reviewBatch(eq(session), any(), anyInt(), anyInt());
+    verify(aiReviewService).summarize(eq(session), any());
+    assertTrue(result.findings().isEmpty());
+  }
+
   /** A rename GitHub reported without a previous path degrades to its current path alone. */
   @Test
   void withheldNoticeFallsBackToTheCurrentPathWhenNoPreviousOneIsReported() {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -263,6 +263,127 @@ class ReviewResultTest {
   }
 
   @Test
+  void truncationDetailToleratesANullPatchlessList() {
+    var detail =
+        new ReviewResult.TruncationDetail(
+            List.of(),
+            List.of(),
+            null,
+            List.of(),
+            List.of(),
+            List.of(),
+            SummaryDegradation.NONE,
+            VerificationCoverage.EMPTY);
+
+    assertEquals(List.of(), detail.patchlessFileNames());
+    assertFalse(detail.hasFileGaps());
+  }
+
+  @Test
+  void coverageGapClauseNamesPatchlessFilesWithoutBlamingTheBudget() {
+    // #628: a file GitHub returned no patch text for was never over any budget — there was
+    // nothing to review. The clause must say so, not tell the reader the review ran out of room.
+    var detail =
+        new ReviewResult.TruncationDetail(
+            List.of(),
+            List.of(),
+            List.of("assets/logo.png"),
+            List.of(),
+            List.of(),
+            List.of(),
+            SummaryDegradation.NONE,
+            VerificationCoverage.EMPTY);
+
+    var clause = ReviewResult.coverageGapClause(1, detail);
+
+    assertFalse(clause.contains("review budget"), clause);
+    assertFalse(clause.contains("size budget"), clause);
+    assertTrue(
+        clause.contains(
+            "1 file(s) could not be reviewed because GitHub provided no diff content for them"
+                + " — binary files, or text diffs too large to display (assets/logo.png)"),
+        clause);
+  }
+
+  @Test
+  void coverageGapClauseKeepsTheBudgetWordingForTrueOmissionsAlongsidePatchlessFiles() {
+    var detail =
+        new ReviewResult.TruncationDetail(
+            List.of("big.java"),
+            List.of(),
+            List.of("blob.bin"),
+            List.of(),
+            List.of(),
+            List.of(),
+            SummaryDegradation.NONE,
+            VerificationCoverage.EMPTY);
+
+    var clause = ReviewResult.coverageGapClause(2, detail);
+
+    assertTrue(
+        clause.contains(
+            "1 file(s) were omitted entirely (big.java) because the diff exceeded the review"
+                + " budget"),
+        clause);
+    assertTrue(clause.contains("no diff content for them"), clause);
+    assertTrue(clause.contains("(blob.bin)"), clause);
+  }
+
+  @Test
+  void coverageGapBriefCountsPatchlessFilesUnderTheirOwnLabel() {
+    var result =
+        new ReviewResult(
+            List.of(),
+            0,
+            0,
+            0,
+            0,
+            null,
+            ReviewState.COMMENT,
+            true,
+            "",
+            List.of(),
+            List.of(),
+            2,
+            false,
+            true,
+            new ReviewResult.TruncationDetail(
+                List.of(),
+                List.of(),
+                List.of("a.png", "b.bin"),
+                List.of(),
+                List.of(),
+                List.of(),
+                SummaryDegradation.NONE,
+                VerificationCoverage.EMPTY));
+
+    var brief = result.coverageGapBrief();
+
+    assertEquals("2 file(s) without diff content from GitHub", brief);
+  }
+
+  @Test
+  void truncationDisclosureRendersForAPatchlessOnlyDetail() {
+    var detail =
+        new ReviewResult.TruncationDetail(
+            List.of(),
+            List.of(),
+            List.of("a.png"),
+            List.of(),
+            List.of(),
+            List.of(),
+            SummaryDegradation.NONE,
+            VerificationCoverage.EMPTY);
+
+    var disclosure = ReviewResult.truncationDisclosure(1, detail);
+
+    assertTrue(detail.hasFileGaps(), "a patchless file is a real per-file coverage gap");
+    assertTrue(disclosure.contains("partial coverage"), disclosure);
+    assertTrue(disclosure.contains("a.png"), disclosure);
+    assertFalse(disclosure.contains("budget"), disclosure);
+  }
+
+  @Test
   void coverageGapClauseNamesTheSpendCeilingSeparatelyFromTheBudgetOmissions() {
     // #499: files skipped because the review's token spend ceiling was reached have a different
     // cause — and a different operator fix — than files the diff budget dropped, so the rendered

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ReviewResultTest.java
@@ -378,6 +378,9 @@ class ReviewResultTest {
     var disclosure = ReviewResult.truncationDisclosure(1, detail);
 
     assertTrue(detail.hasFileGaps(), "a patchless file is a real per-file coverage gap");
+    assertFalse(
+        detail.isEmpty(),
+        "isEmpty() delegates to hasFileGaps(), so a patchless-only detail must not read as empty");
     assertTrue(disclosure.contains("partial coverage"), disclosure);
     assertTrue(disclosure.contains("a.png"), disclosure);
     assertFalse(disclosure.contains("budget"), disclosure);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/VerdictBuilderTest.java
@@ -166,6 +166,74 @@ class VerdictBuilderTest {
   }
 
   @Test
+  void aPatchlessFileHoldsApprovalAndIsDisclosedAsMissingContentNotAsOverBudget() {
+    // #628: a file GitHub returned no patch for was never a candidate for the budget. It must
+    // still hold APPROVE and be disclosed by name, but under its own reason — telling the reader
+    // the review ran out of room points them at raising a budget that would change nothing.
+    var ctx = contextWithLineCapOmissions(0);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of("assets/logo.png"),
+            true,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    assertEquals(1, result.omittedFiles());
+    assertTrue(result.truncated());
+    assertEquals(ReviewState.COMMENT, result.reviewState());
+    assertEquals(List.of(), result.truncation().omittedFileNames());
+    assertEquals(List.of("assets/logo.png"), result.truncation().patchlessFileNames());
+    var summary = result.summaryMarkdown();
+    assertTrue(
+        summary.contains(
+            "1 file(s) could not be reviewed because GitHub provided no diff content for them"
+                + " — binary files, or text diffs too large to display (assets/logo.png)"),
+        summary);
+    assertFalse(summary.contains("review budget"), summary);
+    var checkSummary = VerdictBuilder.checkSummaryForResult(result);
+    assertTrue(checkSummary.contains("1 file(s) without diff content from GitHub"), checkSummary);
+  }
+
+  @Test
+  void aBudgetOmissionAndAPatchlessFileAreDisclosedUnderTheirOwnReasons() {
+    // The two classes coexist in one review: the true budget omission keeps the budget wording,
+    // the patchless file gets its own clause, and neither claims the other's file.
+    var ctx = contextWithLineCapOmissions(0);
+    var plan =
+        new DiffBudgetPlanner.BudgetPlan(
+            List.of(),
+            List.of("big.java"),
+            List.of(),
+            List.of("assets/logo.png"),
+            true,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    var result = builder.build(ctx, CLEAN_RESPONSE, CI_CLEAR, plan);
+
+    assertEquals(2, result.omittedFiles());
+    var summary = result.summaryMarkdown();
+    assertTrue(
+        summary.contains(
+            "1 file(s) were omitted entirely (big.java) because the diff exceeded the review"
+                + " budget"),
+        summary);
+    assertTrue(summary.contains("no diff content for them"), summary);
+    assertTrue(summary.contains("(assets/logo.png)"), summary);
+  }
+
+  @Test
   void aFailedBatchsRuntimeUncoveredFilesHoldApprovalAndAreDisclosedAsCallFailures() {
     // Lead#3 + #655: a batch that failed all its retries records its files on the shared plan. The
     // verdict reads that same instance and must gate approval on them exactly like a planned


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix

## Description

## Summary
- A reviewable file GitHub reports with real additions/deletions but no patch text (binary, or a text diff too large to display) was folded into the plan's budget-omitted list, so the posted review told the maintainer it "exceeded the review budget" — pointing at a budget knob that would change nothing.
- Following the direction recorded in the issue, the omission *reason* is now carried rather than inferred: `DiffBudgetPlanner.BudgetPlan` gains a `patchlessFiles` component and `ReviewResult.TruncationDetail` gains `patchlessFileNames`, each with a convenience constructor preserving the old canonical signature so the call sites were updated in one deliberate pass without churn.
- Every disclosure surface now names the honest cause — "GitHub provided no diff content … binary files, or text diffs too large to display": the review banner / coverage-gap clause, the check-run brief, the on-demand command disclosure (`/describe`, `/changelog`, …), the summary model's changed-files overview, and the withheld-material notice in the batch prompt.
- Behavior is otherwise unchanged: patchless files still hold APPROVE, still drop their walkthrough rows, still trigger the degenerate skip-the-review-call path when they are the only reviewable files, and are never packed into a batch.

## Issue

## Test plan
- [x] Planner tests updated: patchless files land in `patchlessFiles`, not `omittedFiles`, and still make the plan truncated (`DiffBudgetPlannerTest`)
- [x] Verdict tests: patchless disclosed under its own clause, budget wording absent, coexistence with true budget omissions, check-run brief label (`VerdictBuilderTest`)
- [x] Rendering tests: coverage-gap clause/brief, disclosure for patchless-only details, null tolerance (`ReviewResultTest`)
- [x] Pipeline tests: withheld-material notice and summary overview name the real reason; patchless-only plan skips the review call (`FindingPipelineTest`)
- [x] `./mvnw clean compile spotbugs:check spotless:check` and `./mvnw clean test` (3422 tests) pass locally; JaCoCo shows zero uncovered changed lines

## Related Issues

Fixes #628

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

Local gates: `spotless:check`, `spotbugs:check`, full test suite pass; CI green except review follow-ups in progress.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

