### PR TITLE
fix(review): read a diff line with a lexical state machine, not a character walk

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LiveCodeScanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LiveCodeScanner.java
@@ -93,17 +93,25 @@ final class LiveCodeScanner {
    * {@code '} literals, never inside a backtick one, which is a Go raw string and holds the
    * backslash literally. Honouring it there stepped over the closing backtick of a Windows path
    * ({@code `C:\`}) and let the real comment after it pose as live code (#647).
+   *
+   * <p>The last column marks the delimiters a statement terminator can identify as a
+   * <em>closer</em> rather than an opener ({@link #closesLiteralOpenedAboveTheHunk}). Only the
+   * triple-quote spellings carry it, because only they have a language in the corpus that forbids a
+   * body after the opener. The backtick does not: a Go raw string and a JavaScript template literal
+   * put the body right after the opener, so {@code sep := `;abc`} read its own closing backtick as
+   * an opener and blanked the dispatch on the next line, while {@code `, …`} scanned as live text
+   * and matched dispatch words inside quoted prose (#651).
    */
   private static final List<Delimiter> DELIMITERS =
       List.of(
           // Java text block, Kotlin raw string, Python triple-quoted string.
-          new Delimiter("\"\"\"", "\"\"\"", true, false, true),
-          new Delimiter("'''", "'''", true, false, true),
+          new Delimiter("\"\"\"", "\"\"\"", true, false, true, true),
+          new Delimiter("'''", "'''", true, false, true, true),
           // Go raw string and JavaScript template literal share a delimiter; only the latter
           // interpolates, and reading ${…} as code is the direction that keeps real dispatches.
-          new Delimiter("`", "`", false, true, true),
-          new Delimiter("\"", "\"", true, false, false),
-          new Delimiter("'", "'", true, false, false));
+          new Delimiter("`", "`", false, true, true, false),
+          new Delimiter("\"", "\"", true, false, false, false),
+          new Delimiter("'", "'", true, false, false, false));
 
   /**
    * Schemes whose {@code ://} is a URL rather than a label followed by a comment. A closed list is
@@ -265,7 +273,7 @@ final class LiveCodeScanner {
         continue;
       }
       var body = i + delimiter.open().length();
-      if (delimiter.spansLines() && closesAStatement(line, body)) {
+      if (closesLiteralOpenedAboveTheHunk(line, body, delimiter)) {
         return -1;
       }
       if (!delimiter.spansLines()) {
@@ -283,26 +291,51 @@ final class LiveCodeScanner {
 
   /**
    * Whether the delimiter just scanned is a closer whose opener sits above this hunk, rather than
-   * an opener. It is the one shape that tells them apart when a language spells both the same way:
-   * a text block's opening delimiter must be the last thing on its line (JLS 3.10.6) and a template
-   * literal's opener is followed by its body, so a delimiter with a statement terminator after it —
-   * {@code """;}, {@code """,}, {@code """)}, {@code """.formatted(x)} — ends a literal that began
-   * before the first line the diff shows.
+   * an opener. Three things have to hold at once, because a language that spells opener and closer
+   * the same way leaves nothing else to tell them apart.
    *
-   * <p>Without this, a patch whose hunk starts inside a text block read that closer as an opener
-   * and inverted every literal below it, blanking live code all the way to the next delimiter.
-   * Measured over 80 commits of this repository's own history (32535 right-side Java lines): the
-   * opener reading blanked 57 statement-shaped lines, among them live methods of {@code
+   * <p><b>The delimiter must be one a terminator can identify.</b> A Java text block's opening
+   * delimiter must be the last thing on its line (JLS 3.10.6), so a statement terminator after it —
+   * {@code """;}, {@code """,}, {@code """)}, {@code """.formatted(x)} — belongs to the statement a
+   * <em>closer</em> ends. That rationale is what the table's last column records, and it is why the
+   * backtick is not in it: a Go raw string or a JavaScript template literal begins its body
+   * immediately, so the very same test misread both directions of the shape (#651).
+   *
+   * <p><b>A terminator must follow.</b> The set is the punctuation that can abut a closing
+   * delimiter: the statement enders {@code ;} and {@code ,}, the {@code )} of a call, the closing
+   * brace of an initialiser, the closing bracket of a subscript, and the {@code .} or {@code +} of
+   * a call or a concatenation on the literal. The brace and the bracket were missing, so a text
+   * block that ends an array initialiser — its closing delimiter followed by a brace and a
+   * semicolon — still read as an opener and blanked the live code under it, the mirror of the case
+   * this rule was written for (#651).
+   *
+   * <p><b>No closer may follow on the same line.</b> Kotlin and Python do allow a body right after
+   * the opener, so {@code '''; and more'''} is a whole literal whose body merely starts with a
+   * terminator. A delimiter that finds its own closer further along the line opened that literal;
+   * only one with nothing to close against can be the closer of a literal opened above the hunk.
+   *
+   * <p>Without the rule at all, a patch whose hunk starts inside a text block read that closer as
+   * an opener and inverted every literal below it, blanking live code all the way to the next
+   * delimiter. Measured over 80 commits of this repository's own history (32535 right-side Java
+   * lines): the opener reading blanked 57 statement-shaped lines, among them live methods of {@code
    * ReviewResult}, because the hunks that touch this repository's code so often start under a text
    * block constant. The closer reading leaves 23, every one of them the body of a text block that
    * quotes a diff or a JSON payload — which is exactly the text that must be blanked.
    */
-  private static boolean closesAStatement(String line, int after) {
+  private static boolean closesLiteralOpenedAboveTheHunk(
+      String line, int body, Delimiter delimiter) {
+    return delimiter.terminatorMarksCloser()
+        && startsWithTerminator(line, body)
+        && closerIndex(line, body, delimiter.close()) < 0;
+  }
+
+  /** Whether the first non-whitespace character at or after {@code after} ends a statement. */
+  private static boolean startsWithTerminator(String line, int after) {
     var i = after;
     while (i < line.length() && Character.isWhitespace(line.charAt(i))) {
       i++;
     }
-    return i < line.length() && ";,).+".indexOf(line.charAt(i)) >= 0;
+    return i < line.length() && ";,).+}]".indexOf(line.charAt(i)) >= 0;
   }
 
   /**
@@ -456,10 +489,18 @@ final class LiveCodeScanner {
 
   /**
    * An opener the scanner knows, its closing token, whether a backslash escapes inside it, whether
-   * a {@code ${…}} inside it is live code, and whether it may stay open at the end of a line.
+   * a {@code ${…}} inside it is live code, whether it may stay open at the end of a line, and
+   * whether a statement terminator after it marks it as a closer rather than an opener. The last
+   * flag is meaningful only on a delimiter that spans lines — one that cannot is resolved by
+   * looking ahead for its own closer on the same line.
    */
   private record Delimiter(
-      String open, String close, boolean escapes, boolean interpolates, boolean spansLines) {}
+      String open,
+      String close,
+      boolean escapes,
+      boolean interpolates,
+      boolean spansLines,
+      boolean terminatorMarksCloser) {}
 
   /**
    * A region the scan is currently inside: a quoted run being blanked, or the live code of a

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LiveCodeScanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LiveCodeScanner.java
@@ -1,0 +1,504 @@
+/*
+ * Copyright 2026 Thiago Gonzaga
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.thiagogonzaga.thrillhousebot.review;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Separates the code a revision runs from the text it merely quotes, one right-side diff line at a
+ * time, so {@link RebuttalContradiction} can match dispatch constructs against live code only.
+ *
+ * <p>Quoted runs — string literals, character literals, comments — are blanked to spaces rather
+ * than dropped: every offset after them is unchanged, so the caller's evidence quote still shows
+ * the real shape of the line. A line comment is the one exception; it is cut, because nothing after
+ * it is code. Literal delimiters are kept (a blanked string still reads as a string in the quote);
+ * comment delimiters are not, because a comment is not part of the statement around it and leaving
+ * {@code /*} in place would put a non-whitespace token inside an argument list.
+ *
+ * <h2>Why a state machine rather than more tells</h2>
+ *
+ * <p>This replaces a character walk that toggled quote state on any single {@code "}, {@code '} or
+ * {@code `} and special-cased everything else. Each delimiter shape the walk did not model was a
+ * defect, in one direction or the other, and every fix added a tell that interacted with the tells
+ * already there (#647, #780, #651). The shapes left over — Java text blocks, C++ raw strings, block
+ * comments, template-literal interpolations — are not more tells; they are more <em>states</em>, so
+ * the honest fix is to name the states once and let a table of delimiters drive them.
+ *
+ * <p>The machine is deliberately one machine for every language in the corpus rather than a lexer
+ * per language: the delimiter table is the union of the shapes the reviewed diffs actually carry.
+ * That answers every shape whose delimiters are unambiguous across the corpus, and it cannot answer
+ * the two that are genuinely ambiguous without knowing the language — Python's {@code //} floor
+ * division, which reads as a comment start, and a Rust lifetime that pairs with a later apostrophe.
+ * Both are left as they were, both fail by blanking rather than by matching, and both are recorded
+ * in {@code RebuttalContradiction.rightSideCode} as the residue a language hint would close.
+ *
+ * <h2>Which way it errs</h2>
+ *
+ * <p>Every ambiguous decision here resolves toward <em>quoted</em>. Blanking live code costs a
+ * contradiction the caller would otherwise have found, and the decline then stands — which is this
+ * class's default outcome anyway. Matching quoted text costs an argument with a maintainer who was
+ * right, which is the outcome the whole re-check exists to avoid. So an opener whose closer never
+ * arrives blanks the rest of its hunk, and an unrecognised URL scheme reads as a comment.
+ *
+ * <p>The one place that resolves the other way is a template literal's {@code ${…}} interpolation,
+ * which is live code inside a quoted run. Blanking it erased real dispatches (#651); reading it as
+ * code costs an over-fire only for a Go raw string that quotes {@code ${…}} text <em>and</em> names
+ * a dispatch construct inside those braces, which the corpus does not produce.
+ *
+ * <h2>How far state is carried</h2>
+ *
+ * <p>Only the delimiters that are designed to span lines carry across one — text blocks, raw
+ * strings, template literals, block comments — and only from one diff body line to the next. The
+ * caller resets the machine at every line that is not a hunk body line, so a stray delimiter cannot
+ * silence anything past the hunk that holds it: the scan text is a whole multi-file patch rejoined,
+ * where an omitted context region can easily hold the closer that never comes.
+ */
+final class LiveCodeScanner {
+
+  /** A block comment opens here and runs, across lines, to {@link #BLOCK_COMMENT_CLOSE}. */
+  private static final String BLOCK_COMMENT_OPEN = "/*";
+
+  private static final String BLOCK_COMMENT_CLOSE = "*/";
+
+  /**
+   * How far past {@code R"} a C++ raw-string delimiter may run before the opener is read as an
+   * ordinary quote instead. Real delimiters are a word or empty; the bound keeps a stray {@code R"}
+   * from claiming the rest of the line.
+   */
+  private static final int RAW_DELIMITER_LIMIT = 16;
+
+  /**
+   * Openers with a fixed closing token, longest first so {@code """} is not read as {@code ""}
+   * followed by a third quote. {@code spansLines} marks the ones a language lets cross a line
+   * break; the rest must close on the line that opens them or they were not literals at all.
+   *
+   * <p>The escape column says where a backslash escapes the next character: inside {@code "} and
+   * {@code '} literals, never inside a backtick one, which is a Go raw string and holds the
+   * backslash literally. Honouring it there stepped over the closing backtick of a Windows path
+   * ({@code `C:\`}) and let the real comment after it pose as live code (#647).
+   */
+  private static final List<Delimiter> DELIMITERS =
+      List.of(
+          // Java text block, Kotlin raw string, Python triple-quoted string.
+          new Delimiter("\"\"\"", "\"\"\"", true, false, true),
+          new Delimiter("'''", "'''", true, false, true),
+          // Go raw string and JavaScript template literal share a delimiter; only the latter
+          // interpolates, and reading ${…} as code is the direction that keeps real dispatches.
+          new Delimiter("`", "`", false, true, true),
+          new Delimiter("\"", "\"", true, false, false),
+          new Delimiter("'", "'", true, false, false));
+
+  /**
+   * Schemes whose {@code ://} is a URL rather than a label followed by a comment. A closed list is
+   * the only thing that separates {@code https://host} from {@code default://note}: both are
+   * letters, a colon and two slashes, and the character before the colon — all the previous
+   * carve-out looked at — is a letter in both. An unlisted scheme therefore reads as a comment and
+   * the rest of the line is cut, which is the blanking direction and keeps the decline.
+   */
+  private static final Set<String> URL_SCHEMES =
+      Set.of(
+          "http",
+          "https",
+          "ftp",
+          "ftps",
+          "file",
+          "ws",
+          "wss",
+          "git",
+          "ssh",
+          "svn",
+          "jdbc",
+          "s3",
+          "gs",
+          "redis",
+          "mongodb",
+          "postgres",
+          "postgresql",
+          "mysql",
+          "amqp",
+          "kafka",
+          "ldap",
+          "ldaps",
+          "smb",
+          "nfs",
+          "docker",
+          "oci",
+          "hdfs",
+          "classpath");
+
+  /**
+   * The regions still open at the end of the last line, innermost first. Empty means live code —
+   * the state every line starts in once {@link #reset()} has run.
+   */
+  private final Deque<Region> open = new ArrayDeque<>();
+
+  /** Forgets every open region, so the next line is scanned as live code from its first column. */
+  void reset() {
+    open.clear();
+  }
+
+  /**
+   * {@code line} with its quoted runs blanked and any line comment cut, continuing whatever region
+   * the previous line left open.
+   */
+  String scanLine(String line) {
+    var out = new StringBuilder(line.length());
+    var i = 0;
+    while (i < line.length()) {
+      var region = open.peek();
+      if (region != null && !region.live) {
+        i = blank(line, i, out, region);
+        continue;
+      }
+      var next = scanLive(line, i, out, region);
+      if (next < 0) {
+        // A line comment: nothing after it is code, on this line or any other.
+        return out.toString();
+      }
+      i = next;
+    }
+    return out.toString();
+  }
+
+  /**
+   * One step inside a quoted region: its closer ends it, a backslash covers the character after it
+   * where the region escapes, {@code ${} opens live code where the region interpolates, and
+   * anything else is erased.
+   */
+  private int blank(String line, int i, StringBuilder out, Region region) {
+    if (region.escapes && line.charAt(i) == '\\' && i + 1 < line.length()) {
+      out.append("  ");
+      return i + 2;
+    }
+    if (region.interpolates && line.startsWith("${", i)) {
+      open.push(Region.interpolation());
+      out.append("${");
+      return i + 2;
+    }
+    if (line.startsWith(region.closer, i)) {
+      open.pop();
+      out.append(region.hideDelimiters ? " ".repeat(region.closer.length()) : region.closer);
+      return i + region.closer.length();
+    }
+    out.append(' ');
+    return i + 1;
+  }
+
+  /**
+   * One step in live code — top level when {@code region} is null, otherwise inside a template
+   * literal's interpolation. Returns the next index, or {@code -1} when a line comment starts here
+   * and the rest of the line must be cut.
+   *
+   * <p>Comments and URLs are recognised at top level only. Inside an interpolation a {@code //} is
+   * division or the tail of a URL far more often than a comment — a comment there would swallow the
+   * closing brace — and cutting the line would strand the enclosing literal's closer, leaving it
+   * open for the rest of the hunk.
+   */
+  private int scanLive(String line, int i, StringBuilder out, Region region) {
+    var c = line.charAt(i);
+    if (region != null) {
+      if (c == '{') {
+        region.braceDepth++;
+      } else if (c == '}') {
+        if (region.braceDepth == 0) {
+          open.pop();
+          out.append(c);
+          return i + 1;
+        }
+        region.braceDepth--;
+      }
+    } else if (line.startsWith(BLOCK_COMMENT_OPEN, i)) {
+      open.push(Region.blockComment());
+      out.append("  ");
+      return i + BLOCK_COMMENT_OPEN.length();
+    } else if (isDoubleSlash(line, i)) {
+      var url = urlTokenEnd(line, i);
+      if (url < 0) {
+        return -1;
+      }
+      out.append(line, i, url);
+      return url;
+    }
+    var opened = openLiteral(line, i, out);
+    if (opened > 0) {
+      return opened;
+    }
+    out.append(c);
+    return i + 1;
+  }
+
+  /**
+   * Opens the literal starting at {@code i} and returns the index its body begins at, or {@code -1}
+   * when nothing opens here.
+   *
+   * <p>A delimiter that cannot span lines and finds no closer on the line was not a delimiter: a
+   * Rust lifetime, an apostrophe in prose, a stray quote in a log message. It is left as ordinary
+   * text and the scan resumes one character later, so a later closed literal on the same line is
+   * still stepped over whole (#647).
+   */
+  private int openLiteral(String line, int i, StringBuilder out) {
+    var rawBody = rawStringBodyStart(line, i);
+    if (rawBody > 0) {
+      open.push(Region.quoted(")" + line.substring(i + 2, rawBody - 1) + "\"", false, false));
+      out.append(line, i, rawBody);
+      return rawBody;
+    }
+    for (var delimiter : DELIMITERS) {
+      if (!line.startsWith(delimiter.open(), i)) {
+        continue;
+      }
+      var body = i + delimiter.open().length();
+      if (delimiter.spansLines() && closesAStatement(line, body)) {
+        return -1;
+      }
+      if (!delimiter.spansLines()) {
+        var close = closerIndex(line, body, delimiter.close());
+        if (close < 0 || isMisreadApostrophePair(line, delimiter.open().charAt(0), i, close)) {
+          return -1;
+        }
+      }
+      open.push(Region.quoted(delimiter.close(), delimiter.escapes(), delimiter.interpolates()));
+      out.append(delimiter.open());
+      return body;
+    }
+    return -1;
+  }
+
+  /**
+   * Whether the delimiter just scanned is a closer whose opener sits above this hunk, rather than
+   * an opener. It is the one shape that tells them apart when a language spells both the same way:
+   * a text block's opening delimiter must be the last thing on its line (JLS 3.10.6) and a template
+   * literal's opener is followed by its body, so a delimiter with a statement terminator after it —
+   * {@code """;}, {@code """,}, {@code """)}, {@code """.formatted(x)} — ends a literal that began
+   * before the first line the diff shows.
+   *
+   * <p>Without this, a patch whose hunk starts inside a text block read that closer as an opener
+   * and inverted every literal below it, blanking live code all the way to the next delimiter.
+   * Measured over 80 commits of this repository's own history (32535 right-side Java lines): the
+   * opener reading blanked 57 statement-shaped lines, among them live methods of {@code
+   * ReviewResult}, because the hunks that touch this repository's code so often start under a text
+   * block constant. The closer reading leaves 23, every one of them the body of a text block that
+   * quotes a diff or a JSON payload — which is exactly the text that must be blanked.
+   */
+  private static boolean closesAStatement(String line, int after) {
+    var i = after;
+    while (i < line.length() && Character.isWhitespace(line.charAt(i))) {
+      i++;
+    }
+    return i < line.length() && ";,).+".indexOf(line.charAt(i)) >= 0;
+  }
+
+  /**
+   * Index just past a C++ raw string's {@code R"delim(} opener at {@code at}, or {@code -1} when
+   * this is not one. The delimiter is the text between the quote and the paren, and the literal
+   * ends at {@code )delim"} — which is what lets its body carry an unescaped quote, the shape that
+   * closed the old single-quote toggle early and truncated the line at the {@code //} after it.
+   *
+   * <p>An encoding prefix ({@code u8R"}, {@code LR"}) still opens one; an {@code R} that is merely
+   * the last character of an identifier does not, and neither does a delimiter carrying a character
+   * C++ does not allow in one. Both fall back to reading the quote as an ordinary string opener,
+   * which is what the scan did before raw strings were modelled.
+   */
+  private static int rawStringBodyStart(String line, int at) {
+    if (line.charAt(at) != 'R' || !line.startsWith("\"", at + 1) || !isPrefixBoundary(line, at)) {
+      return -1;
+    }
+    var end = at + 2;
+    var limit = Math.min(line.length(), end + RAW_DELIMITER_LIMIT);
+    while (end < limit) {
+      var c = line.charAt(end);
+      if (c == '(') {
+        return end + 1;
+      }
+      if (Character.isWhitespace(c) || "\")\\".indexOf(c) >= 0) {
+        return -1;
+      }
+      end++;
+    }
+    return -1;
+  }
+
+  /** Whether the {@code R} at {@code at}, with any encoding prefix, starts a fresh token. */
+  private static boolean isPrefixBoundary(String line, int at) {
+    var start = at;
+    while (start > 0 && at - start < 2 && "uUL8".indexOf(line.charAt(start - 1)) >= 0) {
+      start--;
+    }
+    return start == 0 || !Character.isJavaIdentifierPart(line.charAt(start - 1));
+  }
+
+  /**
+   * Index of {@code closer} at or after {@code from}, or {@code -1} when the line ends first. A
+   * backslash covers the character after it, which is the rule for every delimiter that reaches
+   * here: only the ones that must close on their own line do, and those are the {@code "} and
+   * {@code '} literals. The delimiters that hold a backslash literally — a Go raw string, a C++ raw
+   * string — span lines, so they are never looked ahead for and {@link #blank} steps over them
+   * instead.
+   */
+  private static int closerIndex(String line, int from, String closer) {
+    var i = from;
+    while (i < line.length()) {
+      if (line.charAt(i) == '\\') {
+        i += 2;
+      } else if (line.startsWith(closer, i)) {
+        return i;
+      } else {
+        i++;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Whether a {@code '}-quoted span is really two unrelated apostrophes with live code between
+   * them, rather than a literal. A lone apostrophe in non-string context — a Rust lifetime ({@code
+   * &'a ctx}, {@code foo::<'a>}) — followed later on the line by a real char literal ({@code '\n'})
+   * or another lifetime pairs with that later apostrophe, and blanking the span would erase any
+   * dispatch between them. Three tells mark a span as misread, each shaped so genuine quoted prose
+   * (which may hold {@code .submit(} text — the very thing blanking exists to erase) keeps
+   * blanking: the opener sits directly after {@code &} or {@code <}, which is Rust lifetime syntax
+   * and never a string opener; the span holds a {@code ;}, which is statement shape, not prose; or
+   * the pairing closer itself opens a char-literal-shaped span, meaning the "closer" was really the
+   * next literal's opener.
+   *
+   * <p>This is the one classification the state machine cannot make structurally: whether {@code
+   * 'a} opens a literal is a fact about the language, not about the delimiter. The tells are kept
+   * as they were (#780) rather than grown, and the residue — two lifetimes with live code and no
+   * semicolon between them — blanks that code, which keeps the decline. Double-quote and backtick
+   * openers have no lifetime-style bare use, so the guard applies to {@code '} alone.
+   */
+  private static boolean isMisreadApostrophePair(String line, char quote, int open, int close) {
+    if (quote != '\'') {
+      return false;
+    }
+    // Lifetime position: an apostrophe directly after & or < ( &'a ctx, foo::<'a> ) is Rust
+    // syntax, never a string opener, whatever its span holds.
+    if (open > 0 && (line.charAt(open - 1) == '&' || line.charAt(open - 1) == '<')) {
+      return true;
+    }
+    // Statement separator: a ; inside the span is code shape, not quoted prose.
+    if (line.substring(open + 1, close).indexOf(';') >= 0) {
+      return true;
+    }
+    // The pairing closer itself opens a char-literal-shaped span — '\n', ',', or a longer escape
+    // like a Rust unicode char (backslash-u{1F600}): the "closer" was really the next literal's
+    // opener, and everything between the two apostrophes is live code. Char-shaped means at most
+    // two characters — one character or a simple escape — or an escape sequence: backslash-led
+    // and short enough for the longest real spelling, Rust's backslash-u{10FFFF} at 9 characters.
+    // Ten leaves a margin without reading a backslash-led prose span as a char.
+    var closerAsOpener = closerIndex(line, close + 1, "'");
+    if (closerAsOpener < 0) {
+      return false;
+    }
+    var charSpan = line.substring(close + 1, closerAsOpener);
+    return charSpan.length() <= 2 || (charSpan.length() <= 10 && charSpan.charAt(0) == '\\');
+  }
+
+  /**
+   * Index just past the URL token whose {@code //} sits at {@code slashes}, or {@code -1} when the
+   * slashes do not belong to a URL and start a comment instead.
+   *
+   * <p>The whole token is consumed, not just the scheme's slash pair: a path may hold a doubled
+   * slash of its own ({@code http://host//v1}), and stopping at the scheme left the scan to read
+   * that pair as a comment start and drop the rest of the line. The token ends at whitespace or at
+   * a character that ends a URL in running code — a quote, a bracket, a statement separator — so
+   * the code after it is still scanned.
+   *
+   * <p>The scheme is read back over letters and digits alone, so a compound scheme is recognised by
+   * its last component ({@code git+ssh://host} matches on {@code ssh}). That errs toward reading a
+   * URL, which keeps the line; requiring the whole {@code git+ssh} to be listed would cut it at the
+   * slashes instead.
+   */
+  private static int urlTokenEnd(String line, int slashes) {
+    if (slashes == 0 || line.charAt(slashes - 1) != ':') {
+      return -1;
+    }
+    var schemeStart = slashes - 1;
+    while (schemeStart > 0 && Character.isLetterOrDigit(line.charAt(schemeStart - 1))) {
+      schemeStart--;
+    }
+    var scheme = line.substring(schemeStart, slashes - 1).toLowerCase(Locale.ROOT);
+    if (!URL_SCHEMES.contains(scheme)) {
+      return -1;
+    }
+    var end = slashes + 2;
+    while (end < line.length() && !endsUrlToken(line.charAt(end))) {
+      end++;
+    }
+    return end;
+  }
+
+  private static boolean endsUrlToken(char c) {
+    return Character.isWhitespace(c) || "\"'`<>()[]{}\\,;".indexOf(c) >= 0;
+  }
+
+  /** Whether a doubled slash sits at {@code at}. */
+  private static boolean isDoubleSlash(String line, int at) {
+    return line.charAt(at) == '/' && at + 1 < line.length() && line.charAt(at + 1) == '/';
+  }
+
+  /**
+   * An opener the scanner knows, its closing token, whether a backslash escapes inside it, whether
+   * a {@code ${…}} inside it is live code, and whether it may stay open at the end of a line.
+   */
+  private record Delimiter(
+      String open, String close, boolean escapes, boolean interpolates, boolean spansLines) {}
+
+  /**
+   * A region the scan is currently inside: a quoted run being blanked, or the live code of a
+   * template literal's interpolation. Mutable because an interpolation counts the braces nested
+   * inside it, which is what tells {@code ${fn({k: v})}} apart from the brace that closes it.
+   */
+  private static final class Region {
+
+    private final String closer;
+    private final boolean escapes;
+    private final boolean interpolates;
+    private final boolean live;
+    private final boolean hideDelimiters;
+    private int braceDepth;
+
+    private Region(
+        String closer,
+        boolean escapes,
+        boolean interpolates,
+        boolean live,
+        boolean hideDelimiters) {
+      this.closer = closer;
+      this.escapes = escapes;
+      this.interpolates = interpolates;
+      this.live = live;
+      this.hideDelimiters = hideDelimiters;
+    }
+
+    static Region quoted(String closer, boolean escapes, boolean interpolates) {
+      return new Region(closer, escapes, interpolates, false, false);
+    }
+
+    /** A comment is not part of the statement around it, so its delimiters are erased too. */
+    static Region blockComment() {
+      return new Region(BLOCK_COMMENT_CLOSE, false, false, false, true);
+    }
+
+    static Region interpolation() {
+      return new Region("}", false, false, true, false);
+    }
+  }
+}

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LiveCodeScanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LiveCodeScanner.java
@@ -92,21 +92,36 @@ final class LiveCodeScanner {
    * <p>The escape column says where a backslash escapes the next character: inside {@code "} and
    * {@code '} literals, never inside a backtick one, which is a Go raw string and holds the
    * backslash literally. Honouring it there stepped over the closing backtick of a Windows path
-   * ({@code `C:\`}) and let the real comment after it pose as live code (#647).
+   * ({@code `C:\`}) and let the real comment after it pose as live code (#647). A triple quote
+   * keeps it, which is right for a Java text block and a Python triple-quoted string and wrong for
+   * a Kotlin raw string, where a backslash is literal: {@code """C:\Users\"""} steps over the first
+   * quote of its own closer and stays open for the rest of the hunk. That residue is left as it is
+   * because the two readings fail in opposite directions and only one of them is affordable —
+   * dropping the escape blanks the Kotlin case correctly but closes a Java text block at an escaped
+   * {@code \"} run, which hands the quoted text after it to the matcher as live code.
    *
-   * <p>The last column marks the delimiters a statement terminator can identify as a
-   * <em>closer</em> rather than an opener ({@link #closesLiteralOpenedAboveTheHunk}). Only the
-   * triple-quote spellings carry it, because only they have a language in the corpus that forbids a
-   * body after the opener. The backtick does not: a Go raw string and a JavaScript template literal
-   * put the body right after the opener, so {@code sep := `;abc`} read its own closing backtick as
-   * an opener and blanked the dispatch on the next line, while {@code `, …`} scanned as live text
-   * and matched dispatch words inside quoted prose (#651).
+   * <p>The last column marks the delimiter a statement terminator can identify as a <em>closer</em>
+   * rather than an opener ({@link #closesLiteralOpenedAboveTheHunk}). Only {@code """} carries it,
+   * and only because Java is in the corpus: a text block's opener must end its line, and the
+   * measurement below was taken on Java. {@code '''} does not, because Python is the only language
+   * in the corpus that spells a literal that way and Python lets the body follow the opener, so the
+   * rule has no premise to stand on there. Neither does the backtick: a Go raw string and a
+   * JavaScript template literal put the body right after the opener, so {@code sep := `;abc`} read
+   * its own closing backtick as an opener and blanked the dispatch on the next line, while {@code
+   * `, …`} scanned as live text and matched dispatch words inside quoted prose (#651).
+   *
+   * <p>What {@code """} still costs, since Kotlin and Python spell their literals that way too: one
+   * of theirs whose body starts with a terminator <em>and</em> runs past the end of its line is
+   * read as a closer and its body scans as live code. Keeping the column for {@code """} trades
+   * that against the 57 blanked Java statement lines measured in {@link
+   * #closesLiteralOpenedAboveTheHunk}; a language hint off the diff header is what would end the
+   * trade.
    */
   private static final List<Delimiter> DELIMITERS =
       List.of(
           // Java text block, Kotlin raw string, Python triple-quoted string.
           new Delimiter("\"\"\"", "\"\"\"", true, false, true, true),
-          new Delimiter("'''", "'''", true, false, true, true),
+          new Delimiter("'''", "'''", true, false, true, false),
           // Go raw string and JavaScript template literal share a delimiter; only the latter
           // interpolates, and reading ${…} as code is the direction that keeps real dispatches.
           new Delimiter("`", "`", false, true, true, false),
@@ -309,10 +324,12 @@ final class LiveCodeScanner {
    * semicolon — still read as an opener and blanked the live code under it, the mirror of the case
    * this rule was written for (#651).
    *
-   * <p><b>No closer may follow on the same line.</b> Kotlin and Python do allow a body right after
-   * the opener, so {@code '''; and more'''} is a whole literal whose body merely starts with a
+   * <p><b>No closer may follow on the same line.</b> Kotlin does allow a body right after the
+   * opener, so {@code """; and more"""} is a whole literal whose body merely starts with a
    * terminator. A delimiter that finds its own closer further along the line opened that literal;
    * only one with nothing to close against can be the closer of a literal opened above the hunk.
+   * The Kotlin literal that this does not save is the one whose terminator-led body runs past the
+   * end of its line, recorded with the rest of the trade on {@link #DELIMITERS}.
    *
    * <p>Without the rule at all, a patch whose hunk starts inside a text block read that closer as
    * an opener and inverted every literal below it, blanking live code all the way to the next

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LiveCodeScanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LiveCodeScanner.java
@@ -124,6 +124,7 @@ final class LiveCodeScanner {
           new Delimiter("'''", "'''", true, false, true, false),
           // Go raw string and JavaScript template literal share a delimiter; only the latter
           // interpolates, and reading ${…} as code is the direction that keeps real dispatches.
+          // Whether a backslash escapes is the file's call, not the table's: see fileNamed.
           new Delimiter("`", "`", false, true, true, false),
           new Delimiter("\"", "\"", true, false, false, false),
           new Delimiter("'", "'", true, false, false, false));
@@ -172,9 +173,41 @@ final class LiveCodeScanner {
    */
   private final Deque<Region> open = new ArrayDeque<>();
 
+  /**
+   * The file extensions whose backtick literal is a JavaScript template literal, where a backslash
+   * escapes, rather than a Go raw string, where it is literal.
+   */
+  private static final Set<String> TEMPLATE_LITERAL_EXTENSIONS =
+      Set.of("js", "jsx", "mjs", "cjs", "ts", "tsx", "mts", "cts", "vue", "svelte");
+
+  /** Whether a backtick literal in the file being scanned honours a backslash escape. */
+  private boolean templateEscapes;
+
   /** Forgets every open region, so the next line is scanned as live code from its first column. */
   void reset() {
     open.clear();
+  }
+
+  /**
+   * Tells the scan which file the lines that follow come from — a path, or the {@code diff --git}
+   * header naming it; only the extension is read. It outlives {@link #reset()}, which runs on every
+   * hunk header of the same file.
+   *
+   * <p>This is the one lexical fact the delimiter table cannot carry on its own. The backtick is
+   * both Go's raw string and JavaScript's template literal, and the two disagree on a backslash: Go
+   * takes it literally, so a Windows path may end right before the closer and honouring the escape
+   * there stepped over the closer and hid the code after it (#647); JavaScript escapes with it, so
+   * {@code \`} is an escaped backtick and reading it as the closer scans the rest of the literal as
+   * live code, the over-fire direction (#651 review). A fragment that names no file keeps the Go
+   * reading the table always had.
+   */
+  void fileNamed(String path) {
+    var dot = path.lastIndexOf('.');
+    var slash = path.lastIndexOf('/');
+    templateEscapes =
+        dot > slash
+            && TEMPLATE_LITERAL_EXTENSIONS.contains(
+                path.substring(dot + 1).toLowerCase(Locale.ROOT));
   }
 
   /**
@@ -304,7 +337,10 @@ final class LiveCodeScanner {
           return -1;
         }
       }
-      open.push(Region.quoted(delimiter.close(), delimiter.escapes(), delimiter.interpolates()));
+      // The backtick is the only delimiter in the table that does not escape on its own, so the
+      // file hint only ever changes that one row.
+      var escapes = delimiter.escapes() || templateEscapes;
+      open.push(Region.quoted(delimiter.close(), escapes, delimiter.interpolates()));
       out.append(delimiter.open());
       return body;
     }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LiveCodeScanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LiveCodeScanner.java
@@ -293,7 +293,14 @@ final class LiveCodeScanner {
       }
       if (!delimiter.spansLines()) {
         var close = closerIndex(line, body, delimiter.close());
-        if (close < 0 || isMisreadApostrophePair(line, delimiter.open().charAt(0), i, close)) {
+        // A single-line literal may still run on: C, C++ and Python continue a string across a
+        // line break with a trailing backslash. Reading the unclosed quote as ordinary text would
+        // scan the literal's remainder as live code, which is the over-fire direction. The region
+        // is carried on the stack instead and closes on the line that closes it.
+        if (close < 0 && !continuesOnNextLine(line, body)) {
+          return -1;
+        }
+        if (close >= 0 && isMisreadApostrophePair(line, delimiter.open().charAt(0), i, close)) {
           return -1;
         }
       }
@@ -371,7 +378,10 @@ final class LiveCodeScanner {
       return -1;
     }
     var end = at + 2;
-    var limit = Math.min(line.length(), end + RAW_DELIMITER_LIMIT);
+    // The delimiter may run RAW_DELIMITER_LIMIT characters, and the '(' sits after the last of
+    // them, so the window has to reach one position past the limit to see a maximal delimiter's
+    // opener. Off by one here fell back to a plain-string read for a legal 16-character delimiter.
+    var limit = Math.min(line.length(), end + RAW_DELIMITER_LIMIT + 1);
     while (end < limit) {
       var c = line.charAt(end);
       if (c == '(') {
@@ -558,5 +568,21 @@ final class LiveCodeScanner {
     static Region interpolation() {
       return new Region("}", false, false, true, false);
     }
+  }
+
+  /**
+   * Whether the literal body starting at {@code body} ends in an unescaped backslash, the
+   * string-continuation marker. Only the body is read: the opener before it is never a backslash.
+   */
+  private static boolean continuesOnNextLine(String line, int body) {
+    var end = line.length();
+    while (end > body && Character.isWhitespace(line.charAt(end - 1))) {
+      end--;
+    }
+    var slashes = 0;
+    while (end - slashes > body && line.charAt(end - slashes - 1) == '\\') {
+      slashes++;
+    }
+    return (slashes & 1) == 1;
   }
 }

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -108,34 +108,27 @@ final class RebuttalContradiction {
           Pattern.compile(
               "newVirtualThreadPerTaskExecutor|newCachedThreadPool|newScheduledThreadPool"
                   + "|newWorkStealingPool"),
-          // A fixed pool of more than one thread. A literal count of 1 is excluded, along with the
-          // whitespace and block comments around it, up to the end of the argument — a closing
-          // paren, or the comma of the ThreadFactory overload, which is the standard way to name a
-          // single worker. Every spelling this misses reports a serial pool as concurrent dispatch
-          // and overrules a decline that was right, so the exclusion is written to be hard to spell
-          // around: the paren alone let newFixedThreadPool(1, factory) through, tolerating only
-          // whitespace let a /* one worker */ next to the count through, and a dot that stops at a
-          // line break let that same comment through again once it wrapped. The evidence text is
-          // one string of rejoined lines, so a comment does span line breaks here.
+          // A fixed pool of more than one thread. A literal count of 1 is excluded, along with
+          // the whitespace around it, up to the end of the argument — a closing paren, or the
+          // comma of the ThreadFactory overload, which is the standard way to name a single
+          // worker. Every spelling this misses reports a serial pool as concurrent dispatch and
+          // overrules a decline that was right.
           //
-          // The skip before the count is possessive because a greedy run backtracks to zero width
-          // and re-matches past its own lookahead, which let newFixedThreadPool( 1 ) escape.
-          //
-          // Both bounds are real: a comment longer than 1024 characters, or a seventeenth run of
-          // them, reads as concurrent — a false positive, since the pool is serial. They exist to
-          // keep the scan over untrusted diff text linear, and nothing more should be read into
-          // them. Successive rounds found a justification comment that wrapped, then one that ran
-          // past 64 characters, then one carrying a long URL past 256, each time because the bound
-          // was asserted to sit above "any real" annotation. It does not: a comment is prose and
-          // prose has no bound. Raising this constant again is not the fix — parsing the argument
-          // list instead of pattern-matching it is (#651).
+          // Only whitespace has to be tolerated between the paren and the count because a block
+          // comment explaining the count — /* one worker */, the natural thing to write next to a
+          // pool of one — has already been blanked to spaces by LiveCodeScanner, wrapped across
+          // lines or not. That is what removed the bounds this pattern used to carry: successive
+          // rounds found a justification comment that wrapped, then one past 64 characters, then
+          // one carrying a long URL past 256, each time because the bound had been asserted to sit
+          // above "any real" annotation. A comment is prose and prose has no bound, so the fix was
+          // to stop matching comments at all (#651). A possessive run over whitespace is linear,
+          // needs no bound, and cannot backtrack to zero width and re-match past its own
+          // lookahead, which is what let newFixedThreadPool( 1 ) escape.
           //
           // A count that is not a literal 1 — a variable, or an expression like 1 + 0 — reads as
           // concurrent. That is deliberate and matches newFixedThreadPool(workers): the class may
           // only overrule a decline on what the code plainly shows, and it cannot evaluate.
-          Pattern.compile(
-              "newFixedThreadPool\\s{0,16}\\((?:\\s|/\\*[\\s\\S]{0,1024}?\\*/){0,16}+"
-                  + "(?!1(?:\\s|/\\*[\\s\\S]{0,1024}?\\*/){0,16}[,)])"),
+          Pattern.compile("newFixedThreadPool\\s*+\\(\\s*+(?!1\\s*+[,)])"),
           // handing the work to an executor
           Pattern.compile("\\.(?:submit|execute)\\s{0,16}\\("),
           // an asynchronous future
@@ -195,9 +188,10 @@ final class RebuttalContradiction {
     if (claim == null) {
       return Optional.empty();
     }
-    // Match evidence only against right-side (added/context) code with line comments stripped: a
-    // dispatch the maintainer deleted this revision, or one that survives only in a comment, is not
-    // live code and must not reopen the finding by quoting a line the code no longer runs (F3).
+    // Match evidence only against right-side (added/context) code, with comments and quoted text
+    // taken out of it: a dispatch the maintainer deleted this revision, or one that survives only
+    // in a comment or a string, is not live code and must not reopen the finding by quoting a line
+    // the code no longer runs (F3).
     var rightSide = rightSideCode(reviewedCode);
     Matcher evidence = earliestMatch(CONCURRENT_DISPATCHES, rightSide);
     if (evidence == null) {
@@ -210,205 +204,57 @@ final class RebuttalContradiction {
 
   /**
    * The reviewed patch reduced to the code the revision actually runs: removed ({@code -}) lines
-   * are dropped and line comments are stripped, so a dispatch construct that was deleted or only
-   * mentioned in a comment cannot pose as live evidence. Added ({@code +}) and context lines are
-   * kept across every file in the patch — cross-file evidence is intentional — with the leading
-   * {@code +} marker dropped: the marker exists for display, not for matching, and a construct
-   * whose argument wraps onto a following added line otherwise carries a {@code \n+} in the middle
-   * of its argument gap. That broke the serial-pool exclusion of {@link #CONCURRENT_DISPATCHES} —
-   * {@code newFixedThreadPool(} with the {@code 1)} on the next added line read as concurrent
-   * dispatch, because the {@code +} is neither whitespace nor a comment and hid the count from the
-   * lookahead — precisely on the code a pull request introduces (#761). Only the one marker column
-   * is dropped; the line's own text (indentation included) stays verbatim, and {@link #clip} still
-   * tolerates a marker when quoting.
+   * are dropped and every remaining line is passed through {@link LiveCodeScanner}, so a dispatch
+   * construct that was deleted, or that survives only inside a comment or a string literal, cannot
+   * pose as live evidence. Added ({@code +}) and context lines are kept across every file in the
+   * patch — cross-file evidence is intentional — with the leading {@code +} marker dropped: the
+   * marker exists for display, not for matching, and a construct whose argument wraps onto a
+   * following added line otherwise carries a {@code \n+} in the middle of its argument gap. That
+   * broke the serial-pool exclusion of {@link #CONCURRENT_DISPATCHES} — {@code newFixedThreadPool(}
+   * with the {@code 1)} on the next added line read as concurrent dispatch, because the {@code +}
+   * is neither whitespace nor a comment and hid the count from the lookahead — precisely on the
+   * code a pull request introduces (#761). Only the one marker column is dropped; the line's own
+   * text (indentation included) stays verbatim, and {@link #clip} still tolerates a marker when
+   * quoting.
+   *
+   * <p>The scanner's state is carried from one hunk body line to the next and reset on every other
+   * line, so a text block or a block comment that opens on one added line and closes on the next is
+   * read as one literal, while a delimiter left open cannot blank anything past its own hunk. The
+   * lines that reset it are the ones that are not code in the first place: the {@code diff --git}
+   * and {@code @@} headers, the {@code ### file} heading and the ```` ```diff ```` fence {@code
+   * ReviewDiffFormatter} wraps each patch in — whose backticks would otherwise open a template
+   * literal over the hunk beneath it.
+   *
+   * <p><b>What the scan still cannot decide.</b> Two residues need to know the language, which a
+   * union-of-delimiters scan does not (#651). Python's {@code //} floor division reads as a comment
+   * start and cuts the line, which loses evidence and keeps the decline — the safe direction. A
+   * {@code #} comment is not a comment to this scan at all, so a dispatch named in one still reads
+   * as live code, which is the expensive direction; stripping {@code #} everywhere is not the fix,
+   * since it would cut a C {@code #include} and a CSS colour. The next step for either is a
+   * per-extension profile keyed off the diff header — a language hint the caller does not always
+   * have, since {@code find} is also handed bare patch fragments.
    */
   private static String rightSideCode(String reviewedCode) {
+    var scanner = new LiveCodeScanner();
     var kept = new ArrayList<String>();
     for (var line : reviewedCode.split("\n", -1)) {
       // A unified-diff removed line (and the "---" old-file header) starts with '-'.
       if (line.startsWith("-")) {
         continue;
       }
-      // An added line (and the "+++" new-file header) starts with '+'; drop the marker column.
-      if (line.startsWith("+")) {
-        line = line.substring(1);
+      // An added line starts with '+' and a context line with a space; everything else is a
+      // header, a heading or a fence, and carries no lexical state into or out of itself.
+      var added = line.startsWith("+");
+      var body = added || line.startsWith(" ");
+      if (!body) {
+        scanner.reset();
       }
-      kept.add(stripLineComment(line));
+      kept.add(scanner.scanLine(added ? line.substring(1) : line));
+      if (!body) {
+        scanner.reset();
+      }
     }
     return String.join("\n", kept);
-  }
-
-  /**
-   * Drops a trailing {@code //} line comment, leaving any code before it intact, and blanks the
-   * contents of every closed string literal to spaces (keeping the delimiters, so offsets are
-   * unchanged). A {@code ://} sequence (a URL scheme) is not treated as a comment start, and
-   * neither is a {@code //} that sits inside a string literal.
-   *
-   * <p>The blanking is the over-fire mirror of the carve-out below: keeping the whole line when the
-   * only {@code //} is quoted also kept the literal's contents as scan text, so dispatch text
-   * quoted in a string — {@code "hand work to .submit( here"} — reached {@link
-   * #CONCURRENT_DISPATCHES} and overruled a decline over code that dispatches nothing. Quoted prose
-   * is never live code, so it is erased rather than matched.
-   *
-   * <p>The string-literal carve-out matters because cutting at the wrong {@code //} silently throws
-   * away the rest of the line — including any dispatch construct on it. A line such as {@code
-   * String base = "//cdn.example.com"; executor.submit(task);}, a Go or C++ raw string ({@code
-   * `a//b`}, {@code R"(a//b)"}), or any quoted path holding a doubled slash used to be truncated at
-   * the quoted slashes, so the {@code executor.submit(} after them never reached {@link
-   * #CONCURRENT_DISPATCHES}. A maintainer's "it runs serially" decline then stood unchallenged over
-   * code that does dispatch concurrently — the false-negative direction this class exists to close.
-   *
-   * <p>Quote tracking is deliberately shallow: it toggles on an unescaped {@code "}, {@code '} or
-   * {@code `} and nothing else. It cannot know a language's escaping rules and does not try to.
-   *
-   * <p>An opener with no closer on the line is therefore assumed to have been something else — a
-   * Rust lifetime ({@code &'a ctx}), an apostrophe in prose — and the scan resumes past it,
-   * treating the opener as ordinary text. Without that a single stray apostrophe kept the whole
-   * trailing comment as scan text, and a dispatch named only inside a comment could overrule a
-   * decline — the false-positive direction, which the plain first-{@code //} cut this carve-out
-   * replaced did not have. Resuming quote-aware (rather than cutting at the first bare {@code //}
-   * the opener swallowed) keeps later literals stepped over whole, so {@code &'a ctx; var s =
-   * "//cdn.example.com"; executor.submit(...)} is not truncated inside the closed string.
-   *
-   * <p>The one escaping rule it does keep is where the escape applies: inside a {@code "} or {@code
-   * '} literal, never inside a backtick one and never outside a literal at all. A Go raw string is
-   * backtick-delimited and holds a backslash literally, so honouring the escape there stepped over
-   * the closing backtick of a Windows path ({@code `C:\`}), left the state open for the rest of the
-   * line, and kept a real trailing comment as live code. That is the false positive — a decline
-   * overruled by text the code does not run — which is the worse direction, and the plain
-   * first-{@code //} cut this carve-out replaced did not have it.
-   *
-   * <p>A <em>multi-character</em> delimiter is the case this shallowness does not cover, and it
-   * fails the other way. A Java text block or a C++ raw string whose content holds an interior
-   * quote ({@code """<a href="//host">x</a>"""}, {@code R"(a"b//c)"}) closes the scanner's
-   * single-quote state early, so a {@code //} still inside the literal truncates the line and drops
-   * any dispatch after it — the same false negative the carve-out above exists to close, one legal
-   * interior quote away from the shapes that are covered. Closing it needs delimiter-aware openers
-   * rather than a toggle; tracked in #651.
-   *
-   * <p>Two limits of the blanking are accepted for the same reason — each needs knowledge a
-   * line-scoped toggle cannot have, and both are the tokenizer #651 asks for. A literal spanning
-   * lines (a Go raw string, a Java text block) is not blanked: its opener has no closer on the
-   * line, so it is rescanned as ordinary text, and the content lines carry no delimiter at all —
-   * dispatch text quoted there still over-fires. Carrying quote state across lines is not the fix,
-   * because the scan text is a whole multi-file patch rejoined: one stray delimiter would blank
-   * unrelated files' code and silently drop real dispatches — trading a narrow over-fire for a
-   * broad false negative. And a backtick literal is always blanked whole, including a JavaScript
-   * template literal's {@code ${...}} interpolation, which is live code: a dispatch that appears
-   * only inside an interpolation is missed (under-fire, the decline stands). Telling a JS template
-   * apart from a Go raw string quoting literal {@code ${...}} text needs a language hint; erasing
-   * is the conservative side, since over-fire argues with a maintainer who is right.
-   */
-  private static String stripLineComment(String line) {
-    var out = new StringBuilder(line.length());
-    var i = 0;
-    while (i < line.length()) {
-      var c = line.charAt(i);
-      if (c == '"' || c == '\'' || c == '`') {
-        i = appendBlankedLiteral(line, i, out);
-      } else if (isDoubleSlash(line, i)) {
-        if (i > 0 && line.charAt(i - 1) == ':') {
-          out.append("//");
-          i += 2;
-        } else {
-          return out.toString();
-        }
-      } else {
-        out.append(c);
-        i++;
-      }
-    }
-    return out.toString();
-  }
-
-  /**
-   * Index of the quote closing the literal opened at {@code open}, or {@code -1} when the line ends
-   * first. A backslash escapes the next character in a {@code "} or {@code '} literal and not in a
-   * backtick one, which is a Go raw string and holds the backslash literally.
-   */
-  private static int endOfLiteral(String line, int open) {
-    var quote = line.charAt(open);
-    var i = open + 1;
-    while (i < line.length()) {
-      var c = line.charAt(i);
-      if (c == '\\' && quote != '`') {
-        i += 2;
-      } else if (c == quote) {
-        return i;
-      } else {
-        i++;
-      }
-    }
-    return -1;
-  }
-
-  /**
-   * Handles the quote opener at {@code open}: appends its rendering to {@code out} and returns the
-   * index the scan resumes at. A closed literal is stepped over whole — and blanked. Its delimiters
-   * stay (space for space, so every offset after it is unchanged and lineAround still quotes the
-   * real line shape), but its contents are prose, not code the revision runs: a log message, an
-   * error string or a fixture that mentions ".submit(" must not read as live dispatch and overrule
-   * a decline that was right. An opener that never closes — or a lone apostrophe (a Rust lifetime)
-   * paired with a later char literal's opener, whose "span" is really live code — was not one; it
-   * is appended verbatim and rescanned as ordinary text.
-   */
-  private static int appendBlankedLiteral(String line, int open, StringBuilder out) {
-    var quote = line.charAt(open);
-    var close = endOfLiteral(line, open);
-    out.append(quote);
-    if (close < 0 || isMisreadApostrophePair(line, quote, open, close)) {
-      return open + 1;
-    }
-    out.append(" ".repeat(close - open - 1));
-    out.append(line.charAt(close));
-    return close + 1;
-  }
-
-  /**
-   * Whether a {@code '}-quoted span is really two unrelated apostrophes with live code between
-   * them, rather than a literal. A lone apostrophe in non-string context — a Rust lifetime ({@code
-   * &'a ctx}, {@code foo::<'a>}) — followed later on the line by a real char literal ({@code '\n'})
-   * or another lifetime pairs with that later apostrophe, and blanking the span would erase any
-   * dispatch between them: a false negative the pre-blanking scanner did not have. Three tells mark
-   * a span as misread, each shaped so genuine quoted prose (which may hold {@code .submit(} text —
-   * the very thing the blanking exists to erase) keeps blanking: the opener sits directly after
-   * {@code &} or {@code <}, which is Rust lifetime syntax and never a string opener; the span holds
-   * a {@code ;}, which is statement shape, not prose; or the pairing closer itself opens a
-   * char-literal-shaped span, meaning the "closer" was really the next literal's opener. The
-   * residual miss — quoted prose that defeats every tell and also names a dispatch construct — is
-   * far narrower than erasing arbitrary real code. Double-quote and backtick openers have no
-   * lifetime-style bare use, so the guard applies to {@code '} alone.
-   */
-  private static boolean isMisreadApostrophePair(String line, char quote, int open, int close) {
-    if (quote != '\'') {
-      return false;
-    }
-    // Lifetime position: an apostrophe directly after & or < ( &'a ctx, foo::<'a> ) is Rust
-    // syntax, never a string opener, whatever its span holds.
-    if (open > 0 && (line.charAt(open - 1) == '&' || line.charAt(open - 1) == '<')) {
-      return true;
-    }
-    // Statement separator: a ; inside the span is code shape, not quoted prose.
-    if (line.substring(open + 1, close).indexOf(';') >= 0) {
-      return true;
-    }
-    // The pairing closer itself opens a char-literal-shaped span — '\n', ',', or a longer escape
-    // like a Rust unicode char (backslash-u{1F600}): the "closer" was really the next literal's
-    // opener, and everything between the two apostrophes is live code. Char-shaped means at most
-    // two characters — one character or a simple escape — or an escape sequence: backslash-led
-    // and short enough for the longest real spelling, Rust's backslash-u{10FFFF} at 9 characters.
-    // Ten leaves a margin without reading a backslash-led prose span as a char.
-    var closerAsOpener = endOfLiteral(line, close);
-    if (closerAsOpener < 0) {
-      return false;
-    }
-    var charSpan = line.substring(close + 1, closerAsOpener);
-    return charSpan.length() <= 2 || (charSpan.length() <= 10 && charSpan.charAt(0) == '\\');
-  }
-
-  /** Whether a doubled slash sits at {@code at}. */
-  private static boolean isDoubleSlash(String line, int at) {
-    return line.charAt(at) == '/' && at + 1 < line.length() && line.charAt(at + 1) == '/';
   }
 
   /**

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradiction.java
@@ -232,7 +232,9 @@ final class RebuttalContradiction {
    * as live code, which is the expensive direction; stripping {@code #} everywhere is not the fix,
    * since it would cut a C {@code #include} and a CSS colour. The next step for either is a
    * per-extension profile keyed off the diff header — a language hint the caller does not always
-   * have, since {@code find} is also handed bare patch fragments.
+   * have, since {@code find} is also handed bare patch fragments. The header already settles one
+   * fact where it is present: whether a backslash escapes inside a backtick literal ({@link
+   * LiveCodeScanner#fileNamed}).
    */
   private static String rightSideCode(String reviewedCode) {
     var scanner = new LiveCodeScanner();
@@ -248,6 +250,9 @@ final class RebuttalContradiction {
       var body = added || line.startsWith(" ");
       if (!body) {
         scanner.reset();
+      }
+      if (line.startsWith("diff --git ")) {
+        scanner.fileNamed(line);
       }
       kept.add(scanner.scanLine(added ? line.substring(1) : line));
       if (!body) {

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -839,4 +839,281 @@ class RebuttalContradictionTest {
     assertTrue(contradiction.isPresent());
     assertEquals("pool.submit(task);", contradiction.get().evidence());
   }
+
+  /**
+   * A multi-character delimiter whose content legally holds an interior quote. The single-character
+   * quote toggle the scanner used to run closed on that quote, so a {@code //} still inside the
+   * literal truncated the line and the dispatch after it never reached the matcher — the
+   * false-negative direction, which lets a decline that was wrong stand (#651).
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // A Java text block quoting HTML: idiomatic in a Java 25 codebase, not exotic.
+        "+    var html = \"\"\"<a href=\"//cdn.example.com\">x</a>\"\"\";"
+            + " executor.submit(() -> run(ctx));",
+        // A Python triple-quoted string holding an apostrophe.
+        "+    s = '''a'b//c'''; executor.submit(lambda: run(ctx))",
+        // C++ raw strings: bare, with a named delimiter, and with an encoding prefix.
+        "+    auto path = R\"(a\"b//c)\"; executor.submit([]{ run(ctx); });",
+        "+    auto q = R\"sql(a\"b//c)sql\"; executor.submit([]{ run(ctx); });",
+        "+    auto p = u8R\"(a\"b//c)\"; executor.submit([]{ run(ctx); });",
+        // An escape inside a text block does not close it early either.
+        "+    var t = \"\"\"a\\\"b//c\"\"\"; executor.submit(() -> run(ctx));",
+        // A raw string in the first column: the prefix scan must stop at the start of the line.
+        "+R\"(a\"b//c)\"; executor.submit(() -> run(ctx));",
+      })
+  void shouldKeepDispatchAfterALiteralWhoseInteriorQuoteDoesNotCloseIt(String codeLine) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine).isPresent(),
+        "the interior quote does not close the literal, so the dispatch after it is live code: "
+            + codeLine);
+  }
+
+  /** A literal that stays open at the end of a line resumes on the next line of the same hunk. */
+  @Test
+  void shouldKeepDispatchAfterATextBlockWhoseEscapeEndsTheLine() {
+    var code = "+    var t = \"\"\"a\\\n+        b\"\"\"; executor.submit(() -> run(ctx));\n";
+
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", code).isPresent(),
+        "the text block closes on the second line, so the dispatch after it is live code");
+  }
+
+  /**
+   * Dispatch text inside a block comment is not live code. The scan stripped line comments and
+   * nothing else, so a construct sitting in a block comment was quoted back as evidence and
+   * overruled a maintainer whose decline was right — the over-fire direction (#651).
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "+    var n = count; /* executor.submit(() -> run(ctx)); */\n+    run(ctx);\n",
+        "+    /* one dispatch we removed:\n+     * executor.submit(() -> run(ctx));\n"
+            + "+     */\n+    run(ctx);\n",
+      })
+  void shouldNotTreatDispatchTextInsideABlockCommentAsEvidence(String code) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", code).isEmpty(),
+        "a dispatch named only in a block comment is not live code and keeps the decline: " + code);
+  }
+
+  /** The mirror: a closed block comment must not swallow the live code that follows it. */
+  @Test
+  void shouldKeepDispatchAfterAClosedBlockComment() {
+    var codeLine = "+    /* deferred */ executor.submit(() -> run(ctx));\n";
+
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine).isPresent(),
+        "the dispatch sits after the block comment, so it is live code");
+  }
+
+  /**
+   * A literal that spans lines — a text block, a Go raw string, a C++ raw string — carries its
+   * state to the next line of the same hunk, so the dispatch text quoted inside it is blanked
+   * rather than matched as live code (#651).
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "+    var doc = \"\"\"\n+        hand work to executor.submit(task) here\n"
+            + "+        \"\"\";\n",
+        "+    doc := `\n+      each event calls handler.submit(ctx)\n+    `\n",
+        "+    auto sql = R\"sql(\n+      hand work to executor.submit(task)\n+    )sql\";\n",
+      })
+  void shouldNotTreatDispatchTextInsideALiteralThatSpansLinesAsEvidence(String code) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", code).isEmpty(),
+        "the dispatch text is quoted inside a multi-line literal, so it is not live code: " + code);
+  }
+
+  /**
+   * A JavaScript template literal's {@code ${…}} interpolation is live code, not quoted text.
+   * Blanking the backtick literal whole erased a real dispatch sitting inside one — the
+   * false-negative direction, opposite to the quoted-text over-fire the blanking exists to close.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "+    const m = `job ${executor.submit(task)} queued`;",
+        // A template nested inside an interpolation of another template.
+        "+    const m = `a ${ `b ${executor.submit(t)}` } c`;",
+        // Braces inside the interpolation must not close it early.
+        "+    const m = `${ fn({k: v}) } ${executor.submit(t)}`;",
+      })
+  void shouldKeepDispatchInsideATemplateLiteralInterpolation(String codeLine) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine).isPresent(),
+        "an interpolation is live code, so the dispatch inside it refutes the decline: "
+            + codeLine);
+  }
+
+  /** The mirror: a string literal inside an interpolation is still quoted text. */
+  @Test
+  void shouldNotTreatQuotedTextInsideATemplateInterpolationAsEvidence() {
+    var codeLine = "+    const m = `${map[\"hand work to .submit( here\"]}`;\n";
+
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine).isEmpty(),
+        "the dispatch text sits in a string inside the interpolation, so it is not live code");
+  }
+
+  /**
+   * A statement label ends in a colon too, so testing only the character before the slashes read
+   * {@code case 1://} as a URL scheme and kept the real comment after it as live code — the
+   * over-fire direction, where a dispatch named only in a comment overrules a correct decline.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "+    case 1:// executor.submit(() -> run(ctx));",
+        "+    default:// note: executor.submit(() -> run(ctx));",
+        "+  retry:// executor.submit(() -> run(ctx));",
+      })
+  void shouldNotTreatALabelColonAsAUrlScheme(String codeLine) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine).isEmpty(),
+        "the colon belongs to a label, so what follows is a comment: " + codeLine);
+  }
+
+  /**
+   * The scheme carve-out used to skip exactly one slash pair, so a URL whose own path holds a
+   * doubled slash was cut at the second pair and the dispatch after it was lost. A recognised
+   * scheme now consumes the whole URL token.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "+    var url = http://example.com//v1; executor.submit(() -> run(ctx));",
+        "+    var url = https://example.com//v1//v2; executor.submit(() -> run(ctx));",
+        "+    var f = file:///etc//hosts; executor.submit(() -> run(ctx));",
+        // A URL in the first column: the scheme scan must stop at the start of the line.
+        "+http://example.com//v1; executor.submit(() -> run(ctx));",
+        // A URL that runs to the end of the line, with the dispatch before it.
+        "+    executor.submit(() -> run(ctx)); var u = http://example.com//v1",
+      })
+  void shouldKeepDispatchAfterAUrlWhosePathHoldsADoubledSlash(String codeLine) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine).isPresent(),
+        "the doubled slash belongs to the URL, so the dispatch after it is live code: " + codeLine);
+  }
+
+  /**
+   * {@code R"} only opens a raw string when a well-formed delimiter and its {@code (} follow, and
+   * when it is not the tail of an identifier. Everything else falls back to a plain string literal,
+   * which is what the scan did before raw strings were modelled.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // No ( at all: an ordinary string with an R in front of it (a Python raw string).
+        "+    var s = R\"nodelim\"; executor.submit(() -> run(ctx));",
+        // Whitespace cannot appear in a C++ raw-string delimiter.
+        "+    var s = R\"a b(c)\"; executor.submit(() -> run(ctx));",
+        // A delimiter longer than any real one.
+        "+    var s = R\"abcdefghijklmnopqr(x)\"; executor.submit(() -> run(ctx));",
+        // The R is the last character of an identifier, not a raw-string prefix.
+        "+    var s = fooR\"(a)\"; executor.submit(() -> run(ctx));",
+        // A capital R that opens no literal at all.
+        "+    Runnable r = () -> run(ctx); executor.submit(r);",
+      })
+  void shouldFallBackToAPlainStringWhenARawStringOpenerIsNotWellFormed(String codeLine) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", codeLine).isPresent(),
+        "the literal closes at its quote, so the dispatch after it is live code: " + codeLine);
+  }
+
+  /**
+   * Carried state is bounded to one hunk. An unclosed block comment blanks the rest of the hunk it
+   * opens in — the safe direction, since blanking only ever keeps a decline — and the next hunk
+   * header starts from live code again, so one stray delimiter cannot silence a whole patch.
+   */
+  @Test
+  void shouldBoundCarriedLexicalStateToTheHunkThatOpensIt() {
+    var withinHunk =
+        """
+        diff --git a/Worker.java
+        @@ -1,2 +1,4 @@
+        +    var n = count; /* deferred:
+        +    executor.submit(() -> run(ctx));
+        """;
+
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", withinHunk).isEmpty(),
+        "an unclosed block comment blanks the rest of its hunk, which keeps the decline");
+
+    var nextHunk =
+        """
+        diff --git a/Worker.java
+        @@ -1,2 +1,3 @@
+        +    var n = count; /* deferred:
+        @@ -20,2 +20,3 @@
+        +    executor.submit(() -> run(ctx));
+        """;
+
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", nextHunk).isPresent(),
+        "the hunk header ends the carried state, so the next hunk's dispatch is live code");
+  }
+
+  /**
+   * A patch whose hunk starts inside a Java text block shows the closing delimiter without its
+   * opener — the shape a diff of this repository's own history produces constantly, since a text
+   * block constant sits just above the code most hunks touch. Reading that closer as an opener
+   * inverts every literal below it and blanks the live code in between, which is the false-negative
+   * this scan exists to avoid; a delimiter with a statement terminator after it ends a literal, it
+   * does not start one (JLS 3.10.6).
+   */
+  @Test
+  void shouldNotReadATextBlockCloserAtTheTopOfAHunkAsAnOpener() {
+    var midLiteral =
+        "diff --git a/ReviewResult.java\n"
+            + "@@ -340,6 +385,10 @@ public record ReviewResult(\n"
+            + " \n"
+            + "       \"\"\";\n"
+            + " \n"
+            + "+    executor.submit(() -> run(ctx));\n";
+
+    var contradiction = RebuttalContradiction.find(RACE_FINDING, "It runs serially.", midLiteral);
+
+    assertTrue(
+        contradiction.isPresent(),
+        "the hunk opens inside a text block, so its first delimiter closes one and the dispatch"
+            + " below it is live code");
+    assertEquals("executor.submit(() -> run(ctx));", contradiction.get().evidence());
+
+    // The other spelling of the same closer: a text block concatenated with what follows it, where
+    // the terminator sits a space away from the delimiter.
+    var concatenated =
+        "diff --git a/ReviewResult.java\n"
+            + "@@ -340,6 +385,10 @@ public record ReviewResult(\n"
+            + " \n"
+            + "       \"\"\" + SUFFIX;\n"
+            + "+    executor.submit(() -> run(ctx));\n";
+
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", concatenated).isPresent(),
+        "a closer whose terminator is a space away still ends a literal rather than starting one");
+  }
+
+  /**
+   * The reviewed code arrives as {@code ReviewDiffFormatter} builds it: file sections whose patch
+   * sits inside a ```` ```diff ```` fence. A fence line is not a diff body line, so its backticks
+   * must not open a template literal that blanks the hunk under it.
+   */
+  @Test
+  void shouldNotLetAMarkdownFenceInTheFormattedDiffBlankTheHunk() {
+    var formatted =
+        """
+        ### src/main/java/Worker.java (modified, +1 -0)
+        ```diff
+        @@ -1,2 +1,3 @@
+        +    executor.submit(() -> run(ctx));
+        ```
+        """;
+
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", formatted).isPresent(),
+        "the ```diff fence is a section delimiter, not a literal opener");
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -889,8 +889,12 @@ class RebuttalContradictionTest {
   @ValueSource(
       strings = {
         "+    var n = count; /* executor.submit(() -> run(ctx)); */\n+    run(ctx);\n",
-        "+    /* one dispatch we removed:\n+     * executor.submit(() -> run(ctx));\n"
-            + "+     */\n+    run(ctx);\n",
+        """
+        +    /* one dispatch we removed:
+        +     * executor.submit(() -> run(ctx));
+        +     */
+        +    run(ctx);
+        """,
       })
   void shouldNotTreatDispatchTextInsideABlockCommentAsEvidence(String code) {
     assertTrue(
@@ -916,8 +920,11 @@ class RebuttalContradictionTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "+    var doc = \"\"\"\n+        hand work to executor.submit(task) here\n"
-            + "+        \"\"\";\n",
+        """
+        +    var doc = \"""
+        +        hand work to executor.submit(task) here
+        +        \""";
+        """,
         "+    doc := `\n+      each event calls handler.submit(ctx)\n+    `\n",
         "+    auto sql = R\"sql(\n+      hand work to executor.submit(task)\n+    )sql\";\n",
       })
@@ -1067,12 +1074,14 @@ class RebuttalContradictionTest {
   @Test
   void shouldNotReadATextBlockCloserAtTheTopOfAHunkAsAnOpener() {
     var midLiteral =
-        "diff --git a/ReviewResult.java\n"
-            + "@@ -340,6 +385,10 @@ public record ReviewResult(\n"
-            + " \n"
-            + "       \"\"\";\n"
-            + " \n"
-            + "+    executor.submit(() -> run(ctx));\n";
+        """
+        diff --git a/ReviewResult.java
+        @@ -340,6 +385,10 @@ public record ReviewResult(
+        \s
+               \""";
+        \s
+        +    executor.submit(() -> run(ctx));
+        """;
 
     var contradiction = RebuttalContradiction.find(RACE_FINDING, "It runs serially.", midLiteral);
 
@@ -1085,15 +1094,114 @@ class RebuttalContradictionTest {
     // The other spelling of the same closer: a text block concatenated with what follows it, where
     // the terminator sits a space away from the delimiter.
     var concatenated =
-        "diff --git a/ReviewResult.java\n"
-            + "@@ -340,6 +385,10 @@ public record ReviewResult(\n"
-            + " \n"
-            + "       \"\"\" + SUFFIX;\n"
-            + "+    executor.submit(() -> run(ctx));\n";
+        """
+        diff --git a/ReviewResult.java
+        @@ -340,6 +385,10 @@ public record ReviewResult(
+        \s
+               \""" + SUFFIX;
+        +    executor.submit(() -> run(ctx));
+        """;
 
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "It runs serially.", concatenated).isPresent(),
         "a closer whose terminator is a space away still ends a literal rather than starting one");
+  }
+
+  /**
+   * A text block that ends an array initialiser or a subscript is followed by a brace or a bracket,
+   * neither of which was a statement terminator to the closer rule — so the delimiter that ends it
+   * read as an <em>opener</em> and blanked the live code below it, which is the very case the rule
+   * was written to prevent for {@code """;} (#651).
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // The last element of an array initialiser: the closer, a brace, a semicolon.
+        "};",
+        // A text block used as a subscript, or the last element of a list literal.
+        "];",
+      })
+  void shouldReadATextBlockCloserFollowedByABraceOrABracketAsACloser(String terminator) {
+    var code =
+        """
+        diff --git a/Fixtures.java
+        @@ -340,6 +385,10 @@ final class Fixtures {
+        \s
+               \"""%s
+        +    executor.submit(() -> run(ctx));
+        """
+            .formatted(terminator);
+
+    var contradiction = RebuttalContradiction.find(RACE_FINDING, "It runs serially.", code);
+
+    assertTrue(
+        contradiction.isPresent(),
+        "the delimiter closes the initialiser's text block, so the dispatch below it is live code: "
+            + terminator);
+    assertEquals("executor.submit(() -> run(ctx));", contradiction.get().evidence());
+  }
+
+  /**
+   * The closer rule holds only where a language forbids a body after the opener (JLS 3.10.6). A Go
+   * raw string and a JavaScript template literal start their body immediately, so a body that opens
+   * with a statement terminator made the scan read the literal's own <em>closing</em> backtick as
+   * an opener, push a region, and blank the real dispatch on the next line — the false-negative
+   * class this scan exists to close (#651).
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // Go: a raw string holding a separator, dispatch on the next body line.
+        "+    sep := `;abc`\n+    executor.submit(() -> run(ctx));\n",
+        // Kotlin and Python do let a triple-quoted body follow the opener, so a literal that closes
+        // on its own line opened one however its body starts — the closer rule may not claim it.
+        "+    val sep = \"\"\", \"\"\"\n+    executor.submit(task);\n",
+        "+    tail = '''); END'''\n+    executor.submit(task)\n",
+      })
+  void shouldNotReadALiteralsOwnCloserAsAnOpenerWhenItsBodyStartsWithATerminator(String code) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", code).isPresent(),
+        "the literal closes on its own line, so the dispatch after it is live code: " + code);
+  }
+
+  /**
+   * The mirror of the same misreading: scanned as a closer, the whole line stayed live and the
+   * dispatch words quoted inside the literal were matched as evidence, overruling a decline that
+   * was right — the expensive direction (#651).
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "+    const m = `, hand work to .submit( here`;\n",
+        "+    s = '''; hand work to .submit( here'''\n",
+      })
+  void shouldNotTreatQuotedTextAsLiveBecauseItsBodyStartsWithATerminator(String code) {
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", code).isEmpty(),
+        "the dispatch text sits inside the literal, so it is not live code: " + code);
+  }
+
+  /**
+   * What restricting the rule costs, kept explicit: a hunk that starts inside a Go raw string shows
+   * only its closing backtick, which now reads as an opener and blanks the rest of the hunk. That
+   * is the under-fire direction — a decline that stands is this class's default outcome — and it is
+   * the side every ambiguity here is resolved toward, unlike the reading it replaces, which made a
+   * template literal's own quoted body live code.
+   */
+  @Test
+  void shouldBlankTheHunkWhenOnlyAGoRawStringsClosingBacktickIsVisible() {
+    var code =
+        """
+        diff --git a/worker.go
+        @@ -10,4 +10,6 @@ func run(ctx context.Context) {
+             hand work to executor.submit here
+           `)
+        +  executor.submit(func() { handle(ctx) })
+        """;
+
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "It runs serially.", code).isEmpty(),
+        "a lone backtick has no reading that is safe both ways, so it blanks and keeps the decline");
   }
 
   /**

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -1174,6 +1174,10 @@ class RebuttalContradictionTest {
       strings = {
         "+    const m = `, hand work to .submit( here`;\n",
         "+    s = '''; hand work to .submit( here'''\n",
+        // The same shape spanning lines, where nothing on the opener's line can close it:
+        // Python is the only language in the corpus that spells a literal with ''', and it
+        // lets the body follow the opener, so the rule has no premise to stand on there.
+        "+    s = '''; hand work to executor.submit(task)\n+    and more'''\n",
       })
   void shouldNotTreatQuotedTextAsLiveBecauseItsBodyStartsWithATerminator(String code) {
     assertTrue(

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -1228,4 +1228,103 @@ class RebuttalContradictionTest {
         RebuttalContradiction.find(RACE_FINDING, "It runs serially.", formatted).isPresent(),
         "the ```diff fence is a section delimiter, not a literal opener");
   }
+
+  /** A legal C++ raw-string delimiter runs to sixteen characters; the window has to see the '('. */
+  @Test
+  void readsARawStringWithTheMaximalDelimiter() {
+    var diff =
+        """
+        diff --git a/src/a.cc b/src/a.cc
+        @@ -1,2 +1,3 @@
+        +    auto s = R"0123456789abcdef(a"b//c)0123456789abcdef"; executor.submit(run);
+        """;
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff)
+            .isPresent(),
+        "the dispatch after a maximal-delimiter raw string is live code and must be seen");
+  }
+
+  /**
+   * A trailing backslash carries a single-line literal onto the next line; its body stays quoted.
+   */
+  @Test
+  void keepsABackslashContinuedStringQuotedOnTheNextLine() {
+    var diff =
+        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,4 @@\n"
+            + "+    const char* s = \"log: hand work to \\\n"
+            + "+        executor.execute( here\"; return 0;\n";
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff).isEmpty(),
+        "the continued literal's remainder is quoted text, not a dispatch");
+  }
+
+  /** Trailing whitespace after the continuation backslash is still a continuation. */
+  @Test
+  void keepsAContinuedStringQuotedWhenSpacesFollowTheBackslash() {
+    var diff =
+        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,4 @@\n"
+            + "+    const char* s = \"log: hand work to \\   \n"
+            + "+        executor.execute( here\"; return 0;\n";
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff).isEmpty(),
+        "spaces after the backslash do not turn the literal back into live code");
+  }
+
+  /** An escaped backslash at the line end is a character, not a continuation. */
+  @Test
+  void readsAnEscapedBackslashAtLineEndAsNoContinuation() {
+    var diff =
+        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,4 @@\n"
+            + "+    const char* s = \"path\\\\\"; \n"
+            + "+    executor.execute(run);\n";
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff)
+            .isPresent(),
+        "the literal closed on its own line, so the dispatch below it is live");
+  }
+
+  /** A line that is nothing but backslashes is read to its start without running past it. */
+  @Test
+  void readsALineOfOnlyBackslashesAsAContinuation() {
+    var diff =
+        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,5 @@\n"
+            + "+    const char* s = \"hand work to \\"
+            + "\n+\\\n"
+            + "+        executor.execute( here\"; return 0;\n";
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff).isEmpty(),
+        "the literal is still open across the backslash-only line");
+  }
+
+  @Test
+  void readsAQuoteFollowedOnlyBySpacesAsProse() {
+    var diff =
+        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,5 @@\n"
+            + "+    puts(\"   \n"
+            + "+    executor.execute(work);\n";
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff)
+            .isPresent(),
+        "a lone quote with nothing after it opens no literal, so the next line is live code");
+  }
+
+  @Test
+  void readsABodyOfOnlyBackslashesByParity() {
+    var continued =
+        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,5 @@\n"
+            + "+    const char* s = \"\\\\\\"
+            + "\n+        executor.execute( here\"; return 0;\n";
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", continued)
+            .isEmpty(),
+        "three backslashes are an escaped one plus a continuation");
+    var escaped =
+        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,5 @@\n"
+            + "+    const char* s = \"\\\\"
+            + "\n+    executor.execute(work);\n";
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", escaped)
+            .isPresent(),
+        "two backslashes are one escaped backslash and no continuation");
+  }
 }

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -1327,4 +1327,38 @@ class RebuttalContradictionTest {
             .isPresent(),
         "two backslashes are one escaped backslash and no continuation");
   }
