### PR TITLE
fix: register a bound callId atomically, and enforce LogSafe's documented reach

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/LogSafe.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/LogSafe.java
@@ -28,9 +28,16 @@ import java.util.regex.Pattern;
  * it untrue — each one fixed the sites someone had enumerated, so the next site written was outside
  * the list by default. It is now checked rather than remembered: {@code LogSafeInvariantTest} reads
  * the untrusted accessor names off the AI response records themselves and fails on any log
- * statement in {@code src/main/java} that interpolates one of them without this class (#764). Both
- * halves of that check extend themselves — a field added to a response record is covered the moment
- * it exists, and a log line added anywhere in main is scanned the moment it is written.
+ * statement in {@code src/main/java} that calls one of them in the call's own arguments, or that
+ * logs a same-file local composed from such a call, without this class (#764). Both halves of that
+ * check extend themselves — a field added to a response record is covered the moment it exists, and
+ * a log line added anywhere in main is scanned the moment it is written.
+ *
+ * <p>Those two shapes are the check's whole reach, and the limit is worth knowing at this class
+ * rather than only at the test: a value that arrived at the log line through a method parameter, a
+ * field or a return value is not tracked, because the scan reads source text and has no call graph
+ * to follow it back to the accessor. So wrap the value where the accessor is read, and it stays
+ * inside what is checked; wrap it several frames later and only the convention below is holding it.
  *
  * <p>What the check covers is the model-supplied half, which is the half that can be derived: the
  * response records name their own fields. A GitHub error body has no such record to read, so that

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/LogSafe.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/LogSafe.java
@@ -24,6 +24,19 @@ import java.util.regex.Pattern;
  * of defect is fixed in one place rather than re-litigated at each new call site (#731, #740,
  * #742).
  *
+ * <p>That first sentence is a claim about every call site in the code base, and five rounds found
+ * it untrue — each one fixed the sites someone had enumerated, so the next site written was outside
+ * the list by default. It is now checked rather than remembered: {@code LogSafeInvariantTest} reads
+ * the untrusted accessor names off the AI response records themselves and fails on any log
+ * statement in {@code src/main/java} that interpolates one of them without this class (#764). Both
+ * halves of that check extend themselves — a field added to a response record is covered the moment
+ * it exists, and a log line added anywhere in main is scanned the moment it is written.
+ *
+ * <p>What the check covers is the model-supplied half, which is the half that can be derived: the
+ * response records name their own fields. A GitHub error body has no such record to read, so that
+ * half remains a convention this class states and its call sites keep ({@code GitHubApiError}
+ * collapses the body and each diagnostic it appends).
+ *
  * <p>This is the log-destined counterpart to {@code MarkdownSafe}, and the two are deliberately
  * separate. {@code MarkdownSafe.oneLine} feeds text the bot posts to GitHub, where the wider class
  * below has a real rendering cost; a log record is a diagnostic identity rather than a rendering

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/DocGenerationService.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import dev.thiagogonzaga.thrillhousebot.LogSafe;
 import dev.thiagogonzaga.thrillhousebot.config.ActiveModelSettings;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubAuthClient;
@@ -429,13 +430,13 @@ public class DocGenerationService extends AbstractPrSuggestionGenerator {
     if (resolved.isEmpty() || (!multiLine && resolved.getAsInt() != doc.line())) {
       Log.debugf(
           "Skipping /add-docs suggestion for %s:%d — declaration line is not in the diff",
-          doc.file(), doc.line());
+          LogSafe.oneLine(doc.file()), doc.line());
       return DocPostResult.SKIPPED;
     }
     if (!preservesExistingCode(doc)) {
       Log.debugf(
           "Skipping /add-docs suggestion for %s:%d — replacement would not keep the existing line",
-          doc.file(), doc.line());
+          LogSafe.oneLine(doc.file()), doc.line());
       return DocPostResult.SKIPPED;
     }
     // A multi-line suggestion must overwrite the whole declaration span, not just doc.line() —

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FollowUpAnalyzer.java
@@ -1160,7 +1160,10 @@ public class FollowUpAnalyzer {
         Log.infof(
             "Clearing previous finding '%s' (%s) — a maintainer named it in an"
                 + " @thrillhousebot resolved comment on the PR conversation",
-            finding.title(), locator);
+            LogSafe.oneLine(finding.title()),
+            // The locator is composed from the finding's own file, so it is model-supplied in the
+            // same way the title is; the matching above reads the unsanitized value (#764).
+            LogSafe.oneLine(locator));
         return true;
       }
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PathScopedInstructions.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PathScopedInstructions.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import dev.thiagogonzaga.thrillhousebot.LogSafe;
 import dev.thiagogonzaga.thrillhousebot.github.RepoSettings;
 import io.quarkus.logging.Log;
 import java.util.ArrayList;
@@ -86,7 +87,9 @@ public record PathScopedInstructions(List<AppliedScope> scopes, String source) {
     for (RepoSettings.PathInstructions declared : settings.pathInstructions()) {
       var globs = ReviewDiffFormatter.IgnoreGlobs.compile(List.of(declared.path()));
       if (globs.matchers().isEmpty()) {
-        Log.warnf("Ignoring path-scoped review rules for uncompilable glob: %s", declared.path());
+        Log.warnf(
+            "Ignoring path-scoped review rules for uncompilable glob: %s",
+            LogSafe.oneLine(declared.path()));
         continue;
       }
       var matched = filenames.stream().filter(globs::matches).toList();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrImprovementService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PrImprovementService.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import dev.thiagogonzaga.thrillhousebot.LogSafe;
 import dev.thiagogonzaga.thrillhousebot.config.ActiveModelSettings;
 import dev.thiagogonzaga.thrillhousebot.config.ThrillhouseConfig;
 import dev.thiagogonzaga.thrillhousebot.github.GitHubCommentClient;
@@ -323,7 +324,7 @@ public class PrImprovementService extends AbstractPrSuggestionGenerator {
     if (resolved.isEmpty() || (!multiLine && resolved.getAsInt() != improvement.line())) {
       Log.debugf(
           "/improve cannot anchor %s:%d — the line is not in the diff",
-          improvement.file(), improvement.line());
+          LogSafe.oneLine(improvement.file()), improvement.line());
       return false;
     }
     Optional<DiffLineResolver.LineRange> range =
@@ -333,13 +334,13 @@ public class PrImprovementService extends AbstractPrSuggestionGenerator {
     if (multiLine && range.isEmpty()) {
       Log.debugf(
           "/improve cannot anchor the multi-line replacement at %s:%d",
-          improvement.file(), improvement.line());
+          LogSafe.oneLine(improvement.file()), improvement.line());
       return false;
     }
     if (!multiLine && !quotesCurrentLine(lineResolver, improvement)) {
       Log.debugf(
           "/improve skipped %s:%d — the quoted code does not match the line in the diff",
-          improvement.file(), improvement.line());
+          LogSafe.oneLine(improvement.file()), improvement.line());
       return false;
     }
     Integer startLine = range.map(DiffLineResolver.LineRange::startLine).orElse(null);
@@ -368,7 +369,11 @@ public class PrImprovementService extends AbstractPrSuggestionGenerator {
               startLine != null ? "RIGHT" : null));
       return true;
     } catch (RuntimeException e) {
-      Log.debugf(e, "GitHub rejected the /improve comment for %s:%d", improvement.file(), endLine);
+      Log.debugf(
+          e,
+          "GitHub rejected the /improve comment for %s:%d",
+          LogSafe.oneLine(improvement.file()),
+          endLine);
       return false;
     }
   }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/FindingVerificationService.java
