### PR TITLE
ci: build the native image on pull requests that touch its inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,21 @@ permissions:
   actions: read
 
 jobs:
-  # Did this push change anything other than docs (*.md, docs/**)? The native build and image
+  # Did this change touch anything other than docs (*.md, docs/**)? The native build and image
   # publish (main only) are skipped for docs-only commits. Fails open — anything uncertain
   # (first push, missing parent, a multi-file change) counts as code, so a real change is never
   # skipped. Note: a docs-only main commit then has no per-SHA image, so do not cut a release
   # from one (the release workflow verifies the image exists).
+  #
+  # `native` narrows `code` to the inputs the native image is built from: pom.xml, main sources
+  # and resources (reflection, resource loading and serialization fail natively before they fail
+  # on the JVM), the Dockerfiles, and this workflow, which holds the build command. A pull
+  # request builds the native image only when it touches one of those (#792); main always does.
   changes:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      native: ${{ steps.filter.outputs.native }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -31,19 +37,37 @@ jobs:
       - id: filter
         env:
           BEFORE: ${{ github.event.before }}
+          BASE: ${{ github.event.pull_request.base.sha }}
           SHA: ${{ github.sha }}
         run: |
-          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] \
-            || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+          # A push diffs the pushed range. A pull request diffs its merge commit against the base
+          # tip, which is the pull request's own change set: event.before is unset on `opened`,
+          # and on `synchronize` names the previous head, whose diff to the new merge commit also
+          # carries everything the base branch gained in between.
+          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
+            from="$BASE"
+            range=("${BASE}...${SHA}")
+          else
+            from="$BEFORE"
+            range=("$BEFORE" "$SHA")
+          fi
+          if [ -z "$from" ] || [ "$from" = "0000000000000000000000000000000000000000" ] \
+            || ! git cat-file -e "${from}^{commit}" 2>/dev/null; then
             echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "native=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          changed=$(git diff --name-only "$BEFORE" "$SHA")
-          if [ -z "$changed" ] || printf '%s\n' "$changed" | grep -qvE '(\.md$|^docs/)'; then
-            echo "code=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "code=false" >> "$GITHUB_OUTPUT"
+          changed=$(git diff --name-only "${range[@]}")
+          code=true
+          native=true
+          if [ -n "$changed" ]; then
+            printf '%s\n' "$changed" | grep -qvE '(\.md$|^docs/)' || code=false
+            printf '%s\n' "$changed" \
+              | grep -qE '^(pom\.xml$|src/main/(java|resources|docker)/|\.github/workflows/ci\.yml$)' \
+              || native=false
           fi
+          echo "code=${code}" >> "$GITHUB_OUTPUT"
+          echo "native=${native}" >> "$GITHUB_OUTPUT"
 
   format:
     runs-on: ubuntu-latest
@@ -154,9 +178,17 @@ jobs:
           name: frontend-dist
           path: frontend/out/
 
+  # main builds on every code change, since the image publish below consumes the binaries. A
+  # pull request builds when it touches something the native image is made from (#792), so a
+  # change that links on the JVM and fails natively is caught before it reaches main. The gate
+  # is a job-level `if`, like every other conditional job here: a skipped run reports a
+  # `skipped` conclusion, which satisfies a required check.
   native-build:
     needs: [frontend, changes]
-    if: github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'
+    if: >-
+      needs.changes.outputs.code == 'true' &&
+      (github.ref == 'refs/heads/main' ||
+       (github.event_name == 'pull_request' && needs.changes.outputs.native == 'true'))
     strategy:
       matrix:
         include:
@@ -181,7 +213,10 @@ jobs:
           name: frontend-dist
           path: src/main/resources/META-INF/resources/dashboard/
       - run: ./mvnw package -Pnative -DskipTests -Dquarkus.native.container-build=true
