### PR TITLE
chore(review): clear the Sonar smell on main and a stale sentence in walkRefused

### DIFF
--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingDeduplicator.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/FindingDeduplicator.java
@@ -184,7 +184,7 @@ public class FindingDeduplicator {
     // RiskLevel natural order is most-severe-first (CRITICAL..LOW); an even cluster takes the more
     // severe of the two central values (the lower index).
     int mid = ranked.size() / 2;
-    RiskLevel severity = ranked.size() % 2 == 0 ? ranked.get(mid - 1) : ranked.get(mid);
+    RiskLevel severity = ranked.get(ranked.size() % 2 == 0 ? mid - 1 : mid);
     // Confidence natural order is most-certain-first (HIGH < MEDIUM < LOW), so min() selects the
     // highest confidence among members carrying the chosen severity.
     Confidence confidence =

--- a/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
+++ b/src/main/java/dev/thiagogonzaga/thrillhousebot/review/JacocoCoverageReport.java
@@ -538,9 +538,9 @@ final class JacocoCoverageReport {
    * is leaving — so skipping past a bomb entry would pay exactly the cost the aggregate budget
    * exists to refuse.
    *
-   * <p>The cap counts entries that could carry a report. Directories are walked past without
-   * charge, so a tree-shaped artifact is judged by how much content it holds rather than by how
-   * deeply it is nested.
+   * <p>The cap counts file entries, report or not. Directories are drained against the aggregate
+   * budget like everything else but not charged to the cap, so a tree-shaped artifact is judged by
+   * how much content it holds rather than by how deeply it is nested.
    *
    * @return {@code true} when a limit stopped the walk, so whatever merged is a prefix the archive
    *     chose and no report may be built from it


### PR DESCRIPTION
## What type of PR is this?

- [x] 🔧 Refactor
- [x] 📝 Documentation

## Description

Two small items from the pre-release audit of the PRs merged since v0.6.6.

- SonarCloud's one open issue on `main` (S9358, `FindingDeduplicator`): the median pick wrapped two `get()` calls in a conditional; the conditional now selects the index.
- `JacocoCoverageReport.walkRefused`'s javadoc still said "Directories are walked past without charge", a sentence the last commit of #789 made false — directory-named entries are drained against the aggregate budget and only left off the entry cap. It also said the cap "counts entries that could carry a report", while the code counts every file entry. The javadoc now describes the code; whether the cap should count only report entries is #813.

## Related Issues

N/A (the cap semantics are tracked in #813).

## How Has This Been Tested?

- [x] Unit tests

`./mvnw -B clean compile spotbugs:check spotless:check` (`BugInstance size is 0`) and the full `./mvnw -B clean test`: 3631 tests, 0 failures. The median expression is equivalent for both parities of `ranked.size()`, and `FindingDeduplicatorTest` covers both.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

N/A

## Additional Notes

None.
