### PR TITLE
refactor(review): clear the Sonar smells left by #788, #790 and #791

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LiveCodeScanner.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/LiveCodeScanner.java
@@ -324,18 +324,8 @@ final class LiveCodeScanner {
       if (closesLiteralOpenedAboveTheHunk(line, body, delimiter)) {
         return -1;
       }
-      if (!delimiter.spansLines()) {
-        var close = closerIndex(line, body, delimiter.close());
-        // A single-line literal may still run on: C, C++ and Python continue a string across a
-        // line break with a trailing backslash. Reading the unclosed quote as ordinary text would
-        // scan the literal's remainder as live code, which is the over-fire direction. The region
-        // is carried on the stack instead and closes on the line that closes it.
-        if (close < 0 && !continuesOnNextLine(line, body)) {
-          return -1;
-        }
-        if (close >= 0 && isMisreadApostrophePair(line, delimiter.open().charAt(0), i, close)) {
-          return -1;
-        }
+      if (!delimiter.spansLines() && opensNoLiteral(line, i, body, delimiter)) {
+        return -1;
       }
       // The backtick is the only delimiter in the table that does not escape on its own, so the
       // file hint only ever changes that one row.
@@ -345,6 +335,23 @@ final class LiveCodeScanner {
       return body;
     }
     return -1;
+  }
+
+  /**
+   * Whether a delimiter that cannot span lines opened nothing at {@code i}: it has no closer on its
+   * line and no continuation to carry it on, or the pair it closes is a misread apostrophe pair.
+   *
+   * <p>A single-line literal may still run on: C, C++ and Python continue a string across a line
+   * break with a trailing backslash. Reading the unclosed quote as ordinary text would scan the
+   * literal's remainder as live code, which is the over-fire direction. The region is carried on
+   * the stack instead and closes on the line that closes it.
+   */
+  private static boolean opensNoLiteral(String line, int i, int body, Delimiter delimiter) {
+    var close = closerIndex(line, body, delimiter.close());
+    if (close < 0) {
+      return !continuesOnNextLine(line, body);
+    }
+    return isMisreadApostrophePair(line, delimiter.open().charAt(0), i, close);
   }
 
   /**

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/LogSafeInvariantTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/LogSafeInvariantTest.java
@@ -113,18 +113,17 @@ class LogSafeInvariantTest {
    * the value logged was {@code file() + ":" + line()} composed a few lines earlier, so a check
    * that only read the log call's own accessors saw a bare identifier and passed it (#764).
    *
-   * <p>Possessive around the {@code =} for the reason {@link #CONVERSION} is: {@code \s} and {@code
-   * [^;]} both match whitespace, so the run after the {@code =} splits every way between them, and
-   * an initializer this scan reaches with no {@code ;} beyond it makes the match try each split.
-   * Measured on 24 000 spaces, 2 494 ms; possessive, under 1 ms. A differential run over 400 000
-   * random inputs found no input the two forms answer differently.
-   */
-  /**
-   * A local's name and the start of its initializer. The initializer's END is found by {@link
-   * #initializerEnd}, not by this pattern: a {@code [^;]} class stops at the first semicolon
-   * wherever it sits, and {@code String msg = "prefix; " + finding.title();} then captured only
-   * {@code "prefix}, which {@link #withoutLiterals} dropped as an unterminated literal, so the
-   * accessor was never seen and the local never marked tainted.
+   * <p>The pattern matches a local's name and the start of its initializer. The initializer's END
+   * is found by {@link #initializerEnd}, not by the pattern: a {@code [^;]} class stops at the
+   * first semicolon wherever it sits, and {@code String msg = "prefix; " + finding.title();} then
+   * captured only {@code "prefix}, which {@link #withoutLiterals} dropped as an unterminated
+   * literal, so the accessor was never seen and the local never marked tainted.
+   *
+   * <p>Possessive around the {@code =} for the reason {@link #CONVERSION} is: while the pattern
+   * still ended in {@code [^;]}, that class and {@code \s} both matched whitespace, so the run
+   * after the {@code =} split every way between them, and an initializer with no {@code ;} beyond
+   * it made the match try each split. Measured on 24 000 spaces, 2 494 ms; possessive, under 1 ms.
+   * A differential run over 400 000 random inputs found no input the two forms answer differently.
    */
   private static final Pattern LOCAL_DECLARATION =
       Pattern.compile("\\b(?:final\\s+)?(?:String|var)\\s++(\\w+)\\s*+=\\s*+", Pattern.DOTALL);

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/github/RepoSettingsResolverTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/github/RepoSettingsResolverTest.java
@@ -991,7 +991,7 @@ class RepoSettingsResolverTest {
   void refusesADiamondAliasLadderThatStaysUnderTheAliasCeiling() {
     var yaml = new StringBuilder("l0: &l0 [x, x]\n");
     for (var i = 1; i <= 24; i++) {
-      yaml.append("l%d: &l%d [*l%d, *l%d]\n".formatted(i, i, i - 1, i - 1));
+      yaml.append("l" + i + ": &l" + i + " [*l" + (i - 1) + ", *l" + (i - 1) + "]\n");
     }
     yaml.append("review:\n  ignored-files: [kept/**]\n");
 

--- a/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
+++ b/src/test/java/dev/thiagogonzaga/thrillhousebot/review/RebuttalContradictionTest.java
@@ -1250,9 +1250,12 @@ class RebuttalContradictionTest {
   @Test
   void keepsABackslashContinuedStringQuotedOnTheNextLine() {
     var diff =
-        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,4 @@\n"
-            + "+    const char* s = \"log: hand work to \\\n"
-            + "+        executor.execute( here\"; return 0;\n";
+        """
+        diff --git a/src/a.c b/src/a.c
+        @@ -1,3 +1,4 @@
+        +    const char* s = "log: hand work to \\
+        +        executor.execute( here"; return 0;
+        """;
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff).isEmpty(),
         "the continued literal's remainder is quoted text, not a dispatch");
@@ -1262,9 +1265,12 @@ class RebuttalContradictionTest {
   @Test
   void keepsAContinuedStringQuotedWhenSpacesFollowTheBackslash() {
     var diff =
-        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,4 @@\n"
-            + "+    const char* s = \"log: hand work to \\   \n"
-            + "+        executor.execute( here\"; return 0;\n";
+        """
+        diff --git a/src/a.c b/src/a.c
+        @@ -1,3 +1,4 @@
+        +    const char* s = "log: hand work to \\  \s
+        +        executor.execute( here"; return 0;
+        """;
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff).isEmpty(),
         "spaces after the backslash do not turn the literal back into live code");
@@ -1274,9 +1280,12 @@ class RebuttalContradictionTest {
   @Test
   void readsAnEscapedBackslashAtLineEndAsNoContinuation() {
     var diff =
-        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,4 @@\n"
-            + "+    const char* s = \"path\\\\\"; \n"
-            + "+    executor.execute(run);\n";
+        """
+        diff --git a/src/a.c b/src/a.c
+        @@ -1,3 +1,4 @@
+        +    const char* s = "path\\\\";\s
+        +    executor.execute(run);
+        """;
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff)
             .isPresent(),
@@ -1287,10 +1296,13 @@ class RebuttalContradictionTest {
   @Test
   void readsALineOfOnlyBackslashesAsAContinuation() {
     var diff =
-        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,5 @@\n"
-            + "+    const char* s = \"hand work to \\"
-            + "\n+\\\n"
-            + "+        executor.execute( here\"; return 0;\n";
+        """
+        diff --git a/src/a.c b/src/a.c
+        @@ -1,3 +1,5 @@
+        +    const char* s = "hand work to \\
+        +\\
+        +        executor.execute( here"; return 0;
+        """;
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff).isEmpty(),
         "the literal is still open across the backslash-only line");
@@ -1299,9 +1311,12 @@ class RebuttalContradictionTest {
   @Test
   void readsAQuoteFollowedOnlyBySpacesAsProse() {
     var diff =
-        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,5 @@\n"
-            + "+    puts(\"   \n"
-            + "+    executor.execute(work);\n";
+        """
+        diff --git a/src/a.c b/src/a.c
+        @@ -1,3 +1,5 @@
+        +    puts("  \s
+        +    executor.execute(work);
+        """;
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff)
             .isPresent(),
@@ -1311,17 +1326,23 @@ class RebuttalContradictionTest {
   @Test
   void readsABodyOfOnlyBackslashesByParity() {
     var continued =
-        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,5 @@\n"
-            + "+    const char* s = \"\\\\\\"
-            + "\n+        executor.execute( here\"; return 0;\n";
+        """
+        diff --git a/src/a.c b/src/a.c
+        @@ -1,3 +1,5 @@
+        +    const char* s = "\\\\\\
+        +        executor.execute( here"; return 0;
+        """;
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", continued)
             .isEmpty(),
         "three backslashes are an escaped one plus a continuation");
     var escaped =
-        "diff --git a/src/a.c b/src/a.c\n@@ -1,3 +1,5 @@\n"
-            + "+    const char* s = \"\\\\"
-            + "\n+    executor.execute(work);\n";
+        """
+        diff --git a/src/a.c b/src/a.c
+        @@ -1,3 +1,5 @@
+        +    const char* s = "\\\\
+        +    executor.execute(work);
+        """;
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", escaped)
             .isPresent(),
@@ -1338,7 +1359,11 @@ class RebuttalContradictionTest {
   @ValueSource(strings = {"js", "jsx", "mjs", "cjs", "ts", "tsx", "mts", "cts", "vue", "svelte"})
   void keepsAnEscapedBacktickInsideATemplateLiteral(String extension) {
     var diff =
-        "diff --git a/src/a.%s b/src/a.%s\n@@ -1,3 +1,5 @@\n".formatted(extension, extension)
+        "diff --git a/src/a."
+            + extension
+            + " b/src/a."
+            + extension
+            + "\n@@ -1,3 +1,5 @@\n"
             + "+    const m = `prefix \\` hand work to executor.submit(task) here`;\n";
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff).isEmpty(),
@@ -1354,7 +1379,11 @@ class RebuttalContradictionTest {
   @ValueSource(strings = {"src/a.go", "src/Makefile", "src/v1.2/README"})
   void readsABackslashAsLiteralInsideABacktickOutsideJavaScript(String path) {
     var diff =
-        "diff --git a/%s b/%s\n@@ -1,3 +1,5 @@\n".formatted(path, path)
+        "diff --git a/"
+            + path
+            + " b/"
+            + path
+            + "\n@@ -1,3 +1,5 @@\n"
             + "+    s := `C:\\`; executor.submit(task)\n";
     assertTrue(
         RebuttalContradiction.find(RACE_FINDING, "Declining: this runs serially.", diff)


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor
- [x] ✅ Test

## Description

SonarCloud flagged twelve smells on the code #788, #790 and #791 merged. They were fixed on the PR branches while the PRs were being merged, so they land here instead. No behaviour changes.

- `LiveCodeScanner.openLiteral` was over the cognitive-complexity ceiling (S3776) once the backslash-continuation rule joined the misread-apostrophe rule. Both now live in `opensNoLiteral`, which answers the one question the loop asks: did this delimiter open anything here.
- The continuation fixtures in `RebuttalContradictionTest` are text blocks (S6126 ×7), and the diff headers built per extension are concatenated rather than formatted, as is the alias ladder in `RepoSettingsResolverTest` (S3457 ×3 — a `\n` inside a format string reads as a request for the platform separator).
- The two javadocs on `LogSafeInvariantTest.LOCAL_DECLARATION` are one comment (S8491); the possessive rationale is kept, in the past tense it belongs in now that the pattern no longer ends in `[^;]`.

## Related Issues

Follow-up to #788, #790 and #791. N/A otherwise.

## How Has This Been Tested?

- [x] Unit tests

`./mvnw -B clean compile spotbugs:check spotless:check` (`BugInstance size is 0`) and the full `./mvnw -B clean test` (3586 tests, 0 failures) on this branch. The text-block fixtures were checked to produce the same runtime strings as the concatenations they replace: the backslash-sensitive ones (`\\` for a literal backslash, `\s` for a trailing space) keep the continuation tests passing, which fail when the fixture drifts by one backslash. Patch coverage: no uncovered lines or branches in the `src/main` diff against `main`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

The extraction moves the continuation comment onto `opensNoLiteral`'s javadoc; the logic is byte-for-byte the two `if`s it replaces.