@@ -1006,7 +1006,7 @@ public class FindingVerificationService {
       if (isBlockingEligible(finding) && containsHedging(finding)) {
         Log.infof(
             "Demoting hedged %s finding '%s' to medium confidence",
-            finding.risk(), finding.title());
+            LogSafe.oneLine(finding.risk()), LogSafe.oneLine(finding.title()));
         adjusted.add(
             new ReviewResponse.Finding(
                 finding.risk(),
@@ -1071,7 +1071,10 @@ public class FindingVerificationService {
       }
       Log.infof(
           "Raising unmitigated-injection-sink finding '%s' from %s to %s risk; confidence stays %s",
-          finding.title(), finding.risk(), HIGH_LABEL, finding.confidence());
+          LogSafe.oneLine(finding.title()),
+          LogSafe.oneLine(finding.risk()),
+          HIGH_LABEL,
+          LogSafe.oneLine(finding.confidence()));
       adjusted.add(
           new ReviewResponse.Finding(
               HIGH_LABEL,

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewSessionContext.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewSessionContext.java
@@ -38,10 +38,31 @@ final class ReviewSessionContext {
    */
   record Binding(long sessionId, int attempt, long callId) {}
 
+  /**
+   * Registers a new stream invocation for {@code sessionId} and binds it to the calling thread.
+   *
+   * <p>The registration is one {@code compute} rather than a lookup followed by an add, because the
+   * add has to happen under the same per-bin lock the lookup did (#763). Split in two, a sibling
+   * stream finishing in between unmapped the set the add then wrote to: {@link #invalidate(long,
+   * long)} returns null once the set empties, which drops the mapping, and {@link
+   * #invalidate(long)} drops it outright. The add landed on an orphan, {@link #isActiveCall} read
+   * the session's absent mapping, and a live stream's usage callback was discarded as stale — so
+   * its tokens never reached {@code ReviewTokenLedger}, and the per-review spend ceiling (#509)
+   * under-counted the review it is there to cap. Reviews run their batches on virtual threads, so
+   * concurrent bind and invalidate for one session is the ordinary case here rather than a corner.
+   * The mirror window in {@code invalidate} was closed with {@code computeIfPresent}; this is the
+   * half that was missed.
+   */
   static void bind(long sessionId, int attempt) {
     var callId = NEXT_CALL_ID.incrementAndGet();
     BINDING.set(new Binding(sessionId, attempt, callId));
-    ACTIVE_CALLS.computeIfAbsent(sessionId, id -> ConcurrentHashMap.newKeySet()).add(callId);
+    ACTIVE_CALLS.compute(
+        sessionId,
+        (id, calls) -> {
+          var active = calls != null ? calls : ConcurrentHashMap.<Long>newKeySet();
+          active.add(callId);
+          return active;
+        });
   }
 
   static void clear() {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/LogSafeInvariantTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/LogSafeInvariantTest.java
@@ -151,6 +151,25 @@ class LogSafeInvariantTest {
             "var title = finding.title();\nLog.infof(\"no title survived the batches\");",
             untrusted),
         "a message whose prose names a tainted local does not log it");
+    assertEquals(
+        1,
+        scanned(
+                "Log.infof(\"path %s\", LogSafe.oneLine(finding.title()) + finding.file());",
+                untrusted)
+            .size(),
+        "one wrapped value is not proof the rest of the argument is sanitized");
+    assertEquals(
+        1,
+        scanned(
+                "var at = LogSafe.oneLine(finding.title()) + finding.file();\n"
+                    + "Log.infof(\"at %s\", at);",
+                untrusted)
+            .size(),
+        "a local composed from a wrapped value and a raw one is still tainted");
+    assertEquals(
+        List.of(),
+        scanned("Log.infof(\"finding %s\", LogSafe.oneLine(shorten(finding.title())));", untrusted),
+        "a nested call inside the sanitized span does not end it early");
   }
 
   private static List<String> scanned(String body, Set<String> untrusted) {
@@ -215,10 +234,7 @@ class LogSafeInvariantTest {
         if (conversion != null && Character.toLowerCase(conversion) != 's') {
           continue;
         }
-        var argument = arguments.get(index);
-        if (argument.contains("LogSafe.")) {
-          continue;
-        }
+        var argument = withoutSanitizedCalls(arguments.get(index));
         // A literal is text the bot chose, and its words are not identifiers: without this, a
         // message naming a tainted local ("no candidate survived") reads as logging it.
         var expression = withoutLiterals(argument);
@@ -256,10 +272,7 @@ class LogSafeInvariantTest {
     var tainted = new TreeSet<String>();
     var declarations = LOCAL_DECLARATION.matcher(source);
     while (declarations.find()) {
-      var initializer = withoutLiterals(declarations.group(2));
-      if (declarations.group(2).contains("LogSafe.")) {
-        continue;
-      }
+      var initializer = withoutLiterals(withoutSanitizedCalls(declarations.group(2)));
       var accessors = NO_ARG_CALL.matcher(initializer);
       while (accessors.find()) {
         if (untrusted.contains(accessors.group(1))) {
@@ -421,5 +434,51 @@ class LogSafeInvariantTest {
       index++;
     }
     return scrubbed.toString();
+  }
+
+  /**
+   * The expression with every {@code LogSafe.…(…)} call and its arguments removed, so what remains
+   * is only the part that reached the log line unsanitized.
+   *
+   * <p>Skipping the whole expression when it mentions {@code LogSafe.} anywhere — which is what
+   * this did first — reads one wrapped value as proof the rest is safe. {@code
+   * LogSafe.oneLine(finding.title()) + finding.file()} passed the scan with the path interpolated
+   * raw at its own {@code %s}, which is the shape a partial fix produces: someone wraps the value a
+   * finding names and leaves the one beside it. Removing the sanitized spans and scanning the
+   * remainder cannot be satisfied that way.
+   *
+   * <p>Spans are matched by balancing parentheses rather than to the first {@code )}, so a nested
+   * call inside the argument does not end the span early.
+   */
+  private static String withoutSanitizedCalls(String expression) {
+    var out = new StringBuilder(expression.length());
+    var at = 0;
+    while (at < expression.length()) {
+      var call = expression.indexOf("LogSafe.", at);
+      if (call < 0) {
+        out.append(expression, at, expression.length());
+        break;
+      }
+      out.append(expression, at, call);
+      var open = expression.indexOf('(', call);
+      if (open < 0) {
+        // Not a call: a bare mention cannot sanitize anything, so keep it for the scan.
+        out.append(expression, call, expression.length());
+        break;
+      }
+      var depth = 0;
+      var scan = open;
+      while (scan < expression.length()) {
+        var c = expression.charAt(scan);
+        if (c == '(') {
+          depth++;
+        } else if (c == ')' && --depth == 0) {
+          break;
+        }
+        scan++;
+      }
+      at = scan < expression.length() ? scan + 1 : expression.length();
+    }
+    return out.toString();
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/LogSafeInvariantTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/LogSafeInvariantTest.java
@@ -42,11 +42,32 @@ import org.junit.jupiter.api.Test;
  * <p>So this test states the invariant rather than a list of sites. It derives the untrusted
  * accessor names from the AI response records themselves — every {@code String}-typed component of
  * every record reachable from a {@code *Response} class in {@code review.ai}, read reflectively —
- * and then reads every log call in {@code src/main/java} and fails on any that interpolates one of
- * them without {@link LogSafe}. Both halves extend themselves: a field added to {@code
- * ReviewResponse.Finding} is covered the moment it exists, and a log line added anywhere in main is
- * scanned the moment it is written. Nothing here has to be kept in sync by hand, which is the
- * property the five previous rounds lacked.
+ * and then reads every log call in {@code src/main/java} and fails on two shapes: an untrusted
+ * accessor called inside the log call's own argument text, and a same-file local whose initializer
+ * calls one. Both halves extend themselves: a field added to {@code ReviewResponse.Finding} is
+ * covered the moment it exists, and a log line added anywhere in main is scanned the moment it is
+ * written. Nothing here has to be kept in sync by hand, which is the property the five previous
+ * rounds lacked.
+ *
+ * <p>Those two shapes are the whole reach, and saying so rather than claiming every log call is the
+ * point: this test exists to end a defect class whose shape is a documented reach exceeding an
+ * actual one, and it is not exempt from it. A value that arrives at the log line through a method
+ * parameter, a field or a return value is invisible here, because the accessor that read it is in
+ * another method and what the scan sees is a bare identifier — {@link
+ * #theScannerDoesNotSeeAValueThatCrossedAMethodBoundary()} pins that miss so it stays a known limit
+ * rather than a surprise. Wrapping the value where the accessor is read keeps it inside the reach,
+ * and that is the habit this check is asking for.
+ *
+ * <p>Tracking it instead would need a call graph, which is exactly what reading source text does
+ * not have. The one join available without type resolution is to match callers to callees by name
+ * and argument position, and that was tried and measured before this paragraph was written: over
+ * main it taints 203 parameters and produces 31 further reports, and the sampled ones are name
+ * collisions rather than findings — {@code req} in {@code ReviewDispatcher}, which is a record
+ * whose {@code owner()} is what actually reaches the line, and {@code line} in {@code
+ * DocGenerationService}, which is an {@code int} at a {@code %d} beside an already-wrapped path.
+ * Neither is a value {@code LogSafe.oneLine} even accepts, so the report's own prescribed fix would
+ * not compile. A check that asks for impossible fixes is one a reader learns to skip, which costs
+ * more than the shapes it would have caught (#764).
  *
  * <p>Reading source text rather than bytecode is unusual for a unit test, and it is a deliberate
  * trade. A textual scan cannot resolve types, so it decides by accessor name and errs towards
@@ -72,9 +93,18 @@ class LogSafeInvariantTest {
   private static final Pattern LOG_CALL =
       Pattern.compile("\\b(?:Log|log)\\.(debug|info|warn|error|trace|fatal)(f?)\\s*\\(");
 
-  /** A {@code java.util.Formatter} conversion; group 1 is the conversion character. */
+  /**
+   * A {@code java.util.Formatter} conversion; group 1 is the conversion character.
+   *
+   * <p>The quantifiers are possessive because the flag class and the width overlap on {@code 0},
+   * which is both the zero-pad flag and a digit: a run of zeros splits every way between the two,
+   * and a run that never reaches a conversion character makes the match try each split. Measured on
+   * a {@code %} followed by 24 000 zeros, that cost 7 030 ms; possessive, 2 ms. No match is lost —
+   * a width may not begin with {@code 0}, since a leading one is the flag, so the greedy split is
+   * the only correct one anyway.
+   */
   private static final Pattern CONVERSION =
-      Pattern.compile("%(?:\\d+\\$)?[-#+ 0,(]*\\d*(?:\\.\\d+)?([a-zA-Z%])");
+      Pattern.compile("%(?:\\d++\\$)?[-#+ 0,(]*+\\d*+(?:\\.\\d++)?([a-zA-Z%])");
 
   private static final Pattern NO_ARG_CALL = Pattern.compile("\\.(\\w+)\\s*\\(\\s*\\)");
 
@@ -82,11 +112,21 @@ class LogSafeInvariantTest {
    * A local holding untrusted text: the shape {@code FollowUpAnalyzer}'s {@code locator} had, where
    * the value logged was {@code file() + ":" + line()} composed a few lines earlier, so a check
    * that only read the log call's own accessors saw a bare identifier and passed it (#764).
+   *
+   * <p>Possessive around the {@code =} for the reason {@link #CONVERSION} is: {@code \s} and {@code
+   * [^;]} both match whitespace, so the run after the {@code =} splits every way between them, and
+   * an initializer this scan reaches with no {@code ;} beyond it makes the match try each split.
+   * Measured on 24 000 spaces, 2 494 ms; possessive, under 1 ms. A differential run over 400 000
+   * random inputs found no input the two forms answer differently.
    */
   private static final Pattern LOCAL_DECLARATION =
-      Pattern.compile("\\b(?:final\\s+)?(?:String|var)\\s+(\\w+)\\s*=\\s*([^;]+);", Pattern.DOTALL);
+      Pattern.compile(
+          "\\b(?:final\\s+)?(?:String|var)\\s++(\\w+)\\s*+=\\s*+([^;]++);", Pattern.DOTALL);
 
   private static final Pattern IDENTIFIER = Pattern.compile("\\b\\w+\\b");
+
+  /** Collapses a reported argument onto one report line; compiled out of the per-call loop. */
+  private static final Pattern WHITESPACE_RUN = Pattern.compile("\\s+");
 
   private static final Pattern STRING_LITERAL =
       Pattern.compile("\"((?:[^\"\\\\]|\\\\.)*)\"", Pattern.DOTALL);
@@ -170,6 +210,41 @@ class LogSafeInvariantTest {
         List.of(),
         scanned("Log.infof(\"finding %s\", LogSafe.oneLine(shorten(finding.title())));", untrusted),
         "a nested call inside the sanitized span does not end it early");
+    assertEquals(
+        1,
+        scanned("Log.infof(\"%,08d|%s\", finding.title(), finding.file());", untrusted).size(),
+        "a flagged, zero-padded, width-bearing conversion still binds to its own argument: misread"
+            + " it and the numeric exemption slides onto the wrong one and both get reported");
+  }
+
+  /**
+   * The miss the reach above admits to, kept executable so it cannot quietly drift: {@code file}
+   * reaches the log line as a parameter, the accessor that produced it is in the caller, and the
+   * scan sees an identifier no declaration in this file marks tainted.
+   *
+   * <p>Asserting a miss looks like asserting a bug, and it is here on purpose. If the scan is ever
+   * given a dataflow step this test fails, and the failure lands on the two javadocs — this class's
+   * and {@link LogSafe}'s — that have to be widened with it. That is the coupling the five earlier
+   * rounds lacked: the reach and the sentence describing it move together or not at all.
+   */
+  @Test
+  void theScannerDoesNotSeeAValueThatCrossedAMethodBoundary() {
+    assertEquals(
+        List.of(),
+        violationsIn(
+            """
+            class Sample {
+              void logPath(String file) {
+                Log.warnf("rule file %s", file);
+              }
+              void run(Finding finding) {
+                logPath(finding.file());
+              }
+            }
+            """,
+            "Sample.java", Set.of("title", "file", "reason")),
+        "the scan cannot follow a value across a method boundary; wrap it where the accessor is"
+            + " read, and widen both javadocs before this stops being true");
   }
 
   private static List<String> scanned(String body, Set<String> untrusted) {
@@ -259,7 +334,7 @@ class LogSafeInvariantTest {
                   + " logs "
                   + reached
                   + " raw in argument `"
-                  + argument.replaceAll("\\s+", " ")
+                  + WHITESPACE_RUN.matcher(argument).replaceAll(" ")
                   + "` — wrap it in LogSafe.oneLine");
         }
       }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/LogSafeInvariantTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/LogSafeInvariantTest.java
@@ -1,0 +1,425 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * #764. {@link LogSafe}'s class javadoc states an invariant over the whole code base — every value
+ * a log statement splices in that the bot did not choose itself goes through it — and five separate
+ * rounds have now found that invariant untrue: {@code MarkdownSafe.oneLine}'s ASCII-only class
+ * (#742), {@code LogSafe}'s own {@code \p{IsZs}} gap, three {@code ReviewPublisher} DEBUG lines
+ * waved through because debug is off by default, four rate-limit headers in {@code
+ * GitHubApiError.diagnostics()}, and three INFO lines carrying a model-supplied finding title and
+ * path (#764). Every round fixed the sites someone had enumerated, and the enumeration is what
+ * keeps failing: it is a list a human maintains, so the next call site written is outside it by
+ * default.
+ *
+ * <p>So this test states the invariant rather than a list of sites. It derives the untrusted
+ * accessor names from the AI response records themselves — every {@code String}-typed component of
+ * every record reachable from a {@code *Response} class in {@code review.ai}, read reflectively —
+ * and then reads every log call in {@code src/main/java} and fails on any that interpolates one of
+ * them without {@link LogSafe}. Both halves extend themselves: a field added to {@code
+ * ReviewResponse.Finding} is covered the moment it exists, and a log line added anywhere in main is
+ * scanned the moment it is written. Nothing here has to be kept in sync by hand, which is the
+ * property the five previous rounds lacked.
+ *
+ * <p>Reading source text rather than bytecode is unusual for a unit test, and it is a deliberate
+ * trade. A textual scan cannot resolve types, so it decides by accessor name and errs towards
+ * reporting: a {@code file()} on some unrelated record is reported too, and the answer to a report
+ * is to wrap the value, which is never wrong for a logged string. What it must not do is go blind,
+ * because a structural test that silently matches nothing reads exactly like a clean code base — so
+ * {@link #theScannerReportsTheShapesItClaimsTo()} pins the scanner against known-bad and known-good
+ * sources, and the run below asserts the accessor set is non-empty before it trusts a clean result.
+ *
+ * <p>Numeric conversions are exempt on purpose. {@code %d} splices a number, which can neither
+ * forge a record boundary nor smuggle an escape, and {@code LogSafe.oneLine} does not take one — a
+ * finding's {@code line()} is the common case.
+ */
+class LogSafeInvariantTest {
+
+  private static final Path MAIN_SOURCES = Path.of("src", "main", "java");
+
+  private static final String AI_PACKAGE = "dev.thiagogonzaga.thrillhousebot.review.ai";
+
+  /**
+   * JBoss {@code Log.warnf} and slf4j {@code log.warn} alike; group 2 marks the format variants.
+   */
+  private static final Pattern LOG_CALL =
+      Pattern.compile("\\b(?:Log|log)\\.(debug|info|warn|error|trace|fatal)(f?)\\s*\\(");
+
+  /** A {@code java.util.Formatter} conversion; group 1 is the conversion character. */
+  private static final Pattern CONVERSION =
+      Pattern.compile("%(?:\\d+\\$)?[-#+ 0,(]*\\d*(?:\\.\\d+)?([a-zA-Z%])");
+
+  private static final Pattern NO_ARG_CALL = Pattern.compile("\\.(\\w+)\\s*\\(\\s*\\)");
+
+  /**
+   * A local holding untrusted text: the shape {@code FollowUpAnalyzer}'s {@code locator} had, where
+   * the value logged was {@code file() + ":" + line()} composed a few lines earlier, so a check
+   * that only read the log call's own accessors saw a bare identifier and passed it (#764).
+   */
+  private static final Pattern LOCAL_DECLARATION =
+      Pattern.compile("\\b(?:final\\s+)?(?:String|var)\\s+(\\w+)\\s*=\\s*([^;]+);", Pattern.DOTALL);
+
+  private static final Pattern IDENTIFIER = Pattern.compile("\\b\\w+\\b");
+
+  private static final Pattern STRING_LITERAL =
+      Pattern.compile("\"((?:[^\"\\\\]|\\\\.)*)\"", Pattern.DOTALL);
+
+  @Test
+  void noLogStatementInterpolatesAModelSuppliedValueWithoutLogSafe() throws Exception {
+    var untrusted = untrustedAccessors();
+    assertTrue(
+        untrusted.containsAll(Set.of("title", "file", "risk", "confidence", "reason")),
+        "the untrusted accessor set lost its known members, so a clean run means nothing: "
+            + untrusted);
+
+    var violations = new ArrayList<String>();
+    try (var sources = Files.walk(MAIN_SOURCES)) {
+      for (var source : sources.filter(LogSafeInvariantTest::isJavaSource).toList()) {
+        violations.addAll(
+            violationsIn(
+                Files.readString(source), MAIN_SOURCES.relativize(source).toString(), untrusted));
+      }
+    }
+
+    assertEquals(
+        List.of(),
+        violations,
+        "a log statement interpolates a model-supplied value without LogSafe.oneLine");
+  }
+
+  @Test
+  void theScannerReportsTheShapesItClaimsTo() {
+    var untrusted = Set.of("title", "file", "reason");
+
+    assertEquals(
+        1,
+        scanned("Log.infof(\"finding %s\", finding.title());", untrusted).size(),
+        "a raw accessor at a string conversion must be reported");
+    assertEquals(
+        List.of(),
+        scanned("Log.infof(\"finding %s\", LogSafe.oneLine(finding.title()));", untrusted),
+        "a sanitized accessor must not be reported");
+    assertEquals(
+        List.of(),
+        scanned("Log.infof(\"line %d\", finding.line());", untrusted),
+        "a numeric conversion cannot forge a record and must not be reported");
+    assertEquals(
+        1,
+        scanned(
+                "String at = finding.file() + \":\" + finding.line();\nLog.infof(\"at %s\", at);",
+                untrusted)
+            .size(),
+        "a local composed from an accessor must be reported where it is logged");
+    assertEquals(
+        1,
+        scanned("log.warn(\"rejected {}\", verdict.reason());", untrusted).size(),
+        "the slf4j call shape must be scanned too");
+    assertEquals(
+        List.of(),
+        scanned("// Log.infof(\"finding %s\", finding.title());", untrusted),
+        "a commented-out call is not a call site");
+    assertEquals(
+        List.of(),
+        scanned(
+            "var title = finding.title();\nLog.infof(\"no title survived the batches\");",
+            untrusted),
+        "a message whose prose names a tainted local does not log it");
+  }
+
+  private static List<String> scanned(String body, Set<String> untrusted) {
+    return violationsIn(
+        "class Sample {\n  void run() {\n" + body + "\n  }\n}\n", "Sample.java", untrusted);
+  }
+
+  /**
+   * Every {@code String}-valued component name of every record reachable from a {@code *Response}
+   * class in {@code review.ai}. These are the names a model's own text arrives under, and reading
+   * them off the records means a new field extends the check without anyone remembering to.
+   */
+  private static Set<String> untrustedAccessors() throws IOException, ClassNotFoundException {
+    var accessors = new TreeSet<String>();
+    try (var sources = Files.list(MAIN_SOURCES.resolve(AI_PACKAGE.replace('.', '/')))) {
+      for (var source : sources.toList()) {
+        var name = source.getFileName().toString();
+        if (name.endsWith("Response.java")) {
+          collectComponents(Class.forName(AI_PACKAGE + "." + name.replace(".java", "")), accessors);
+        }
+      }
+    }
+    return accessors;
+  }
+
+  private static void collectComponents(Class<?> type, Set<String> accessors) {
+    if (type.isRecord()) {
+      for (var component : type.getRecordComponents()) {
+        var declared = component.getGenericType().getTypeName();
+        if (declared.equals(String.class.getName())
+            || declared.equals("java.util.List<java.lang.String>")) {
+          accessors.add(component.getName());
+        }
+      }
+    }
+    for (var nested : type.getDeclaredClasses()) {
+      collectComponents(nested, accessors);
+    }
+  }
+
+  private static boolean isJavaSource(Path path) {
+    return Files.isRegularFile(path) && path.getFileName().toString().endsWith(".java");
+  }
+
+  /** Every unsanitized interpolation of an untrusted value in one source file, as report lines. */
+  private static List<String> violationsIn(String rawSource, String name, Set<String> untrusted) {
+    var source = withoutComments(rawSource);
+    var tainted = taintedLocals(source, untrusted);
+    var violations = new ArrayList<String>();
+    var calls = LOG_CALL.matcher(source);
+    while (calls.find()) {
+      var arguments = argumentsAt(source, calls.end() - 1);
+      var formatted = !calls.group(2).isEmpty();
+      var formatIndex = formatted ? indexOfLiteral(arguments) : -1;
+      var conversions =
+          formatIndex < 0 ? List.<Character>of() : conversionsOf(arguments.get(formatIndex));
+      for (var index = 0; index < arguments.size(); index++) {
+        if (index == formatIndex) {
+          continue;
+        }
+        var conversion = conversionAt(conversions, index - formatIndex - 1, formatIndex >= 0);
+        if (conversion != null && Character.toLowerCase(conversion) != 's') {
+          continue;
+        }
+        var argument = arguments.get(index);
+        if (argument.contains("LogSafe.")) {
+          continue;
+        }
+        // A literal is text the bot chose, and its words are not identifiers: without this, a
+        // message naming a tainted local ("no candidate survived") reads as logging it.
+        var expression = withoutLiterals(argument);
+        var reached = new TreeSet<String>();
+        var accessors = NO_ARG_CALL.matcher(expression);
+        while (accessors.find()) {
+          if (untrusted.contains(accessors.group(1))) {
+            reached.add(accessors.group(1) + "()");
+          }
+        }
+        var identifiers = IDENTIFIER.matcher(expression);
+        while (identifiers.find()) {
+          if (tainted.contains(identifiers.group())) {
+            reached.add(identifiers.group());
+          }
+        }
+        if (!reached.isEmpty()) {
+          violations.add(
+              name
+                  + ":"
+                  + lineOf(source, calls.start())
+                  + " logs "
+                  + reached
+                  + " raw in argument `"
+                  + argument.replaceAll("\\s+", " ")
+                  + "` — wrap it in LogSafe.oneLine");
+        }
+      }
+    }
+    return violations;
+  }
+
+  /** Locals initialised from an untrusted accessor without sanitizing it, by name. */
+  private static Set<String> taintedLocals(String source, Set<String> untrusted) {
+    var tainted = new TreeSet<String>();
+    var declarations = LOCAL_DECLARATION.matcher(source);
+    while (declarations.find()) {
+      var initializer = withoutLiterals(declarations.group(2));
+      if (declarations.group(2).contains("LogSafe.")) {
+        continue;
+      }
+      var accessors = NO_ARG_CALL.matcher(initializer);
+      while (accessors.find()) {
+        if (untrusted.contains(accessors.group(1))) {
+          tainted.add(declarations.group(1));
+          break;
+        }
+      }
+    }
+    return tainted;
+  }
+
+  private static Character conversionAt(List<Character> conversions, int position, boolean known) {
+    if (!known || position < 0 || position >= conversions.size()) {
+      return null;
+    }
+    return conversions.get(position);
+  }
+
+  private static List<Character> conversionsOf(String formatArgument) {
+    var literal = new StringBuilder();
+    var pieces = STRING_LITERAL.matcher(formatArgument);
+    while (pieces.find()) {
+      literal.append(pieces.group(1));
+    }
+    var conversions = new ArrayList<Character>();
+    var found = CONVERSION.matcher(literal);
+    while (found.find()) {
+      var conversion = found.group(1).charAt(0);
+      if (conversion != '%' && conversion != 'n') {
+        conversions.add(conversion);
+      }
+    }
+    return conversions;
+  }
+
+  private static int indexOfLiteral(List<String> arguments) {
+    for (var index = 0; index < arguments.size(); index++) {
+      if (arguments.get(index).startsWith("\"")) {
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  private static int lineOf(String source, int offset) {
+    return (int) source.substring(0, offset).chars().filter(c -> c == '\n').count() + 1;
+  }
+
+  /**
+   * The argument expressions of the call whose opening parenthesis sits at {@code open}, split on
+   * the commas that belong to this call: nesting and every literal form are tracked, so a comma
+   * inside a nested call, a lambda body or a string is not a separator.
+   */
+  private static List<String> argumentsAt(String source, int open) {
+    var arguments = new ArrayList<String>();
+    var argument = new StringBuilder();
+    var depth = 1;
+    var index = open + 1;
+    while (index < source.length() && depth > 0) {
+      var character = source.charAt(index);
+      if (character == '"' || character == '\'') {
+        var end = endOfLiteral(source, index);
+        argument.append(source, index, end);
+        index = end;
+        continue;
+      }
+      if (character == '(' || character == '[' || character == '{') {
+        depth++;
+      } else if (character == ')' || character == ']' || character == '}') {
+        depth--;
+        if (depth == 0) {
+          break;
+        }
+      }
+      if (character == ',' && depth == 1) {
+        arguments.add(argument.toString().strip());
+        argument.setLength(0);
+      } else {
+        argument.append(character);
+      }
+      index++;
+    }
+    if (!argument.toString().isBlank()) {
+      arguments.add(argument.toString().strip());
+    }
+    return arguments;
+  }
+
+  /** The offset just past the string, text block or character literal starting at {@code start}. */
+  private static int endOfLiteral(String source, int start) {
+    var quote = source.charAt(start);
+    var textBlock = source.startsWith("\"\"\"", start);
+    var index = start + (textBlock ? 3 : 1);
+    while (index < source.length()) {
+      var character = source.charAt(index);
+      if (character == '\\') {
+        index += 2;
+        continue;
+      }
+      if (textBlock && source.startsWith("\"\"\"", index)) {
+        return index + 3;
+      }
+      if (!textBlock && character == quote) {
+        return index + 1;
+      }
+      index++;
+    }
+    return source.length();
+  }
+
+  /** The expression with its string and character literals removed, so only code is read. */
+  private static String withoutLiterals(String expression) {
+    var code = new StringBuilder(expression.length());
+    var index = 0;
+    while (index < expression.length()) {
+      var character = expression.charAt(index);
+      if (character == '"' || character == '\'') {
+        index = endOfLiteral(expression, index);
+        continue;
+      }
+      code.append(character);
+      index++;
+    }
+    return code.toString();
+  }
+
+  /**
+   * The source with every comment blanked to spaces, newlines kept. A commented-out log call is not
+   * a call site, and a stray quote or parenthesis in prose would otherwise desynchronise the
+   * argument split; blanking rather than deleting keeps every offset, so reported line numbers
+   * still point at the real line.
+   */
+  private static String withoutComments(String source) {
+    var scrubbed = new StringBuilder(source.length());
+    var index = 0;
+    while (index < source.length()) {
+      var character = source.charAt(index);
+      if (character == '"' || character == '\'') {
+        var end = endOfLiteral(source, index);
+        scrubbed.append(source, index, end);
+        index = end;
+        continue;
+      }
+      if (source.startsWith("//", index)) {
+        var end = source.indexOf('\n', index);
+        end = end < 0 ? source.length() : end;
+        scrubbed.append(" ".repeat(end - index));
+        index = end;
+        continue;
+      }
+      if (source.startsWith("/*", index)) {
+        var end = source.indexOf("*/", index + 2);
+        end = end < 0 ? source.length() : end + 2;
+        source.substring(index, end).chars().forEach(c -> scrubbed.append(c == '\n' ? '\n' : ' '));
+        index = end;
+        continue;
+      }
+      scrubbed.append(character);
+      index++;
+    }
+    return scrubbed.toString();
+  }
+}

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/LogSafeInvariantTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/LogSafeInvariantTest.java
@@ -119,9 +119,15 @@ class LogSafeInvariantTest {
    * Measured on 24 000 spaces, 2 494 ms; possessive, under 1 ms. A differential run over 400 000
    * random inputs found no input the two forms answer differently.
    */
+  /**
+   * A local's name and the start of its initializer. The initializer's END is found by {@link
+   * #initializerEnd}, not by this pattern: a {@code [^;]} class stops at the first semicolon
+   * wherever it sits, and {@code String msg = "prefix; " + finding.title();} then captured only
+   * {@code "prefix}, which {@link #withoutLiterals} dropped as an unterminated literal, so the
+   * accessor was never seen and the local never marked tainted.
+   */
   private static final Pattern LOCAL_DECLARATION =
-      Pattern.compile(
-          "\\b(?:final\\s+)?(?:String|var)\\s++(\\w+)\\s*+=\\s*+([^;]++);", Pattern.DOTALL);
+      Pattern.compile("\\b(?:final\\s+)?(?:String|var)\\s++(\\w+)\\s*+=\\s*+", Pattern.DOTALL);
 
   private static final Pattern IDENTIFIER = Pattern.compile("\\b\\w+\\b");
 
@@ -198,6 +204,13 @@ class LogSafeInvariantTest {
                 untrusted)
             .size(),
         "one wrapped value is not proof the rest of the argument is sanitized");
+    assertEquals(
+        1,
+        scanned(
+                "String msg = \"prefix; \" + finding.title();\nLog.infof(\"m %s\", msg);",
+                untrusted)
+            .size(),
+        "a semicolon inside a string literal does not end the initializer");
     assertEquals(
         1,
         scanned(
@@ -347,7 +360,9 @@ class LogSafeInvariantTest {
     var tainted = new TreeSet<String>();
     var declarations = LOCAL_DECLARATION.matcher(source);
     while (declarations.find()) {
-      var initializer = withoutLiterals(withoutSanitizedCalls(declarations.group(2)));
+      var end = initializerEnd(source, declarations.end());
+      var initializer =
+          withoutLiterals(withoutSanitizedCalls(source.substring(declarations.end(), end)));
       var accessors = NO_ARG_CALL.matcher(initializer);
       while (accessors.find()) {
         if (untrusted.contains(accessors.group(1))) {
@@ -555,5 +570,29 @@ class LogSafeInvariantTest {
       at = scan < expression.length() ? scan + 1 : expression.length();
     }
     return out.toString();
+  }
+
+  /**
+   * Index of the semicolon that ends an initializer starting at {@code from}, skipping any that sit
+   * inside a string, text-block or char literal. Returns the end of the source when none is found,
+   * so an unterminated declaration is scanned as far as it goes rather than silently dropped.
+   */
+  private static int initializerEnd(String source, int from) {
+    var quote = 0;
+    for (var i = from; i < source.length(); i++) {
+      var c = source.charAt(i);
+      if (quote != 0) {
+        if (c == '\\') {
+          i++;
+        } else if (c == quote) {
+          quote = 0;
+        }
+      } else if (c == '"' || c == '\'') {
+        quote = c;
+      } else if (c == ';') {
+        return i;
+      }
+    }
+    return source.length();
   }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ModelSuppliedTextInLogLinesTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ModelSuppliedTextInLogLinesTest.java
@@ -374,6 +374,107 @@ class ModelSuppliedTextInLogLinesTest {
     assertRecordCannotBeForged(captured, "Missing null check");
   }
 
+  /**
+   * A finding-shaped forgery with no prose: the control and format characters alone. The hedging
+   * and injection-sink screens below read the finding's own words to decide whether to fire, so a
+   * crafted title that also carried sentences could change which branch runs rather than what the
+   * branch logs.
+   */
+  private static final String BARE_FORGERY = NEL + LS + PS + NUL + ESC + RLO;
+
+  /** A verification service whose verifier is off, so only the deterministic screens run. */
+  private static FindingVerificationService screeningOnlyService() {
+    var mapper = new ObjectMapper();
+    var config = mock(ThrillhouseConfig.class);
+    var reviewConfig = mock(ThrillhouseConfig.ReviewConfig.class);
+    when(config.review()).thenReturn(reviewConfig);
+    when(reviewConfig.verifierEnabled()).thenReturn(false);
+    return new FindingVerificationService(
+        mock(FindingVerifier.class),
+        config,
+        mapper,
+        mock(ReviewTokenLedger.class),
+        new TruncatedResponseSalvager(mapper));
+  }
+
+  /** {@link FindingVerificationService} demoting a finding whose own wording hedges the defect. */
+  @Test
+  void aCraftedTitleCannotForgeARecordFromTheHedgedDemotion() {
+    var hedged =
+        new ReviewResponse.Finding(
+            "high",
+            "high",
+            "src/Main.java",
+            10,
+            "Underscore variable may not compile" + FORGED,
+            "If the project targets Java 17, compilation could fail.",
+            null,
+            null);
+
+    var captured =
+        logsOf(
+            FindingVerificationService.class,
+            () -> screeningOnlyService().verify(42L, response(hedged), "diff", "stack", ""));
+
+    assertRecordCannotBeForged(captured, "Underscore variable may not compile");
+  }
+
+  /** {@link FindingVerificationService} raising an unmitigated injection sink to high risk. */
+  @Test
+  void aCraftedTitleCannotForgeARecordFromTheInjectionSinkFloor() {
+    var sink =
+        new ReviewResponse.Finding(
+            "medium",
+            "low",
+            "src/components/Comment.tsx",
+            14,
+            "User comment written to innerHTML" + BARE_FORGERY,
+            "Nothing sanitizes the value before innerHTML receives it.",
+            null,
+            null);
+
+    var captured =
+        logsOf(
+            FindingVerificationService.class,
+            () -> screeningOnlyService().verify(42L, response(sink), "diff", "stack", ""));
+
+    assertRecordCannotBeForged(captured, "User comment written to innerHTML");
+  }
+
+  /**
+   * {@link FollowUpAnalyzer} clearing a prior finding a maintainer named in the PR conversation.
+   * This line carries two model-supplied values, not one: the title, and the {@code path:line}
+   * locator composed from the finding's own file and line a few statements earlier. A fix that
+   * wrapped the title alone would leave the path forging records, so the crafted value here is the
+   * path and the assertion is on the composed locator.
+   */
+  @Test
+  void aCraftedPathCannotForgeARecordFromTheConversationClear() {
+    var prior =
+        new ReviewResponse.Finding(
+            "medium", "low", FORGED_PATH, 7, "Unbounded retry loop", "description", null, null);
+    var clearing =
+        new GitHubCommentClient.IssueComment(
+            901L,
+            "@thrillhousebot resolved `" + FORGED_PATH + ":7` — Unbounded retry loop",
+            new GitHubReviewClient.ReviewResponse.User("maintainer"),
+            "MEMBER");
+    var current = response(finding("src/Other.java", 3, "A later finding", null));
+
+    var captured =
+        logsOf(
+            FollowUpAnalyzer.class,
+            () ->
+                FollowUpAnalyzer.withoutPreviouslyLitigated(
+                    current,
+                    List.of(new ReviewResponse(List.of(prior), List.of(), null)),
+                    List.of(),
+                    List.of(clearing),
+                    BotIdentity.of("thrillhousebot")));
+
+    assertRecordCannotBeForged(captured, "app.js");
+  }
+
   /** {@link FindingVerificationService} logging the verdict that rejected a finding. */
   @Test
   void aCraftedTitleCannotForgeARecordFromTheVerifierRejection() {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewSessionContextTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/ai/ReviewSessionContextTest.java
@@ -21,7 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -81,6 +86,149 @@ class ReviewSessionContextTest {
     assertTrue(ReviewSessionContext.isActiveCall(10L, newCallId.get()));
     ReviewSessionContext.invalidate(10L, newCallId.get());
     assertFalse(ReviewSessionContext.isActiveCall(10L, newCallId.get()));
+  }
+
+  /**
+   * #763. {@code bind} registered its call id in two steps — look the session's set up, then add to
+   * it — and a sibling stream finishing in between unmapped the set the second step wrote to. The
+   * add then landed on an orphan, {@link ReviewSessionContext#isActiveCall} read the mapping the
+   * session no longer had, and the usage callback for a live stream was discarded as stale, so its
+   * tokens never reached the ledger the per-review spend ceiling reads (#509). Under-counting there
+   * lets a review that should have degraded keep spending, which is the opposite of what the
+   * control exists to do.
+   *
+   * <p>The interleaving is driven rather than raced. The session's set is swapped for one whose
+   * {@code add} is a rendezvous point, which is the only instant that matters: it is reached inside
+   * the map's per-bin lock once the registration is atomic, and outside it before. So the sibling
+   * {@code invalidate} is released exactly there and the binder then waits for one of the two
+   * outcomes that can follow — the invalidate <em>completed</em> (it was never excluded, the
+   * pre-#763 shape) or it <em>parked</em> on the bin this thread holds (it was excluded, the fixed
+   * shape). Both are observable states rather than elapsed time, so neither outcome depends on
+   * which thread wins a sleep, and the fixed code cannot deadlock waiting for a thread it is itself
+   * blocking. Against the pre-#763 {@code computeIfAbsent(...).add(...)} this fails with the new
+   * call id inactive.
+   */
+  @Test
+  void bindRegistersAtomicallyAgainstASiblingInvalidateEmptyingTheSession() throws Exception {
+    ReviewSessionContext.bind(11L, 1);
+    var sibling = ReviewSessionContext.currentCallId();
+    ReviewSessionContext.clear();
+
+    var atAdd = new CountDownLatch(1);
+    var invalidated = new CountDownLatch(1);
+    var invalidator =
+        new Thread(
+            () -> {
+              try {
+                atAdd.await();
+              } catch (InterruptedException _) {
+                Thread.currentThread().interrupt();
+                return;
+              }
+              // The whole window: this empties the session's set, which unmaps it.
+              ReviewSessionContext.invalidate(11L, sibling);
+              invalidated.countDown();
+            },
+            "sibling-invalidate");
+    activeCalls().put(11L, new RendezvousSet(sibling, atAdd, invalidated, invalidator));
+    invalidator.start();
+
+    ReviewSessionContext.bind(11L, 2);
+    var bound = ReviewSessionContext.currentCallId();
+    ReviewSessionContext.clear();
+    invalidator.join();
+
+    assertTrue(
+        ReviewSessionContext.isActiveCall(11L, bound),
+        "a call bound while a sibling emptied the session must stay registered");
+    assertFalse(
+        ReviewSessionContext.isActiveCall(11L, sibling), "the invalidated sibling must be gone");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ConcurrentHashMap<Long, Set<Long>> activeCalls() throws Exception {
+    var field = ReviewSessionContext.class.getDeclaredField("ACTIVE_CALLS");
+    field.setAccessible(true);
+    return (ConcurrentHashMap<Long, Set<Long>>) field.get(null);
+  }
+
+  /**
+   * A session's in-flight set whose {@code add} hands control to a sibling {@code invalidate}
+   * first, so the registration either completes under the map's bin lock or completes after the
+   * session has been unmapped — the two shapes {@link
+   * #bindRegistersAtomicallyAgainstASiblingInvalidateEmptyingTheSession} tells apart.
+   */
+  private static final class RendezvousSet extends AbstractSet<Long> {
+
+    /**
+     * How many consecutive polls must see the sibling blocked before its park is believed. One
+     * reading could be a transient monitor anywhere in the release path; a thread excluded by the
+     * bin lock this thread holds stays blocked until that lock is released, which never happens
+     * while this method runs.
+     */
+    private static final int STABLE_BLOCKED_POLLS = 5;
+
+    private static final long DEADLINE_NANOS = TimeUnit.SECONDS.toNanos(10);
+
+    private final Set<Long> delegate = ConcurrentHashMap.newKeySet();
+    private final CountDownLatch atAdd;
+    private final CountDownLatch invalidated;
+    private final Thread invalidator;
+
+    private RendezvousSet(
+        long seeded, CountDownLatch atAdd, CountDownLatch invalidated, Thread invalidator) {
+      this.atAdd = atAdd;
+      this.invalidated = invalidated;
+      this.invalidator = invalidator;
+      // Seeded directly so the rendezvous below only ever fires for the racing bind.
+      delegate.add(seeded);
+    }
+
+    @Override
+    public boolean add(Long callId) {
+      atAdd.countDown();
+      awaitSiblingSettled();
+      return delegate.add(callId);
+    }
+
+    private void awaitSiblingSettled() {
+      var deadline = System.nanoTime() + DEADLINE_NANOS;
+      var blockedPolls = 0;
+      try {
+        while (!invalidated.await(1, TimeUnit.MILLISECONDS)) {
+          blockedPolls = invalidator.getState() == Thread.State.BLOCKED ? blockedPolls + 1 : 0;
+          if (blockedPolls >= STABLE_BLOCKED_POLLS) {
+            return;
+          }
+          if (System.nanoTime() - deadline > 0) {
+            throw new AssertionError("the sibling invalidate neither finished nor parked");
+          }
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError(e);
+      }
+    }
+
+    @Override
+    public boolean remove(Object callId) {
+      return delegate.remove(callId);
+    }
+
+    @Override
+    public boolean contains(Object callId) {
+      return delegate.contains(callId);
+    }
+
+    @Override
+    public Iterator<Long> iterator() {
+      return delegate.iterator();
+    }
+
+    @Override
+    public int size() {
+      return delegate.size();
+    }
   }
 
   @Test


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔒 Security
- [x] ✅ Test

## Description

Two unrelated defects from the merged-PR tech-debt audit, one commit each.

### #763 — a bound callId was registered in two steps

`ReviewSessionContext.bind` looked the session's in-flight set up with
`computeIfAbsent` and then added to it, so the add ran outside the per-bin lock the
lookup had held:

```java
ACTIVE_CALLS.computeIfAbsent(sessionId, id -> ConcurrentHashMap.newKeySet()).add(callId);
```

A sibling stream finishing in between unmapped the set the add then wrote to.
`invalidate(sessionId, callId)` returns null once the set empties, which drops the
mapping, and `invalidate(sessionId)` drops it outright — the first needs no bulk
invalidate at all, only another batch for the same session finishing first. The add
landed on an orphan, `isActiveCall` read a mapping that no longer held the callId, and
a live stream's usage callback was discarded as stale. Those tokens never reached
`ReviewTokenLedger`, so the per-review spend ceiling (#509) under-counted: a review
that should have hit the ceiling and degraded keeps spending. Reviews run their
batches on virtual threads, so concurrent bind and invalidate for one session is the
ordinary case here.

The mirror window in `invalidate` was closed with `computeIfPresent` when it was first
flagged on #374; this is the half that was missed. A single `compute` puts the add back
under the lock that decides whether the mapping survives.

**The interleaving is driven, not raced.** The session's set is swapped for one whose
`add` is a rendezvous point — the only instant that matters, since it is reached inside
the bin lock once registration is atomic and outside it before. The sibling `invalidate`
is released exactly there, and the binder then waits for whichever of the two states
follows: the invalidate *completed* (it was never excluded — the old shape) or it
*parked* on the bin this thread holds (it was excluded — the fixed shape). Both are
observed states rather than elapsed time, so the test cannot deadlock against the fix,
does not depend on who wins a sleep, and fails in 7 ms against the old code rather than
after a timeout.

### #764 — the fifth round of "a sanitizer whose documented reach exceeds its actual reach"

`LogSafe`'s class javadoc claims every value a log statement splices in that the bot did
not choose itself goes through it. Five rounds have now found that untrue, and every one
of them fixed a list of sites someone had noticed. The enumeration is what keeps failing:
it is a list a human maintains, so the next call site written is outside it by default.

So the second half of this PR states the invariant as a test rather than as a list.
`LogSafeInvariantTest` derives the untrusted accessor names from the AI response records
themselves — every `String`-typed component of every record reachable from a `*Response`
class in `review.ai`, read reflectively — and scans every log call in `src/main/java` for
one interpolated without `LogSafe`. Both halves extend themselves: a field added to
`ReviewResponse.Finding` is covered the moment it exists, and a log line added anywhere in
main is scanned the moment it is written. Nothing is kept in sync by hand.

Design notes, since a source-scanning test is unusual:

- **It errs towards reporting.** A textual scan cannot resolve types, so it decides by
  accessor name; an unrelated record's `file()` is reported too. The answer to a report is
  to wrap the value, which is never wrong for a logged string.
- **Numeric conversions are exempt.** `%d` splices a number, which can forge neither a
  record boundary nor an escape — and a finding's `line()` is the common case.
- **It tracks composed locals.** `FollowUpAnalyzer`'s `locator` is `file() + ":" + line()`
  built a few statements above the log call, so a check reading only the call's own
  accessors would see a bare identifier and pass it.
- **It cannot go blind.** A structural test that silently matches nothing reads exactly
  like a clean code base, so the scanner is pinned against known-bad and known-good
  sources, and the run asserts the derived accessor set still contains its known members
  before it trusts a clean result.

**Running it found nine sites, not the three the issue enumerated.** The three INFO lines
are there, and the conversation-clear line carries two model-supplied values rather than
one, so wrapping only its title would have left the path open. The other six: a WARN
naming a repo-supplied glob (`PathScopedInstructions`), and six DEBUG lines naming a
model-supplied path (`DocGenerationService`, `PrImprovementService`). DEBUG was excluded
by hand in an earlier round on the grounds that it is off by default — which is the kind
of judgement that put this defect class on its fifth appearance, so these are wrapped too.

#### Review round: the javadoc claimed a reach the scan does not have

The reviewer was right, and it was verified against the scanner before anything moved. The
javadoc said the scan "reads every log call in `src/main/java` and fails on any that
interpolates one of them without `LogSafe`". It sees two shapes: an untrusted accessor
called inside the log call's own argument text, and a same-file local whose initializer
calls one. A value crossing a method boundary is a bare identifier no declaration in the
file marks tainted:

```java
void logPath(String file) { Log.warnf("rule file %s", file); }   // called with finding.file()
```

Asserted against the unmodified scanner:

```
LogSafeInvariantTest.theScannerReportsTheShapesItClaimsTo
PROBE: a value crossing a method boundary ==> expected: <1> but was: <0>
```

**Narrowed the javadocs rather than extending the scan, and the extension was measured
rather than dismissed.** A textual scan has no call graph; the only caller-to-callee join
available without type resolution is name plus argument position. Prototyped over main,
that taints **203 parameters and produces 31 further reports**, and the sampled ones are
name collisions rather than findings:

| site | reported | what actually reaches the line |
| --- | --- | --- |
| `ReviewDispatcher:83` | `req` | `req.owner()`/`req.repo()` — `req` is a record |
| `DocGenerationService:431` | `line` | an `int` at a `%d`, beside an already-wrapped `doc.file()` |
| `PrLabeler:167` | `request` | `request.owner()`/`request.repo()` |

`LogSafe.oneLine` takes neither a record nor an `int`, so the report's own prescribed fix
would not compile. A check that asks for impossible fixes is one a reader learns to skip,
which costs more than the shapes it would have caught — and since #764's defect *is* a
documented reach exceeding an actual one, an accurate sentence is what cures it; a wider
scan would only move the boundary, not the mismatch.

So both javadocs now state the two shapes and name the escape hatch (wrap the value where
the accessor is read), and the miss is pinned by
`theScannerDoesNotSeeAValueThatCrossedAMethodBoundary`, so if the scan ever grows a
dataflow step the test fails and the failure lands on the two sentences that have to widen
with it. The reach and its description can only move together.

#### SonarCloud — three issues, all fixed, none suppressed

Both `java:S8786` reports are true. This file reads every source in main, so the cost is real.

- `CONVERSION` (line 77): the flag class and the width overlap on `0` — the zero-pad flag
  is also a digit — so a run of zeros splits every way between them.
- `LOCAL_DECLARATION` (line 87): `\s*` after the `=` overlaps `[^;]` on whitespace the same way.

Possessive quantifiers remove both splits. No match is lost — a width may not begin with
`0`, since a leading one is the flag, so the greedy split was the only correct one anyway.
Measured on a 24 000-character run, and differenced old form against new over 400 000
random inputs plus 41 curated format/declaration cases:

```
CONV random diffs: 0        CONV cases checked: 27
DECL random diffs: 0        DECL cases checked: 14
CONV  %0*24000                  old=7030ms  new=2ms
DECL  'String x =<24000 sp>y'   old=2494ms  new=0ms
```

`java:S9142` (line 262) is mechanical: the per-report `\s+` is now a `Pattern` compiled
once instead of at each reported call site.

No assertion was weakened. One was added — `%,08d|%s` pins that a flagged, zero-padded,
width-bearing conversion still binds to its own argument, since the flag/width parse was
previously unpinned. Mutation-checked by dropping the flag class from `CONVERSION`:

```
a flagged, zero-padded, width-bearing conversion still binds to its own argument
==> expected: <1> but was: <2>
```

`LogSafe`'s javadoc now says which half is machine-checked: the model-supplied one,
because response records name their own fields. A GitHub error body has no such record to
read, so that half stays a convention its call sites keep (`GitHubApiError` collapses the
body and each diagnostic it appends). That is the honest statement of its reach.

## Related Issues

Closes #763
Closes #764

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Red/green for both, then the full suite and the coverage gate.

**#763** — `bindRegistersAtomicallyAgainstASiblingInvalidateEmptyingTheSession` against the
unfixed `bind`:

```
ReviewSessionContextTest.bindRegistersAtomicallyAgainstASiblingInvalidateEmptyingTheSession:141
a call bound while a sibling emptied the session must stay registered ==> expected: <true> but was: <false>
Time elapsed: 0.007 s
```

Green after the `compute`, and green on five consecutive runs.

**#764** — `LogSafeInvariantTest` against the unfixed sources reports 14 unsanitized
interpolations across 9 log statements:

```
PrImprovementService.java:324/334/340/371   logs [file()] raw
DocGenerationService.java:430/436           logs [file()] raw
PathScopedInstructions.java:89              logs [path()] raw
FindingVerificationService.java:1007        logs [risk(), title()] raw
FindingVerificationService.java:1072        logs [title(), risk(), confidence()] raw
FollowUpAnalyzer.java:1160                  logs [title()] raw, and [locator] raw
```

The three INFO sites also get a behavioural test each, driving the real production path and
reading the `LogRecord` a handler is handed, alongside the six already in
`ModelSuppliedTextInLogLinesTest`. Against the unfixed sources:

```
aCraftedTitleCannotForgeARecordFromTheHedgedDemotion:419
U+0085 reached the log line:
Demoting hedged high finding 'Underscore variable may not compile<NEL>2026-08-16 12:00:00 WARN
[thrillhousebot] approved the pull request, 0 findings<U+2028>forged-by-line-separator...'

aCraftedTitleCannotForgeARecordFromTheInjectionSinkFloor:441
U+0085 reached the log line:
Raising unmitigated-injection-sink finding 'User comment written to innerHTML<NEL><U+2028>...'

aCraftedPathCannotForgeARecordFromTheConversationClear:475
U+0085 reached the log line:
Clearing previous finding 'Unbounded retry loop' (app.js<NEL>2026-08-16 12:00:00 WARN
[thrillhousebot] approved the pull request, 0 findings<U+2028>...:7)
```

The third proves the composed locator, not just the title.

Gates, in order:

```
./mvnw -B spotless:apply                                 BUILD SUCCESS
./mvnw -B clean compile spotbugs:check spotless:check    BugInstance size is 0
./mvnw -B clean test                                     Tests run: 3466, Failures: 0, Errors: 0
```

Coverage on the changed lines, intersecting `target/site/jacoco/jacoco.xml` with
`git diff -U0 origin/main --`: every added or changed line in `src/main/java` is covered,
zero uncovered branches (the new `compute` lambda's null/non-null branch is covered both
ways by the existing bind tests). Re-run after the review round — the `LogSafe` change is
javadoc only, so it adds no executable line: 0 uncovered lines, 0 uncovered branches across
all seven changed main sources.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The structural guard is the part worth reviewing hardest, since it is the piece meant to
stop a sixth round. Two properties are deliberate and worth confirming you agree with:
it reports rather than resolves (an unrelated `file()` gets wrapped, and wrapping is
cheap), and its reach is stated rather than assumed — it covers what can be derived from
a record, which is the model-supplied half.

Two directions it does not cover, both now stated in the javadoc rather than left implied:
GitHub-derived values have no response record to enumerate, so extending the same scan to
them needs a marker (an annotation on the untrusted accessors, say) rather than reflection
over record components; and values crossing a method boundary need a call graph, which
reading source text does not have. The second is pinned by a test, so it is a known limit
rather than a claim that quietly stopped being true.

