### PR TITLE
fix(review): harden the patch-coverage report reader (zip-bomb bound, cross-module attribution, failed-run, multi-module merge)

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -182,11 +182,13 @@ final class JacocoCoverageReport {
   }
 
   /**
-   * Every report entry whose path is a whole-segment suffix of {@code repositoryPath}, in the order
-   * the reports listed them; empty for a null, blank, or unmentioned path. Deliberately says
-   * nothing about ambiguity: whether more than one match must be refused, and whether the single
-   * match is also claimed by another repository path, are decisions only {@link
-   * #uncoveredLinesByPath} can make, because they depend on the rest of the requested paths.
+   * Every report entry whose path is a whole-segment suffix of {@code repositoryPath}; empty for a
+   * null, blank, or unmentioned path. The order is unspecified — the index behind it is hashed by
+   * file name — and nothing here depends on it, because a second match makes the attribution
+   * ambiguous whichever one came first. Deliberately says nothing about that ambiguity: whether
+   * more than one match must be refused, and whether the single match is also claimed by another
+   * repository path, are decisions only {@link #uncoveredLinesByPath} can make, because they depend
+   * on the rest of the requested paths.
    */
   private List<SourceFile> suffixMatches(String repositoryPath) {
     if (repositoryPath == null || repositoryPath.isBlank()) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -280,32 +280,7 @@ final class JacocoCoverageReport {
     var merged = new HashMap<String, NavigableSet<Integer>>();
     var aborted = false;
     try (var zip = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
-      var seen = 0;
-      var inflatedTotal = 0L;
-      for (var entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry(), seen++) {
-        if (seen >= MAX_ZIP_ENTRIES) {
-          // Stopping here and keeping the merge would hand the same prefix-choosing power the bomb
-          // abort refuses: pad an archive past the cap and whoever built it decides which reports
-          // the merge saw, while the result still reads as this build's coverage. Lines the unread
-          // reports cover come back uncovered, against a diff the model is told to treat as fact,
-          // so the archive is refused whole for the same reason.
-          Log.debugf(
-              "Coverage artifact carries more than %d entries; refusing it rather than merging the"
-                  + " prefix that fit",
-              MAX_ZIP_ENTRIES);
-          aborted = true;
-          break;
-        }
-        var read = readEntryInto(zip, entry, MAX_TOTAL_INFLATED_BYTES - inflatedTotal, merged);
-        if (read < 0) {
-          Log.debugf(
-              "Coverage artifact inflates past the %d-byte aggregate cap; refusing it as a zip bomb",
-              MAX_TOTAL_INFLATED_BYTES);
-          aborted = true;
-          break;
-        }
-        inflatedTotal += read;
-      }
+      aborted = walkRefused(zip, merged);
     } catch (IOException | RuntimeException e) {
       Log.debugf(e, "Could not read the coverage artifact archive");
       aborted = true;
@@ -547,5 +522,56 @@ final class JacocoCoverageReport {
     } catch (XMLStreamException e) {
       Log.debug("Failed to close the coverage report reader", e);
     }
+  }
+
+  /**
+   * Walks the archive's entries into {@code merged}, and reports whether it gave up.
+   *
+   * <p>Each refusal leaves by returning rather than by breaking, which keeps the two limits reading
+   * as the two answers they are. It also matters mechanically: a {@code continue} here would run
+   * the loop's update expression, and {@code getNextEntry} inflates the remainder of the entry it
+   * is leaving — so skipping past a bomb entry would pay exactly the cost the aggregate budget
+   * exists to refuse.
+   *
+   * <p>The cap counts entries that could carry a report. Directories are walked past without
+   * charge, so a tree-shaped artifact is judged by how much content it holds rather than by how
+   * deeply it is nested.
+   *
+   * @return {@code true} when a limit stopped the walk, so whatever merged is a prefix the archive
+   *     chose and no report may be built from it
+   */
+  private static boolean walkRefused(ZipInputStream zip, Map<String, NavigableSet<Integer>> merged)
+      throws IOException {
+    var seen = 0;
+    var inflatedTotal = 0L;
+    for (var entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()) {
+      if (entry.isDirectory()) {
+        // Directory entries carry no data, so skipping one costs nothing and can never hide a
+        // report. Counting them would refuse the shape this reader most needs to handle: a coverage
+        // artifact is usually a whole target/ tree rather than a flat list of reports, so its
+        // directories alone can outnumber the modules and push a handful of jacoco.xml files past a
+        // cap meant to bound how much content is read.
+        continue;
+      }
+      if (seen++ >= MAX_ZIP_ENTRIES) {
+        // Padding an archive past the cap would otherwise let whoever built it decide which reports
+        // the merge saw, while the result still reads as this build's coverage: lines the unread
+        // reports cover come back uncovered, against a diff the model is told to treat as fact.
+        Log.debugf(
+            "Coverage artifact carries more than %d entries; refusing it rather than merging the"
+                + " prefix that fit",
+            MAX_ZIP_ENTRIES);
+        return true;
+      }
+      var read = readEntryInto(zip, entry, MAX_TOTAL_INFLATED_BYTES - inflatedTotal, merged);
+      if (read < 0) {
+        Log.debugf(
+            "Coverage artifact inflates past the %d-byte aggregate cap; refusing it as a zip bomb",
+            MAX_TOTAL_INFLATED_BYTES);
+        return true;
+      }
+      inflatedTotal += read;
+    }
+    return false;
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -218,7 +218,8 @@ final class JacocoCoverageReport {
    * a JaCoCo report is merged, so a multi-module artifact carrying one report per module
    * contributes all of them rather than only the first. {@link #EMPTY} when the bytes are not a
    * readable zip, hold no such entry, or hold nothing this parser understands. The merged size is
-   * bounded by {@link #MAX_SOURCE_FILES} (and each file by {@link #MAX_LINES_PER_FILE}).
+   * bounded by {@link #MAX_SOURCE_FILES} (and each file by {@link #MAX_LINES_PER_FILE}); a path two
+   * reports both describe keeps only what they agree on, for the reasons on {@link #mergeInto}.
    *
    * <p>Every entry — not only the {@code .xml} we want — is inflated through a counting copy
    * bounded by {@link #MAX_TOTAL_INFLATED_BYTES}. Reading only the entries we care about is not
@@ -264,29 +265,43 @@ final class JacocoCoverageReport {
     } catch (IOException | RuntimeException e) {
       Log.debugf(e, "Could not read the coverage artifact archive");
     }
+    // An intersection that emptied out says every report disagreed about that file, which is not
+    // coverage data; the rest of the class may assume a present path has at least one line.
+    merged.values().removeIf(NavigableSet::isEmpty);
     return merged.isEmpty() ? EMPTY : new JacocoCoverageReport(merged);
   }
 
   /**
-   * Unions one report's uncovered lines into the accumulator, bounded by {@link #MAX_SOURCE_FILES}
-   * source files and {@link #MAX_LINES_PER_FILE} lines each so a pathological multi-module artifact
-   * cannot grow the merged map without limit. A report path shared by two modules (itself a
-   * same-named collision the {@link #uncoveredLinesByPath} guard later drops) unions rather than
-   * overwrites, so no module's lines are silently lost before that guard runs.
+   * Adds one report's uncovered lines to the accumulator, bounded by {@link #MAX_SOURCE_FILES} so a
+   * pathological multi-module artifact cannot grow the merged map without limit — each file's line
+   * list is already capped at {@link #MAX_LINES_PER_FILE} by the parse that produced it.
+   *
+   * <p>A report path <em>two</em> reports both describe keeps only the lines every one of them
+   * recorded as missed, never their union. Two reports claim one path when a same-named class
+   * exists in two modules, and when one class is measured twice — a per-module report sitting next
+   * to an aggregate report of the same build, which the {@code **}{@code /jacoco.xml} upload this
+   * merge exists for collects together. Unioning is wrong for both: it charges one module's misses
+   * to the other module's file, and it reports a line as never executed that the aggregate run did
+   * execute. Neither is something {@link #uncoveredLinesByPath} can catch afterwards — it sees one
+   * merged entry with one repository file matching it — so the disagreement has to be resolved
+   * here, at the only point that still knows two reports claimed the same path. Intersecting is
+   * sound whichever file the entry later matches: a line every report recorded as missed is missed
+   * in that file's own report too.
    */
   private static void mergeInto(
       Map<String, NavigableSet<Integer>> merged, Map<String, NavigableSet<Integer>> one) {
     for (var entry : one.entrySet()) {
-      if (!merged.containsKey(entry.getKey()) && merged.size() >= MAX_SOURCE_FILES) {
+      var already = merged.get(entry.getKey());
+      if (already != null) {
+        Log.debugf(
+            "Two coverage reports describe %s; keeping only what they agree on", entry.getKey());
+        already.retainAll(entry.getValue());
         continue;
       }
-      var target = merged.computeIfAbsent(entry.getKey(), unused -> new TreeSet<>());
-      for (var line : entry.getValue()) {
-        if (target.size() >= MAX_LINES_PER_FILE) {
-          break;
-        }
-        target.add(line);
+      if (merged.size() >= MAX_SOURCE_FILES) {
+        continue;
       }
+      merged.put(entry.getKey(), entry.getValue());
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -17,6 +17,7 @@ package dev.thiagogonzaga.thrillhousebot.review;
 
 import io.quarkus.logging.Log;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -47,8 +48,9 @@ import javax.xml.stream.XMLStreamReader;
  *
  * <p>The bytes come from a workflow artifact uploaded by an arbitrary repository, so parsing is
  * defensive throughout — external entities and DTD loading are off, the archive's entry count and
- * uncompressed size are capped against a zip bomb, and every failure yields an {@link #EMPTY}
- * report rather than an exception.
+ * its <em>aggregate</em> inflated size are both capped against a zip bomb (see {@link
+ * #MAX_TOTAL_INFLATED_BYTES}), and every failure yields an {@link #EMPTY} report rather than an
+ * exception.
  */
 final class JacocoCoverageReport {
 
@@ -57,6 +59,17 @@ final class JacocoCoverageReport {
 
   /** Ceiling on one entry's decompressed size — a coverage report is not tens of megabytes. */
   static final int MAX_ENTRY_BYTES = 64 * 1024 * 1024;
+
+  /**
+   * Aggregate ceiling on bytes inflated across <em>all</em> entries of one archive — the zip-bomb
+   * guard. A per-entry cap alone is not enough: skipping to the next entry inflates the whole of
+   * the current one, so a maximally-compressed 16&nbsp;MB artifact could otherwise drive gigabytes
+   * of decompression. Every entry is read through a counting copy that charges this running budget,
+   * and the walk aborts the moment the budget is blown. Generous enough for the largest legitimate
+   * multi-module report (the download itself is capped far lower, at {@code
+   * ArtifactZipFetcher.MAX_BYTES}), tight enough that inflation stays well under a second of CPU.
+   */
+  static final long MAX_TOTAL_INFLATED_BYTES = 128L * 1024 * 1024;
 
   /** Ceiling on how many source files one report may contribute. */
   static final int MAX_SOURCE_FILES = 5_000;
@@ -143,6 +156,12 @@ final class JacocoCoverageReport {
    * The coverage in a downloaded artifact archive: the first {@code .xml} entry that parses as a
    * JaCoCo report with at least one source file wins. {@link #EMPTY} when the bytes are not a
    * readable zip, hold no such entry, or hold nothing this parser understands.
+   *
+   * <p>Every entry — not only the {@code .xml} we want — is inflated through a counting copy
+   * bounded by {@link #MAX_TOTAL_INFLATED_BYTES}. Reading only the entries we care about is not
+   * enough: the next {@link ZipInputStream#getNextEntry()} implicitly inflates the whole of an
+   * unread entry to reach the following header, which is exactly the path a maximally-compressed
+   * archive takes to gigabytes. The walk aborts the moment the aggregate budget is blown.
    */
   static JacocoCoverageReport fromArtifactZip(byte[] zipBytes) {
     if (zipBytes == null || zipBytes.length == 0) {
@@ -150,13 +169,27 @@ final class JacocoCoverageReport {
     }
     try (var zip = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
       var seen = 0;
+      var inflatedTotal = 0L;
       for (var entry = zip.getNextEntry();
           entry != null && seen < MAX_ZIP_ENTRIES;
           entry = zip.getNextEntry(), seen++) {
-        if (!entry.isDirectory() && entry.getName().toLowerCase(Locale.ROOT).endsWith(".xml")) {
-          // readNBytes bounds the decompressed size regardless of what the entry's header claims,
-          // which is the only number a zip bomb cannot lie its way past.
-          var report = parse(new ByteArrayInputStream(zip.readNBytes(MAX_ENTRY_BYTES)));
+        var budgetLeft = MAX_TOTAL_INFLATED_BYTES - inflatedTotal;
+        var isReport =
+            !entry.isDirectory() && entry.getName().toLowerCase(Locale.ROOT).endsWith(".xml");
+        // Every entry is drained through the counting copy — a report to collect, anything else to
+        // discard — because leaving an entry partly read would hand the implicit inflation back to
+        // the next getNextEntry(). Only the aggregate budget can stop the drain.
+        var sink = isReport ? new ByteArrayOutputStream() : null;
+        var read = inflateEntry(zip, budgetLeft, MAX_ENTRY_BYTES, sink);
+        if (read < 0) {
+          Log.debugf(
+              "Coverage artifact inflates past the %d-byte aggregate cap; refusing it as a zip bomb",
+              MAX_TOTAL_INFLATED_BYTES);
+          break;
+        }
+        inflatedTotal += read;
+        if (sink != null && sink.size() > 0) {
+          var report = parse(new ByteArrayInputStream(sink.toByteArray()));
           if (!report.isEmpty()) {
             Log.infof("Read patch coverage from artifact entry %s", entry.getName());
             return report;
@@ -167,6 +200,39 @@ final class JacocoCoverageReport {
       Log.debugf(e, "Could not read the coverage artifact archive");
     }
     return EMPTY;
+  }
+
+  /**
+   * Fully inflates the current zip entry, charging its bytes against {@code budgetLeft}. Returns
+   * the number of bytes inflated, or {@code -1} the moment that running aggregate budget is
+   * exceeded — the archive is then a decompression bomb and the caller must abandon it. The whole
+   * entry is always consumed (short of an abort) so the next {@code getNextEntry()} never has to
+   * inflate a remainder. When {@code sink} is non-null, up to {@code collectLimit} bytes are
+   * captured into it for parsing; a report larger than that captures nothing — a truncated report
+   * is not one — but is still drained so the walk can safely reach the next entry.
+   */
+  private static long inflateEntry(
+      ZipInputStream zip, long budgetLeft, int collectLimit, ByteArrayOutputStream sink)
+      throws IOException {
+    var buffer = new byte[8192];
+    var read = 0L;
+    var collecting = sink != null;
+    int n;
+    while ((n = zip.read(buffer)) != -1) {
+      read += n;
+      if (read > budgetLeft) {
+        return -1;
+      }
+      if (collecting) {
+        if (read > collectLimit) {
+          collecting = false;
+          sink.reset();
+        } else {
+          sink.write(buffer, 0, n);
+        }
+      }
+    }
+    return read;
   }
 
   /** Parses one JaCoCo XML document, or {@link #EMPTY} when it is not one / cannot be read. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -63,7 +63,13 @@ final class JacocoCoverageReport {
   /** Entries walked in the artifact archive before the rest are ignored. */
   static final int MAX_ZIP_ENTRIES = 512;
 
-  /** Ceiling on one entry's decompressed size — a coverage report is not tens of megabytes. */
+  /**
+   * Ceiling on how much of one entry is <em>kept</em> for parsing — a coverage report is not tens
+   * of megabytes. Deliberately not a ceiling on inflation: an entry past this is still drained in
+   * full and simply contributes nothing (half a report is not a report), because stopping the read
+   * early would hand the rest of the entry to the next {@code getNextEntry()} to inflate anyway.
+   * Only {@link #MAX_TOTAL_INFLATED_BYTES} bounds the decompression itself.
+   */
   static final int MAX_ENTRY_BYTES = 64 * 1024 * 1024;
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -234,6 +234,7 @@ final class JacocoCoverageReport {
       return EMPTY;
     }
     var merged = new HashMap<String, NavigableSet<Integer>>();
+    var aborted = false;
     try (var zip = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
       var seen = 0;
       var inflatedTotal = 0L;
@@ -245,12 +246,23 @@ final class JacocoCoverageReport {
           Log.debugf(
               "Coverage artifact inflates past the %d-byte aggregate cap; refusing it as a zip bomb",
               MAX_TOTAL_INFLATED_BYTES);
+          aborted = true;
           break;
         }
         inflatedTotal += read;
       }
     } catch (IOException | RuntimeException e) {
       Log.debugf(e, "Could not read the coverage artifact archive");
+      aborted = true;
+    }
+    // A walk that gave up carries no partial answer out. Whatever merged before the abort is a
+    // prefix chosen by the archive, not by the build: an attacker who appends a bomb entry after a
+    // benign report would otherwise decide which reports the merge sees, and the truncated result
+    // reads as complete coverage — lines the rest of the artifact covers come back "uncovered".
+    // The same holds for an IOException mid-walk, where the prefix is chosen by where the stream
+    // broke. This is what the class javadoc means by every failure yielding EMPTY.
+    if (aborted) {
+      return EMPTY;
     }
     // An intersection that emptied out says every report disagreed about that file, which is not
     // coverage data; the rest of the class may assume a present path has at least one line.

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -215,20 +215,24 @@ final class JacocoCoverageReport {
   // ---------------------------------------------------------------- parsing
 
   /**
-   * The coverage in a downloaded artifact archive: the first {@code .xml} entry that parses as a
-   * JaCoCo report with at least one source file wins. {@link #EMPTY} when the bytes are not a
-   * readable zip, hold no such entry, or hold nothing this parser understands.
+   * The coverage in a downloaded artifact archive: <em>every</em> {@code .xml} entry that parses as
+   * a JaCoCo report is merged, so a multi-module artifact carrying one report per module
+   * contributes all of them rather than only the first. {@link #EMPTY} when the bytes are not a
+   * readable zip, hold no such entry, or hold nothing this parser understands. The merged size is
+   * bounded by {@link #MAX_SOURCE_FILES} (and each file by {@link #MAX_LINES_PER_FILE}).
    *
    * <p>Every entry — not only the {@code .xml} we want — is inflated through a counting copy
    * bounded by {@link #MAX_TOTAL_INFLATED_BYTES}. Reading only the entries we care about is not
    * enough: the next {@link ZipInputStream#getNextEntry()} implicitly inflates the whole of an
    * unread entry to reach the following header, which is exactly the path a maximally-compressed
-   * archive takes to gigabytes. The walk aborts the moment the aggregate budget is blown.
+   * archive takes to gigabytes. The walk aborts the moment the aggregate budget is blown, keeping
+   * whatever it had already merged.
    */
   static JacocoCoverageReport fromArtifactZip(byte[] zipBytes) {
     if (zipBytes == null || zipBytes.length == 0) {
       return EMPTY;
     }
+    var merged = new HashMap<String, NavigableSet<Integer>>();
     try (var zip = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
       var seen = 0;
       var inflatedTotal = 0L;
@@ -251,17 +255,40 @@ final class JacocoCoverageReport {
         }
         inflatedTotal += read;
         if (sink != null && sink.size() > 0) {
-          var report = parse(new ByteArrayInputStream(sink.toByteArray()));
-          if (!report.isEmpty()) {
+          var one = parseToMap(new ByteArrayInputStream(sink.toByteArray()));
+          if (!one.isEmpty()) {
             Log.infof("Read patch coverage from artifact entry %s", entry.getName());
-            return report;
+            mergeInto(merged, one);
           }
         }
       }
     } catch (IOException | RuntimeException e) {
       Log.debugf(e, "Could not read the coverage artifact archive");
     }
-    return EMPTY;
+    return merged.isEmpty() ? EMPTY : new JacocoCoverageReport(merged);
+  }
+
+  /**
+   * Unions one report's uncovered lines into the accumulator, bounded by {@link #MAX_SOURCE_FILES}
+   * source files and {@link #MAX_LINES_PER_FILE} lines each so a pathological multi-module artifact
+   * cannot grow the merged map without limit. A report path shared by two modules (itself a
+   * same-named collision the {@link #uncoveredLinesByPath} guard later drops) unions rather than
+   * overwrites, so no module's lines are silently lost before that guard runs.
+   */
+  private static void mergeInto(
+      Map<String, NavigableSet<Integer>> merged, Map<String, NavigableSet<Integer>> one) {
+    for (var entry : one.entrySet()) {
+      if (!merged.containsKey(entry.getKey()) && merged.size() >= MAX_SOURCE_FILES) {
+        continue;
+      }
+      var target = merged.computeIfAbsent(entry.getKey(), unused -> new TreeSet<>());
+      for (var line : entry.getValue()) {
+        if (target.size() >= MAX_LINES_PER_FILE) {
+          break;
+        }
+        target.add(line);
+      }
+    }
   }
 
   /**
@@ -299,13 +326,23 @@ final class JacocoCoverageReport {
 
   /** Parses one JaCoCo XML document, or {@link #EMPTY} when it is not one / cannot be read. */
   static JacocoCoverageReport parse(InputStream xml) {
+    var map = parseToMap(xml);
+    return map.isEmpty() ? EMPTY : new JacocoCoverageReport(map);
+  }
+
+  /**
+   * The raw uncovered-lines-per-report-path map of one JaCoCo XML document, or an empty map when it
+   * is not one / cannot be read. The archive walk merges these across entries before building a
+   * single report; {@link #parse} wraps one directly.
+   */
+  static Map<String, NavigableSet<Integer>> parseToMap(InputStream xml) {
     XMLStreamReader reader = null;
     try {
       reader = secureInputFactory().createXMLStreamReader(xml);
-      return new JacocoCoverageReport(readSourceFiles(reader));
+      return readSourceFiles(reader);
     } catch (XMLStreamException | RuntimeException e) {
       Log.debugf(e, "Could not parse the coverage report as JaCoCo XML");
-      return EMPTY;
+      return Map.of();
     } finally {
       closeQuietly(reader);
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -22,9 +22,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -121,26 +123,19 @@ final class JacocoCoverageReport {
    * path (the same class compiled twice into different source roots) is genuine ambiguity: an empty
    * set is returned rather than a guess, because attributing another module's coverage to this file
    * would be the one failure mode that produces a wrong finding instead of no finding.
+   *
+   * <p>The one-path case of {@link #uncoveredLinesByPath}, and deliberately routed through it so
+   * there is a single matching policy to reason about. It can only see the ambiguity one path
+   * exposes; the mirror image — one report entry that matches several repository files — is
+   * invisible from here, which is why the review's intersection resolves its whole file list at
+   * once instead of calling this per file.
    */
   NavigableSet<Integer> uncoveredLines(String repositoryPath) {
-    if (repositoryPath == null || repositoryPath.isBlank()) {
-      return new TreeSet<>();
-    }
-    var candidates = byFileName.get(fileName(repositoryPath));
-    if (candidates == null) {
-      return new TreeSet<>();
-    }
-    SourceFile matched = null;
-    for (var candidate : candidates) {
-      if (isSuffixPath(repositoryPath, candidate.path())) {
-        if (matched != null) {
-          Log.debugf("Ambiguous coverage entries for %s; ignoring them", repositoryPath);
-          return new TreeSet<>();
-        }
-        matched = candidate;
-      }
-    }
-    return matched == null ? new TreeSet<>() : matched.uncoveredLines();
+    // singletonList, not List.of: a null path is a case the by-path resolver already answers, and
+    // List.of would turn it into a NullPointerException out of a best-effort review enrichment.
+    var resolved =
+        uncoveredLinesByPath(Collections.singletonList(repositoryPath)).get(repositoryPath);
+    return resolved == null ? new TreeSet<>() : resolved;
   }
 
   /**
@@ -160,8 +155,12 @@ final class JacocoCoverageReport {
    */
   Map<String, NavigableSet<Integer>> uncoveredLinesByPath(Collection<String> repositoryPaths) {
     var matchesByPath = new LinkedHashMap<String, List<SourceFile>>();
+    // Keyed by identity, not by value: a SourceFile record's hashCode would hash its whole line
+    // set, and the counting below only ever asks whether two paths reached the same entry object.
     var pathsPerEntry = new IdentityHashMap<SourceFile, Integer>();
-    for (var repositoryPath : repositoryPaths) {
+    // Distinct paths, so the same file listed twice cannot make an entry look like it matches two
+    // repository files and drop coverage that is in fact unambiguous.
+    for (var repositoryPath : new LinkedHashSet<>(repositoryPaths)) {
       if (repositoryPath == null || repositoryPath.isBlank()) {
         continue;
       }
@@ -299,8 +298,11 @@ final class JacocoCoverageReport {
    * inflate a remainder. When {@code sink} is non-null, up to {@code collectLimit} bytes are
    * captured into it for parsing; a report larger than that captures nothing — a truncated report
    * is not one — but is still drained so the walk can safely reach the next entry.
+   *
+   * <p>Package-private so a test can drive the two bounds directly: reaching either through {@link
+   * #fromArtifactZip} alone would mean building a 64&nbsp;MB XML entry.
    */
-  private static long inflateEntry(
+  static long inflateEntry(
       ZipInputStream zip, long budgetLeft, int collectLimit, ByteArrayOutputStream sink)
       throws IOException {
     var buffer = new byte[8192];

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -217,17 +217,26 @@ final class JacocoCoverageReport {
   /**
    * The coverage in a downloaded artifact archive: <em>every</em> {@code .xml} entry that parses as
    * a JaCoCo report is merged, so a multi-module artifact carrying one report per module
-   * contributes all of them rather than only the first. {@link #EMPTY} when the bytes are not a
-   * readable zip, hold no such entry, or hold nothing this parser understands. The merged size is
-   * bounded by {@link #MAX_SOURCE_FILES} (and each file by {@link #MAX_LINES_PER_FILE}); a path two
-   * reports both describe keeps only what they agree on, for the reasons on {@link #mergeInto}.
+   * contributes all of them rather than only the first. The merged size is bounded by {@link
+   * #MAX_SOURCE_FILES} (and each file by {@link #MAX_LINES_PER_FILE}); a path two reports both
+   * describe keeps only what they agree on, for the reasons on {@link #mergeInto}, and a path they
+   * agree on nothing about is dropped outright rather than reaching callers as a file with an empty
+   * line set.
+   *
+   * <p>{@link #EMPTY} when the bytes are not a readable zip, hold no such entry, hold nothing this
+   * parser understands — or when the walk gave up part-way, per the paragraph below. At most {@link
+   * #MAX_ZIP_ENTRIES} entries are walked, so a report sitting behind that many others is never
+   * reached.
    *
    * <p>Every entry — not only the {@code .xml} we want — is inflated through a counting copy
    * bounded by {@link #MAX_TOTAL_INFLATED_BYTES}. Reading only the entries we care about is not
    * enough: the next {@link ZipInputStream#getNextEntry()} implicitly inflates the whole of an
    * unread entry to reach the following header, which is exactly the path a maximally-compressed
-   * archive takes to gigabytes. The walk aborts the moment the aggregate budget is blown, keeping
-   * whatever it had already merged.
+   * archive takes to gigabytes. The moment that aggregate budget is blown — or the stream breaks
+   * mid-walk — the archive is abandoned and <em>everything</em> already merged is discarded for
+   * {@link #EMPTY}: the surviving prefix is chosen by whoever built the archive rather than by the
+   * build, so returning it would report as uncovered whatever the unread remainder covers. No
+   * partial answer leaves this method; the abort itself carries the full reasoning.
    */
   static JacocoCoverageReport fromArtifactZip(byte[] zipBytes) {
     if (zipBytes == null || zipBytes.length == 0) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.TreeSet;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import javax.xml.XMLConstants;
 import javax.xml.stream.XMLInputFactory;
@@ -239,14 +240,7 @@ final class JacocoCoverageReport {
       for (var entry = zip.getNextEntry();
           entry != null && seen < MAX_ZIP_ENTRIES;
           entry = zip.getNextEntry(), seen++) {
-        var budgetLeft = MAX_TOTAL_INFLATED_BYTES - inflatedTotal;
-        var isReport =
-            !entry.isDirectory() && entry.getName().toLowerCase(Locale.ROOT).endsWith(".xml");
-        // Every entry is drained through the counting copy — a report to collect, anything else to
-        // discard — because leaving an entry partly read would hand the implicit inflation back to
-        // the next getNextEntry(). Only the aggregate budget can stop the drain.
-        var sink = isReport ? new ByteArrayOutputStream() : null;
-        var read = inflateEntry(zip, budgetLeft, MAX_ENTRY_BYTES, sink);
+        var read = readEntryInto(zip, entry, MAX_TOTAL_INFLATED_BYTES - inflatedTotal, merged);
         if (read < 0) {
           Log.debugf(
               "Coverage artifact inflates past the %d-byte aggregate cap; refusing it as a zip bomb",
@@ -254,13 +248,6 @@ final class JacocoCoverageReport {
           break;
         }
         inflatedTotal += read;
-        if (sink != null && sink.size() > 0) {
-          var one = parseToMap(new ByteArrayInputStream(sink.toByteArray()));
-          if (!one.isEmpty()) {
-            Log.infof("Read patch coverage from artifact entry %s", entry.getName());
-            mergeInto(merged, one);
-          }
-        }
       }
     } catch (IOException | RuntimeException e) {
       Log.debugf(e, "Could not read the coverage artifact archive");
@@ -269,6 +256,36 @@ final class JacocoCoverageReport {
     // coverage data; the rest of the class may assume a present path has at least one line.
     merged.values().removeIf(NavigableSet::isEmpty);
     return merged.isEmpty() ? EMPTY : new JacocoCoverageReport(merged);
+  }
+
+  /**
+   * Inflates one archive entry within {@code budgetLeft} and merges it into {@code merged} when it
+   * turns out to be a JaCoCo report, answering how many bytes it cost — or {@code -1} when the
+   * aggregate budget is gone and the archive must be abandoned.
+   *
+   * <p>Every entry is drained through the counting copy, a report to collect and anything else to
+   * discard, because leaving an entry partly read hands the implicit inflation back to the next
+   * {@code getNextEntry()}. Only the aggregate budget stops the drain.
+   */
+  private static long readEntryInto(
+      ZipInputStream zip,
+      ZipEntry entry,
+      long budgetLeft,
+      Map<String, NavigableSet<Integer>> merged)
+      throws IOException {
+    var isReport =
+        !entry.isDirectory() && entry.getName().toLowerCase(Locale.ROOT).endsWith(".xml");
+    var sink = isReport ? new ByteArrayOutputStream() : null;
+    var read = inflateEntry(zip, budgetLeft, MAX_ENTRY_BYTES, sink);
+    if (read < 0 || sink == null || sink.size() == 0) {
+      return read;
+    }
+    var one = parseToMap(new ByteArrayInputStream(sink.toByteArray()));
+    if (!one.isEmpty()) {
+      Log.infof("Read patch coverage from artifact entry %s", entry.getName());
+      mergeInto(merged, one);
+    }
+    return read;
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -162,19 +162,7 @@ final class JacocoCoverageReport {
     // Distinct paths, so the same file listed twice cannot make an entry look like it matches two
     // repository files and drop coverage that is in fact unambiguous.
     for (var repositoryPath : new LinkedHashSet<>(repositoryPaths)) {
-      if (repositoryPath == null || repositoryPath.isBlank()) {
-        continue;
-      }
-      var candidates = byFileName.get(fileName(repositoryPath));
-      if (candidates == null) {
-        continue;
-      }
-      var matched = new ArrayList<SourceFile>();
-      for (var candidate : candidates) {
-        if (isSuffixPath(repositoryPath, candidate.path())) {
-          matched.add(candidate);
-        }
-      }
+      var matched = suffixMatches(repositoryPath);
       if (matched.isEmpty()) {
         continue;
       }
@@ -185,21 +173,60 @@ final class JacocoCoverageReport {
     }
     var result = new LinkedHashMap<String, NavigableSet<Integer>>();
     for (var entry : matchesByPath.entrySet()) {
-      var matched = entry.getValue();
-      if (matched.size() != 1) {
-        Log.debugf("Ambiguous coverage entries for %s; ignoring them", entry.getKey());
-        continue;
+      var sourceFile = unambiguousEntry(entry.getKey(), entry.getValue(), pathsPerEntry);
+      if (sourceFile != null) {
+        result.put(entry.getKey(), sourceFile.uncoveredLines());
       }
-      var sourceFile = matched.get(0);
-      if (pathsPerEntry.get(sourceFile) != 1) {
-        Log.debugf(
-            "Coverage entry %s matches more than one repository file; ignoring it",
-            sourceFile.path());
-        continue;
-      }
-      result.put(entry.getKey(), sourceFile.uncoveredLines());
     }
     return result;
+  }
+
+  /**
+   * Every report entry whose path is a whole-segment suffix of {@code repositoryPath}, in the order
+   * the reports listed them; empty for a null, blank, or unmentioned path. Deliberately says
+   * nothing about ambiguity: whether more than one match must be refused, and whether the single
+   * match is also claimed by another repository path, are decisions only {@link
+   * #uncoveredLinesByPath} can make, because they depend on the rest of the requested paths.
+   */
+  private List<SourceFile> suffixMatches(String repositoryPath) {
+    if (repositoryPath == null || repositoryPath.isBlank()) {
+      return List.of();
+    }
+    var candidates = byFileName.get(fileName(repositoryPath));
+    if (candidates == null) {
+      return List.of();
+    }
+    var matched = new ArrayList<SourceFile>();
+    for (var candidate : candidates) {
+      if (isSuffixPath(repositoryPath, candidate.path())) {
+        matched.add(candidate);
+      }
+    }
+    return matched;
+  }
+
+  /**
+   * The one report entry {@code repositoryPath} may take its lines from, or {@code null} when the
+   * attribution is ambiguous from either side: several entries suffix-match this path, or the
+   * single entry that does is also suffix-matched by another path in the same request ({@code
+   * pathsPerEntry} holds that count, built over all of them). Both directions are refused rather
+   * than guessed at, for the reason on {@link #uncoveredLinesByPath} — another module's coverage
+   * charged to this file is a wrong finding, where no attribution is merely no finding.
+   */
+  private static SourceFile unambiguousEntry(
+      String repositoryPath, List<SourceFile> matched, Map<SourceFile, Integer> pathsPerEntry) {
+    if (matched.size() != 1) {
+      Log.debugf("Ambiguous coverage entries for %s; ignoring them", repositoryPath);
+      return null;
+    }
+    var sourceFile = matched.get(0);
+    if (pathsPerEntry.get(sourceFile) != 1) {
+      Log.debugf(
+          "Coverage entry %s matches more than one repository file; ignoring it",
+          sourceFile.path());
+      return null;
+    }
+    return sourceFile;
   }
 
   /** Whether {@code suffix} is {@code path} itself or a whole-segment tail of it. */
@@ -334,12 +361,12 @@ final class JacocoCoverageReport {
         Log.debugf(
             "Two coverage reports describe %s; keeping only what they agree on", entry.getKey());
         already.retainAll(entry.getValue());
-        continue;
+      } else if (merged.size() < MAX_SOURCE_FILES) {
+        // The cap bounds only how many NEW paths the accumulator takes on; a path already in it is
+        // always intersected above, so reaching the cap can never turn a disagreement into a
+        // union.
+        merged.put(entry.getKey(), entry.getValue());
       }
-      if (merged.size() >= MAX_SOURCE_FILES) {
-        continue;
-      }
-      merged.put(entry.getKey(), entry.getValue());
     }
   }
 

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -21,7 +21,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -138,6 +141,65 @@ final class JacocoCoverageReport {
       }
     }
     return matched == null ? new TreeSet<>() : matched.uncoveredLines();
+  }
+
+  /**
+   * Uncovered lines for a whole set of repository paths at once, dropping any attribution that is
+   * ambiguous from <em>either</em> side. A repository path two report entries suffix-match is the
+   * ambiguity {@link #uncoveredLines} already refuses. Its symmetric twin — one report entry that
+   * suffix-matches two repository paths — is refused here too: in a multi-module or multi-variant
+   * build the same {@code com/example/Foo.java} report path is a whole-segment suffix of every
+   * module's copy, and a {@code <package name="">} default-package entry suffix-matches every file
+   * of that name. Attributing one module's coverage to another module's same-named class is the one
+   * failure mode that produces a wrong finding instead of no finding, so only a report entry that
+   * uniquely matches exactly one of these paths (and is uniquely matched by it) contributes lines.
+   *
+   * <p>Callers that resolve a whole file list — the patch-coverage intersection — must use this
+   * rather than calling {@link #uncoveredLines} per file, because the cross-file collision is
+   * invisible to any single-path lookup.
+   */
+  Map<String, NavigableSet<Integer>> uncoveredLinesByPath(Collection<String> repositoryPaths) {
+    var matchesByPath = new LinkedHashMap<String, List<SourceFile>>();
+    var pathsPerEntry = new IdentityHashMap<SourceFile, Integer>();
+    for (var repositoryPath : repositoryPaths) {
+      if (repositoryPath == null || repositoryPath.isBlank()) {
+        continue;
+      }
+      var candidates = byFileName.get(fileName(repositoryPath));
+      if (candidates == null) {
+        continue;
+      }
+      var matched = new ArrayList<SourceFile>();
+      for (var candidate : candidates) {
+        if (isSuffixPath(repositoryPath, candidate.path())) {
+          matched.add(candidate);
+        }
+      }
+      if (matched.isEmpty()) {
+        continue;
+      }
+      matchesByPath.put(repositoryPath, matched);
+      for (var sourceFile : matched) {
+        pathsPerEntry.merge(sourceFile, 1, Integer::sum);
+      }
+    }
+    var result = new LinkedHashMap<String, NavigableSet<Integer>>();
+    for (var entry : matchesByPath.entrySet()) {
+      var matched = entry.getValue();
+      if (matched.size() != 1) {
+        Log.debugf("Ambiguous coverage entries for %s; ignoring them", entry.getKey());
+        continue;
+      }
+      var sourceFile = matched.get(0);
+      if (pathsPerEntry.get(sourceFile) != 1) {
+        Log.debugf(
+            "Coverage entry %s matches more than one repository file; ignoring it",
+            sourceFile.path());
+        continue;
+      }
+      result.put(entry.getKey(), sourceFile.uncoveredLines());
+    }
+    return result;
   }
 
   /** Whether {@code suffix} is {@code path} itself or a whole-segment tail of it. */

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -282,9 +282,20 @@ final class JacocoCoverageReport {
     try (var zip = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
       var seen = 0;
       var inflatedTotal = 0L;
-      for (var entry = zip.getNextEntry();
-          entry != null && seen < MAX_ZIP_ENTRIES;
-          entry = zip.getNextEntry(), seen++) {
+      for (var entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry(), seen++) {
+        if (seen >= MAX_ZIP_ENTRIES) {
+          // Stopping here and keeping the merge would hand the same prefix-choosing power the bomb
+          // abort refuses: pad an archive past the cap and whoever built it decides which reports
+          // the merge saw, while the result still reads as this build's coverage. Lines the unread
+          // reports cover come back uncovered, against a diff the model is told to treat as fact,
+          // so the archive is refused whole for the same reason.
+          Log.debugf(
+              "Coverage artifact carries more than %d entries; refusing it rather than merging the"
+                  + " prefix that fit",
+              MAX_ZIP_ENTRIES);
+          aborted = true;
+          break;
+        }
         var read = readEntryInto(zip, entry, MAX_TOTAL_INFLATED_BYTES - inflatedTotal, merged);
         if (read < 0) {
           Log.debugf(

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -261,9 +261,11 @@ final class JacocoCoverageReport {
    *
    * <p>{@link #EMPTY} when the bytes are not a readable zip, hold no such entry, hold nothing this
    * parser understands — or when the walk gave up part-way, per the paragraph below. At most {@link
-   * #MAX_ZIP_ENTRIES} file entries are read; directory entries pass uncounted, since they carry no
-   * data and cost nothing to step over. An archive with more file entries than that is refused
-   * whole rather than merged as far as the cap allowed.
+   * #MAX_ZIP_ENTRIES} file entries are read. Directory entries are not counted against that cap,
+   * but they are not trusted either: a name ending in a slash may still carry a payload, so each
+   * one is drained against the same aggregate budget as a file and refused the same way when it
+   * blows it. An archive with more file entries than the cap is refused whole rather than merged as
+   * far as the cap allowed.
    *
    * <p>Every entry — not only the {@code .xml} we want — is inflated through a counting copy
    * bounded by {@link #MAX_TOTAL_INFLATED_BYTES}. Reading only the entries we care about is not

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -15,6 +15,7 @@
  */
 package dev.thiagogonzaga.thrillhousebot.review;
 
+import dev.thiagogonzaga.thrillhousebot.LogSafe;
 import io.quarkus.logging.Log;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -231,7 +232,7 @@ final class JacocoCoverageReport {
     if (pathsPerEntry.get(sourceFile) != 1) {
       Log.debugf(
           "Coverage entry %s matches more than one repository file; ignoring it",
-          sourceFile.path());
+          LogSafe.oneLine(sourceFile.path()));
       return null;
     }
     return sourceFile;
@@ -548,11 +549,24 @@ final class JacocoCoverageReport {
     var inflatedTotal = 0L;
     for (var entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()) {
       if (entry.isDirectory()) {
-        // Directory entries carry no data, so skipping one costs nothing and can never hide a
-        // report. Counting them would refuse the shape this reader most needs to handle: a coverage
-        // artifact is usually a whole target/ tree rather than a flat list of reports, so its
-        // directories alone can outnumber the modules and push a handful of jacoco.xml files past a
-        // cap meant to bound how much content is read.
+        // A name ending in '/' is not a promise of zero data: nothing in the local-header format
+        // stops a crafted entry called bomb/ carrying megabytes of deflate. Leaving it to the
+        // loop's
+        // getNextEntry() would inflate that payload uncharged, since the stream must dispose of the
+        // current entry before it can reach the next header. So the entry is drained here, against
+        // the same aggregate budget as everything else, and refused the same way when it blows it.
+        // A real directory costs one immediate EOF read. It is still not charged to the entry cap:
+        // a coverage artifact is usually a whole target/ tree, and its directories alone can push
+        // a handful of jacoco.xml files past a cap that bounds how much content is read.
+        var drained = inflateEntry(zip, MAX_TOTAL_INFLATED_BYTES - inflatedTotal, 0, null);
+        if (drained < 0) {
+          Log.debugf(
+              "Coverage artifact inflates past the %d-byte aggregate cap inside a directory entry;"
+                  + " refusing it as a zip bomb",
+              MAX_TOTAL_INFLATED_BYTES);
+          return true;
+        }
+        inflatedTotal += drained;
         continue;
       }
       if (seen++ >= MAX_ZIP_ENTRIES) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -260,8 +260,9 @@ final class JacocoCoverageReport {
    *
    * <p>{@link #EMPTY} when the bytes are not a readable zip, hold no such entry, hold nothing this
    * parser understands — or when the walk gave up part-way, per the paragraph below. At most {@link
-   * #MAX_ZIP_ENTRIES} entries are walked, so a report sitting behind that many others is never
-   * reached.
+   * #MAX_ZIP_ENTRIES} file entries are read; directory entries pass uncounted, since they carry no
+   * data and cost nothing to step over. An archive with more file entries than that is refused
+   * whole rather than merged as far as the cap allowed.
    *
    * <p>Every entry — not only the {@code .xml} we want — is inflated through a counting copy
    * bounded by {@link #MAX_TOTAL_INFLATED_BYTES}. Reading only the entries we care about is not
@@ -315,8 +316,9 @@ final class JacocoCoverageReport {
       long budgetLeft,
       Map<String, NavigableSet<Integer>> merged)
       throws IOException {
-    var isReport =
-        !entry.isDirectory() && entry.getName().toLowerCase(Locale.ROOT).endsWith(".xml");
+    // Directories never reach here: walkRefused steps over them before charging the cap, so the
+    // only question left is whether this file entry is a report.
+    var isReport = entry.getName().toLowerCase(Locale.ROOT).endsWith(".xml");
     var sink = isReport ? new ByteArrayOutputStream() : null;
     var read = inflateEntry(zip, budgetLeft, MAX_ENTRY_BYTES, sink);
     if (read < 0 || sink == null || sink.size() == 0) {

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PatchCoverageResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PatchCoverageResolver.java
@@ -244,10 +244,16 @@ public class PatchCoverageResolver {
    */
   static List<UncoveredFile> intersectWithAddedLines(
       JacocoCoverageReport report, List<GitHubPullRequestClient.FileDiff> reviewableFiles) {
+    // Resolve the whole file list at once so a report entry that suffix-matches more than one of
+    // these repository paths (a multi-module build's same-named class) is dropped rather than
+    // attributed to each — a per-file lookup cannot see that cross-file collision.
+    var uncoveredByPath =
+        report.uncoveredLinesByPath(
+            reviewableFiles.stream().map(GitHubPullRequestClient.FileDiff::filename).toList());
     var result = new ArrayList<UncoveredFile>();
     for (var file : reviewableFiles) {
-      var reportedUncovered = report.uncoveredLines(file.filename());
-      if (reportedUncovered.isEmpty()) {
+      var reportedUncovered = uncoveredByPath.get(file.filename());
+      if (reportedUncovered == null || reportedUncovered.isEmpty()) {
         continue;
       }
       var uncoveredAdditions = new TreeSet<Integer>();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PatchCoverageResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PatchCoverageResolver.java
@@ -273,8 +273,10 @@ public class PatchCoverageResolver {
             reviewableFiles.stream().map(GitHubPullRequestClient.FileDiff::filename).toList());
     var result = new ArrayList<UncoveredFile>();
     for (var file : reviewableFiles) {
+      // Absent means either the report says nothing about this file or the attribution was
+      // ambiguous and was dropped; a present entry always carries at least one uncovered line.
       var reportedUncovered = uncoveredByPath.get(file.filename());
-      if (reportedUncovered == null || reportedUncovered.isEmpty()) {
+      if (reportedUncovered == null) {
         continue;
       }
       var uncoveredAdditions = new TreeSet<Integer>();

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PatchCoverageResolver.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/PatchCoverageResolver.java
@@ -25,7 +25,9 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.NavigableSet;
+import java.util.Set;
 import java.util.TreeSet;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -60,6 +62,15 @@ public class PatchCoverageResolver {
 
   /** Only a finished run has uploaded its artifacts. */
   private static final String COMPLETED = "completed";
+
+  /**
+   * Run conclusions whose coverage report may be trusted as measured fact. {@code success} is the
+   * ordinary green run; {@code neutral} is a deliberate non-failing outcome (a run that chose to
+   * pass without asserting). Every other completed conclusion — {@code failure}, {@code cancelled},
+   * {@code timed_out}, {@code skipped}, {@code action_required}, {@code stale} — is a run that did
+   * not finish its work, so its report describes an aborted build, not the code under review.
+   */
+  private static final Set<String> USABLE_CONCLUSIONS = Set.of("success", "neutral");
 
   /** Runs whose artifact list is fetched before the search gives up, bounding the API cost. */
   static final int MAX_RUNS_PROBED = 10;
@@ -179,12 +190,17 @@ public class PatchCoverageResolver {
     if (runs == null) {
       return null;
     }
-    // Declarative rather than a loop with jumps: the policy is "only runs for this exact commit,
-    // and at most MAX_RUNS_PROBED of them", and saying it once here keeps the walk below to the
-    // single thing it does — look for the named artifact.
+    // Declarative rather than a loop with jumps: the policy is "only SUCCEEDED runs for this exact
+    // commit, and at most MAX_RUNS_PROBED of them", and saying it once here keeps the walk below to
+    // the single thing it does — look for the named artifact. The conclusion filter is necessary
+    // but not sufficient: a run reported success can still upload a partial report, and this cannot
+    // tell that apart — but a report from a run that failed, was cancelled, or timed out (commonly
+    // still uploaded via `if: always()`) is the run stopping short, not measured coverage, and its
+    // ci=0 regions must not reach the model as fact.
     var candidates =
         runs.workflowRuns().stream()
             .filter(run -> headSha.equalsIgnoreCase(run.headSha()))
+            .filter(run -> isUsableConclusion(run.conclusion()))
             .limit(MAX_RUNS_PROBED)
             .toList();
     for (var run : candidates) {
@@ -194,6 +210,11 @@ public class PatchCoverageResolver {
       }
     }
     return null;
+  }
+
+  /** Whether a completed run's conclusion means its coverage report can be trusted as fact. */
+  private static boolean isUsableConclusion(String conclusion) {
+    return conclusion != null && USABLE_CONCLUSIONS.contains(conclusion.toLowerCase(Locale.ROOT));
   }
 
   /** The named, unexpired artifact's id on one run, or {@code null} when it has none. */

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
@@ -353,6 +353,40 @@ class JacocoCoverageReportTest {
     }
 
     @Test
+    void mergesEveryXmlReportNotJustTheFirst() throws IOException {
+      var entries = new LinkedHashMap<String, String>();
+      entries.put(
+          "module-a/jacoco.xml",
+          """
+          <report name="a">
+            <package name="com/example/a">
+              <sourcefile name="Alpha.java"><line nr="1" mi="1" ci="0"/></sourcefile>
+            </package>
+          </report>
+          """);
+      entries.put(
+          "module-b/jacoco.xml",
+          """
+          <report name="b">
+            <package name="com/example/b">
+              <sourcefile name="Beta.java"><line nr="2" mi="1" ci="0"/></sourcefile>
+            </package>
+          </report>
+          """);
+
+      var report = JacocoCoverageReport.fromArtifactZip(zipOf(entries));
+
+      assertEquals(
+          List.of(1),
+          List.copyOf(report.uncoveredLines("module-a/src/main/java/com/example/a/Alpha.java")),
+          "the first module's report is read");
+      assertEquals(
+          List.of(2),
+          List.copyOf(report.uncoveredLines("module-b/src/main/java/com/example/b/Beta.java")),
+          "a second module's report must not be lost to a first-match-wins walk");
+    }
+
+    @Test
     void degradesToEmptyWhenTheArchiveIsTruncatedMidEntry() throws IOException {
       var whole = zipOf(Map.of("jacoco.xml", REPORT));
       var truncated = java.util.Arrays.copyOf(whole, whole.length / 2);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
@@ -408,8 +408,9 @@ class JacocoCoverageReportTest {
       // reaches it is a reader that paid the full inflation cost first.
       var perEntry = JacocoCoverageReport.MAX_ENTRY_BYTES / 2;
       assertTrue(
-          perEntry < JacocoCoverageReport.MAX_ENTRY_BYTES,
-          "the bomb must not be refusable by the per-entry ceiling");
+          perEntry < JacocoCoverageReport.MAX_TOTAL_INFLATED_BYTES,
+          "no single entry may blow the budget on its own, or it is not the aggregate bound this"
+              + " archive is refused by");
       var bytes = new ByteArrayOutputStream();
       try (var zip = new ZipOutputStream(bytes)) {
         var zeros = new byte[64 * 1024];

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
@@ -363,6 +363,34 @@ class JacocoCoverageReportTest {
     }
 
     @Test
+    void refusesAnArchiveThatInflatesPastTheAggregateCap() throws IOException {
+      var bytes = new ByteArrayOutputStream();
+      try (var zip = new ZipOutputStream(bytes)) {
+        // A maximally-compressible entry whose inflated size alone blows the aggregate budget,
+        // placed BEFORE the real report so reaching the report requires inflating the bomb. On the
+        // unfixed code, skipping this non-XML entry inflates the whole of it to find the next
+        // header, and the report behind it is then read as fact.
+        zip.putNextEntry(new ZipEntry("bomb.bin"));
+        var zeros = new byte[64 * 1024];
+        var written = 0L;
+        var target = JacocoCoverageReport.MAX_TOTAL_INFLATED_BYTES + zeros.length;
+        while (written <= target) {
+          zip.write(zeros);
+          written += zeros.length;
+        }
+        zip.closeEntry();
+        zip.putNextEntry(new ZipEntry("jacoco.xml"));
+        zip.write(REPORT.getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
+      }
+
+      assertTrue(
+          JacocoCoverageReport.fromArtifactZip(bytes.toByteArray()).isEmpty(),
+          "an archive inflating past the aggregate cap must be refused, not walked to the report"
+              + " hidden behind the bomb");
+    }
+
+    @Test
     void degradesToEmptyWhenTheArchiveIsUnusable() throws IOException {
       assertTrue(JacocoCoverageReport.fromArtifactZip(null).isEmpty(), "no bytes, no coverage");
       assertTrue(JacocoCoverageReport.fromArtifactZip(new byte[0]).isEmpty(), "empty bytes");

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -325,12 +326,13 @@ class JacocoCoverageReportTest {
     @Test
     void skipsXmlEntriesThatCarryNoCoverage() throws IOException {
       var entries = new LinkedHashMap<String, String>();
+      entries.put("empty.xml", "");
       entries.put("a-surefire-report.xml", "<testsuite name=\"x\"/>");
       entries.put("jacoco.xml", REPORT);
 
       assertFalse(
           JacocoCoverageReport.fromArtifactZip(zipOf(entries)).isEmpty(),
-          "an unrelated XML entry earlier in the archive must not end the search");
+          "an empty or unrelated XML entry earlier in the archive must not end the search");
     }
 
     @Test
@@ -398,21 +400,28 @@ class JacocoCoverageReportTest {
 
     @Test
     void refusesAnArchiveThatInflatesPastTheAggregateCap() throws IOException {
+      // Every bomb entry stays WELL under the per-entry ceiling, so only their running sum can
+      // refuse this archive: a per-entry bound alone — what the reader had before — lets all of it
+      // through. Nothing here is XML either, which is the whole point: the unfixed walk skipped a
+      // non-XML entry without reading it, and the next getNextEntry() then inflated the whole of it
+      // to reach the following header. The real report sits BEHIND the bomb, so a reader that
+      // reaches it is a reader that paid the full inflation cost first.
+      var perEntry = JacocoCoverageReport.MAX_ENTRY_BYTES / 2;
+      assertTrue(
+          perEntry < JacocoCoverageReport.MAX_ENTRY_BYTES,
+          "the bomb must not be refusable by the per-entry ceiling");
       var bytes = new ByteArrayOutputStream();
       try (var zip = new ZipOutputStream(bytes)) {
-        // A maximally-compressible entry whose inflated size alone blows the aggregate budget,
-        // placed BEFORE the real report so reaching the report requires inflating the bomb. On the
-        // unfixed code, skipping this non-XML entry inflates the whole of it to find the next
-        // header, and the report behind it is then read as fact.
-        zip.putNextEntry(new ZipEntry("bomb.bin"));
         var zeros = new byte[64 * 1024];
-        var written = 0L;
-        var target = JacocoCoverageReport.MAX_TOTAL_INFLATED_BYTES + zeros.length;
-        while (written <= target) {
-          zip.write(zeros);
-          written += zeros.length;
+        var inflated = 0L;
+        for (var i = 0; inflated <= JacocoCoverageReport.MAX_TOTAL_INFLATED_BYTES; i++) {
+          zip.putNextEntry(new ZipEntry("pad" + i + ".bin"));
+          for (var written = 0; written < perEntry; written += zeros.length) {
+            zip.write(zeros);
+          }
+          zip.closeEntry();
+          inflated += perEntry;
         }
-        zip.closeEntry();
         zip.putNextEntry(new ZipEntry("jacoco.xml"));
         zip.write(REPORT.getBytes(StandardCharsets.UTF_8));
         zip.closeEntry();
@@ -422,6 +431,91 @@ class JacocoCoverageReportTest {
           JacocoCoverageReport.fromArtifactZip(bytes.toByteArray()).isEmpty(),
           "an archive inflating past the aggregate cap must be refused, not walked to the report"
               + " hidden behind the bomb");
+    }
+
+    @Test
+    void drainsButCollectsNothingFromAnEntryPastThePerEntryCeiling() throws IOException {
+      var sink = new ByteArrayOutputStream();
+      try (var zip =
+          new ZipInputStream(new ByteArrayInputStream(zipOf(Map.of("jacoco.xml", REPORT))))) {
+        zip.getNextEntry();
+
+        var read = JacocoCoverageReport.inflateEntry(zip, Long.MAX_VALUE, 8, sink);
+
+        assertEquals(
+            REPORT.getBytes(StandardCharsets.UTF_8).length,
+            read,
+            "the entry is drained in full even when nothing is kept, so the walk can reach the"
+                + " next header without the implicit inflation");
+        assertEquals(
+            0,
+            sink.size(),
+            "a report past the per-entry ceiling contributes nothing — half a report is not a"
+                + " report");
+      }
+    }
+
+    @Test
+    void capsTheSourceFilesMergedAcrossReports() throws IOException {
+      var first = new StringBuilder("<report name=\"a\"><package name=\"a\">");
+      for (var i = 0; i < JacocoCoverageReport.MAX_SOURCE_FILES; i++) {
+        first
+            .append("<sourcefile name=\"F")
+            .append(i)
+            .append(".java\"><line nr=\"1\" mi=\"1\" ci=\"0\"/></sourcefile>");
+      }
+      first.append("</package></report>");
+      var entries = new LinkedHashMap<String, String>();
+      entries.put("module-a/jacoco.xml", first.toString());
+      entries.put(
+          "module-b/jacoco.xml",
+          """
+          <report name="b">
+            <package name="b">
+              <sourcefile name="Extra.java"><line nr="1" mi="1" ci="0"/></sourcefile>
+            </package>
+          </report>
+          """);
+
+      var report = JacocoCoverageReport.fromArtifactZip(zipOf(entries));
+
+      assertFalse(
+          report.uncoveredLines("mod/a/F0.java").isEmpty(), "the first report's files are merged");
+      assertTrue(
+          report.uncoveredLines("mod/b/Extra.java").isEmpty(),
+          "merging a second report cannot grow the map past the source-file cap");
+    }
+
+    @Test
+    void capsTheLinesOneSourceFileMergesAcrossReports() throws IOException {
+      var first =
+          new StringBuilder(
+              "<report name=\"a\"><package name=\"a\"><sourcefile name=\"Huge.java\">");
+      for (var nr = 1; nr <= JacocoCoverageReport.MAX_LINES_PER_FILE; nr++) {
+        first.append("<line nr=\"").append(nr).append("\" mi=\"1\" ci=\"0\"/>");
+      }
+      first.append("</sourcefile></package></report>");
+      var entries = new LinkedHashMap<String, String>();
+      entries.put("module-a/jacoco.xml", first.toString());
+      entries.put(
+          "module-b/jacoco.xml",
+          """
+          <report name="b">
+            <package name="a">
+              <sourcefile name="Huge.java"><line nr="99999" mi="1" ci="0"/></sourcefile>
+            </package>
+          </report>
+          """);
+
+      var lines =
+          JacocoCoverageReport.fromArtifactZip(zipOf(entries)).uncoveredLines("mod/a/Huge.java");
+
+      assertEquals(
+          JacocoCoverageReport.MAX_LINES_PER_FILE,
+          lines.size(),
+          "the merge is bounded per file, not only per report");
+      assertFalse(
+          lines.contains(99_999), "a second report cannot push one file's line list past the cap");
     }
 
     @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
@@ -435,6 +435,49 @@ class JacocoCoverageReportTest {
     }
 
     @Test
+    void refusesAnArchiveWithMoreEntriesThanItWalks() throws IOException {
+      // Same prefix-choosing power as the bomb abort, reached by padding instead: the report is
+      // read, the cap is hit, and the merge that fit would otherwise be returned as this build's
+      // coverage with every line the unread reports cover reported uncovered.
+      var bytes = new ByteArrayOutputStream();
+      try (var zip = new ZipOutputStream(bytes)) {
+        zip.putNextEntry(new ZipEntry("jacoco.xml"));
+        zip.write(REPORT.getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
+        for (var i = 0; i <= JacocoCoverageReport.MAX_ZIP_ENTRIES; i++) {
+          zip.putNextEntry(new ZipEntry("pad" + i + ".txt"));
+          zip.write(new byte[] {'x'});
+          zip.closeEntry();
+        }
+      }
+
+      assertTrue(
+          JacocoCoverageReport.fromArtifactZip(bytes.toByteArray()).isEmpty(),
+          "an archive longer than the entry cap yields EMPTY, not the prefix that fit");
+    }
+
+    @Test
+    void readsAnArchiveThatExactlyFillsTheEntryCap() throws IOException {
+      // The boundary the refusal must not swallow: an archive using every entry it is allowed is
+      // read in full, so the cap refuses only what it cannot walk.
+      var bytes = new ByteArrayOutputStream();
+      try (var zip = new ZipOutputStream(bytes)) {
+        zip.putNextEntry(new ZipEntry("jacoco.xml"));
+        zip.write(REPORT.getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
+        for (var i = 0; i < JacocoCoverageReport.MAX_ZIP_ENTRIES - 1; i++) {
+          zip.putNextEntry(new ZipEntry("pad" + i + ".txt"));
+          zip.write(new byte[] {'x'});
+          zip.closeEntry();
+        }
+      }
+
+      assertFalse(
+          JacocoCoverageReport.fromArtifactZip(bytes.toByteArray()).isEmpty(),
+          "an archive that fits inside the cap is still read");
+    }
+
+    @Test
     void carriesNoPartialAnswerOutOfAnArchiveItRefused() throws IOException {
       // The report sits BEFORE the bomb this time, so the walk has merged real coverage by the
       // moment it gives up. Returning that prefix would let whoever built the archive choose which

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
@@ -487,35 +487,79 @@ class JacocoCoverageReportTest {
     }
 
     @Test
-    void capsTheLinesOneSourceFileMergesAcrossReports() throws IOException {
-      var first =
-          new StringBuilder(
-              "<report name=\"a\"><package name=\"a\"><sourcefile name=\"Huge.java\">");
-      for (var nr = 1; nr <= JacocoCoverageReport.MAX_LINES_PER_FILE; nr++) {
-        first.append("<line nr=\"").append(nr).append("\" mi=\"1\" ci=\"0\"/>");
-      }
-      first.append("</sourcefile></package></report>");
+    void keepsOnlyWhatTwoReportsOfTheSamePathAgreeOn() throws IOException {
+      // Two reports in one artifact both claiming com/example/Foo.java, which is what a
+      // **/jacoco.xml upload collects when a class exists in two modules, or when a per-module
+      // report sits next to an aggregate report of the same build. Unioning their misses charges
+      // one build's misses to the other's file — and the by-path ambiguity guard cannot catch it
+      // afterwards, because the merge has collapsed the two into one entry that exactly one
+      // repository file matches.
       var entries = new LinkedHashMap<String, String>();
-      entries.put("module-a/jacoco.xml", first.toString());
+      entries.put(
+          "module-a/jacoco.xml",
+          """
+          <report name="a">
+            <package name="com/example">
+              <sourcefile name="Foo.java">
+                <line nr="1" mi="1" ci="0"/>
+                <line nr="2" mi="1" ci="0"/>
+              </sourcefile>
+            </package>
+          </report>
+          """);
       entries.put(
           "module-b/jacoco.xml",
           """
           <report name="b">
-            <package name="a">
-              <sourcefile name="Huge.java"><line nr="99999" mi="1" ci="0"/></sourcefile>
+            <package name="com/example">
+              <sourcefile name="Foo.java">
+                <line nr="2" mi="1" ci="0"/>
+                <line nr="3" mi="1" ci="0"/>
+              </sourcefile>
+              <sourcefile name="Bar.java"><line nr="7" mi="1" ci="0"/></sourcefile>
             </package>
           </report>
           """);
 
-      var lines =
-          JacocoCoverageReport.fromArtifactZip(zipOf(entries)).uncoveredLines("mod/a/Huge.java");
+      var report = JacocoCoverageReport.fromArtifactZip(zipOf(entries));
 
       assertEquals(
-          JacocoCoverageReport.MAX_LINES_PER_FILE,
-          lines.size(),
-          "the merge is bounded per file, not only per report");
-      assertFalse(
-          lines.contains(99_999), "a second report cannot push one file's line list past the cap");
+          List.of(2),
+          List.copyOf(report.uncoveredLines("module-a/src/main/java/com/example/Foo.java")),
+          "only a line every report recorded as missed may be reported; a line one of them saw"
+              + " executed was executed");
+      assertEquals(
+          List.of(7),
+          List.copyOf(report.uncoveredLines("module-b/src/main/java/com/example/Bar.java")),
+          "a path only one report describes is untouched by that intersection");
+    }
+
+    @Test
+    void dropsAPathTwoReportsAgreeOnNothingAbout() throws IOException {
+      var entries = new LinkedHashMap<String, String>();
+      entries.put(
+          "module-a/jacoco.xml",
+          """
+          <report name="a">
+            <package name="com/example">
+              <sourcefile name="Foo.java"><line nr="1" mi="1" ci="0"/></sourcefile>
+            </package>
+          </report>
+          """);
+      entries.put(
+          "module-b/jacoco.xml",
+          """
+          <report name="b">
+            <package name="com/example">
+              <sourcefile name="Foo.java"><line nr="2" mi="1" ci="0"/></sourcefile>
+            </package>
+          </report>
+          """);
+
+      assertTrue(
+          JacocoCoverageReport.fromArtifactZip(zipOf(entries)).isEmpty(),
+          "two reports that agree on nothing leave no coverage behind, not an empty entry the"
+              + " rest of the reader would have to special-case");
     }
 
     @Test

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
@@ -435,6 +435,35 @@ class JacocoCoverageReportTest {
     }
 
     @Test
+    void carriesNoPartialAnswerOutOfAnArchiveItRefused() throws IOException {
+      // The report sits BEFORE the bomb this time, so the walk has merged real coverage by the
+      // moment it gives up. Returning that prefix would let whoever built the archive choose which
+      // reports the merge sees: append a bomb after a benign report and the truncated result reads
+      // as complete coverage, so every line the rest of the artifact covers comes back uncovered.
+      var perEntry = JacocoCoverageReport.MAX_ENTRY_BYTES / 2;
+      var bytes = new ByteArrayOutputStream();
+      try (var zip = new ZipOutputStream(bytes)) {
+        zip.putNextEntry(new ZipEntry("jacoco.xml"));
+        zip.write(REPORT.getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
+        var zeros = new byte[64 * 1024];
+        var inflated = 0L;
+        for (var i = 0; inflated <= JacocoCoverageReport.MAX_TOTAL_INFLATED_BYTES; i++) {
+          zip.putNextEntry(new ZipEntry("pad" + i + ".bin"));
+          for (var written = 0; written < perEntry; written += zeros.length) {
+            zip.write(zeros);
+          }
+          zip.closeEntry();
+          inflated += perEntry;
+        }
+      }
+
+      assertTrue(
+          JacocoCoverageReport.fromArtifactZip(bytes.toByteArray()).isEmpty(),
+          "a refused archive yields EMPTY, not the reports that happened to precede the bomb");
+    }
+
+    @Test
     void drainsButCollectsNothingFromAnEntryPastThePerEntryCeiling() throws IOException {
       var sink = new ByteArrayOutputStream();
       try (var zip =

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
@@ -435,6 +435,27 @@ class JacocoCoverageReportTest {
     }
 
     @Test
+    void walksPastDirectoriesWithoutSpendingTheEntryCap() throws IOException {
+      // A coverage artifact is usually a whole target/ tree, so its directory entries can outnumber
+      // its reports several times over. Charging them to the cap refuses the multi-module shape the
+      // merge exists for, with the report sitting readable near the front.
+      var bytes = new ByteArrayOutputStream();
+      try (var zip = new ZipOutputStream(bytes)) {
+        zip.putNextEntry(new ZipEntry("jacoco.xml"));
+        zip.write(REPORT.getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
+        for (var i = 0; i <= JacocoCoverageReport.MAX_ZIP_ENTRIES; i++) {
+          zip.putNextEntry(new ZipEntry("module" + i + "/target/classes/"));
+          zip.closeEntry();
+        }
+      }
+
+      assertFalse(
+          JacocoCoverageReport.fromArtifactZip(bytes.toByteArray()).isEmpty(),
+          "directories carry no report, so nesting must not cost the archive its coverage");
+    }
+
+    @Test
     void refusesAnArchiveWithMoreEntriesThanItWalks() throws IOException {
       // Same prefix-choosing power as the bomb abort, reached by padding instead: the report is
       // read, the cap is hit, and the merge that fit would otherwise be returned as this build's

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReportTest.java
@@ -435,6 +435,34 @@ class JacocoCoverageReportTest {
     }
 
     @Test
+    void refusesABombCarriedUnderADirectoryName() throws IOException {
+      // A trailing slash is only a name. Each of these entries is a "directory" to the reader and a
+      // full payload to the deflater, and none may reach the report behind them without the walk
+      // paying for the inflation it does.
+      var perEntry = JacocoCoverageReport.MAX_ENTRY_BYTES / 2;
+      var bytes = new ByteArrayOutputStream();
+      try (var zip = new ZipOutputStream(bytes)) {
+        var zeros = new byte[64 * 1024];
+        var inflated = 0L;
+        for (var i = 0; inflated <= JacocoCoverageReport.MAX_TOTAL_INFLATED_BYTES; i++) {
+          zip.putNextEntry(new ZipEntry("bomb" + i + "/"));
+          for (var written = 0; written < perEntry; written += zeros.length) {
+            zip.write(zeros);
+          }
+          zip.closeEntry();
+          inflated += perEntry;
+        }
+        zip.putNextEntry(new ZipEntry("jacoco.xml"));
+        zip.write(REPORT.getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
+      }
+
+      assertTrue(
+          JacocoCoverageReport.fromArtifactZip(bytes.toByteArray()).isEmpty(),
+          "a payload under a directory-shaped name must be charged to the aggregate cap");
+    }
+
+    @Test
     void walksPastDirectoriesWithoutSpendingTheEntryCap() throws IOException {
       // A coverage artifact is usually a whole target/ tree, so its directory entries can outnumber
       // its reports several times over. Charging them to the cap refuses the multi-module shape the

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PatchCoverageResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PatchCoverageResolverTest.java
@@ -266,8 +266,11 @@ class PatchCoverageResolverTest {
     void ignoresCoverageFromARunThatDidNotSucceed() {
       // With the common `if: always()` upload, a run that aborted still attaches the artifact — but
       // its ci=0 regions are the run stopping short, not measured fact. A failed conclusion must be
-      // skipped before its artifacts are even listed.
-      givenRuns(new GitHubActionsClient.WorkflowRun(42L, "ci", HEAD_SHA, "completed", "failure"));
+      // skipped before its artifacts are even listed, and so must an absent one: a run GitHub
+      // reports as completed with no conclusion is not a run that said it succeeded.
+      givenRuns(
+          new GitHubActionsClient.WorkflowRun(41L, "ci", HEAD_SHA, "completed", null),
+          new GitHubActionsClient.WorkflowRun(42L, "ci", HEAD_SHA, "completed", "failure"));
       when(actionsClient.listRunArtifacts(any(), any(), eq("o"), eq("r"), eq(42L), anyInt()))
           .thenReturn(
               new GitHubActionsClient.RunArtifacts(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PatchCoverageResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PatchCoverageResolverTest.java
@@ -263,6 +263,27 @@ class PatchCoverageResolverTest {
     }
 
     @Test
+    void ignoresCoverageFromARunThatDidNotSucceed() {
+      // With the common `if: always()` upload, a run that aborted still attaches the artifact — but
+      // its ci=0 regions are the run stopping short, not measured fact. A failed conclusion must be
+      // skipped before its artifacts are even listed.
+      givenRuns(new GitHubActionsClient.WorkflowRun(42L, "ci", HEAD_SHA, "completed", "failure"));
+      when(actionsClient.listRunArtifacts(any(), any(), eq("o"), eq("r"), eq(42L), anyInt()))
+          .thenReturn(
+              new GitHubActionsClient.RunArtifacts(
+                  1, List.of(new GitHubActionsClient.Artifact(99L, ARTIFACT, 1_024, false))));
+      givenDownloadRedirectsTo(BLOB);
+      when(zipFetcher.fetch(BLOB)).thenReturn(zippedReport(REPORT));
+
+      assertEquals(
+          "",
+          resolve(true, ARTIFACT),
+          "coverage from a failed or cancelled run is not something the model may treat as fact");
+      verify(actionsClient, never())
+          .listRunArtifacts(any(), any(), any(), any(), anyLong(), anyInt());
+    }
+
+    @Test
     void degradesToNoContextWhenTheDownloadCannotBeFollowed() {
       givenRunWithArtifact(ARTIFACT);
       givenDownloadRedirectsTo(null);
@@ -301,7 +322,8 @@ class PatchCoverageResolverTest {
     void probesOnlyABoundedNumberOfRunsForTheSameCommit() {
       var runs = new GitHubActionsClient.WorkflowRun[PatchCoverageResolver.MAX_RUNS_PROBED + 4];
       for (var i = 0; i < runs.length; i++) {
-        runs[i] = new GitHubActionsClient.WorkflowRun(i + 1L, "ci", HEAD_SHA, "completed", "ok");
+        runs[i] =
+            new GitHubActionsClient.WorkflowRun(i + 1L, "ci", HEAD_SHA, "completed", "success");
       }
       givenRuns(runs);
       when(actionsClient.listRunArtifacts(any(), any(), any(), any(), anyLong(), anyInt()))

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PatchCoverageResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/PatchCoverageResolverTest.java
@@ -490,6 +490,49 @@ class PatchCoverageResolverTest {
     }
 
     @Test
+    void dropsAReportEntryThatMatchesMoreThanOneRepositoryFile() {
+      // One report entry in a shared package suffix-matches the same-named class in two modules of
+      // a multi-module build. Attributing module-a's uncovered lines to module-b (or the other way)
+      // is the symmetric twin of the existing N-entries->1-path guard and must be refused.
+      var report =
+          JacocoCoverageReport.parse(
+              new java.io.ByteArrayInputStream(
+                  """
+                  <report name="multi">
+                    <package name="com/example">
+                      <sourcefile name="Foo.java"><line nr="1" mi="1" ci="0"/></sourcefile>
+                    </package>
+                  </report>
+                  """
+                      .getBytes(StandardCharsets.UTF_8)));
+      var files =
+          List.of(
+              new FileDiff(
+                  "module-a/src/main/java/com/example/Foo.java",
+                  "modified",
+                  1,
+                  0,
+                  1,
+                  "@@ -1,0 +1,1 @@\n+x"),
+              new FileDiff(
+                  "module-b/src/main/java/com/example/Foo.java",
+                  "modified",
+                  1,
+                  0,
+                  1,
+                  "@@ -1,0 +1,1 @@\n+x"));
+
+      var uncovered = PatchCoverageResolver.intersectWithAddedLines(report, files);
+
+      assertTrue(
+          uncovered.isEmpty(),
+          () ->
+              "one report entry matches both modules' same-named class; attributing it to either is"
+                  + " a guess: "
+                  + uncovered.stream().map(PatchCoverageResolver.UncoveredFile::path).toList());
+    }
+
+    @Test
     void breaksATieOnPathSoTheOrderIsStableAcrossReviews() {
       var report =
           JacocoCoverageReport.parse(


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔒 Security
- [x] ✅ Test

## Description

Four defects in the patch-coverage report reader (`#115`, new in v0.6.0), written on
`fix/coverage-report-hardening` off `release/v0.6.0` and brought onto current `main` here, plus a
fifth found while re-validating them against today's code.

All of it is latent: `thrillhousebot.review.patch-coverage.enabled` defaults `false`. It still
matters, because none of these degrade to *no* coverage signal — they degrade to a *wrong* one, and
`PATCH_COVERAGE_REQUEST` tells the model the section is "measurement, not inference — treat it as
fact about those lines".

**1. Aggregate decompression was unbounded — a zip bomb, reachable from a fork.**
`fromArtifactZip` bounded each entry with `readNBytes(MAX_ENTRY_BYTES)` but nothing bounded the
total: the next `getNextEntry()` implicitly inflates the whole remainder of an unread entry to
reach the following header, so an entry the walk *skipped* was inflated in full anyway. A
maximally-compressed artifact at the 16 MB `ArtifactZipFetcher.MAX_BYTES` download ceiling reaches
roughly 16 GB of decompression per review, and a `pull_request`-triggered workflow that builds a
fork's code lets a fork PR publish such an artifact under the configured name for the head SHA
under review. The class javadoc claimed the archive's "entry count and uncompressed size are
capped"; only the first half was true. Every entry — report or not — is now inflated through a
counting copy charging a running `MAX_TOTAL_INFLATED_BYTES` (128 MB) budget, each one drained in
full so the next `getNextEntry()` never inflates a remainder, and the walk abandons the archive the
moment the budget is blown. The javadoc now says what the code does.

**2. One report entry attributed to every same-named repository file.** `uncoveredLines` refused
the N-entries→1-path ambiguity but not its mirror. `com/example/Foo.java` is a whole-segment suffix
of *every* module's copy of that class, and a `<package name="">` default-package entry
suffix-matches every file of that name anywhere, so module-a's misses were reported against
module-b's same-named class — the exact failure the method's own comment says it exists to avoid.
The intersection now resolves the whole reviewable-file list at once and drops any attribution
ambiguous from either side; only a unique 1:1 report↔path match contributes lines.

**3. Coverage from a run that did not succeed was used as fact.** `findArtifactId` filtered runs on
`status == "completed"` and never read `conclusion`, which `WorkflowRun` parsed and nothing
consumed. With the common `if: always()` coverage upload, a run that aborted partway still attaches
its artifact, and its large `ci=0` regions became "measured fact" about untested code. Runs are now
also filtered on `conclusion` (`success`/`neutral` accepted, and an absent conclusion is not a run
that said it succeeded) before their artifacts are listed. Necessary, not sufficient — a green run
can still emit a partial report under `-Dmaven.test.failure.ignore=true` or a skipped module — and
the code says so.

**4. A multi-module artifact lost every report but the first.** `fromArtifactZip` returned on the
first `.xml` that parsed non-empty, so a build uploading `**/jacoco.xml` kept one module and
silently discarded the rest. Every `.xml` entry now contributes, within the same aggregate
inflation budget and the existing `MAX_SOURCE_FILES` / `MAX_LINES_PER_FILE` caps.

**5. Found while re-validating: merging two reports of the same path unioned their misses.** Fix 4
merged by union, and fix 2's guard was expected to catch the collisions that creates. It cannot:
by the time it runs, the merge has already collapsed the two entries into one that exactly one
repository file suffix-matches, so nothing looks ambiguous. Two entries claim one path in precisely
the situations a `**/jacoco.xml` upload produces — a same-named class in two modules, and one class
measured twice when a per-module report is collected next to an aggregate report of the same build
— and the union charges module-b's misses to module-a's file, or reports a line as never executed
that the aggregate run did execute. The merge now intersects, which is sound whichever repository
file the entry later matches: a line every report recorded as missed is missed in that file's own
report too. A path the reports agree on nothing about is dropped rather than left as an empty
entry.

### Re-validation against current `main`

The branch was four commits off a base from two weeks and dozens of PRs ago. All four defects
reproduce verbatim on today's `main` — none had been fixed or made redundant in the meantime, and
the only change to `JacocoCoverageReport` since that base was extracting a `/` separator into a
constant. Beyond finding 5, rebasing surfaced three things worth calling out:

- `uncoveredLines` and the new `uncoveredLinesByPath` ended up carrying two copies of the same
  suffix-matching walk, with only the by-path copy reachable from `src/main`. The single-path form
  now delegates, so there is one matching policy to reason about.
- Resolving a whole file list has to be duplicate-safe: the same path listed twice would look like
  two repository files matching one entry and drop coverage that is in fact unambiguous.
- The original zip-bomb test padded the archive with one entry far *larger* than the per-entry
  ceiling, so it could not tell the new aggregate bound apart from the per-entry bound already
  there — a reader that simply refused any oversized entry would have passed it. The padding is now
  several entries each half the per-entry ceiling whose sum alone passes the aggregate budget, with
  the real report still hidden behind them.

## Related Issues

Part of #483 — deliberately **not** `Closes`.

The issue carries six acceptance criteria; this PR satisfies four. **F7** (config-key candidate files
under an ignored path are still fetched and rendered) and **F9** (the dead `defaultBranch` fallback in
`ReviewContextLoader.resolveConfigKeyContext`) are outside this branch's file scope, both need
`ReviewContextLoader` changes, and both were verified still open on `main`. The issue's own
Environment section says as much: the branch "carries the first four fixes; F7/F9 remain to be
written." Auto-closing here would leave two boxes unticked and the work forgotten

Not in this PR: the issue's last two acceptance criteria (F7, config-key candidate files bypassing
the review's ignore globs; F9, the dead `defaultBranch` fallback in `ReviewContextLoader`). Both are
outside this branch's file scope, both are still open on `main`, and both want their own change to
`ReviewContextLoader` — worth a follow-up issue rather than folding into this one.

## How Has This Been Tested?

- [x] Unit tests

Every behavioural change was run against the unfixed code first:

| Fix | Test | Verbatim failure before the fix |
| --- | --- | --- |
| 1 | `refusesAnArchiveThatInflatesPastTheAggregateCap` | `an archive inflating past the aggregate cap must be refused, not walked to the report hidden behind the bomb ==> expected: <true> but was: <false>` |
| 2 | `dropsAReportEntryThatMatchesMoreThanOneRepositoryFile` | `one report entry matches both modules' same-named class; attributing it to either is a guess: [module-a/src/main/java/com/example/Foo.java, module-b/src/main/java/com/example/Foo.java] ==> expected: <true> but was: <false>` |
| 3 | `ignoresCoverageFromARunThatDidNotSucceed` | `coverage from a failed or cancelled run is not something the model may treat as fact ==> expected: <> but was: <### Patch coverage for this diff …>` |
| 4 | `mergesEveryXmlReportNotJustTheFirst` | `a second module's report must not be lost to a first-match-wins walk ==> expected: <[2]> but was: <[]>` |
| 5 | `keepsOnlyWhatTwoReportsOfTheSamePathAgreeOn` | `only a line every report recorded as missed may be reported; a line one of them saw executed was executed ==> expected: <[2]> but was: <[1, 2, 3]>` |

Gates on JDK 25:

```
./mvnw -B clean compile spotbugs:check spotless:check   → BugInstance size is 0, BUILD SUCCESS
./mvnw -B clean test                                    → Tests run: 3467, Failures: 0, Errors: 0, Skipped: 0
```

Patch coverage on the changed lines, from `target/site/jacoco/jacoco.xml` intersected with
`git diff -U0 origin/main --`: **0 uncovered lines and 0 uncovered branches** across both changed
source files.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

The feature stays off by default; nothing here changes behaviour for a repository that configures no
coverage artifact. The source branch `fix/coverage-report-hardening` is the only copy of the
original work and has been left untouched.