+      # Only the main-branch image publish consumes the binaries; a pull request build proves
+      # the link and keeps nothing.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: github.ref == 'refs/heads/main'
         with:
           name: native-binary-${{ matrix.arch }}
           path: target/*-runner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to ThrillhouseBot.
 
 ## [Unreleased]
 
+### Changed
+
+- **A pull request that touches the native image's inputs builds the native image** (#792): `native-build` ran only on `main`, so the only image a pull request ever built was the JVM one, and a change that links on the JVM and fails under GraalVM (reflection, resource loading, serialization, a swapped YAML engine) reached `main` before anything built it. The `changes` job now also reports whether the pull request's own diff touches `pom.xml`, `src/main/java`, `src/main/resources`, `src/main/docker` or the CI workflow, and `native-build` runs on a pull request when it does. Pushes to `main` build as before. A pull request build keeps no binary, and a skipped run reports a `skipped` conclusion, so the job can be made a required check without blocking a docs or test-only change. The build proves the image links; there are no `@QuarkusIntegrationTest` classes, so a failure that only shows when the code path runs, such as a missing reflection registration, is still not covered (#671)
+
 ## [0.6.7] — 2026-09-07
 
 Two production reviews drove this one: a pull request that was approved after most of the model's answer was thrown away, and one that was pushed to while under review and lost every finding to the push. The rest is hardening found by auditing the merged pull requests and by dogfooding the repository configuration. No configuration changes; upgrading is a redeploy. The one behaviour a deployment may notice is that `ignored-files` globs now match the way the documentation always said they did, so a pattern that was silently doing nothing starts excluding files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,8 @@ If you changed the dashboard, also run `cd frontend && npm ci && npm run test &&
 
 To exercise the UI without a backend, run `cd frontend && npm run dev:mock`.
 CI additionally runs Dependency Review (required), SonarCloud, Trivy, and a Docker
-build check on pull requests — see **Dual-gate merge policy** below.
+build check on pull requests, plus the GraalVM native build when the change touches
+`pom.xml`, `src/main/**` or the CI workflow — see **Dual-gate merge policy** below.
 To build a disposable test image for a branch or PR (JVM or native, without
 touching `latest`), use the **Docker test image** workflow in Actions
 (`.github/workflows/docker-test-image.yml`).


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] 📝 Documentation
- [x] 🏗️ CI/CD

## Description

Every claim in #792 checks out against `origin/main`: `native-build` is gated with `if: github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'`, `docker-pr` is the only image job on a pull request and packages a `mutable-jar` through `Dockerfile.jvm`, there is no `@QuarkusIntegrationTest` anywhere under `src/`, and the release workflow's `verify` job does gate on the per-SHA images existing in GHCR. On the last completed pull-request run before this branch (run `34116091654`, the 0.6.7 release PR): `changes: success`, `docker-pr: success`, `native-build: skipped`.

This is direction 1 from the issue with a path filter as the cost control.

**`changes` reports a second output, `native`.** It is true when the diff touches `pom.xml`, `src/main/java/**`, `src/main/resources/**`, `src/main/docker/**` or `.github/workflows/ci.yml` (the file that holds the native build command, so a change to the build itself is exercised too). It keeps the job's fail-open rule: an unresolvable range reports both outputs true. The job already computed `code` from a hand-rolled `git diff --name-only`, so `native` is derived from the same file list rather than adding a second mechanism.

**On a pull request the diff is now the pull request's own change set.** The job diffed `github.event.before..github.sha`, which is a push-shaped range: on `opened` `event.before` is unset (the job failed open), and on `synchronize` it names the previous head, whose diff to the new merge commit also carries everything the base gained in between. A pull request now diffs `pull_request.base.sha...github.sha`. Nothing consumed `code` on pull requests before this change, so this only affects the new gate. The push path is unchanged.

**`native-build` runs on a pull request when `code` and `native` are both true.** The main-branch condition is the same as before (`code == 'true'` on `refs/heads/main`), so docs-only commits on `main` still skip the build and the image publish, and pushes to `develop` / `release/**` still never build. Both matrix legs run on a pull request as they do on `main`; they run in parallel, so the wall-clock cost is one build.

**A pull request build keeps no binary.** The `upload-artifact` step now runs only on `main`, where the `docker` job consumes the artifacts. On a pull request the build is the proof and a 100 MB binary per leg would sit in artifact storage for 90 days for nothing. The `Docker test image` workflow remains the way to get a native image for a branch.

**Required-check friendly.** The gate is a job-level `if`, the same shape as `docker`, `trivy-image` and `docker-pr`; a job skipped that way reports a `skipped` conclusion, which GitHub counts as satisfied for a required status check. The `main-protection` ruleset is not touched (it requires `format`, `test`, `frontend`, `trivy`, `dependency-review`); adding `native-build (ubuntu-latest, amd64)` to it is the maintainer's call and would not block docs or test-only pull requests.

**Integration tests.** The repository has no `@QuarkusIntegrationTest` class, so there is nothing to run in the native job. This build proves the image links; a failure that only shows when the code path runs, such as a missing reflection registration, is still uncovered and stays with #671.

`CONTRIBUTING.md` says the native build runs on pull requests that touch those paths, and `CHANGELOG.md` has the entry under `[Unreleased]` → `Changed`.

## Related Issues

Fixes #792
Related: #671 (native integration tests), #790 (the change that prompted the issue), #170 (introduced the `changes` job)

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

**Red.** On `origin/main`, `native-build` carries `if: github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'`, so no `pull_request` run can execute it. Run `34116091654` (the last completed pull-request run before this branch) shows the outcome: `changes: success`, `docker-pr: success`, `native-build: skipped`.

**Filter script harness.** The `run:` body of the `filter` step was extracted verbatim from the new `ci.yml` and executed under `bash -e` with `GITHUB_EVENT_NAME`, `BEFORE`, `BASE`, `SHA` and `GITHUB_OUTPUT` set, over real commits from this repository classified by what they touch (`40c2496` touches only `CHANGELOG.md`; `74c13cc` only `src/test/**`; `46207a1` `src/main/java/**`; `fb47dc3` only `frontend/**`; `4e87e5f` only `website/**`):

```
== push (main) ==
first push (before zeros)                    rc=0 code=true native=true
missing parent                               rc=0 code=true native=true
docs-only commit 40c2496                     rc=0 code=false native=false
src/test-only commit 74c13cc                 rc=0 code=true native=false
src/main/java commit 46207a1                 rc=0 code=true native=true
frontend-only commit fb47dc3                 rc=0 code=true native=false
empty diff (before == sha)                   rc=0 code=true native=true
== pull_request (base.sha ... merge sha) ==
opened, base unset (fail open)               rc=0 code=true native=true
docs-only PR 40c2496                         rc=0 code=false native=false
src/test-only PR 74c13cc                     rc=0 code=true native=false
src/main/java PR 46207a1                     rc=0 code=true native=true
frontend-only PR fb47dc3                     rc=0 code=true native=false
website-only PR 4e87e5f                      rc=0 code=true native=false
release commit as PR v0.6.6..7               rc=0 code=true native=true
```

**actionlint.** `actionlint -color` (1.7.12, shellcheck enabled, with the `.actions-ref` side-path mirrored the way the CI job does it) exits 0 on the tree.

**Cost, measured on this pull request.** This branch changes `.github/workflows/ci.yml`, which is in the filter, so this run is the first pull request to build the native image. Measured on run `34122402294` (head `9c94aab`), where `changes` reported `native=true` and both legs ran:

| job | duration | started | finished |
|---|---|---|---|
| `native-build (ubuntu-latest, amd64)` | **5m40s** | 12:32:45 | 12:38:25 |
| `native-build (ubuntu-24.04-arm, arm64)` | **4m18s** | 12:32:47 | 12:37:05 |
| `test` (the previous critical path) | 5m26s | 12:32:21 | 12:37:47 |

The run was created at 12:32:18 and finished at 12:38:26, so the native build added about 10 runner-minutes and 38 seconds of wall-clock to a pull request that touches the filter's paths (the run would otherwise have ended with `test` at 12:37:47). The legs wait only on `frontend` (21s), so they start with the rest of the pipeline. For reference the same jobs on the last three `main` runs took 4m40s to 5m56s per leg.

No Java changes; the Java gates do not apply.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Screenshots / Logs

See the harness output above.

## Additional Notes

`frontend/**` is deliberately outside the filter: the dashboard bundle is copied into the native image but cannot change how it links, and `docker-pr` already packages it on every pull request. `src/main/docker/**` is in the filter as asked in the review of the issue, though the native job builds no image; a Dockerfile change is cheap to cover and rare.