+
+  /**
+   * #651 review. The backtick is Go's raw string and JavaScript's template literal, and the two
+   * disagree on a backslash. In a JavaScript file {@code \`} is an escaped backtick; reading it as
+   * the closer scanned the rest of the literal as live code and overruled a maintainer who was
+   * right. The diff header names the file, and its extension decides.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"js", "jsx", "mjs", "cjs", "ts", "tsx", "mts", "cts", "vue", "svelte"})
+  void keepsAnEscapedBacktickInsideATemplateLiteral(String extension) {
+    var diff =
+        "diff --git a/src/a.%s b/src/a.%s\n@@ -1,3 +1,5 @@\n".formatted(extension, extension)
+            + "+    const m = `prefix \\` hand work to executor.submit(task) here`;\n";
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff).isEmpty(),
+        "the escaped backtick does not close the template literal in a ." + extension + " file");
+  }
+
+  /**
+   * The Go reading stays where the file is not JavaScript, or names no extension at all: the
+   * backslash is literal, the backtick after it closes the raw string, and the code after it is
+   * live.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"src/a.go", "src/Makefile", "src/v1.2/README"})
+  void readsABackslashAsLiteralInsideABacktickOutsideJavaScript(String path) {
+    var diff =
+        "diff --git a/%s b/%s\n@@ -1,3 +1,5 @@\n".formatted(path, path)
+            + "+    s := `C:\\`; executor.submit(task)\n";
+    assertTrue(
+        RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff)
+            .isPresent(),
+        "a backslash before the closing backtick is literal in " + path);
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 🔧 Refactor

## Description

## Problem

`RebuttalContradiction` may only overrule a maintainer's "this runs serially"
decline on code the revision actually runs, so it has to tell live code from
quoted text. It did that with a character walk that toggled quote state on any
single `"`, `'` or `` ` ``, plus one tell per shape the toggle got wrong. Every
delimiter the walk did not model was a defect, and they ran in both directions:

- **Over-fire** — quoted text read as live code, which argues with a maintainer
  who is right: a dispatch inside a block comment, inside a multi-line literal,
  or after `case 1://` (a label colon read as a URL scheme) counted as evidence.
- **Under-fire** — live code blanked or cut, which lets a wrong decline stand: a
  Java text block or C++ raw string holding an interior quote closed the toggle
  early, so the `//` still inside the literal truncated the line; a template
  literal's `${…}` interpolation was blanked whole though it is live code; a URL
  whose own path holds `//` was cut at the second pair.

#651 asks for the decision rather than a seventh tell.

## What this does

The walk is replaced by `LiveCodeScanner`, a small explicit state machine over
the hunk. One delimiter table — text blocks and triple quotes, C++ raw strings,
template literals and Go raw strings, quotes, char literals, block comments —
drives the states, and a stack carries a template literal's interpolation (live
code inside a quoted run) and the multi-line delimiters from one hunk body line
to the next.

**Why a state machine and not another tell.** The shapes left over are not more
tells, they are more *states*: naming them once and letting a table drive them is
what stops the class of bug recurring, and it deletes tells rather than adding
them. Blanking block comments upstream, for instance, removed the 1024-character
and 16-run bounds `newFixedThreadPool`'s serial-pool exclusion carried — three
review rounds had raised those bounds in turn, each time because a justification
comment ran past the last one. The issue asked for the "hard to spell around"
claim above that pattern to go when this was fixed properly; it is gone.

**Why not a lexer per language.** The delimiter table is the union of the shapes
the reviewed diffs carry, which answers every shape whose delimiters are
unambiguous across the corpus. A per-language profile would need a lexical spec
per language and a file header the caller does not always supply — `find` is also
handed bare patch fragments. Two ambiguities genuinely need that hint and are
left alone, documented, both failing by blanking: Python's `//` floor division,
and a Rust lifetime that pairs with a later apostrophe when neither a `&`/`<`
prefix, a `;` in the span, nor a char-shaped closer marks it.

**Which way it errs.** Toward *quoted*. When this class fires it overrules a
human, so an over-fire costs an argument with a maintainer who was right, while
an under-fire leaves the decline standing — the class's default outcome anyway.
So an opener whose closer never arrives blanks the rest of its hunk, and an
unlisted URL scheme reads as a comment. The single exception is `${…}`, which is
read as live code: blanking it erased real dispatches, and the over-fire it
admits needs a Go raw string that quotes `${…}` text *and* names a dispatch
construct inside those braces.

**How far state is carried.** Only from one diff body line to the next, and only
for the delimiters designed to span lines. The scanner is reset at every line
that is not a hunk body line — `diff --git` and `@@` headers, the `### file`
heading, the ` ```diff ` fence `ReviewDiffFormatter` wraps each patch in — so one
stray delimiter cannot silence anything past its own hunk, and the fence's own
backticks cannot open a template literal over the hunk beneath it.

## States fixed

| State | Direction it failed | Now |
| --- | --- | --- |
| Java text block / triple quote with an interior quote | under-fire | closes at `"""`, not at the interior quote |
| C++ raw string `R"delim( … )delim"` (incl. `u8R"`) | under-fire | closes at its own delimiter |
| Multi-line literal body (text block, Go raw string, raw string) | over-fire | blanked across the hunk's lines |
| Block comment, single- and multi-line | over-fire | blanked, delimiters included |
| Template literal `${…}` interpolation | under-fire | scanned as live code, brace-nested |
| `case 1://`, `default://note` — a label colon read as a scheme | over-fire | only a listed scheme opens a URL |
| `http://host//v1` — a doubled slash in a URL path | under-fire | the whole URL token is consumed |
| A hunk that starts inside a text block | under-fire | a delimiter with a statement terminator after it closes, it does not open |

The last one is not in the issue; measurement found it. Reading the closer that
opens such a hunk as an opener inverts every literal below it: over 80 commits of
this repository's own history (32535 right-side Java lines) that blanked 57
statement-shaped lines, live methods of `ReviewResult` among them. With the rule,
23 remain and every one is the body of a text block quoting a diff or a JSON
payload — the text that must be blanked.

## Left deliberately

- **Python `//` floor division** cuts the line as if it were a comment. It needs
  a language hint; it fails by cutting, so the decline stands.
- **A `#` comment** is not a comment to this scan, so a dispatch named in one
  reads as live code. Stripping `#` everywhere would cut `#include` and CSS
  colours; it needs the same hint. Recorded in the javadoc.
- **The Rust lifetime residue**: two lifetimes with live code and no `;` between
  them blanks that code. The three tells are kept as they were rather than grown.
- The issue comment's "long char-literal escapes (`'\u{1F600}'`) are missed" was
  checked against the code and is not so — the tell already admits escapes up to
  ten characters, and `'\u{1F600}'` / `'A'` have had tests since #780. They
  stay green.

## Tests

Every state has a test through the real entry point, `RebuttalContradiction.find`
with a diff fixture — no private helper is called directly. New: text blocks,
triple quotes, C++ raw strings (bare, named delimiter, encoding prefix, and four
malformed shapes that must fall back to a plain string), block comments,
multi-line literals, template interpolations (nested, and with braces inside),
label colons, URL paths, the hunk-boundary bound, the ` ```diff ` fence, and the
mid-text-block hunk start.

Red/green: the 20 new cases covering the issue's states fail against `main` with
verbatim assertion failures, and the mid-text-block case fails against the state
machine without the closer rule. Full suite: 3493 tests, 0 failures, 0 errors.
Patch coverage: every changed line and branch in `LiveCodeScanner` and
`RebuttalContradiction` is covered by `RebuttalContradictionTest` alone.

## Related Issues

Closes #651

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

Local gates: `spotless:apply`, `clean compile spotbugs:check spotless:check`
(BugInstance size is 0), `clean test` (3493 tests, 0 failures). Coverage measured
by intersecting `target/site/jacoco/jacoco.xml` with `git diff -U0 origin/main`.
Behaviour measured by scanning 80 commits of this repository's own history
(44477 right-side lines) and counting the live-code lines the scan blanked.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

`LiveCodeScanner` is package-private and has no test of its own on purpose: every
case is driven through `RebuttalContradiction.find`, so the tests pin the
behaviour the bot has rather than the shape of the helper.
